### PR TITLE
Fix #7079: Race condition resolving wallet address with ENS

### DIFF
--- a/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
@@ -265,9 +265,11 @@ public class SendTokenStore: ObservableObject {
     let normalizedToAddress = sendAddress.lowercased()
     let isSupportedENSExtension = sendAddress.endsWithSupportedENSExtension
     if isSupportedENSExtension {
+      self.resolvedAddress = nil
       self.isResolvingAddress = true
       defer { self.isResolvingAddress = false }
-      let (address, isOffchainConsentRequired, status, _) = await rpcService.ensGetEthAddr(sendAddress)
+      let domain = sendAddress
+      let (address, isOffchainConsentRequired, status, _) = await rpcService.ensGetEthAddr(domain)
       guard !Task.isCancelled else { return }
       if isOffchainConsentRequired {
         self.isOffchainResolveRequired = true
@@ -281,6 +283,10 @@ public class SendTokenStore: ObservableObject {
       // If found address is the same as the selectedAccounts Wallet Address
       if address.lowercased() == normalizedFromAddress {
         addressError = .sameAsFromAddress
+        return
+      }
+      guard domain == sendAddress, !Task.isCancelled else {
+        // address changed while resolving, or validation cancelled.
         return
       }
       // store address for sending
@@ -327,9 +333,11 @@ public class SendTokenStore: ObservableObject {
     let normalizedToAddress = sendAddress.lowercased()
     let isSupportedSNSExtension = sendAddress.endsWithSupportedSNSExtension
     if isSupportedSNSExtension {
+      self.resolvedAddress = nil
       self.isResolvingAddress = true
       defer { self.isResolvingAddress = false }
-      let (address, status, _) = await rpcService.snsGetSolAddr(sendAddress)
+      let domain = sendAddress
+      let (address, status, _) = await rpcService.snsGetSolAddr(domain)
       guard !Task.isCancelled else { return }
       if status != .success || address.isEmpty {
         addressError = .snsError(domain: sendAddress)
@@ -338,6 +346,10 @@ public class SendTokenStore: ObservableObject {
       // If found address is the same as the selectedAccounts Wallet Address
       if address.lowercased() == normalizedFromAddress {
         addressError = .sameAsFromAddress
+        return
+      }
+      guard domain == sendAddress, !Task.isCancelled else {
+        // address changed while resolving, or validation cancelled.
         return
       }
       // store address for sending

--- a/Tests/BraveWalletTests/SendTokenStoreTests.swift
+++ b/Tests/BraveWalletTests/SendTokenStoreTests.swift
@@ -677,7 +677,7 @@ class SendTokenStoreTests: XCTestCase {
     let resolvedAddressExpectation = expectation(description: "sendTokenStore-resolvedAddress")
     XCTAssertNil(store.resolvedAddress)  // Initial state
     store.$resolvedAddress
-      .dropFirst(2) // Initial value, reset to nil in `sendAddress` didSet
+      .dropFirst(3) // Initial value, reset to nil in `sendAddress` didSet, reset to nil in `validateSolanaSendAddress`
       .sink { resolvedAddress in
         defer { resolvedAddressExpectation.fulfill() }
         XCTAssertEqual(resolvedAddress, expectedAddress)
@@ -714,7 +714,7 @@ class SendTokenStoreTests: XCTestCase {
     let resolvedAddressExpectation = expectation(description: "sendTokenStore-resolvedAddress")
     XCTAssertNil(store.resolvedAddress)  // Initial state
     store.$resolvedAddress
-      .dropFirst() // Initial value
+      .dropFirst(2) // Initial value, reset to nil in `validateSolanaSendAddress`
       .sink { resolvedAddress in
         defer { resolvedAddressExpectation.fulfill() }
         XCTAssertNil(resolvedAddress)
@@ -766,7 +766,7 @@ class SendTokenStoreTests: XCTestCase {
     let resolvedAddressExpectation = expectation(description: "sendTokenStore-resolvedAddress")
     XCTAssertNil(store.resolvedAddress)  // Initial state
     store.$resolvedAddress
-      .dropFirst(2) // Initial value, reset to nil in `sendAddress` didSet
+      .dropFirst(3) // Initial value, reset to nil in `sendAddress` didSet, reset to nil in `validateSolanaSendAddress`
       .sink { resolvedAddress in
         defer { resolvedAddressExpectation.fulfill() }
         XCTAssertEqual(resolvedAddress, expectedAddress)
@@ -812,7 +812,7 @@ class SendTokenStoreTests: XCTestCase {
     let resolvedAddressExpectation = expectation(description: "sendTokenStore-resolvedAddress")
     XCTAssertNil(store.resolvedAddress)  // Initial state
     store.$resolvedAddress
-      .dropFirst(2) // Initial value, reset to nil in `sendAddress` didSet
+      .dropFirst(3) // Initial value, reset to nil in `sendAddress` didSet, reset to nil in `validateEthereumSendAddress`
       .sink { resolvedAddress in
         defer { resolvedAddressExpectation.fulfill() }
         XCTAssertEqual(resolvedAddress, expectedAddress)
@@ -891,7 +891,7 @@ class SendTokenStoreTests: XCTestCase {
     let resolvedAddressExpectation = expectation(description: "sendTokenStore-resolvedAddress")
     XCTAssertNil(store.resolvedAddress)  // Initial state
     store.$resolvedAddress
-      .dropFirst() // Initial value
+      .dropFirst(2) // Initial value, reset to nil in `validateEthereumSendAddress`
       .sink { resolvedAddress in
         defer { resolvedAddressExpectation.fulfill() }
         XCTAssertNil(resolvedAddress)
@@ -943,7 +943,7 @@ class SendTokenStoreTests: XCTestCase {
     let resolvedAddressExpectation = expectation(description: "sendTokenStore-resolvedAddress")
     XCTAssertNil(store.resolvedAddress)  // Initial state
     store.$resolvedAddress
-      .dropFirst(2) // Initial value, reset to nil in `sendAddress` didSet
+      .dropFirst(3) // Initial value, reset to nil in `sendAddress` didSet, reset to nil in `validateEthereumSendAddress`
       .sink { resolvedAddress in
         defer { resolvedAddressExpectation.fulfill() }
         XCTAssertEqual(resolvedAddress, expectedAddress)


### PR DESCRIPTION
## Summary of Changes
- Potential race condition when resolving an ENS address.
    - Tricky to reproduce, but it could occur when `sendAddress` changes during network request to resolve the address. 
    - Fixed by verifying the domain we were resolving matches the current `sendAddress` prior to assigning the `resolvedAddress:
<img width="828" alt="7079" src="https://user-images.githubusercontent.com/5314553/224375191-2597021e-5073-4311-a129-7bf3f2bcfda7.png">

This pull request fixes #7079

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
Tricky to reproduce. 
1. Set ENS Offchain preference to `Ask`
2. Enter `offchain.eth` and quickly change to `offchainexample.eth`
3. Verify offchain message is shown without any resolved address displayed below it.


## Screenshots:

https://user-images.githubusercontent.com/5314553/224376185-646adc21-fc00-4832-9249-b42490553c5c.mp4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
