### PR TITLE
Fix #6820: Allow to permanently delete Sync accounts

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController.swift
@@ -124,7 +124,7 @@ public class BrowserViewController: UIViewController {
   var pageZoomBar: UIHostingController<PageZoomView>?
   private var pageZoomListener: NSObjectProtocol?
   private var openTabsModelStateListener: SendTabToSelfModelStateListener?
-  private var syncServicStateListener: AnyObject?
+  private var syncServiceStateListener: AnyObject?
   let collapsedURLBarView = CollapsedURLBarView()
 
   // Single data source used for all favorites vcs
@@ -364,14 +364,14 @@ public class BrowserViewController: UIViewController {
       })
     
     // Observer watching state change in sync chain
-    syncServicStateListener = braveCore.syncAPI.addServiceStateObserver { [weak self] in
+    syncServiceStateListener = braveCore.syncAPI.addServiceStateObserver { [weak self] in
       guard let self = self else { return }
       // Observe Sync State in order to determine if the sync chain is deleted
       // from another device - Clean local sync chain
       if self.braveCore.syncAPI.shouldLeaveSyncGroup {
         self.braveCore.syncAPI.leaveSyncGroup()
       }
-    } onServiceShutdown: {}
+    }
   }
 
   deinit {

--- a/Sources/Brave/Frontend/Browser/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController.swift
@@ -124,6 +124,7 @@ public class BrowserViewController: UIViewController {
   var pageZoomBar: UIHostingController<PageZoomView>?
   private var pageZoomListener: NSObjectProtocol?
   private var openTabsModelStateListener: SendTabToSelfModelStateListener?
+  private var syncServicStateListener: AnyObject?
   let collapsedURLBarView = CollapsedURLBarView()
 
   // Single data source used for all favorites vcs
@@ -361,6 +362,16 @@ public class BrowserViewController: UIViewController {
           }
         }
       })
+    
+    // Observer watching state change in sync chain
+    syncServicStateListener = braveCore.syncAPI.addServiceStateObserver { [weak self] in
+      guard let self = self else { return }
+      // Observe Sync State in order to determine if the sync chain is deleted
+      // from another device - Clean local sync chain
+      if self.braveCore.syncAPI.shouldLeaveSyncGroup {
+        self.braveCore.syncAPI.leaveSyncGroup()
+      }
+    } onServiceShutdown: {}
   }
 
   deinit {

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -783,11 +783,11 @@ extension BrowserViewController {
       titleWeight: .semibold,
       titleSize: 21
     )
-    popup.addButton(title: Strings.openExternalAppURLDontAllow, fontSize: 16) { () -> PopupViewDismissType in
+    popup.addButton(title: Strings.openExternalAppURLDontAllow) { () -> PopupViewDismissType in
       removeTabIfEmpty()
       return .flyDown
     }
-    popup.addButton(title: Strings.openExternalAppURLAllow, type: .primary, fontSize: 16) { () -> PopupViewDismissType in
+    popup.addButton(title: Strings.openExternalAppURLAllow, type: .primary) { () -> PopupViewDismissType in
       UIApplication.shared.open(url, options: [:], completionHandler: openedURLCompletionHandler)
       removeTabIfEmpty()
       return .flyDown

--- a/Sources/Brave/Frontend/Browser/Tabs/TabTray/TabTrayController.swift
+++ b/Sources/Brave/Frontend/Browser/Tabs/TabTray/TabTrayController.swift
@@ -211,7 +211,7 @@ class TabTrayController: LoadingViewController {
           $0.updateSyncStatusPanel(for: self.emptyPanelState)
         }
       }
-    } onServiceShutdown: {}
+    }
   }
 
   @available(*, unavailable)

--- a/Sources/Brave/Frontend/Browser/Tabs/TabTray/TabTrayController.swift
+++ b/Sources/Brave/Frontend/Browser/Tabs/TabTray/TabTrayController.swift
@@ -47,7 +47,8 @@ class TabTrayController: LoadingViewController {
   let tabManager: TabManager
   let braveCore: BraveCoreMain
   private var openTabsSessionServiceListener: OpenTabsSessionStateListener?
-  
+  private var syncServicStateListener: AnyObject?
+
   weak var delegate: TabTrayDelegate?
   weak var toolbarUrlActionsDelegate: ToolbarUrlActionsDelegate?
   
@@ -200,6 +201,17 @@ class TabTrayController: LoadingViewController {
           }
         }
       })
+    
+    // Adding State Sync Observer to watch the states change in sync chain
+    syncServicStateListener = braveCore.syncAPI.addServiceStateObserver { [weak self] in
+      guard let self = self else { return }
+
+      if self.braveCore.syncAPI.shouldLeaveSyncGroup {
+        self.tabSyncView.do {
+          $0.updateSyncStatusPanel(for: self.emptyPanelState)
+        }
+      }
+    } onServiceShutdown: {}
   }
 
   @available(*, unavailable)

--- a/Sources/Brave/Frontend/Sync/BraveCore/BraveSyncAPIExtensions.swift
+++ b/Sources/Brave/Frontend/Sync/BraveCore/BraveSyncAPIExtensions.swift
@@ -31,6 +31,7 @@ extension BraveSyncAPI {
     return Preferences.Chromium.syncEnabled.value
   }
   
