### PR TITLE
Fix #6782: Remove empty tabs when handling external URLs

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -741,7 +741,8 @@ extension BrowserViewController {
     _ url: URL,
     tab: Tab?,
     navigationAction: WKNavigationAction,
-    openedURLCompletionHandler: ((Bool) -> Void)? = nil) {
+    openedURLCompletionHandler: ((Bool) -> Void)? = nil
+  ) {
     
     let isMainFrame = navigationAction.targetFrame?.isMainFrame == true
     
@@ -765,6 +766,13 @@ extension BrowserViewController {
       }
     }
     
+    // If the tab is empty when handling an external URL we should remove the tab once the user decides
+    func removeTabIfEmpty() {
+      if let tab = tab, tab.url == nil {
+        tabManager.removeTab(tab)
+      }
+    }
+    
     view.endEditing(true)
     let popup = AlertPopupView(
       imageView: nil,
@@ -774,10 +782,12 @@ extension BrowserViewController {
       titleSize: 21
     )
     popup.addButton(title: Strings.openExternalAppURLDontAllow, fontSize: 16) { () -> PopupViewDismissType in
+      removeTabIfEmpty()
       return .flyDown
     }
     popup.addButton(title: Strings.openExternalAppURLAllow, type: .primary, fontSize: 16) { () -> PopupViewDismissType in
       UIApplication.shared.open(url, options: [:], completionHandler: openedURLCompletionHandler)
+      removeTabIfEmpty()
       return .flyDown
     }
     popup.showWithType(showType: .flyUp)


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #6782 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
- Verify if you can that the ad with the App Store link closes the empty tab after selecting to open/close the link
- Verify if you can that opening an App Store link (or any other third party app's scheme) from in a tab that has a prior page loaded doesn't close the non-empty page

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
