### PR TITLE
Fix #6859: Ensure valid favicon image sizes are used within fav widgets

### DIFF
--- a/App/BraveWidgets/FavoritesWidget.swift
+++ b/App/BraveWidgets/FavoritesWidget.swift
@@ -8,6 +8,7 @@ import SwiftUI
 import Strings
 import BraveShared
 import BraveWidgetsModels
+import Favicon
 
 struct FavoritesWidget: Widget {
   var body: some WidgetConfiguration {
@@ -127,6 +128,15 @@ private struct FavoritesGridView: View {
       return redactionReasons.contains(.placeholder)
     }
   }
+  
+  func image(for favicon: Favicon) -> UIImage? {
+    guard let image = favicon.image else { return nil }
+    if #available(iOS 15.0, *) {
+      return image.preparingThumbnail(of: CGSize(width: 128, height: 128))
+    } else {
+      return image.scale(toSize: CGSize(width: 128, height: 128))
+    }
+  }
 
   var body: some View {
     LazyVGrid(columns: Array(repeating: .init(.flexible()), count: 4), spacing: 8) {
@@ -136,7 +146,7 @@ private struct FavoritesGridView: View {
             destination: favorite.url,
             label: {
               Group {
-                if let attributes = favorite.favicon, let image = attributes.image {
+                if let attributes = favorite.favicon, let image = image(for: attributes) {
                   FaviconImage(image: image, contentMode: .scaleAspectFit, includePadding: false)
                     .background(Color(attributes.backgroundColor))
                 } else {
@@ -153,7 +163,7 @@ private struct FavoritesGridView: View {
               .background(Color(UIColor.braveBackground).opacity(0.05).clipShape(itemShape))
               .overlay(
                 itemShape
-                  .strokeBorder(Color(UIColor.braveSeparator).opacity(0.1), lineWidth: pixelLength)
+                  .strokeBorder(Color(UIColor.braveLabel).opacity(0.2), lineWidth: pixelLength)
               )
               .padding(widgetFamily == .systemMedium ? 4 : 0)
             })


### PR DESCRIPTION
Also fixes the overlay border not being visible for transparent icons

## Summary of Changes

This pull request probably fixes #6859 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan

- Install Brave fresh
- Add a favs widget (you should see regular favs)
- Visit Twitter & Reddit favourite from within Brave so their icons upgrade from the bundled one
- Force close Brave (from the app picker) then relaunch Brave _or_ edit your favourites in some way (add/delete/move) to reload the widget
- Widget should display new icons now instead of the error/open-in-brave message

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
