### PR TITLE
Fix #6965: Duplicate add network requests can be shown

### DIFF
--- a/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -386,14 +386,14 @@ public class CryptoStore: ObservableObject {
     return pendingRequest != nil
   }
 
-  private struct AddNetworkCompletion {
+  struct AddNetworkCompletion {
     let chainId: String
     let completion: (_ error: String?) -> Void
   }
   // Helper to store the completion block of an Add Network request.
   // The completion closure is handled in `onAddEthereumChainRequestCompleted`
   // when we determine if the chain was added successfully or not.
-  private var addNetworkWebpageRequestCompletion: AddNetworkCompletion?
+  var addNetworkWebpageRequestCompletion: AddNetworkCompletion?
   
   func handleWebpageRequestResponse(
     _ response: WebpageRequestResponse,
@@ -517,7 +517,6 @@ extension CryptoStore: BraveWalletJsonRpcServiceObserver {
     if let addNetworkWebpageRequestCompletion {
       addNetworkWebpageRequestCompletion.completion(error.isEmpty ? nil : error)
       self.addNetworkWebpageRequestCompletion = nil
-      prepare()
     }
   }
   

--- a/Sources/BraveWallet/Panels/Add Suggested Network/SuggestedNetworkView.swift
+++ b/Sources/BraveWallet/Panels/Add Suggested Network/SuggestedNetworkView.swift
@@ -262,14 +262,10 @@ struct SuggestedNetworkView: View {
       // this can occur when Add Network is dismissed while still loading...
       // we need to show loading state again, and handle success/failure response
       if case let .addNetwork(network) = mode,
-         let pendingCompletion = cryptoStore.addNetworkWebpageRequestCompletion,
-         pendingCompletion.chainId == network.chainId {
+         cryptoStore.addNetworkDappRequestCompletion[network.chainId] != nil {
         self.isLoading = true
         // overwrite the completion closure with a new one for this new view instance
-        cryptoStore.addNetworkWebpageRequestCompletion = .init(
-          chainId: network.chainId,
-          completion: handleAddNetworkCompletion
-        )
+        cryptoStore.addNetworkDappRequestCompletion[network.chainId] = handleAddNetworkCompletion
       }
     }
   }

--- a/Sources/BraveWallet/WalletHostingViewController.swift
+++ b/Sources/BraveWallet/WalletHostingViewController.swift
@@ -68,8 +68,8 @@ public class WalletHostingViewController: UIHostingController<CryptoView> {
         presentingContext: presentingContext
       )
     )
-    rootView.dismissAction = { [unowned self] in
-      self.dismiss(animated: true)
+    rootView.dismissAction = { [weak self] in
+      self?.dismiss(animated: true)
     }
     rootView.openWalletURLAction = { [unowned self] url in
       (self.presentingViewController ?? self).dismiss(animated: true) { [self] in


### PR DESCRIPTION
## Summary of Changes
- Adding a new ethereum chain requires a network call, however we were not waiting for the response of attempting to add the new chain before dismissing the Add Network request modal. This could create a race condition where we still have the add network request pending when we are dismissing the Add Network request modal, so it would be shown again.
- Added a loading state and error alert to `SuggestedNetworkView`. Error will dismiss the modal after as the add chain request is removed in core: https://github.com/brave/brave-core/blob/b31c48fff4b9aecdef95a9bba344f9329b3ab1e7/components/brave_wallet/browser/json_rpc_service.cc#L521
- Added an optional completion closure to `handleWebpageRequestResponse` so `SuggestedNetworkView` knows when to start/stop loading, and can now show an error alert when failing to add the network

This pull request fixes #6965

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Visit Chainlist.org
2. Connect your wallet and try adding a few chains.
3. Verify each only shows 'add network' modal once before showing 'switch network' modal.
4. Find [Astar on Chainlist.org](https://chainlist.org/chain/592) and try to add it.
5. (assuming it still fails) Verify loading state is shown, and wait for timeout on the request.
6. Verify closing the alert will dismiss the Add Network modal as the request is removed when error is received.


## Screenshots:

Add Network Fixed:

https://user-images.githubusercontent.com/5314553/222518389-fcbbb88d-eb9e-4858-adb1-4febe0a41de6.mov

Add Network error alert (new):


https://user-images.githubusercontent.com/5314553/222572235-60a70c66-4d3c-4ef1-ab02-8dc6bbe01311.mov


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
