### PR TITLE
Fix #7075: Update swap learn more links to privacy policy

### DIFF
--- a/Sources/BraveWallet/Crypto/BuySendSwap/SwapCryptoView.swift
+++ b/Sources/BraveWallet/Crypto/BuySendSwap/SwapCryptoView.swift
@@ -187,10 +187,10 @@ struct SwapCryptoView: View {
       }
     }
     
-    var url: URL? {
+    var url: URL {
       switch self {
-      case .zeroX: return URL(string: "https://0x.org/")
-      case .jupiter: return URL(string: "https://jup.ag")
+      case .zeroX: return WalletConstants.zeroXPrivacyPolicy
+      case .jupiter: return WalletConstants.jupiterPrivacyPolicy
       }
     }
     
@@ -494,8 +494,7 @@ struct SwapCryptoView: View {
           primaryButton: Alert.Button.default(
             Text(Strings.learnMore),
             action: {
-              guard let url = dexAggregator.url else { return }
-              openWalletURL(url)
+              openWalletURL(dexAggregator.url)
             }),
           secondaryButton: Alert.Button.cancel(Text(Strings.OKString))
         )

--- a/Sources/BraveWallet/Crypto/Stores/SwapTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SwapTokenStore.swift
@@ -566,7 +566,8 @@ public class SwapTokenStore: ObservableObject {
        let newFromAmountWrapped = BDouble(newFromAmount),
        let selectedToToken,
        let newToAmount = formatter.decimalString(for: "\(route.otherAmountThreshold)", radix: .decimal, decimals: Int(selectedToToken.decimals)),
-       let newToAmountWrapped = BDouble(newToAmount) {
+       let newToAmountWrapped = BDouble(newToAmount),
+       newFromAmountWrapped != 0 {
       let rate = newToAmountWrapped / newFromAmountWrapped
       selectedFromTokenPrice = rate.decimalDescription
     }

--- a/Sources/BraveWallet/WalletConstants.swift
+++ b/Sources/BraveWallet/WalletConstants.swift
@@ -28,6 +28,12 @@ struct WalletConstants {
   
   /// The url to learn more about ENS off-chain lookups
   static let braveWalletENSOffchainURL = URL(string: "https://github.com/brave/brave-browser/wiki/ENS-offchain-lookup")!
+  
+  /// The url to the privacy policy for 0x swaps
+  static let zeroXPrivacyPolicy = URL(string: "https://www.0x.org/privacy")!
+  
+  /// The url to the privacy policy for Jupiter swaps
+  static let jupiterPrivacyPolicy = URL(string: "https://docs.jup.ag/legal/privacy-policy")!
 
   /// The currently supported test networks.
   static let supportedTestNetworkChainIds = [


### PR DESCRIPTION
## Summary of Changes
- Update the 'Learn More' alert button to link the 0x/Jupiter privacy policy

This pull request fixes #7075

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Open Swap
2. Change network to Solana Mainnet
3. Tap `i` icon, then tap 'Learn More' in the alert
4. Verify opens directly to jupiter privacy policy: https://docs.jup.ag/legal/privacy-policy
5. Open Swap
6. Change network to Ethereum Mainnet
7. Tap `i` icon, then tap 'Learn More' in the alert
8. Verify opens directly to 0x privacy policy: https://www.0x.org/privacy


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
