### PR TITLE
Fix #7116: Fix favicon flickering and rendering large

### DIFF
--- a/Sources/Brave/Frontend/Browser/Search/SearchViewController.swift
+++ b/Sources/Brave/Frontend/Browser/Search/SearchViewController.swift
@@ -7,6 +7,7 @@ import Shared
 import Storage
 import BraveShared
 import Data
+import Favicon
 
 // MARK: - SearchViewControllerDelegate
 
@@ -617,7 +618,7 @@ public class SearchViewController: SiteTableViewController, LoaderListener {
         cell.imageView?.contentMode = .scaleAspectFit
         cell.imageView?.layer.borderColor = SearchViewControllerUX.iconBorderColor.cgColor
         cell.imageView?.layer.borderWidth = SearchViewControllerUX.iconBorderWidth
-        cell.imageView?.image = UIImage()
+        cell.imageView?.image = FaviconFetcher.getIconFromCache(for: site.tileURL)?.image ?? Favicon.defaultImage
         cell.imageView?.loadFavicon(for: site.tileURL)
         cell.backgroundColor = .secondaryBraveBackground
       }

--- a/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarksViewController.swift
+++ b/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarksViewController.swift
@@ -415,6 +415,7 @@ class BookmarksViewController: SiteTableViewController, ToolbarUrlActionsProtoco
           cell.imageView?.clearMonogramFavicon()
 
           if let urlString = item.url, let url = URL(string: urlString) {
+            cell.imageView?.image = FaviconFetcher.getIconFromCache(for: url)?.image ?? Favicon.defaultImage
             cell.imageView?.loadFavicon(for: url, monogramFallbackCharacter: item.title?.first) { [weak cell] favicon in
               if favicon?.isMonogramImage == true, let icon = item.bookmarkNode.icon {
                 cell?.imageView?.image = icon

--- a/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/HistoryViewController.swift
+++ b/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/HistoryViewController.swift
@@ -231,12 +231,12 @@ class HistoryViewController: SiteTableViewController, ToolbarUrlActionsProtocol 
       $0.setLines(historyItem.title, detailText: historyItem.url.absoluteString)
 
       $0.imageView?.contentMode = .scaleAspectFit
-      $0.imageView?.image = Favicon.defaultImage
       $0.imageView?.layer.borderColor = BraveUX.faviconBorderColor.cgColor
       $0.imageView?.layer.borderWidth = BraveUX.faviconBorderWidth
       $0.imageView?.layer.cornerRadius = 6
       $0.imageView?.layer.cornerCurve = .continuous
       $0.imageView?.layer.masksToBounds = true
+      $0.imageView?.image = FaviconFetcher.getIconFromCache(for: historyItem.url)?.image ?? Favicon.defaultImage
 
       let domain = Domain.getOrCreate(
         forUrl: historyItem.url,

--- a/Sources/Favicon/FaviconFetcher.swift
+++ b/Sources/Favicon/FaviconFetcher.swift
@@ -90,8 +90,12 @@ public class FaviconFetcher {
     return favicon
   }
   
+  /// Retrieves a Favicon from the cache
+  public static func getIconFromCache(for url: URL) -> Favicon? {
+    getFromCache(for: url)
+  }
+  
   /// Stores a Favicon in the cache if not persistent, and not a monogram image.
-  /// If the
   public static func updateCache(_ favicon: Favicon?, for url: URL, persistent: Bool) {
     guard let favicon, !favicon.isMonogramImage else {
       let cachedURL = cacheURL(for: url)

--- a/Sources/Favicon/UIImage+FaviconRenderer.swift
+++ b/Sources/Favicon/UIImage+FaviconRenderer.swift
@@ -98,6 +98,8 @@ extension UIImage {
 
 // MARK: - Rendering
 extension UIImage {
+  private static let maxScaledFaviconSize = 256.0
+  
   /// Renders an image to a canvas with a background colour and passing
   @MainActor
   static func renderFavicon(_ image: UIImage, backgroundColor: UIColor?, shouldScale: Bool) async -> Favicon {
@@ -106,6 +108,12 @@ extension UIImage {
       
       var idealSize = image.size
       var padding = hasTransparentEdges ? 4.0 : 0.0
+      
+      if shouldScale && max(idealSize.width, idealSize.height) > maxScaledFaviconSize {
+        let ratio = maxScaledFaviconSize / max(idealSize.width, idealSize.height)
+        idealSize.width *= ratio
+        idealSize.height *= ratio
+      }
       
       if shouldScale && hasTransparentEdges {
         padding = max(idealSize.width, idealSize.height) * 0.20


### PR DESCRIPTION
## Summary of Changes
- Some Favicons that are too large such as Twitter (Twitter has a favicon of 1024 x 1024).
- Max favicon size is now 256x256 (scaled down) and a minimum of 64x64 (scaled up). 
   Anything else is rendered as is.
- Fixed fetching favicons from cache immediately instead of waiting on the `Task` to do it. 
   Tasks are too slow and will display the result on the next render queue causing flickering. 
   So we fetch it immediately if it exists already.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7116

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
