### PR TITLE
Fix #7059: Don't show Brave News reload button on RSS-only feed

### DIFF
--- a/Sources/Brave/WebFilters/AdblockRustEngine.swift
+++ b/Sources/Brave/WebFilters/AdblockRustEngine.swift
@@ -30,7 +30,6 @@ extension AdblockEngine {
     }
     
     guard let requestHost = requestURL.host, let sourceHost = sourceURL.host else {
-      assertionFailure("You must provide absolute paths for `requestURL` and `sourceURL`")
       return false
     }
     

--- a/Sources/BraveNews/Composer/FeedDataSource.swift
+++ b/Sources/BraveNews/Composer/FeedDataSource.swift
@@ -513,7 +513,8 @@ public class FeedDataSource: ObservableObject {
 
   /// Whether or not the feed content is currently expired and needs to be reloaded
   public var isFeedContentExpired: Bool {
-    return followedLocales.allSatisfy({ isResourceExpired(.feed, localeIdentifier: $0) })
+    let locales = followedLocales
+    return !locales.isEmpty && locales.allSatisfy({ isResourceExpired(.feed, localeIdentifier: $0) })
   }
 
   /// Whether or not the sources are currently expired and needs to be reloaded


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #7059 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
