### PR TITLE
Fix #7034: Stops multiple tabs from activating.

### DIFF
--- a/Sources/Brave/Frontend/Browser/Tabs/TabBar/TabsBarViewController.swift
+++ b/Sources/Brave/Frontend/Browser/Tabs/TabBar/TabsBarViewController.swift
@@ -414,8 +414,15 @@ extension TabsBarViewController: UICollectionViewDataSource {
     updateData()
 
     guard let selectedTab = tabList[destinationIndexPath.row] else { return }
-    // The line below selects tab without deselecting others
-    // manager.selectTab(selectedTab)
+    
+    // Deselects all tabBarCells before selecting a new one
+    for i in 0...tabs.count - 1 {
+        if let cell = collectionView.cellForItem(at: IndexPath(row: i, section: 0)) as? TabBarCell {
+          cell.isSelected = false
+          cell.configure()
+        }
+    }
+    manager.selectTab(selectedTab)
   }
 }
 

--- a/Sources/Brave/Frontend/Browser/Tabs/TabBar/TabsBarViewController.swift
+++ b/Sources/Brave/Frontend/Browser/Tabs/TabBar/TabsBarViewController.swift
@@ -414,7 +414,8 @@ extension TabsBarViewController: UICollectionViewDataSource {
     updateData()
 
     guard let selectedTab = tabList[destinationIndexPath.row] else { return }
-    manager.selectTab(selectedTab)
+    // The line below selects tab without deselecting others
+    // manager.selectTab(selectedTab)
   }
 }
 


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes brave/brave-browser#36102

I only commented out the code that selects the tab after moving it.  In this way we can't have two or more tabs active (selected) at the same time.
I noticed that the previously selected tab is not being deselected.

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Right now you can move around tabs but the selected one won't change until tapping it again, before or after moving it.

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
