### PR TITLE
Fix #4740: Update copy on Shields popover in advanced controls section

### DIFF
--- a/Sources/Brave/Frontend/Shields/AdvancedControlsBarView.swift
+++ b/Sources/Brave/Frontend/Shields/AdvancedControlsBarView.swift
@@ -20,7 +20,7 @@ class AdvancedControlsBarView: UIControl {
   }
 
   private let label = UILabel().then {
-    $0.text = Strings.Shields.advancedControls
+    $0.text = Strings.Shields.advancedControls.capitalized
     $0.font = .systemFont(ofSize: 16)
     $0.textColor = .braveLabel
     $0.numberOfLines = 0

--- a/Sources/BraveShared/BraveStrings.swift
+++ b/Sources/BraveShared/BraveStrings.swift
@@ -1345,7 +1345,7 @@ extension Strings {
     public static let reportBrokenSiteBody2 = NSLocalizedString("ReportBrokenSiteBody2", tableName: "BraveShared", bundle: .module, value: "Note: This site address will be submitted with your Brave version number and your IP address (which will not be stored).", comment: "")
     public static let reportBrokenSubmitButtonTitle = NSLocalizedString("ReportBrokenSubmitButtonTitle", tableName: "BraveShared", bundle: .module, value: "Submit", comment: "")
     public static let globalControls = NSLocalizedString("BraveShieldsGlobalControls", tableName: "BraveShared", bundle: .module, value: "Global Controls", comment: "")
-    public static let globalChangeButton = NSLocalizedString("BraveShieldsGlobalChangeButton", tableName: "BraveShared", bundle: .module, value: "Change global Shields defaults", comment: "")
+    public static let globalChangeButton = NSLocalizedString("BraveShieldsGlobalChangeButton", tableName: "BraveShared", bundle: .module, value: "Change Shields Global Defaults", comment: "")
     public static let siteReportedTitle = NSLocalizedString("SiteReportedTitle", tableName: "BraveShared", bundle: .module, value: "Thank You", comment: "")
     public static let siteReportedBody = NSLocalizedString("SiteReportedBody", tableName: "BraveShared", bundle: .module, value: "Thanks for letting Brave's developers know that there's something wrong with this site. We'll do our best to fix it!", comment: "")
   }


### PR DESCRIPTION
Also title-cases the "Advanced Controls" button

## Summary of Changes

This pull request fixes #4740 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Screenshots:

![Simulator Screenshot - iPhone 14 Pro - 2023-03-08 at 16 44 26](https://user-images.githubusercontent.com/529104/223857528-b9b58a94-0a80-4424-ad72-78f6154b7c3c.png)

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
