### PR TITLE
No Bug: Add xcconfig to handle building Brave service keys into the app

### DIFF
--- a/App/Client.xcodeproj/project.pbxproj
+++ b/App/Client.xcodeproj/project.pbxproj
@@ -134,6 +134,7 @@
 		273ACA2228492ECB008A58BB /* WebRTC.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = WebRTC.xcframework; path = ../ThirdParty/JitsiMeet/WebRTC.xcframework; sourceTree = "<group>"; };
 		273DFB18284FDB1D007781AF /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = Shortcuts/ja.lproj/BrowserIntents.strings; sourceTree = "<group>"; };
 		27465DC3284FDB6F0056FDB2 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = Shortcuts/sv.lproj/BrowserIntents.strings; sourceTree = "<group>"; };
+		274831D629C10EB700B96AAD /* Keys.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Keys.xcconfig; sourceTree = "<group>"; };
 		275A4C39284FDB290016F5A8 /* ko-KR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "ko-KR"; path = "Shortcuts/ko-KR.lproj/BrowserIntents.strings"; sourceTree = "<group>"; };
 		276FEA8B284FDB7A001A0718 /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = Shortcuts/tr.lproj/BrowserIntents.strings; sourceTree = "<group>"; };
 		277CA004284FDB34002E8470 /* ms */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ms; path = Shortcuts/ms.lproj/BrowserIntents.strings; sourceTree = "<group>"; };
@@ -349,6 +350,7 @@
 		0A24F83B233EB5B4004D2F3A /* Local */ = {
 			isa = PBXGroup;
 			children = (
+				274831D629C10EB700B96AAD /* Keys.xcconfig */,
 				0A24F83C233EB5B4004D2F3A /* BuildId.xcconfig */,
 				0A24F83D233EB5B4004D2F3A /* Version.xcconfig */,
 				0A24F83E233EB5B4004D2F3A /* DevTeam.xcconfig */,

--- a/App/Configuration/Base.xcconfig
+++ b/App/Configuration/Base.xcconfig
@@ -9,6 +9,7 @@
 
 #include "Local/BuildId.xcconfig"
 #include "Local/Version.xcconfig"
+#include "Local/Keys.xcconfig"
 
 // Xcode 14.3b1 uses `-strict-concurrency=targeted` as the default. This can be removed when a Xcode build
 // moves this back to `minimal`. See https://github.com/apple/swift/pull/63786

--- a/App/Configuration/Debug.xcconfig
+++ b/App/Configuration/Debug.xcconfig
@@ -7,8 +7,6 @@
 
 MOZ_BUNDLE_DISPLAY_NAME = Brave ($(USER))
 
-BRAVE_API_KEY = key
-BRAVE_SERVICES_KEY = key
 BRAVE_URL_SCHEME = brave-debug
 
 // Bundle Identifier

--- a/App/Configuration/Local.templates/Keys.xcconfig
+++ b/App/Configuration/Local.templates/Keys.xcconfig
@@ -1,0 +1,5 @@
+// Stats API key
+BRAVE_API_KEY = key
+
+// Needed for access to many Brave services
+BRAVE_SERVICES_KEY = key


### PR DESCRIPTION
## Summary of Changes

Adds the ability to safely compile in Brave keys while making local builds

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
