### PR TITLE
Fix #6182: Send to Unstoppable Domain wallet address

### DIFF
--- a/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
@@ -329,6 +329,11 @@ public class SendTokenStore: ObservableObject {
   }
   
   @MainActor private func resolveUnstoppableDomain(_ domain: String) async {
+    guard selectedSendToken != nil else {
+      // token is required for `unstoppableDomainsGetWalletAddr`
+      // else it returns `invalidParams` error immediately
+      return
+    }
     self.resolvedAddress = nil
     self.isResolvingAddress = true
     defer { self.isResolvingAddress = false }

--- a/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
@@ -17,6 +17,8 @@ public class SendTokenStore: ObservableObject {
   @Published var selectedSendToken: BraveWallet.BlockchainToken? {
     didSet {
       update() // need to update `selectedSendTokenBalance` and `selectedSendNFTMetadata`
+      // Unstoppable Domains are resolved based on currently selected token.
+      validateSendAddress()
     }
   }
   /// The current selected NFT metadata. Default with nil value.
@@ -75,6 +77,7 @@ public class SendTokenStore: ObservableObject {
     case notSolAddress
     case snsError(domain: String)
     case ensError(domain: String)
+    case udError(domain: String)
 
     var errorDescription: String? {
       switch self {
@@ -93,6 +96,8 @@ public class SendTokenStore: ObservableObject {
       case .snsError:
         return String.localizedStringWithFormat(Strings.Wallet.sendErrorDomainNotRegistered, BraveWallet.CoinType.sol.localizedTitle)
       case .ensError:
+        return String.localizedStringWithFormat(Strings.Wallet.sendErrorDomainNotRegistered, BraveWallet.CoinType.eth.localizedTitle)
+      case .udError:
         return String.localizedStringWithFormat(Strings.Wallet.sendErrorDomainNotRegistered, BraveWallet.CoinType.eth.localizedTitle)
       }
     }
@@ -264,6 +269,7 @@ public class SendTokenStore: ObservableObject {
     let normalizedFromAddress = fromAddress.lowercased()
     let normalizedToAddress = sendAddress.lowercased()
     let isSupportedENSExtension = sendAddress.endsWithSupportedENSExtension
+    let isSupportedUDExtension = sendAddress.endsWithSupportedUDExtension
     if isSupportedENSExtension {
       self.resolvedAddress = nil
       self.isResolvingAddress = true
@@ -292,6 +298,8 @@ public class SendTokenStore: ObservableObject {
       // store address for sending
       resolvedAddress = address
       addressError = nil
+    } else if isSupportedUDExtension {
+      await resolveUnstoppableDomain(sendAddress)
     } else {
       if !sendAddress.isETHAddress {
         // 1. check if send address is a valid eth address
@@ -320,6 +328,26 @@ public class SendTokenStore: ObservableObject {
     }
   }
   
+  @MainActor private func resolveUnstoppableDomain(_ domain: String) async {
+    self.resolvedAddress = nil
+    self.isResolvingAddress = true
+    defer { self.isResolvingAddress = false }
+    let token = selectedSendToken
+    let (address, status, _) = await rpcService.unstoppableDomainsGetWalletAddr(domain, token: token)
+    guard !Task.isCancelled else { return }
+    if status != .success || address.isEmpty {
+      addressError = .udError(domain: sendAddress)
+      return
+    }
+    guard domain == sendAddress, token == selectedSendToken, !Task.isCancelled else {
+      // address changed while resolving, or validation cancelled.
+      return
+    }
+    // store address for sending
+    resolvedAddress = address
+    addressError = nil
+  }
+  
   public func enableENSOffchainLookup() {
     Task { @MainActor in
       rpcService.setEnsOffchainLookupResolveMethod(.enabled)
@@ -332,6 +360,7 @@ public class SendTokenStore: ObservableObject {
     let normalizedFromAddress = fromAddress.lowercased()
     let normalizedToAddress = sendAddress.lowercased()
     let isSupportedSNSExtension = sendAddress.endsWithSupportedSNSExtension
+    let isSupportedUDExtension = sendAddress.endsWithSupportedUDExtension
     if isSupportedSNSExtension {
       self.resolvedAddress = nil
       self.isResolvingAddress = true
@@ -355,6 +384,8 @@ public class SendTokenStore: ObservableObject {
       // store address for sending
       resolvedAddress = address
       addressError = nil
+    } else if isSupportedUDExtension {
+      await resolveUnstoppableDomain(sendAddress)
     } else { // not supported SNS extension, validate address
       let isValid = await walletService.isBase58EncodedSolanaPubkey(sendAddress)
       if !isValid {

--- a/Sources/BraveWallet/Extensions/BraveWalletExtensions.swift
+++ b/Sources/BraveWallet/Extensions/BraveWalletExtensions.swift
@@ -312,4 +312,9 @@ public extension String {
   var endsWithSupportedSNSExtension: Bool {
     WalletConstants.supportedSNSExtensions.contains(where: hasSuffix)
   }
+  
+  /// Returns true if the string ends with a supported UD extension.
+  var endsWithSupportedUDExtension: Bool {
+    WalletConstants.supportedUDExtensions.contains(where: hasSuffix)
+  }
 }

--- a/Sources/BraveWallet/WalletConstants.swift
+++ b/Sources/BraveWallet/WalletConstants.swift
@@ -61,6 +61,8 @@ struct WalletConstants {
   static let supportedENSExtensions = [".eth"]
   /// The supported Solana Name Service (SNS) extensions
   static let supportedSNSExtensions = [".sol"]
+  /// The supported Unstoppable Domain (UD) extensions
+  static let supportedUDExtensions = [".crypto", ".x", ".nft", ".dao", ".wallet", ".888", ".blockchain", ".bitcoin"]
   
   /// The link for users to learn more about Solana SPL token account creation in transaction confirmation screen
   static let splTokenAccountCreationLink = URL(string: "https://support.brave.com/hc/en-us/articles/5546517853325")!

--- a/Tests/BraveWalletTests/SendTokenStoreTests.swift
+++ b/Tests/BraveWalletTests/SendTokenStoreTests.swift
@@ -24,7 +24,8 @@ class SendTokenStoreTests: XCTestCase {
     solanaBalance: UInt64 = 0,
     splTokenBalance: String = "0",
     snsGetSolAddr: String = "",
-    ensGetEthAddr: String = ""
+    ensGetEthAddr: String = "",
+    unstoppableDomainsGetWalletAddr: String = ""
   ) -> (BraveWallet.TestKeyringService, BraveWallet.TestJsonRpcService, BraveWallet.TestBraveWalletService, BraveWallet.TestEthTxManagerProxy, BraveWallet.TestSolanaTxManagerProxy) {
     let keyringService = BraveWallet.TestKeyringService()
     keyringService._addObserver = { _ in }
@@ -45,6 +46,9 @@ class SendTokenStoreTests: XCTestCase {
     }
     rpcService._ensGetEthAddr = { _, completion in
       completion(ensGetEthAddr, false, .success, "")
+    }
+    rpcService._unstoppableDomainsGetWalletAddr = { _, _, completion in
+      completion(unstoppableDomainsGetWalletAddr, .success, "")
     }
     rpcService._erc721Metadata = { _, _, _, completion in
       let metadata = """
@@ -960,6 +964,130 @@ class SendTokenStoreTests: XCTestCase {
       XCTAssertEqual(createdWithToAddress, expectedAddress)
     }
     waitForExpectations(timeout: 3) { error in
+      XCTAssertNil(error)
+    }
+  }
+  
+  /// Test `resolvedAddress` will be assigned the address returned from `unstoppableDomainsGetWalletAddr` when a Ethereum network is selected.
+  func testUDAddressResolutionEthNetwork() {
+    let domain = "brave.crypto"
+    let expectedAddress = "0xxxxxxxxxxxyyyyyyyyyyzzzzzzzzzz0000000000"
+    
+    let (keyringService, rpcService, walletService, ethTxManagerProxy, solTxManagerProxy) = setupServices(
+      selectedCoin: .eth,
+      unstoppableDomainsGetWalletAddr: expectedAddress
+    )
+    
+    let store = SendTokenStore(
+      keyringService: keyringService,
+      rpcService: rpcService,
+      walletService: walletService,
+      txService: MockTxService(),
+      blockchainRegistry: MockBlockchainRegistry(),
+      ethTxManagerProxy: ethTxManagerProxy,
+      solTxManagerProxy: solTxManagerProxy,
+      prefilledToken: nil,
+      ipfsApi: nil
+    )
+    
+    let resolvedAddressExpectation = expectation(description: "sendTokenStore-resolvedAddress")
+    XCTAssertNil(store.resolvedAddress)  // Initial state
+    store.$resolvedAddress
+      .dropFirst(3) // Initial value, reset to nil in `sendAddress` didSet, reset to nil in `validateEthereumSendAddress`
+      .sink { resolvedAddress in
+        defer { resolvedAddressExpectation.fulfill() }
+        XCTAssertEqual(resolvedAddress, expectedAddress)
+      }.store(in: &cancellables)
+    
+    store.sendAddress = domain
+    
+    waitForExpectations(timeout: 1) { error in
+      XCTAssertNil(error)
+    }
+  }
+  
+  /// Test `addressError` will be assigned an `ensError` if error is returned from `unstoppableDomainsGetWalletAddr`.
+  func testUDAddressResolutionFailure() {
+    let domain = "brave.eth"
+    let (keyringService, rpcService, walletService, ethTxManagerProxy, solTxManagerProxy) = setupServices(
+      selectedCoin: .eth
+    )
+    rpcService._unstoppableDomainsGetWalletAddr = { _, _, completion in
+      completion("", .internalError, "Something went wrong")
+    }
+    
+    let store = SendTokenStore(
+      keyringService: keyringService,
+      rpcService: rpcService,
+      walletService: walletService,
+      txService: MockTxService(),
+      blockchainRegistry: MockBlockchainRegistry(),
+      ethTxManagerProxy: ethTxManagerProxy,
+      solTxManagerProxy: solTxManagerProxy,
+      prefilledToken: nil,
+      ipfsApi: nil
+    )
+    
+    let resolvedAddressExpectation = expectation(description: "sendTokenStore-resolvedAddress")
+    XCTAssertNil(store.resolvedAddress)  // Initial state
+    store.$resolvedAddress
+      .dropFirst(2) // Initial value, reset to nil in `validateEthereumSendAddress`
+      .sink { resolvedAddress in
+        defer { resolvedAddressExpectation.fulfill() }
+        XCTAssertNil(resolvedAddress)
+      }.store(in: &cancellables)
+    
+    let addressErrorExpectation = expectation(description: "sendTokenStore-addressError")
+    XCTAssertNil(store.resolvedAddress)  // Initial state
+    store.$addressError
+      .dropFirst() // Initial value
+      .sink { addressError in
+        defer { addressErrorExpectation.fulfill() }
+        XCTAssertEqual(addressError, .ensError(domain: domain))
+      }.store(in: &cancellables)
+    
+    store.sendAddress = domain
+    
+    waitForExpectations(timeout: 1) { error in
+      XCTAssertNil(error)
+    }
+  }
+  
+  /// Test `resolvedAddress` will be assigned the address returned from `unstoppableDomainsGetWalletAddr` when a Solana network is selected.
+  func testUDAddressResolutionSolNetwork() {
+    let domain = "brave.crypto"
+    let expectedAddress = "xxxxxxxxxxyyyyyyyyyyzzzzzzzzzz0000000000"
+    
+    let (keyringService, rpcService, walletService, ethTxManagerProxy, solTxManagerProxy) = setupServices(
+      selectedCoin: .sol,
+      selectedNetwork: .mockSolana,
+      unstoppableDomainsGetWalletAddr: expectedAddress
+    )
+    
+    let store = SendTokenStore(
+      keyringService: keyringService,
+      rpcService: rpcService,
+      walletService: walletService,
+      txService: MockTxService(),
+      blockchainRegistry: MockBlockchainRegistry(),
+      ethTxManagerProxy: ethTxManagerProxy,
+      solTxManagerProxy: solTxManagerProxy,
+      prefilledToken: nil,
+      ipfsApi: nil
+    )
+    
+    let resolvedAddressExpectation = expectation(description: "sendTokenStore-resolvedAddress")
+    XCTAssertNil(store.resolvedAddress)  // Initial state
+    store.$resolvedAddress
+      .dropFirst(3) // Initial value, reset to nil in `sendAddress` didSet, reset to nil in `validateSolanaSendAddress`
+      .sink { resolvedAddress in
+        defer { resolvedAddressExpectation.fulfill() }
+        XCTAssertEqual(resolvedAddress, expectedAddress)
+      }.store(in: &cancellables)
+    
+    store.sendAddress = domain
+    
+    waitForExpectations(timeout: 1) { error in
       XCTAssertNil(error)
     }
   }

--- a/Tests/BraveWalletTests/SendTokenStoreTests.swift
+++ b/Tests/BraveWalletTests/SendTokenStoreTests.swift
@@ -986,9 +986,24 @@ class SendTokenStoreTests: XCTestCase {
       blockchainRegistry: MockBlockchainRegistry(),
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
-      prefilledToken: nil,
+      prefilledToken: .previewToken,
       ipfsApi: nil
     )
+    
+    let waitForPrefilledTokenExpectation = expectation(description: "waitForPrefilledToken")
+    store.$selectedSendToken
+      .dropFirst()
+      .sink { selectedSendToken in
+        defer { waitForPrefilledTokenExpectation.fulfill() }
+        XCTAssertEqual(selectedSendToken, .previewToken)
+      }
+      .store(in: &cancellables)
+    store.update()
+    // wait for store to be setup with given `prefilledToken`
+    wait(for: [waitForPrefilledTokenExpectation], timeout: 1)
+    // release above sink on `selectedSendToken`
+    // to avoid repeated calls to expectation
+    cancellables.removeAll()
     
     let resolvedAddressExpectation = expectation(description: "sendTokenStore-resolvedAddress")
     XCTAssertNil(store.resolvedAddress)  // Initial state
@@ -1024,9 +1039,24 @@ class SendTokenStoreTests: XCTestCase {
       blockchainRegistry: MockBlockchainRegistry(),
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
-      prefilledToken: nil,
+      prefilledToken: .previewToken,
       ipfsApi: nil
     )
+    
+    let waitForPrefilledTokenExpectation = expectation(description: "waitForPrefilledToken")
+    store.$selectedSendToken
+      .dropFirst()
+      .sink { selectedSendToken in
+        defer { waitForPrefilledTokenExpectation.fulfill() }
+        XCTAssertEqual(selectedSendToken, .previewToken)
+      }
+      .store(in: &cancellables)
+    store.update()
+    // wait for store to be setup with given `prefilledToken`
+    wait(for: [waitForPrefilledTokenExpectation], timeout: 1)
+    // release above sink on `selectedSendToken`
+    // to avoid repeated calls to expectation
+    cancellables.removeAll()
     
     let resolvedAddressExpectation = expectation(description: "sendTokenStore-resolvedAddress")
     XCTAssertNil(store.resolvedAddress)  // Initial state
@@ -1072,9 +1102,24 @@ class SendTokenStoreTests: XCTestCase {
       blockchainRegistry: MockBlockchainRegistry(),
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
-      prefilledToken: nil,
+      prefilledToken: .mockSolToken,
       ipfsApi: nil
     )
+    
+    let waitForPrefilledTokenExpectation = expectation(description: "waitForPrefilledToken")
+    store.$selectedSendToken
+      .dropFirst()
+      .sink { selectedSendToken in
+        defer { waitForPrefilledTokenExpectation.fulfill() }
+        XCTAssertEqual(selectedSendToken, .mockSolToken)
+      }
+      .store(in: &cancellables)
+    store.update()
+    // wait for store to be setup with given `prefilledToken`
+    wait(for: [waitForPrefilledTokenExpectation], timeout: 1)
+    // release above sink on `selectedSendToken`
+    // to avoid repeated calls to expectation
+    cancellables.removeAll()
     
     let resolvedAddressExpectation = expectation(description: "sendTokenStore-resolvedAddress")
     XCTAssertNil(store.resolvedAddress)  // Initial state


### PR DESCRIPTION
## Summary of Changes
- Implements resolving unstoppable domains in wallet send address field (Ethereum mainnet, EVMs and Solana supported).
- Calls to [UnstoppableDomainsResolveDns](https://github.com/brave/brave-core/blob/master/components/brave_wallet/browser/json_rpc_service.cc#L1818) are proxied via Infura.
- Unstoppable Domains can be resolved to a different address depending on the token being sent. As such we now validate the ethereum address to perform this lookup when the `selectedSendToken` changes.
- Supported TLDs: `.crypto`, `.x`, `.nft`, `.dao`, `.wallet`, `.888`, `.blockchain`, `.bitcoin`

This pull request fixes brave/brave-ios#6182

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
Test resolving unstoppable domains on multiple networks (Solana supported too!). Valid registered domains can be found on `https://unstoppabledomains.com/`.
Test resolving unstoppable domains can change depending on the currently selected token.
    * Ex. [jim-unstoppable.crypto](https://ud.me/jim-unstoppable.crypto)


## Screenshots:

https://user-images.githubusercontent.com/5314553/225998113-3e3d54ca-8f90-40af-a3b6-4010172514d0.mp4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
