### PR TITLE
Fix #6991: Display "Never Saved" domains in password sync

### DIFF
--- a/Sources/Brave/Frontend/Login/LoginInfoViewController.swift
+++ b/Sources/Brave/Frontend/Login/LoginInfoViewController.swift
@@ -49,6 +49,7 @@ class LoginInfoViewController: LoginAuthViewController {
 
   private var credentials: PasswordForm {
     didSet {
+      navigationItem.rightBarButtonItem?.isEnabled = !credentials.isBlockedByUser
       tableView.reloadData()
     }
   }
@@ -119,6 +120,7 @@ class LoginInfoViewController: LoginAuthViewController {
     navigationItem.do {
       $0.title = URL(string: credentials.signOnRealm)?.baseDomain ?? ""
       $0.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .edit, target: self, action: #selector(edit))
+      $0.rightBarButtonItem?.isEnabled = !credentials.isBlockedByUser
     }
 
     tableView.do {
@@ -246,12 +248,11 @@ extension LoginInfoViewController {
   }
 
   override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-    switch section {
-    case Section.information.rawValue:
-      return InfoItem.allCases.count
-    default:
+    guard section == Section.information.rawValue else {
       return 1
     }
+    
+  return credentials.isBlockedByUser ? 1 : InfoItem.allCases.count
   }
 
   override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {

--- a/Sources/Brave/Frontend/Login/LoginListDataSource.swift
+++ b/Sources/Brave/Frontend/Login/LoginListDataSource.swift
@@ -1,0 +1,141 @@
+// Copyright 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import BraveCore
+
+class LoginListDataSource {
+    
+  private let passwordAPI: BravePasswordAPI
+  
+  private(set) var credentialList = [PasswordForm]()
+  private(set) var blockedList = [PasswordForm]()
+  private var isCredentialsRefreshing = false
+  
+  var isCredentialsBeingSearched = false
+  
+  var isDataSourceEmpty: Bool {
+    get {
+      return credentialList.isEmpty && blockedList.isEmpty
+    }
+  }
+
+  // MARK: Internal
+  
+  init(with passwordAPI: BravePasswordAPI) {
+    self.passwordAPI = passwordAPI
+  }
+  
+  func fetchLoginInfo(_ searchQuery: String? = nil, completion: @escaping (Bool) -> Void) {
+    if !isCredentialsRefreshing {
+      isCredentialsRefreshing = true
+      
+      passwordAPI.getSavedLogins { credentials in
+        self.reloadEntries(with: searchQuery, passwordForms: credentials) { editEnabled in
+          completion(editEnabled)
+        }
+      }
+    }
+  }
+  
+  func fetchPasswordFormFor(indexPath: IndexPath) -> PasswordForm? {
+    if isCredentialsBeingSearched {
+      switch indexPath.section {
+      case 0:
+        return credentialList.isEmpty ? blockedList[safe: indexPath.item] : credentialList[safe: indexPath.item]
+      case 1:
+        return blockedList[safe: indexPath.item]
+      default:
+        return nil
+      }
+    } else {
+      switch indexPath.section {
+      case 1:
+        return credentialList.isEmpty ? blockedList[safe: indexPath.item] : credentialList[safe: indexPath.item]
+      case 2:
+        return blockedList[safe: indexPath.item]
+      default:
+        return nil
+      }
+    }
+  }
+  
+  func fetchNumberOfSections() -> Int {
+    // Option - Saved Logins - Never Saved
+    var sectionCount = 3
+    
+    if blockedList.isEmpty {
+      sectionCount -= 1
+    }
+    
+    if credentialList.isEmpty {
+      sectionCount -= 1
+    }
+        
+    return isCredentialsBeingSearched ? sectionCount - 1 : sectionCount
+  }
+  
+  func fetchNumberOfRowsInSection(section: Int) -> Int {
+    switch section {
+    case 0:
+      if !isCredentialsBeingSearched {
+        return 1
+      }
+      
+      return credentialList.isEmpty ? blockedList.count : credentialList.count
+    case 1:
+      if !isCredentialsBeingSearched {
+        return credentialList.isEmpty ? blockedList.count : credentialList.count
+      }
+      
+      return blockedList.count
+    case 2:
+      return isCredentialsBeingSearched ? 0 : blockedList.count
+    default:
+      return 0
+    }
+  }
+
+  // MARK: Private
+  
+  private func reloadEntries(with query: String? = nil, passwordForms: [PasswordForm], completion: @escaping (Bool) -> Void) {
+    // Clear the blocklist before new items append
+    blockedList.removeAll()
+    
+    if let query = query, !query.isEmpty {
+      credentialList = passwordForms.filter { form in
+        if let origin = form.url.origin.url?.absoluteString.lowercased(), origin.contains(query) {
+          if form.isBlockedByUser {
+            blockedList.append(form)
+          }
+          return !form.isBlockedByUser
+        }
+        
+        if let username = form.usernameValue?.lowercased(), username.contains(query) {
+          if form.isBlockedByUser {
+            blockedList.append(form)
+          }
+          return !form.isBlockedByUser
+        }
+        
+        return false
+      }
+    } else {
+      credentialList = passwordForms.filter { form in
+        // Check If the website is blocked by user with Never Save functionality
+        if form.isBlockedByUser {
+          blockedList.append(form)
+        }
+        
+        return !form.isBlockedByUser
+      }
+    }
+    
+    DispatchQueue.main.async {
+      self.isCredentialsRefreshing = false
+      completion(!self.credentialList.isEmpty)
+    }
+  }
+}

--- a/Sources/Brave/Frontend/Login/LoginListViewController.swift
+++ b/Sources/Brave/Frontend/Login/LoginListViewController.swift
@@ -317,18 +317,18 @@ extension LoginListViewController {
     
     if isCredentialsBeingSearched {
       switch section {
-      case 1:
+      case 0:
         headerView.titleLabel.text = savedLoginHeaderText
-      case 2:
+      case 1:
         headerView.titleLabel.text = neverSavedHeaderText
       default:
         headerView.titleLabel.text = ""
       }
     } else {
       switch section {
-      case 0:
-        headerView.titleLabel.text = savedLoginHeaderText
       case 1:
+        headerView.titleLabel.text = savedLoginHeaderText
+      case 2:
         headerView.titleLabel.text = neverSavedHeaderText
       default:
         headerView.titleLabel.text = ""

--- a/Sources/BraveShared/BraveStrings.swift
+++ b/Sources/BraveShared/BraveStrings.swift
@@ -3108,6 +3108,13 @@ extension Strings {
         bundle: .module,
         value: "Saved Logins",
         comment: "The header title displayed over the login list")
+    public static let loginListNeverSavedHeaderTitle =
+      NSLocalizedString(
+        "login.loginListNeverSavedHeaderTitle",
+        tableName: "BraveShared",
+        bundle: .module,
+        value: "Never Saved",
+        comment: "The header title displayed over the never saved login list entry")
     public static let loginInfoDetailsHeaderTitle =
       NSLocalizedString(
         "login.loginInfoDetailsHeaderTitle",


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This PR is handling the case when a login credentials item is marked as Never Saved on desktop side. A new category is added for the table to show Never saved Items and they can be searched and deleted. The detail panel show show only relevant information and quick action for Never Saved.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6991

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->

- Mark a Credential Never Saved on desktop
- Sync Passwords
- Observe iOS

## Screenshots:

![11 11](https://user-images.githubusercontent.com/6643505/224791367-a771c7f3-7281-49d5-82b9-db905ac35842.png)


https://user-images.githubusercontent.com/6643505/224790300-142574e6-b531-488d-90a2-612fc971f3e0.mp4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
