### PR TITLE
Ref #6820: ShouldLeaveSyncGroup causes sync chain leave prematurely

### DIFF
--- a/Sources/Brave/Frontend/Sync/BraveCore/BraveSyncAPIExtensions.swift
+++ b/Sources/Brave/Frontend/Sync/BraveCore/BraveSyncAPIExtensions.swift
@@ -37,7 +37,7 @@ extension BraveSyncAPI {
       return false
     }
     
-    return !(isSyncFeatureActive && isFirstSetupComplete) || isSyncAccountDeletedNoticePending
+    return (!isSyncFeatureActive && !isFirstSetupComplete) || isSyncAccountDeletedNoticePending
   }
 
   var isSendTabToSelfVisible: Bool {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

Fixing should leave sync chain criteria causes sync chain to leave prematurely

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request references #6820

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
