### PR TITLE
Revert "Fix #6254: Fix engine crashes by using serial queue for cosmetic filters"

### DIFF
--- a/Sources/Brave/Frontend/Browser/Helpers/LaunchHelper.swift
+++ b/Sources/Brave/Frontend/Browser/Helpers/LaunchHelper.swift
@@ -27,10 +27,6 @@ public actor LaunchHelper {
     
     // Otherwise prepare the services and await the task
     let task = Task {
-      #if DEBUG
-      let startTime = CFAbsoluteTimeGetCurrent()
-      #endif
-      
       // Load cached data
       // This is done first because compileResources and loadCachedRuleLists need their results
       async let loadBundledResources: Void = ContentBlockerManager.shared.loadBundledResources()
@@ -42,11 +38,6 @@ public actor LaunchHelper {
       async let compiledResourcesCompile: Void = AdBlockEngineManager.shared.compileResources()
       async let cachedRuleListLoad: Void = ContentBlockerManager.shared.loadCachedRuleLists()
       _ = await (compiledResourcesCompile, cachedRuleListLoad)
-      
-      #if DEBUG
-      let timeElapsed = CFAbsoluteTimeGetCurrent() - startTime
-      ContentBlockerManager.log.debug("Adblock loaded: \(timeElapsed)s")
-      #endif
       
       // This one is non-blocking
       performPostLoadTasks(adBlockService: adBlockService)

--- a/Sources/Brave/Frontend/Browser/LinkPreviewViewController.swift
+++ b/Sources/Brave/Frontend/Browser/LinkPreviewViewController.swift
@@ -45,10 +45,10 @@ class LinkPreviewViewController: UIViewController {
     }
 
     let domain = Domain.getOrCreate(forUrl: url, persistent: !PrivateBrowsingManager.shared.isPrivateBrowsing)
+    let compiledRuleTypes = ContentBlockerManager.shared.compiledRuleTypes(for: domain)
     
     Task(priority: .userInitiated) {
-      let ruleLists = await ContentBlockerManager.shared.ruleLists(for: domain)
-      
+      let ruleLists = await ContentBlockerManager.shared.loadRuleLists(for: Set(compiledRuleTypes.map({ $0.ruleType })))
       for ruleList in ruleLists {
         webView.configuration.userContentController.add(ruleList)
       }

--- a/Sources/Brave/Frontend/Browser/Playlist/Managers & Cache/PlaylistCacheLoader.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/Managers & Cache/PlaylistCacheLoader.swift
@@ -557,7 +557,7 @@ extension PlaylistWebLoader: WKNavigationDelegate {
       if let requestURL = navigationAction.request.url,
          let targetFrame = navigationAction.targetFrame {
         tab.currentPageData?.addSubframeURL(forRequestURL: requestURL, isForMainFrame: targetFrame.isMainFrame)
-        let scriptTypes = await tab.currentPageData?.makeUserScriptTypes(domain: domainForMainFrame) ?? []
+        let scriptTypes = tab.currentPageData?.makeUserScriptTypes(domain: domainForMainFrame) ?? []
         tab.setCustomUserScript(scripts: scriptTypes)
       }
       
@@ -584,8 +584,8 @@ extension PlaylistWebLoader: WKNavigationDelegate {
         domainForShields.shield_adblockAndTp = true
         
         // Load block lists
-        let ruleLists = await ContentBlockerManager.shared.ruleLists(for: domainForShields)
-        tab.contentBlocker.set(ruleLists: ruleLists)
+        let enabledRuleTypes = ContentBlockerManager.shared.compiledRuleTypes(for: domainForShields)
+        tab.contentBlocker.ruleListTypes = enabledRuleTypes
 
         let isScriptsEnabled = !domainForShields.isShieldExpected(.NoScript, considerAllShieldsOption: true)
         preferences.allowsContentJavaScript = isScriptsEnabled
@@ -593,6 +593,7 @@ extension PlaylistWebLoader: WKNavigationDelegate {
 
       // Cookie Blocking code below
       tab.setScript(script: .cookieBlocking, enabled: Preferences.Privacy.blockAllCookies.value)
+
       return (.allow, preferences)
     }
 
@@ -613,7 +614,7 @@ extension PlaylistWebLoader: WKNavigationDelegate {
     if let responseURL = responseURL,
        tab.currentPageData?.upgradeFrameURL(forResponseURL: responseURL, isForMainFrame: navigationResponse.isForMainFrame) == true,
        let domain = tab.currentPageData?.domain(persistent: false) {
-      let scriptTypes = await tab.currentPageData?.makeUserScriptTypes(domain: domain) ?? []
+      let scriptTypes = tab.currentPageData?.makeUserScriptTypes(domain: domain) ?? []
       tab.setCustomUserScript(scripts: scriptTypes)
     }
 

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/ContentBlockerScriptHandler.swift
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/ContentBlockerScriptHandler.swift
@@ -82,7 +82,7 @@ extension ContentBlockerHelper: TabContentScript {
         guard let requestURL = NSURL(idnString: dto.data.resourceURL) as URL? else { return }
         guard let sourceURL = NSURL(idnString: dto.data.sourceURL) as URL? else { return }
         guard let domainURLString = domain.url else { return }
-        let loadedRuleTypes = ContentBlockerManager.shared.enabledRuleTypes(for: domain)
+        let loadedRuleTypes = Set(self.loadedRuleTypeWithSourceTypes.map({ $0.ruleType }))
         
         let blockedType = await TPStatsBlocklistChecker.shared.blockedTypes(
           requestURL: requestURL,

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/CosmeticFiltersScriptHandler.swift
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/CosmeticFiltersScriptHandler.swift
@@ -58,7 +58,7 @@ class CosmeticFiltersScriptHandler: TabContentScript {
         
         let selectorArrays = await cachedEngines.asyncConcurrentMap { cachedEngine -> [String] in
           do {
-            return try await cachedEngine.selectorsForCosmeticRules(
+            return try cachedEngine.selectorsForCosmeticRules(
               frameURL: frameURL,
               ids: dto.data.ids,
               classes: dto.data.classes

--- a/Sources/Brave/WebFilters/AdBlockEngineManager.swift
+++ b/Sources/Brave/WebFilters/AdBlockEngineManager.swift
@@ -184,39 +184,41 @@ public actor AdBlockEngineManager: Sendable {
 }
 
 #if DEBUG
-private extension AdBlockEngineManager {
+extension AdBlockEngineManager {
   /// A method that logs info on the given resources
-  func debug(compiledResults: [ResourceWithVersion: Result<Void, Error>]) {
-    log.debug("Loaded \(compiledResults.count) (total) engine resources:")
-    
-    compiledResults.sorted(by: { $0.key.order < $1.key.order })
-      .forEach { (resourceWithVersion, compileResult) in
+  fileprivate func debug(compiledResults: [ResourceWithVersion: Result<Void, Error>]) {
+    let resourcesString = compiledResults.sorted(by: { $0.key.order < $1.key.order })
+      .map { (resourceWithVersion, compileResult) -> String in
         let resultString: String
         
         switch compileResult {
         case .success:
-          resultString = "✔︎"
+          resultString = "success"
         case .failure(let error):
-          resultString = "\(error)"
+          resultString = error.localizedDescription
         }
         
         let sourceDebugString = [
-          "", resourceWithVersion.debugDescription,
-          "\(resultString)",
-        ].joined(separator: " ")
+          resourceWithVersion.debugDescription,
+          "result: \(resultString)",
+        ].joined(separator: ", ")
         
-        log.debug("\(sourceDebugString)")
-      }
+        return ["{", sourceDebugString, "}"].joined()
+      }.joined(separator: ", ")
+
+    log.debug("Loaded \(self.enabledResources.count, privacy: .public) (total) engine resources: \(resourcesString, privacy: .public)")
   }
 }
 
 extension AdBlockEngineManager.ResourceWithVersion: CustomDebugStringConvertible {
   public var debugDescription: String {
     return [
-      "#\(order)",
-      "\(resource.source.debugDescription).\(resource.type.debugDescription)",
-      "v\(version ?? "nil")",
-    ].joined(separator: " ")
+      "order: \(order)",
+      "fileName: \(fileURL.lastPathComponent)",
+      "source: \(resource.source.debugDescription)",
+      "version: \(version ?? "nil")",
+      "type: \(resource.type.debugDescription)"
+    ].joined(separator: ", ")
   }
 }
 

--- a/Sources/Brave/WebFilters/ContentBlocker/ContentBlockerManager.swift
+++ b/Sources/Brave/WebFilters/ContentBlocker/ContentBlockerManager.swift
@@ -307,42 +307,51 @@ final public class ContentBlockerManager: Sendable {
     return ruleList
   }
   
-  @MainActor public func enabledRuleTypes(for domain: Domain) -> Set<ContentBlockerManager.BlocklistRuleType> {
+  /// Return the enabled rule types for this domain and the enabled settings
+  @MainActor public func compiledRuleTypes(for domain: Domain) -> Set<RuleTypeWithSourceType> {
     let filterLists = FilterListResourceDownloader.shared.filterLists
     
     if domain.shield_allOff == 1 {
       return []
     }
     
-    var results = Set<ContentBlockerManager.BlocklistRuleType>()
+    var results = Set<RuleTypeWithSourceType>()
 
     // Get domain specific rule types
     if domain.isShieldExpected(.AdblockAndTp, considerAllShieldsOption: true) {
-      results.insert(.general(.blockAds))
-      results.insert(.general(.blockTrackers))
+      if let sourceType = self.sourceType(for: .general(.blockAds)) {
+        results.insert(RuleTypeWithSourceType(ruleType: .general(.blockAds), sourceType: sourceType))
+      }
+      
+      if let sourceType = self.sourceType(for: .general(.blockTrackers)) {
+        results.insert(RuleTypeWithSourceType(ruleType: .general(.blockTrackers), sourceType: sourceType))
+      }
     }
     
     // Get filter list specific rule types
     filterLists.forEach { filterList in
       guard filterList.isEnabled else { return }
-      results.insert(filterList.makeRuleType())
+      let ruleType = filterList.makeRuleType()
+      
+      guard let sourceType = self.sourceType(for: ruleType) else {
+        return
+      }
+      
+      guard cachedRuleList(for: ruleType) != nil else {
+        return
+      }
+      
+      results.insert(RuleTypeWithSourceType(ruleType: ruleType, sourceType: sourceType))
     }
     
     // Get global rule types
     if Preferences.Privacy.blockAllCookies.value {
-      results.insert(.general(.blockCookies))
+      if let sourceType = sourceType(for: .general(.blockCookies)) {
+        results.insert(RuleTypeWithSourceType(ruleType: .general(.blockCookies), sourceType: sourceType))
+      }
     }
     
     return results
-  }
-  
-  /// Return the enabled rule types for this domain and the enabled settings
-  @MainActor public func ruleLists(for domain: Domain) -> Set<WKContentRuleList> {
-    let ruleTypes = enabledRuleTypes(for: domain)
-    
-    return Set(ruleTypes.compactMap { ruleType in
-      return self.cachedRuleList(for: ruleType)
-    })
   }
   
   /// Return a source type for the given rule type
@@ -358,13 +367,41 @@ final public class ContentBlockerManager: Sendable {
   }
   
   /// Get the cached rule list for this rule type. Returns nil if it's either not compiled or there were errors during compilation
-  private func cachedRuleList(for ruleType: BlocklistRuleType) -> WKContentRuleList? {
+  public func cachedRuleList(for ruleType: BlocklistRuleType) -> WKContentRuleList? {
     guard let compileResult = cachedCompileResults[ruleType.identifier] else { return nil }
     
     switch compileResult.result {
     case .success(let ruleList): return ruleList
     case .failure: return nil
     }
+  }
+  
+  /// Load the rule lists for the given rule types
+  public func loadRuleLists(for ruleTypes: Set<BlocklistRuleType>) async -> [WKContentRuleList] {
+    return await withTaskGroup(of: WKContentRuleList?.self) { group in
+      for ruleType in ruleTypes {
+        group.addTask {
+          do {
+            return try await self.loadRuleList(for: ruleType)
+          } catch {
+            Self.log.error("\(error.localizedDescription)")
+            return nil
+          }
+        }
+      }
+      
+      var results: [WKContentRuleList] = []
+      for await ruleList in group {
+        guard let ruleList = ruleList else { continue }
+        results.append(ruleList)
+      }
+      return results
+    }
+  }
+  
+  /// Load the rule list for the given rule type
+  public func loadRuleList(for ruleType: BlocklistRuleType) async throws -> WKContentRuleList? {
+    return try await ruleStore.contentRuleList(forIdentifier: ruleType.identifier)
   }
 
   /// Compile the data and set it for the given general type.
@@ -388,44 +425,45 @@ final public class ContentBlockerManager: Sendable {
   #if DEBUG
   /// A method that logs info on the given resources
   private func debug(resources: [String: Resource]) {
-    Self.log.debug("Compiled \(resources.count) block list resources:")
-    
-    resources
+    let resourcesString = resources
       .sorted(by: { lhs, rhs in
         lhs.value.url.absoluteString < rhs.value.url.absoluteString
       })
-      .forEach { identifier, compiledResource in
+      .map { identifier, compiledResource -> String in
+        let sourceString: String
+        let versionString: String
         let resultString: String
+        
+        switch compiledResource.sourceType {
+        case .bundled:
+          sourceString = "bundled"
+          versionString = "nil"
+        case .downloaded(let version):
+          sourceString = "downloaded"
+          versionString = version ?? "nil"
+        }
         
         switch self.cachedCompileResults[identifier]?.result {
         case .failure(let error):
           resultString = error.localizedDescription
         case .success:
-          resultString = "✔︎"
+          resultString = "success"
         case .none:
-          resultString = "?"
+          resultString = "nil"
         }
         
         let resourcesDebugString = [
-          identifier, compiledResource.sourceType.debugDescription,
-          resultString
-        ].joined(separator: " ")
+          "identifier: \(identifier)",
+          "fileName: \(compiledResource.url.lastPathComponent)",
+          "source: \(sourceString)",
+          "version: \(versionString)",
+          "result: \(resultString)"
+        ].joined(separator: ", ")
         
-        Self.log.debug(" \(resourcesDebugString)")
-      }
+        return ["{", resourcesDebugString, "}"].joined()
+      }.joined(separator: ", ")
+
+    Self.log.debug("Compiled \(resources.count, privacy: .public) additional block list resources: \(resourcesString, privacy: .public))")
   }
   #endif
 }
-
-#if DEBUG
-extension ContentBlockerManager.BlocklistSourceType: CustomDebugStringConvertible {
-  public var debugDescription: String {
-    switch self {
-    case .bundled:
-      return "bundled"
-    case .downloaded(let version):
-      return version ?? "nil"
-    }
-  }
-}
-#endif

--- a/Sources/Brave/WebFilters/ShieldStats/Adblock/AdBlockStats.swift
+++ b/Sources/Brave/WebFilters/ShieldStats/Adblock/AdBlockStats.swift
@@ -43,13 +43,13 @@ public class AdBlockStats {
   }
   
   /// This returns all the user script types for the given frame
-  func makeEngineScriptTypes(frameURL: URL, isMainFrame: Bool, domain: Domain) async -> Set<UserScriptType> {
+  @MainActor func makeEngineScriptTypes(frameURL: URL, isMainFrame: Bool, domain: Domain) -> Set<UserScriptType> {
     // Add any engine scripts for this frame
-    return await cachedEngines.enumerated().asyncMap({ (index, cachedEngine) -> Set<UserScriptType> in
-      guard await cachedEngine.isEnabled(for: domain) else { return [] }
+    return cachedEngines.enumerated().map({ (index, cachedEngine) -> Set<UserScriptType> in
+      guard cachedEngine.isEnabled(for: domain) else { return [] }
       
       do {
-        return try await cachedEngine.makeEngineScriptTypes(
+        return try cachedEngine.makeEngineScriptTypes(
           frameURL: frameURL, isMainFrame: isMainFrame, domain: domain, index: index
         )
       } catch {

--- a/Tests/ClientTests/PageDataTests.swift
+++ b/Tests/ClientTests/PageDataTests.swift
@@ -22,7 +22,7 @@ final class PageDataTests: XCTestCase {
       // When
       // We get the script types for the main frame
       let domain = pageData.domain(persistent: false)
-      let mainFrameRequestTypes = await pageData.makeUserScriptTypes(domain: domain)
+      let mainFrameRequestTypes = pageData.makeUserScriptTypes(domain: domain)
       
       // Then
       // We get only entries of the main frame
@@ -34,7 +34,7 @@ final class PageDataTests: XCTestCase {
       
       // When
       // Nothing has changed
-      let unchangedScriptTypes = await pageData.makeUserScriptTypes(domain: domain)
+      let unchangedScriptTypes = pageData.makeUserScriptTypes(domain: domain)
       
       // Then
       // We get the same result as before
@@ -48,7 +48,7 @@ final class PageDataTests: XCTestCase {
       // We get an aditional scripts for sub-frame
       // NOTE: This is because we have no engines on AdBlockStats.
       // If we were to add some engines we might see additional types
-      let addedSubFrameFrameRequestTypes = await pageData.makeUserScriptTypes(domain: domain)
+      let addedSubFrameFrameRequestTypes = pageData.makeUserScriptTypes(domain: domain)
       let expectedMainAndSubFrameTypes: Set<UserScriptType> = [
         .siteStateListener, .nacl, .farblingProtection(etld: "example.com")
       ]
@@ -61,7 +61,7 @@ final class PageDataTests: XCTestCase {
       // Then
       // We get the same result as before
       XCTAssertTrue(isUpgradedMainFrame)
-      let upgradedMainFrameRequestTypes = await pageData.makeUserScriptTypes(domain: domain)
+      let upgradedMainFrameRequestTypes = pageData.makeUserScriptTypes(domain: domain)
       XCTAssertEqual(upgradedMainFrameRequestTypes, unchangedScriptTypes)
       
       // When
@@ -71,7 +71,7 @@ final class PageDataTests: XCTestCase {
       // Then
       // We get the same result as before
       XCTAssertTrue(isUpgradedSubFrame)
-      let upgradedSubFrameFrameRequestTypes = await pageData.makeUserScriptTypes(domain: domain)
+      let upgradedSubFrameFrameRequestTypes = pageData.makeUserScriptTypes(domain: domain)
       XCTAssertEqual(upgradedSubFrameFrameRequestTypes, unchangedScriptTypes)
       
       expectation.fulfill()


### PR DESCRIPTION
This reverts commit ed8cc34de60881853928ab6a09e58083191c1ac2.

## Summary of Changes

This pull request reverts #6936 due to performance concerns on page loads

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