+  /// Property that determines if the local sync chain should be resetted
   var shouldLeaveSyncGroup: Bool {
     guard isInSyncGroup else {
       return false

--- a/Sources/Brave/Frontend/Sync/BraveCore/BraveSyncAPIExtensions.swift
+++ b/Sources/Brave/Frontend/Sync/BraveCore/BraveSyncAPIExtensions.swift
@@ -47,7 +47,7 @@ extension BraveSyncAPI {
   
   @discardableResult
   func joinSyncGroup(codeWords: String, syncProfileService: BraveSyncProfileServiceIOS) -> Bool {
-    if self.setSyncCode(codeWords) {
+    if setSyncCode(codeWords) {
       Preferences.Chromium.syncEnabled.value = true
       enableSyncTypes(syncProfileService: syncProfileService)
 

--- a/Sources/Brave/Frontend/Sync/BraveCore/BraveSyncAPIExtensions.swift
+++ b/Sources/Brave/Frontend/Sync/BraveCore/BraveSyncAPIExtensions.swift
@@ -98,11 +98,11 @@ extension BraveSyncAPI {
     }
   }
 
-  func addServiceStateObserver(_ observer: @escaping () -> Void) -> AnyObject {
+  func addServiceStateObserver(_ onStateChanged: @escaping () -> Void, onServiceShutdown: @escaping () -> Void) -> AnyObject {
     let serviceStateListener = BraveSyncServiceListener(onRemoved: { [weak self] observer in
       self?.serviceObservers.remove(observer)
     })
-    serviceStateListener.observer = createSyncServiceObserver(observer, onSyncServiceShutdown: {})
+    serviceStateListener.observer = createSyncServiceObserver(onStateChanged, onSyncServiceShutdown: onServiceShutdown)
 
     serviceObservers.add(serviceStateListener)
     return serviceStateListener

--- a/Sources/Brave/Frontend/Sync/BraveCore/BraveSyncAPIExtensions.swift
+++ b/Sources/Brave/Frontend/Sync/BraveCore/BraveSyncAPIExtensions.swift
@@ -32,7 +32,11 @@ extension BraveSyncAPI {
   }
   
   var shouldLeaveSyncGroup: Bool {
-    return (isInSyncGroup && !isSyncFeatureActive && !isFirstSetupComplete) || (isInSyncGroup && isSyncAccountDeletedNoticePending)
+    guard isInSyncGroup else {
+      return false
+    }
+    
+    return !(isSyncFeatureActive && isFirstSetupComplete) || isSyncAccountDeletedNoticePending
   }
 
   var isSendTabToSelfVisible: Bool {
@@ -68,9 +72,9 @@ extension BraveSyncAPI {
 
   /// Method for leaving sync chain
   /// Removing Observers, clearing local preferences and calling reset chain on brave-core side
-  /// - Parameter includeObservers: Parameter that decides if observers should be removed
-  func leaveSyncGroup(includeObservers: Bool = true) {
-    if includeObservers {
+  /// - Parameter preservingObservers: Parameter that decides if observers should be preserved or removed
+  func leaveSyncGroup(preservingObservers: Bool = false) {
+    if !preservingObservers {
       // Remove all observers before leaving the sync chain
       removeAllObservers()
     }
@@ -114,7 +118,7 @@ extension BraveSyncAPI {
   ///   - onStateChanged: Callback for sync service state changes
   ///   - onServiceShutdown: Callback for sync service shutdown
   /// - Returns: Listener for service
-  func addServiceStateObserver(_ onStateChanged: @escaping () -> Void, onServiceShutdown: @escaping () -> Void) -> AnyObject {
+  func addServiceStateObserver(_ onStateChanged: @escaping () -> Void, onServiceShutdown: @escaping () -> Void = {}) -> AnyObject {
     let serviceStateListener = BraveSyncServiceListener(onRemoved: { [weak self] observer in
       self?.serviceObservers.remove(observer)
     })

--- a/Sources/Brave/Frontend/Sync/BraveCore/BraveSyncAPIExtensions.swift
+++ b/Sources/Brave/Frontend/Sync/BraveCore/BraveSyncAPIExtensions.swift
@@ -30,6 +30,10 @@ extension BraveSyncAPI {
   var isInSyncGroup: Bool {
     return Preferences.Chromium.syncEnabled.value
   }
+  
+  var shouldLeaveSyncGroup: Bool {
+    return (isInSyncGroup && !isSyncFeatureActive && !isFirstSetupComplete) || (isInSyncGroup && isSyncAccountDeletedNoticePending)
+  }
 
   var isSendTabToSelfVisible: Bool {
     guard let json = getDeviceListJSON(), let data = json.data(using: .utf8) else {

--- a/Sources/Brave/Frontend/Sync/BraveCore/BraveSyncAPIExtensions.swift
+++ b/Sources/Brave/Frontend/Sync/BraveCore/BraveSyncAPIExtensions.swift
@@ -60,6 +60,9 @@ extension BraveSyncAPI {
     deleteDevice(deviceGuid)
   }
 
+  /// Method for leaving sync chain
+  /// Removing Observers, clearing local preferences and calling reset chain on brave-core side
+  /// - Parameter includeObservers: Parameter that decides if observers should be removed
   func leaveSyncGroup(includeObservers: Bool = true) {
     if includeObservers {
       // Remove all observers before leaving the sync chain
@@ -98,6 +101,13 @@ extension BraveSyncAPI {
     }
   }
 
+  /// Method to add observer for SyncService for onStateChanged and onSyncShutdown
+  /// OnStateChanged can be called in various situations like successful initialization - services unavaiable
+  /// sync shutdown - sync errors - sync chain deleted
+  /// - Parameters:
+  ///   - onStateChanged: Callback for sync service state changes
+  ///   - onServiceShutdown: Callback for sync service shutdown
+  /// - Returns: Listener for service
   func addServiceStateObserver(_ onStateChanged: @escaping () -> Void, onServiceShutdown: @escaping () -> Void) -> AnyObject {
     let serviceStateListener = BraveSyncServiceListener(onRemoved: { [weak self] observer in
       self?.serviceObservers.remove(observer)

--- a/Sources/Brave/Frontend/Sync/BraveCore/BraveSyncAPIExtensions.swift
+++ b/Sources/Brave/Frontend/Sync/BraveCore/BraveSyncAPIExtensions.swift
@@ -52,8 +52,10 @@ extension BraveSyncAPI {
   @discardableResult
   func joinSyncGroup(codeWords: String, syncProfileService: BraveSyncProfileServiceIOS) -> Bool {
     if setSyncCode(codeWords) {
-      Preferences.Chromium.syncEnabled.value = true
       enableSyncTypes(syncProfileService: syncProfileService)
+      requestSync()
+      setSetupComplete()
+      Preferences.Chromium.syncEnabled.value = true
 
       return true
     }

--- a/Sources/Brave/Frontend/Sync/BraveCore/BraveSyncAPIExtensions.swift
+++ b/Sources/Brave/Frontend/Sync/BraveCore/BraveSyncAPIExtensions.swift
@@ -60,10 +60,12 @@ extension BraveSyncAPI {
     deleteDevice(deviceGuid)
   }
 
-  func leaveSyncGroup() {
-    // Remove all observers before leaving the sync chain
-    removeAllObservers()
-
+  func leaveSyncGroup(includeObservers: Bool = true) {
+    if includeObservers {
+      // Remove all observers before leaving the sync chain
+      removeAllObservers()
+    }
+    
     resetSyncChain()
     Preferences.Chromium.syncEnabled.value = false
   }

--- a/Sources/Brave/Frontend/Sync/SyncAddDeviceViewController.swift
+++ b/Sources/Brave/Frontend/Sync/SyncAddDeviceViewController.swift
@@ -151,7 +151,7 @@ class SyncAddDeviceViewController: SyncViewController {
   override func viewDidAppear(_ animated: Bool) {
     super.viewDidAppear(animated)
     
-    if !syncAPI.isInSyncGroup {
+    if !syncAPI.isInSyncGroup && !syncAPI.isSyncFeatureActive && !syncAPI.isFirstSetupComplete {
       showInitializationError()
     }
   }

--- a/Sources/Brave/Frontend/Sync/SyncPairWordsViewController.swift
+++ b/Sources/Brave/Frontend/Sync/SyncPairWordsViewController.swift
@@ -171,18 +171,6 @@ class SyncPairWordsViewController: SyncViewController {
   private func checkCodes() {
     Logger.module.debug("check codes")
 
-    func alert(title: String? = nil, message: String? = nil) {
-      if syncAPI.isInSyncGroup {
-        // No alert
-        return
-      }
-      let title = title ?? Strings.unableToConnectTitle
-      let message = message ?? Strings.unableToConnectDescription
-      let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-      alert.addAction(UIAlertAction(title: Strings.OKString, style: .default, handler: nil))
-      self.present(alert, animated: true, completion: nil)
-    }
-
     let codes = self.codewordsView.codeWords().joined(separator: " ")
     let syncCodeValidation = syncAPI.getWordsValidationResult(codes)
     if syncCodeValidation == .wrongWordsNumber {
@@ -190,16 +178,8 @@ class SyncPairWordsViewController: SyncViewController {
       return
     }
 
-    self.view.endEditing(true)
+    view.endEditing(true)
     enableNavigationPrevention()
-
-    // forced timeout
-    DispatchQueue.main.asyncAfter(
-      deadline: DispatchTime.now() + Double(Int64(25.0) * Int64(NSEC_PER_SEC)) / Double(NSEC_PER_SEC),
-      execute: {
-        self.disableNavigationPrevention()
-        alert()
-      })
 
     if syncCodeValidation == .valid {
       let words = syncAPI.getWordsFromTimeLimitedWords(codes)
@@ -208,9 +188,30 @@ class SyncPairWordsViewController: SyncViewController {
       alert(message: syncCodeValidation.errorDescription)
       disableNavigationPrevention()
     }
-
+  }
+  
+  private func timeoutSyncSetup() {
+    DispatchQueue.main.asyncAfter(deadline: .now() + 25.0) {
+      self.disableNavigationPrevention()
+      self.alert()
+    }
+  }
+  
+  private func alert(title: String? = nil, message: String? = nil) {
+    if syncAPI.isInSyncGroup {
+      return
+    }
+    
+    let title = title ?? Strings.unableToConnectTitle
+    let message = message ?? Strings.unableToConnectDescription
+    
+    let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+    alert.addAction(UIAlertAction(title: Strings.OKString, style: .default, handler: nil))
+    present(alert, animated: true, completion: nil)
   }
 }
+
+// MARK: NavigationPrevention
 
 extension SyncPairWordsViewController: NavigationPrevention {
   func enableNavigationPrevention() {

--- a/Sources/Brave/Frontend/Sync/SyncPairWordsViewController.swift
+++ b/Sources/Brave/Frontend/Sync/SyncPairWordsViewController.swift
@@ -77,6 +77,8 @@ class SyncPairWordsViewController: SyncViewController {
 
     title = Strings.syncAddDeviceWordsTitle
 
+    doLayout()
+
     codewordsView.wordCountChangeCallback = { [weak self] count in
       self?.wordCountLabel.text = String(format: Strings.wordCount, count)
     }

--- a/Sources/Brave/Frontend/Sync/SyncPairWordsViewController.swift
+++ b/Sources/Brave/Frontend/Sync/SyncPairWordsViewController.swift
@@ -9,12 +9,19 @@ import os.log
 
 class SyncPairWordsViewController: SyncViewController {
 
-  weak var delegate: SyncPairControllerDelegate?
-  var scrollView: UIScrollView!
-  var containerView: UIView!
-  var codewordsView: SyncCodewordsView!
-
-  lazy var wordCountLabel: UILabel = {
+  private let scrollView = UIScrollView().then {
+    $0.translatesAutoresizingMaskIntoConstraints = false
+  }
+  private let containerView = UIView().then {
+    $0.translatesAutoresizingMaskIntoConstraints = false
+    $0.backgroundColor = .braveBackground
+    $0.layer.shadowColor = UIColor.braveSeparator.cgColor
+    $0.layer.shadowRadius = 0
+    $0.layer.shadowOpacity = 1.0
+    $0.layer.shadowOffset = CGSize(width: 0, height: 0.5)
+  }
+  
+  private lazy var wordCountLabel: UILabel = {
     let label = UILabel()
     label.font = UIFont.systemFont(ofSize: 13, weight: UIFont.Weight.regular)
     label.textColor = .braveLabel
@@ -22,26 +29,33 @@ class SyncPairWordsViewController: SyncViewController {
     return label
   }()
 
-  lazy var copyPasteButton: UIButton = {
+  private lazy var copyPasteButton: UIButton = {
     let button = UIButton()
     button.setImage(UIImage(named: "copy_paste", in: .module, compatibleWith: nil)?.template, for: .normal)
-    button.addTarget(self, action: #selector(SEL_paste), for: .touchUpInside)
+    button.addTarget(self, action: #selector(pasteButtonPressed), for: .touchUpInside)
     button.tintColor = .braveLabel
     return button
   }()
 
-  lazy var useCameraButton = UIButton().then {
+  private lazy var useCameraButton = UIButton().then {
     $0.setTitle(Strings.syncSwitchBackToCameraButton, for: .normal)
     $0.addTarget(self, action: #selector(useCameraButtonTapped), for: .touchDown)
     $0.setTitleColor(.braveLabel, for: .normal)
     $0.titleLabel?.font = UIFont.systemFont(ofSize: 15, weight: UIFont.Weight.regular)
   }
 
-  var loadingView: UIView!
-  let loadingSpinner = UIActivityIndicatorView(style: .large)
-
+  private let loadingView = UIView().then {
+    $0.backgroundColor = UIColor(white: 0.5, alpha: 0.5)
+    $0.isHidden = true
+  }
+  private let loadingSpinner = UIActivityIndicatorView(style: .large)
+  
+  private var codewordsView = SyncCodewordsView(data: [])
   private let syncAPI: BraveSyncAPI
+  weak var delegate: SyncPairControllerDelegate?
 
+  // MARK: Lifecycle
+  
   init(syncAPI: BraveSyncAPI) {
     self.syncAPI = syncAPI
     super.init(nibName: nil, bundle: nil)
@@ -63,97 +77,89 @@ class SyncPairWordsViewController: SyncViewController {
 
     title = Strings.syncAddDeviceWordsTitle
 
-    scrollView = UIScrollView()
-    scrollView.translatesAutoresizingMaskIntoConstraints = false
+    codewordsView.wordCountChangeCallback = { [weak self] count in
+      self?.wordCountLabel.text = String(format: Strings.wordCount, count)
+    }
+  
+    loadingSpinner.startAnimating()
+
+    navigationItem.rightBarButtonItem = UIBarButtonItem(
+      title: Strings.confirm, style: .done, target: self, action: #selector(doneButtonPressed))
+
+    edgesForExtendedLayout = UIRectEdge()
+  }
+  
+  override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
+    codewordsView.becomeFirstResponder()
+  }
+  
+  private func doLayout() {
     view.addSubview(scrollView)
 
-    containerView = UIView()
-    containerView.translatesAutoresizingMaskIntoConstraints = false
-    containerView.backgroundColor = .braveBackground
-    containerView.layer.shadowColor = UIColor.braveSeparator.cgColor
-    containerView.layer.shadowRadius = 0
-    containerView.layer.shadowOpacity = 1.0
-    containerView.layer.shadowOffset = CGSize(width: 0, height: 0.5)
     scrollView.addSubview(containerView)
-
-    codewordsView = SyncCodewordsView(data: [])
-    codewordsView.wordCountChangeCallback = { (count) in
-      self.wordCountLabel.text = String(format: Strings.wordCount, count)
-    }
+    
     containerView.addSubview(codewordsView)
     containerView.addSubview(wordCountLabel)
     containerView.addSubview(copyPasteButton)
-
-    loadingSpinner.startAnimating()
-
-    loadingView = UIView()
-    loadingView.backgroundColor = UIColor(white: 0.5, alpha: 0.5)
-    loadingView.isHidden = true
+    
     loadingView.addSubview(loadingSpinner)
 
     view.addSubview(loadingView)
     view.addSubview(useCameraButton)
-
-    navigationItem.rightBarButtonItem = UIBarButtonItem(title: Strings.confirm, style: .done, target: self, action: #selector(SEL_done))
-
-    edgesForExtendedLayout = UIRectEdge()
-
-    scrollView.snp.makeConstraints { (make) in
-      make.edges.equalTo(self.view)
+    
+    scrollView.snp.makeConstraints {
+      $0.edges.equalTo(view)
     }
 
-    containerView.snp.makeConstraints { (make) in
+    containerView.snp.makeConstraints {
       // Making these edges based off of the scrollview removes selectability on codewords.
       //  This currently works for all layouts and enables interaction, so using `view` instead.
-      make.top.equalTo(self.view)
-      make.left.equalTo(self.view)
-      make.right.equalTo(self.view)
-      make.height.equalTo(295)
-      make.width.equalTo(self.view)
+      $0.top.equalTo(view)
+      $0.left.equalTo(view)
+      $0.right.equalTo(view)
+      $0.height.equalTo(295)
+      $0.width.equalTo(view)
     }
 
-    codewordsView.snp.makeConstraints { (make) in
-      make.edges.equalTo(self.containerView).inset(UIEdgeInsets(top: 0, left: 0, bottom: 45, right: 0))
+    codewordsView.snp.makeConstraints {
+      $0.edges.equalTo(containerView).inset(UIEdgeInsets(top: 0, left: 0, bottom: 45, right: 0))
     }
 
-    wordCountLabel.snp.makeConstraints { (make) in
-      make.top.equalTo(codewordsView.snp.bottom)
-      make.left.equalTo(codewordsView).inset(24)
+    wordCountLabel.snp.makeConstraints {
+      $0.top.equalTo(codewordsView.snp.bottom)
+      $0.left.equalTo(codewordsView).inset(24)
     }
 
-    copyPasteButton.snp.makeConstraints { (make) in
-      make.size.equalTo(45)
-      make.right.equalTo(containerView).inset(15)
-      make.bottom.equalTo(containerView).inset(15)
+    copyPasteButton.snp.makeConstraints {
+      $0.size.equalTo(45)
+      $0.right.equalTo(containerView).inset(15)
+      $0.bottom.equalTo(containerView).inset(15)
     }
 
-    loadingView.snp.makeConstraints { (make) in
-      make.edges.equalTo(loadingView.superview!)
+    loadingView.snp.makeConstraints {
+      $0.edges.equalTo(loadingView.superview!)
     }
 
-    loadingSpinner.snp.makeConstraints { (make) in
-      make.center.equalTo(loadingView)
+    loadingSpinner.snp.makeConstraints {
+      $0.center.equalTo(loadingView)
     }
 
-    useCameraButton.snp.makeConstraints { make in
-      make.top.equalTo(containerView.snp.bottom).offset(16)
-      make.left.equalTo(self.view)
-      make.right.equalTo(self.view)
-      make.centerX.equalTo(self.view)
+    useCameraButton.snp.makeConstraints {
+      $0.top.equalTo(containerView.snp.bottom).offset(16)
+      $0.left.equalTo(view)
+      $0.right.equalTo(view)
+      $0.centerX.equalTo(view)
     }
   }
-
+  
+  // MARK: Actions
+  
   @objc func useCameraButtonTapped() {
-    self.navigationController?.popViewController(animated: true)
+    navigationController?.popViewController(animated: true)
   }
 
-  override func viewWillAppear(_ animated: Bool) {
-    super.viewWillAppear(animated)
-
-    codewordsView.becomeFirstResponder()
-  }
-
-  @objc func SEL_paste() {
+  @objc func pasteButtonPressed() {
     if let contents = UIPasteboard.general.string, !contents.isEmpty {
       // remove linebreaks and whitespace, split into codewords.
       codewordsView.setCodewords(data: contents.separatedBy(" "))
@@ -162,42 +168,49 @@ class SyncPairWordsViewController: SyncViewController {
     }
   }
 
-  @objc func SEL_done() {
+  @objc func doneButtonPressed() {
     doIfConnected {
       self.checkCodes()
     }
   }
-
+  
+  // MARK: Internal
+  
+  /// Check Codes is performing code word validation from core side to determine
+  /// the sync code words entered are valid and not expired
+  /// This is pre validation before  sync chain not deleted confirmation
   private func checkCodes() {
-    Logger.module.debug("check codes")
-
     let codes = self.codewordsView.codeWords().joined(separator: " ")
     let syncCodeValidation = syncAPI.getWordsValidationResult(codes)
     if syncCodeValidation == .wrongWordsNumber {
-      alert(title: Strings.notEnoughWordsTitle, message: Strings.notEnoughWordsDescription)
+      showAlert(title: Strings.notEnoughWordsTitle, message: Strings.notEnoughWordsDescription)
       return
     }
 
     view.endEditing(true)
     enableNavigationPrevention()
+    
+    timeoutSyncSetup()
 
     if syncCodeValidation == .valid {
       let words = syncAPI.getWordsFromTimeLimitedWords(codes)
       delegate?.syncOnWordsEntered(self, codeWords: words)
     } else {
-      alert(message: syncCodeValidation.errorDescription)
+      showAlert(message: syncCodeValidation.errorDescription)
       disableNavigationPrevention()
     }
   }
   
+  /// Time out and disable loading for sync setup
   private func timeoutSyncSetup() {
+    // Time out after 25 sec
     DispatchQueue.main.asyncAfter(deadline: .now() + 25.0) {
       self.disableNavigationPrevention()
-      self.alert()
+      self.showAlert()
     }
   }
   
-  private func alert(title: String? = nil, message: String? = nil) {
+  private func showAlert(title: String? = nil, message: String? = nil) {
     if syncAPI.isInSyncGroup {
       return
     }

--- a/Sources/Brave/Frontend/Sync/SyncSettingsTableViewController.swift
+++ b/Sources/Brave/Frontend/Sync/SyncSettingsTableViewController.swift
@@ -174,7 +174,15 @@ class SyncSettingsTableViewController: UIViewController, UITableViewDelegate, UI
         }
       case .syncChainDeleted:
         // Call Sync Account Delete
-        self.navigationController?.popToRootViewController(animated: true)
+        
+        self.syncAPI.permanentlyDeleteAccount { [weak self] status in
+          guard let self else { return }
+          self.syncAPI.leaveSyncGroup()
+
+          print("Test \(status)")
+          self.navigationController?.popToRootViewController(animated: true)
+        }
+        
       }
       return .flyDown
     }

--- a/Sources/Brave/Frontend/Sync/SyncSettingsTableViewController.swift
+++ b/Sources/Brave/Frontend/Sync/SyncSettingsTableViewController.swift
@@ -233,7 +233,7 @@ class SyncSettingsTableViewController: SyncViewController, UITableViewDelegate, 
             self.navigationController?.popToRootViewController(animated: true)
           }
         }
-      default:
+      case .syncChainDeleteError:
         break
       }
       return .flyDown

--- a/Sources/Brave/Frontend/Sync/SyncSettingsTableViewController.swift
+++ b/Sources/Brave/Frontend/Sync/SyncSettingsTableViewController.swift
@@ -103,7 +103,7 @@ class SyncSettingsTableViewController: SyncViewController, UITableViewDelegate, 
       // Observe Sync State in order to determine if the sync chain is deleted
       // from another device - Clean local sync chain
       self?.restartSyncSetupIfNecessary()
-    } onServiceShutdown: {}
+    }
     
     syncDeviceObserver = syncAPI.addDeviceStateObserver { [weak self] in
       self?.updateDeviceList()
@@ -218,15 +218,14 @@ class SyncSettingsTableViewController: SyncViewController, UITableViewDelegate, 
           self.enableNavigationPrevention()
           
           // Permanently Delete action is called on brave-core side
-          self.syncAPI.permanentlyDeleteAccount { [weak self] status in
-            guard let self else { return }
+          self.syncAPI.permanentlyDeleteAccount { status in
             
             switch status {
             case .throttled, .partialFailure, .transientError:
               self.presentAlertPopup(for: .syncChainDeleteError)
             default:
               // Clearing local preferences and calling reset chain on brave-core side
-              self.syncAPI.leaveSyncGroup(includeObservers: false)
+              self.syncAPI.leaveSyncGroup(preservingObservers: true)
             }
             
             self.disableNavigationPrevention()
@@ -569,6 +568,5 @@ extension SyncSettingsTableViewController: NavigationPrevention {
     loadingView.isHidden = true
     navigationItem.rightBarButtonItem?.isEnabled = true
     navigationItem.hidesBackButton = false
-
   }
 }

--- a/Sources/Brave/Frontend/Sync/SyncWelcomeViewController.swift
+++ b/Sources/Brave/Frontend/Sync/SyncWelcomeViewController.swift
@@ -195,7 +195,7 @@ class SyncWelcomeViewController: SyncViewController {
           bvc?.present(SyncAlerts.initializationError, animated: true)
         }
       }
-    } onServiceShutdown: {}
+    }
   }
 
   @objc
@@ -277,9 +277,7 @@ extension SyncWelcomeViewController: SyncPairControllerDelegate {
     
     // DidJoinSyncChain is checking If the chain user trying to join is deleted recently
     // returning an error accordingly - only error is Deleted Sync Chain atm
-    syncAPI.setDidJoinSyncChain { [weak self] result in
-      guard let self else { return }
-
+    syncAPI.setDidJoinSyncChain { result in
       if result {
         // If chain is not deleted start listening for device state observer
         // to validate devices are added to chain and show settings

--- a/Sources/Brave/Frontend/Sync/SyncWelcomeViewController.swift
+++ b/Sources/Brave/Frontend/Sync/SyncWelcomeViewController.swift
@@ -277,15 +277,19 @@ extension SyncWelcomeViewController: SyncPairControllerDelegate {
 
   func syncOnWordsEntered(_ controller: UIViewController & NavigationPrevention, codeWords: String) {
     controller.enableNavigationPrevention()
+    
     syncDeviceInfoObserver = syncAPI.addDeviceStateObserver { [weak self] in
       guard let self = self else { return }
       self.syncServiceObserver = nil
       self.syncDeviceInfoObserver = nil
+      
       controller.disableNavigationPrevention()
       self.pushSettings()
     }
 
+
     syncAPI.joinSyncGroup(codeWords: codeWords, syncProfileService: syncProfileServices)
+    
     syncAPI.requestSync()
     syncAPI.setSetupComplete()
   }

--- a/Sources/Brave/Frontend/Sync/SyncWelcomeViewController.swift
+++ b/Sources/Brave/Frontend/Sync/SyncWelcomeViewController.swift
@@ -195,6 +195,8 @@ class SyncWelcomeViewController: SyncViewController {
           bvc?.present(SyncAlerts.initializationError, animated: true)
         }
       }
+    } onServiceShutdown: {
+      
     }
   }
 
@@ -278,7 +280,7 @@ extension SyncWelcomeViewController: SyncPairControllerDelegate {
   func syncOnWordsEntered(_ controller: UIViewController & NavigationPrevention, codeWords: String) {
     controller.enableNavigationPrevention()
     
-    syncAPI.setJoinSyncChain { [weak self] result in
+    syncAPI.setDidJoinSyncChain { [weak self] result in
       guard let self else { return }
 
       if result {

--- a/Sources/Brave/Frontend/Sync/SyncWelcomeViewController.swift
+++ b/Sources/Brave/Frontend/Sync/SyncWelcomeViewController.swift
@@ -189,7 +189,7 @@ class SyncWelcomeViewController: SyncViewController {
     syncServiceObserver = syncAPI.addServiceStateObserver { [weak self] in
       guard let self = self else { return }
 
-      if !self.syncAPI.isInSyncGroup {
+      if !self.syncAPI.isInSyncGroup && !self.syncAPI.isSyncFeatureActive && !self.syncAPI.isFirstSetupComplete {
         let bvc = self.currentScene?.browserViewController
         self.dismiss(animated: true) {
           bvc?.present(SyncAlerts.initializationError, animated: true)
@@ -208,7 +208,6 @@ class SyncWelcomeViewController: SyncViewController {
   }
 
   @objc func newToSyncAction() {
-    handleSyncSetupFailure()
     let addDevice = SyncSelectDeviceTypeViewController()
     addDevice.syncInitHandler = { [weak self] (title, type) in
       guard let self = self else { return }
@@ -241,15 +240,13 @@ class SyncWelcomeViewController: SyncViewController {
       }
 
       self.syncAPI.joinSyncGroup(codeWords: self.syncAPI.getSyncCode(), syncProfileService: self.syncProfileServices)
-      self.syncAPI.requestSync()
-      self.syncAPI.setSetupComplete()
+      self.handleSyncSetupFailure()
     }
 
     self.navigationController?.pushViewController(addDevice, animated: true)
   }
 
   @objc func existingUserAction() {
-    handleSyncSetupFailure()
     let pairCamera = SyncPairCameraViewController(syncAPI: syncAPI)
     pairCamera.delegate = self
     self.navigationController?.pushViewController(pairCamera, animated: true)
@@ -317,7 +314,6 @@ extension SyncWelcomeViewController: SyncPairControllerDelegate {
     // In parallel set code words - request sync and setup complete
     // should be called on brave-core side
     syncAPI.joinSyncGroup(codeWords: codeWords, syncProfileService: syncProfileServices)
-    syncAPI.requestSync()
-    syncAPI.setSetupComplete()
+    handleSyncSetupFailure()
   }
 }

--- a/Sources/BraveShared/BraveStrings.swift
+++ b/Sources/BraveShared/BraveStrings.swift
@@ -909,6 +909,7 @@ extension Strings {
   public static let syncRemoveThisDeviceQuestionDesc = NSLocalizedString("SyncRemoveThisDeviceQuestionDesc", tableName: "BraveShared", bundle: .module, value: "This device will be disconnected from sync group and no longer receive or send sync data. All existing data will remain on device.", comment: "Sync remove device?")
   public static let pair = NSLocalizedString("Pair", tableName: "BraveShared", bundle: .module, value: "Pair", comment: "Sync pair device settings section title")
   public static let syncAddAnotherDevice = NSLocalizedString("SyncAddAnotherDevice", tableName: "BraveShared", bundle: .module, value: "Add New Device", comment: "Add New Device cell button.")
+  public static let syncDeleteAccount = NSLocalizedString("SyncDeleteAccount", tableName: "BraveShared", bundle: .module, value: "Delete Sync Account", comment: "Delete Sync Account cell title for button.")
   public static let syncTabletOrMobileDevice = NSLocalizedString("SyncTabletOrMobileDevice", tableName: "BraveShared", bundle: .module, value: "Tablet or Phone", comment: "Tablet or phone button title")
   public static let syncAddTabletOrPhoneTitle = NSLocalizedString("SyncAddTabletOrPhoneTitle", tableName: "BraveShared", bundle: .module, value: "Add a Tablet or Phone", comment: "Add Tablet or phone title")
   public static let syncComputerDevice = NSLocalizedString("SyncComputerDevice", tableName: "BraveShared", bundle: .module, value: "Computer", comment: "Computer device button title")
@@ -2940,7 +2941,11 @@ extension Strings {
         comment: "Bookmarks migration website page description")
     /// Important: Do NOT change the `KEY` parameter without updating it in
     /// BraveCore's brave_bookmarks_importer.mm file.
-    public static let importFolderName = NSLocalizedString("SyncImportFolderName", tableName: "BraveShared", bundle: .module, value: "Imported Bookmarks", comment: "Folder name for where bookmarks are imported into when the root folder is not empty.")
+    public static let importFolderName =
+      NSLocalizedString(
+        "SyncImportFolderName", tableName: "BraveShared", bundle: .module,
+        value: "Imported Bookmarks",
+        comment: "Folder name for where bookmarks are imported into when the root folder is not empty.")
     public static let v2MigrationTitle =
       NSLocalizedString(
         "sync.v2MigrationTitle", tableName: "BraveShared", bundle: .module,
@@ -2977,6 +2982,20 @@ extension Strings {
         "sync.syncSettingsTitle", tableName: "BraveShared", bundle: .module,
         value: "Sync Settings",
         comment: "Title for Sync Settings Toggle Header")
+    public static let syncDeleteAccountAlertTitle =
+    NSLocalizedString(
+      "sync.syncDeleteAccount", tableName: "BraveShared", bundle: .module,
+      value: "Delete Sync Account",
+      comment: "Title for Alert used action Delete Sync Account.")
+    public static let syncDeleteAccountAlertDescriptionPart1 =
+    NSLocalizedString(
+      "sync.syncDeleteAccountAlertDescriptionPart1", tableName: "BraveShared", bundle: .module,
+      value: "Deleting your account will remove your encrypted data from Brave servers and disable Sync on all of your connected devices. It will not however delete the data that is stored locally on those devices.",
+      comment: "Part 1 Description for Alert used action Delete Sync Account.")
+    public static let syncDeleteAccountAlertDescriptionPart2 = NSLocalizedString(
+      "sync.syncDeleteAccountAlertDescriptionPart2", tableName: "BraveShared", bundle: .module,
+      value: "Deleting your account will remove your encrypted data from Brave servers and disable Sync on all of your connected devices. It will not however delete the data that is stored locally on those devices.",
+      comment: "Part 2 Description for Alert used action Delete Sync Account.")
   }
 }
 

--- a/Sources/BraveShared/BraveStrings.swift
+++ b/Sources/BraveShared/BraveStrings.swift
@@ -2995,7 +2995,7 @@ extension Strings {
     public static let syncDeleteAccountAlertDescriptionPart2 =
       NSLocalizedString(
         "sync.syncDeleteAccountAlertDescriptionPart2", tableName: "BraveShared", bundle: .module,
-        value: "Deleting your account will remove your encrypted data from Brave servers and disable Sync on all of your connected devices. It will not however delete the data that is stored locally on those devices.",
+        value: "This deletion is permanent and there is no way to recover the data. Should you decide to start using Sync again, you will need to create a new account and re-add each device one by one.",
         comment: "Part 2 Description for Alert used action Delete Sync Account.")
     public static let syncChainAlreadyDeletedAlertTitle =
       NSLocalizedString(

--- a/Sources/BraveShared/BraveStrings.swift
+++ b/Sources/BraveShared/BraveStrings.swift
@@ -3007,7 +3007,16 @@ extension Strings {
         "sync.syncChainAlreadyDeletedAlertDescription", tableName: "BraveShared", bundle: .module,
         value: "Could not join this chain. Account was deleted.",
         comment: "Alert description for the occasion when an user is trying to join a already deleted account")
-
+    public static let syncChainAccountDeletionErrorTitle =
+      NSLocalizedString(
+        "sync.syncChainAccountDeletionErrorTitle", tableName: "BraveShared", bundle: .module,
+        value: "Sync Device",
+        comment: "Alert title for error while deleting sync chain")
+    public static let syncChainAccountDeletionErrorDescription =
+      NSLocalizedString(
+        "sync.syncChainAccountDeletionErrorDescription", tableName: "BraveShared", bundle: .module,
+        value: "Sync Device",
+        comment: "Alert description for error while deleting sync chain")
   }
 }
 

--- a/Sources/BraveShared/BraveStrings.swift
+++ b/Sources/BraveShared/BraveStrings.swift
@@ -2983,19 +2983,31 @@ extension Strings {
         value: "Sync Settings",
         comment: "Title for Sync Settings Toggle Header")
     public static let syncDeleteAccountAlertTitle =
-    NSLocalizedString(
-      "sync.syncDeleteAccount", tableName: "BraveShared", bundle: .module,
-      value: "Delete Sync Account",
-      comment: "Title for Alert used action Delete Sync Account.")
+      NSLocalizedString(
+        "sync.syncDeleteAccount", tableName: "BraveShared", bundle: .module,
+        value: "Delete Sync Account",
+        comment: "Title for Alert used action Delete Sync Account.")
     public static let syncDeleteAccountAlertDescriptionPart1 =
-    NSLocalizedString(
-      "sync.syncDeleteAccountAlertDescriptionPart1", tableName: "BraveShared", bundle: .module,
-      value: "Deleting your account will remove your encrypted data from Brave servers and disable Sync on all of your connected devices. It will not however delete the data that is stored locally on those devices.",
-      comment: "Part 1 Description for Alert used action Delete Sync Account.")
-    public static let syncDeleteAccountAlertDescriptionPart2 = NSLocalizedString(
-      "sync.syncDeleteAccountAlertDescriptionPart2", tableName: "BraveShared", bundle: .module,
-      value: "Deleting your account will remove your encrypted data from Brave servers and disable Sync on all of your connected devices. It will not however delete the data that is stored locally on those devices.",
-      comment: "Part 2 Description for Alert used action Delete Sync Account.")
+      NSLocalizedString(
+        "sync.syncDeleteAccountAlertDescriptionPart1", tableName: "BraveShared", bundle: .module,
+        value: "Deleting your account will remove your encrypted data from Brave servers and disable Sync on all of your connected devices. It will not however delete the data that is stored locally on those devices.",
+        comment: "Part 1 Description for Alert used action Delete Sync Account.")
+    public static let syncDeleteAccountAlertDescriptionPart2 =
+      NSLocalizedString(
+        "sync.syncDeleteAccountAlertDescriptionPart2", tableName: "BraveShared", bundle: .module,
+        value: "Deleting your account will remove your encrypted data from Brave servers and disable Sync on all of your connected devices. It will not however delete the data that is stored locally on those devices.",
+        comment: "Part 2 Description for Alert used action Delete Sync Account.")
+    public static let syncChainAlreadyDeletedAlertTitle =
+      NSLocalizedString(
+        "sync.syncChainAlreadyDeletedAlertTitle", tableName: "BraveShared", bundle: .module,
+        value: "Sync Device",
+        comment: "Alert title for the occasion when an user is trying to join a already deleted account")
+    public static let syncChainAlreadyDeletedAlertDescription =
+      NSLocalizedString(
+        "sync.syncChainAlreadyDeletedAlertDescription", tableName: "BraveShared", bundle: .module,
+        value: "Could not join this chain. Account was deleted.",
+        comment: "Alert description for the occasion when an user is trying to join a already deleted account")
+
   }
 }
 

--- a/Sources/BraveUI/UIKit/AlertPopupView.swift
+++ b/Sources/BraveUI/UIKit/AlertPopupView.swift
@@ -21,7 +21,7 @@ public class AlertPopupView: UIKitPopupView {
   fileprivate let kPadding: CGFloat = 20.0
 
   public init(
-    imageView: UIView?, title: String, message: String, inputType: UIKeyboardType? = nil,
+    imageView: UIView? = nil, title: String, message: String, inputType: UIKeyboardType? = nil,
     secureInput: Bool = false, inputPlaceholder: String? = nil, titleWeight: UIFont.Weight = UIFont.Weight.bold, titleSize: CGFloat = 24, dismissHandler: (() -> Bool)? = nil
   ) {
     super.init(frame: CGRect.zero)

--- a/Sources/BraveUI/UIKit/UIKitPopupView.swift
+++ b/Sources/BraveUI/UIKit/UIKitPopupView.swift
@@ -498,7 +498,7 @@ open class UIKitPopupView: UIView, UIGestureRecognizerDelegate {
     setNeedsLayout()
   }
 
-  public func addButton(title: String, type: ButtonType = .secondary, fontSize: CGFloat? = nil, tapped: (() -> PopupViewDismissType)?) {
+  public func addButton(title: String, type: ButtonType = .secondary, fontSize: CGFloat? = 15, tapped: (() -> PopupViewDismissType)?) {
     let buttonData: ButtonData = ButtonData()
     buttonData.title = title
     buttonData.handler = tapped


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This Pull Request includes the "Delete Sync Chain" functionality on iOS which is the equivalent of the Permanently delete sync account on Android and desktop https://github.com/brave/brave-core/pull/13562.

The brave-core PR exposes https://github.com/brave/brave-core/pull/17369 the interface for necessary functionality on brave sync service such as 

- Adds support for iOS Chromium Sync API delete chain functionality so we can deleted sync chains and detect deleted accounts.
- Adds observer methods regarding to deleted account functionality so we can update our data and UI on iOS side.
- Adds support for Sync Profile so we can give proper errors while joining deleted accounts.

The PR consists of 3 major parts 

1. The Delete Action

The delete button is added to Sync Settings and this is handling functionality like the actual delete chain action, removing sync observers, resetting the chain and clearing the local preferences. The delete action will show an alert to user similar to Android but using the design used for pop-ups in iOS settings.

2. The Account Deleted Error

After validating sync code words, a new callback is added to validate if account is not deleted and if it is deleted according to error type, app shows account deleted error alert and like delete chain action it will removing sync observers and clears the local preferences.

3. The Account Deleted Observer

Adding an observer and handling different cases for different parts of the application when the sync chain is deleted from another device.

Security Ticket: https://github.com/brave/security/issues/1207

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6820

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan - Screenshots::
<!-- Any useful notes explaining how best to test and verify. -->

### Test Plan 1: Delete Sync Chain

- Create a Sync Chain either from Desktop/Android or from iOS and join the same chain with the devices
- Press button Delete Sync Account and approve deletion
- Observe iOS device will navigate back to settings
- Observe desktop will update and show join sync chain screen.


https://user-images.githubusercontent.com/6643505/221986792-c76e73cf-9dbb-4bd9-8f07-253ae8f0b343.mov

![221986853-338580c7-45d1-4dc9-b403-dced60f07809](https://user-images.githubusercontent.com/6643505/222449090-3df315e0-9c7c-471e-a883-11cdeb57caac.png)



### Test Plan 2: Join a Deleted Sync Chain

- Create a Sync Chain either from Desktop/Android and save the code word or qr code
- Try to join the chain with that code words - qr code
- Observe iOS will return an error about deleted chain


https://user-images.githubusercontent.com/6643505/221990656-13257ba4-a063-4249-a869-fd1063e20a00.mov

![221986853-338580c7-45d1-4dc9-b403-dce809111122](https://user-images.githubusercontent.com/6643505/222502380-d429af59-4446-4391-803b-5d0636476994.png)


### Test Plan 3: Receive a notification from deleted sync chain

- Create a Sync Chain either from Desktop/Android or from iOS and join the same chain with the devices
- Press button Delete Sync Account and approve deletion on Desktop or Android (delete sync account using other device pair)
- Observe iOS device will navigate back to settings


https://user-images.githubusercontent.com/6643505/222004522-29dd2d7e-2067-48c7-bc54-7d390bf05a83.mov


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
