### PR TITLE
No bug: Bump Brave core to 1.50.x beta

### DIFF
--- a/Sources/Brave/Frontend/Browser/UserScriptManager.swift
+++ b/Sources/Brave/Frontend/Browser/UserScriptManager.swift
@@ -278,18 +278,22 @@ class UserScriptManager {
         }
       }
       
-      if let solanaProvider = tab.walletSolProvider {
-        solanaProvider.isSolanaKeyringCreated { isSolanaKeyringCreated in
-          guard isSolanaKeyringCreated, // don't inject if Solana keyring is not created.
-                let walletStandardScript = tab.walletSolProviderScripts[.walletStandard]
-          else { return }
-          let wkScript = WKUserScript(
-            source: walletStandardScript,
-            injectionTime: .atDocumentEnd,
-            forMainFrameOnly: true,
-            in: SolanaProviderScriptHandler.scriptSandbox)
-          scriptController.addUserScript(wkScript)
-        }
+      // TODO: Check Wallet changes
+      if let walletStandardScript = tab.walletSolProviderScripts[.walletStandard] {
+        let script = """
+        window.__firefox__.execute(function($, $Object) {
+           \(walletStandardScript)
+           window.addEventListener('wallet-standard:app-ready', (e) => {
+              walletStandardBrave.initialize(window.braveSolana);
+          })
+        });
+        """
+        let wkScript = WKUserScript(
+          source: script,
+          injectionTime: .atDocumentStart,
+          forMainFrameOnly: true,
+          in: SolanaProviderScriptHandler.scriptSandbox)
+        scriptController.addUserScript(wkScript)
       }
       
       // TODO: Refactor this and get rid of the `UserScriptType`

--- a/Sources/Brave/Frontend/Browser/UserScriptManager.swift
+++ b/Sources/Brave/Frontend/Browser/UserScriptManager.swift
@@ -278,7 +278,6 @@ class UserScriptManager {
         }
       }
       
-      // TODO: Check Wallet changes
       if let walletStandardScript = tab.walletSolProviderScripts[.walletStandard] {
         let script = """
         window.__firefox__.execute(function($, $Object) {

--- a/Sources/BraveWallet/Preview Content/MockAssetRatioService.swift
+++ b/Sources/BraveWallet/Preview Content/MockAssetRatioService.swift
@@ -36,6 +36,10 @@ class MockAssetRatioService: BraveWalletAssetRatioService {
     completion("", nil)
   }
   
+  func sellUrl(_ provider: BraveWallet.OffRampProvider, chainId: String, address: String, symbol: String, amount: String, currencyCode: String, completion: @escaping (String, String?) -> Void) {
+    completion("", nil)
+  }
+  
   func coinMarkets(_ vsAsset: String, limit: UInt8, completion: @escaping (Bool, [BraveWallet.CoinMarket]) -> Void) {
     completion(false, [])
   }

--- a/Sources/BraveWallet/Preview Content/MockAssetRatioService.swift
+++ b/Sources/BraveWallet/Preview Content/MockAssetRatioService.swift
@@ -43,10 +43,6 @@ class MockAssetRatioService: BraveWalletAssetRatioService {
   func coinMarkets(_ vsAsset: String, limit: UInt8, completion: @escaping (Bool, [BraveWallet.CoinMarket]) -> Void) {
     completion(false, [])
   }
-  
-  func sellUrl(_ provider: BraveWallet.OffRampProvider, chainId: String, address: String, symbol: String, amount: String, currencyCode: String, completion: @escaping (String, String?) -> Void) {
-    completion("", nil)
-  }
 }
 
 #endif

--- a/Sources/BraveWallet/Preview Content/MockBlockchainRegistry.swift
+++ b/Sources/BraveWallet/Preview Content/MockBlockchainRegistry.swift
@@ -44,6 +44,10 @@ class MockBlockchainRegistry: BraveWalletBlockchainRegistry {
     completion(Self.testTokens)
   }
   
+  func sellTokens(_ provider: BraveWallet.OffRampProvider, chainId: String, completion: @escaping ([BraveWallet.BlockchainToken]) -> Void) {
+    completion(Self.testTokens)
+  }
+  
   func providersBuyTokens(_ providers: [NSNumber], chainId: String, completion: @escaping ([BraveWallet.BlockchainToken]) -> Void) {
     completion(Self.testTokens)
   }

--- a/Sources/BraveWallet/Preview Content/MockBlockchainRegistry.swift
+++ b/Sources/BraveWallet/Preview Content/MockBlockchainRegistry.swift
@@ -43,6 +43,10 @@ class MockBlockchainRegistry: BraveWalletBlockchainRegistry {
   func buyTokens(_ provider: BraveWallet.OnRampProvider, chainId: String, completion: @escaping ([BraveWallet.BlockchainToken]) -> Void) {
     completion(Self.testTokens)
   }
+  
+  func providersBuyTokens(_ providers: [NSNumber], chainId: String, completion: @escaping ([BraveWallet.BlockchainToken]) -> Void) {
+    completion(Self.testTokens)
+  }
 
   func buyUrl(_ provider: BraveWallet.OnRampProvider, chainId: String, address: String, symbol: String, amount: String, completion: @escaping (String, String?) -> Void) {
     completion("", nil)

--- a/Sources/BraveWallet/Preview Content/MockBlockchainRegistry.swift
+++ b/Sources/BraveWallet/Preview Content/MockBlockchainRegistry.swift
@@ -67,8 +67,4 @@ class MockBlockchainRegistry: BraveWalletBlockchainRegistry {
   func onRampCurrencies(_ completion: @escaping ([BraveWallet.OnRampCurrency]) -> Void) {
     completion([])
   }
-  
-  func sellTokens(_ provider: BraveWallet.OffRampProvider, chainId: String, completion: @escaping ([BraveWallet.BlockchainToken]) -> Void) {
-    completion([])
-  }
 }

--- a/Sources/BraveWallet/Preview Content/MockJsonRpcService.swift
+++ b/Sources/BraveWallet/Preview Content/MockJsonRpcService.swift
@@ -206,6 +206,10 @@ class MockJsonRpcService: BraveWalletJsonRpcService {
   func code(_ address: String, coin: BraveWallet.CoinType, chainId: String, completion: @escaping (String, BraveWallet.ProviderError, String) -> Void) {
     completion("", .internalError, "Error Message")
   }
+  
+  func ensGetContentHash(_ domain: String, completion: @escaping ([NSNumber], Bool, BraveWallet.ProviderError, String) -> Void) {
+    completion([], false, .internalError, "Error Message")
+  }
 }
 
 extension BraveWallet.NetworkInfo {

--- a/Sources/BraveWallet/Preview Content/MockJsonRpcService.swift
+++ b/Sources/BraveWallet/Preview Content/MockJsonRpcService.swift
@@ -44,6 +44,11 @@ class MockJsonRpcService: BraveWalletJsonRpcService {
     completion("10", .success, "")
   }
   
+  // TODO: Check Wallet changes
+  func erc20TokenBalances(_ contracts: [String], address: String, chainId: String, completion: @escaping ([BraveWallet.ERC20BalanceResult], BraveWallet.ProviderError, String) -> Void) {
+    completion([.init(contractAddress: "", balance: "10")], .success, "")
+  }
+  
   func request(_ jsonPayload: String, autoRetryOnNetworkChange: Bool, id: MojoBase.Value, coin: BraveWallet.CoinType, completion: @escaping (MojoBase.Value, MojoBase.Value, Bool, String, Bool) -> Void) {
     completion(.init(), .init(), true, "", false)
   }

--- a/Sources/BraveWallet/Preview Content/MockJsonRpcService.swift
+++ b/Sources/BraveWallet/Preview Content/MockJsonRpcService.swift
@@ -44,7 +44,6 @@ class MockJsonRpcService: BraveWalletJsonRpcService {
     completion("10", .success, "")
   }
   
-  // TODO: Check Wallet changes
   func erc20TokenBalances(_ contracts: [String], address: String, chainId: String, completion: @escaping ([BraveWallet.ERC20BalanceResult], BraveWallet.ProviderError, String) -> Void) {
     completion([.init(contractAddress: "", balance: "10")], .success, "")
   }

--- a/Sources/BraveWallet/Preview Content/MockJsonRpcService.swift
+++ b/Sources/BraveWallet/Preview Content/MockJsonRpcService.swift
@@ -204,7 +204,7 @@ class MockJsonRpcService: BraveWalletJsonRpcService {
   }
   
   func code(_ address: String, coin: BraveWallet.CoinType, chainId: String, completion: @escaping (String, BraveWallet.ProviderError, String) -> Void) {
-    completion("", .internalError, "")
+    completion("", .internalError, "Error Message")
   }
 }
 

--- a/Sources/BraveWallet/Preview Content/MockKeyringService.swift
+++ b/Sources/BraveWallet/Preview Content/MockKeyringService.swift
@@ -339,7 +339,9 @@ class MockKeyringService: BraveWalletKeyringService {
     completion(true)
   }
 
-  func removeHardwareAccount(_ address: String, password: String, coin: BraveWallet.CoinType, completion: @escaping (Bool) -> Void) {
+  // TODO: Check Wallet changes
+  func removeHardwareAccount(_ address: String, coin: BraveWallet.CoinType, completion: @escaping (Bool) -> Void) {
+    completion(true)
   }
 
   func notifyUserInteraction() {

--- a/Sources/BraveWallet/Preview Content/MockKeyringService.swift
+++ b/Sources/BraveWallet/Preview Content/MockKeyringService.swift
@@ -361,7 +361,7 @@ extension BraveWallet.AccountInfo {
     isImported: false,
     hardware: nil,
     coin: .eth,
-    keyringId: ""
+    keyringId: BraveWallet.DefaultKeyringId
   )
   
   static let mockSolAccount: BraveWallet.AccountInfo = .init(
@@ -370,7 +370,7 @@ extension BraveWallet.AccountInfo {
     isImported: false,
     hardware: nil,
     coin: .sol,
-    keyringId: ""
+    keyringId: BraveWallet.SolanaKeyringId
   )
   
   static let mockFilAccount: BraveWallet.AccountInfo = .init(
@@ -379,7 +379,7 @@ extension BraveWallet.AccountInfo {
     isImported: false,
     hardware: nil,
     coin: .fil,
-    keyringId: ""
+    keyringId: BraveWallet.FilecoinKeyringId
   )
 }
 

--- a/Sources/BraveWallet/Preview Content/MockKeyringService.swift
+++ b/Sources/BraveWallet/Preview Content/MockKeyringService.swift
@@ -361,7 +361,7 @@ extension BraveWallet.AccountInfo {
     isImported: false,
     hardware: nil,
     coin: .eth,
-    keyringId: nil
+    keyringId: ""
   )
   
   static let mockSolAccount: BraveWallet.AccountInfo = .init(
@@ -370,7 +370,7 @@ extension BraveWallet.AccountInfo {
     isImported: false,
     hardware: nil,
     coin: .sol,
-    keyringId: nil
+    keyringId: ""
   )
   
   static let mockFilAccount: BraveWallet.AccountInfo = .init(
@@ -379,7 +379,7 @@ extension BraveWallet.AccountInfo {
     isImported: false,
     hardware: nil,
     coin: .fil,
-    keyringId: nil
+    keyringId: ""
   )
 }
 

--- a/Sources/BraveWallet/Preview Content/MockKeyringService.swift
+++ b/Sources/BraveWallet/Preview Content/MockKeyringService.swift
@@ -339,7 +339,6 @@ class MockKeyringService: BraveWalletKeyringService {
     completion(true)
   }
 
-  // TODO: Check Wallet changes
   func removeHardwareAccount(_ address: String, coin: BraveWallet.CoinType, completion: @escaping (Bool) -> Void) {
     completion(true)
   }

--- a/Tests/BraveWalletTests/TransactionParserTests.swift
+++ b/Tests/BraveWalletTests/TransactionParserTests.swift
@@ -897,7 +897,7 @@ class TransactionParserTests: XCTestCase {
         accountParams: [
           .init(name: "from_account", localizedName: "From Account"),
           .init(name: "to_account", localizedName: "To Account"),],
-        params: [.init(name: "lamports", localizedName: "Lamports", value: "10000")]
+        params: [.init(name: "lamports", localizedName: "Lamports", value: "10000", type: .uint64)]
       )
     )
     let expectedParsedTransfer = SolanaTxDetails.ParsedSolanaInstruction(
@@ -932,7 +932,7 @@ class TransactionParserTests: XCTestCase {
           .init(name: "nonce_authority", localizedName: "Nonce Authority")
         ],
         params: [
-          .init(name: "lamports", localizedName: "Lamports", value: "40")
+          .init(name: "lamports", localizedName: "Lamports", value: "40", type: .uint64)
         ]
       )
     )
@@ -965,9 +965,9 @@ class TransactionParserTests: XCTestCase {
           .init(name: "new_account", localizedName: "New Account"),
         ],
         params: [
-          .init(name: "lamports", localizedName: "Lamports", value: "2000"),
-          .init(name: "space", localizedName: "Space", value: "1"),
-          .init(name: "owner_program", localizedName: "Owner Program", value: toPubkey)
+          .init(name: "lamports", localizedName: "Lamports", value: "2000", type: .uint64),
+          .init(name: "space", localizedName: "Space", value: "1", type: .unknown),
+          .init(name: "owner_program", localizedName: "Owner Program", value: toPubkey, type: .unknown)
         ]
       )
     )
@@ -999,11 +999,11 @@ class TransactionParserTests: XCTestCase {
           .init(name: "created_account", localizedName: "Created Account"),
         ],
         params: [
-          .init(name: "lamports", localizedName: "Lamports", value: "300"),
-          .init(name: "base", localizedName: "Base", value: toPubkey),
-          .init(name: "seed", localizedName: "Seed", value: ""),
-          .init(name: "space", localizedName: "Space", value: "1"),
-          .init(name: "owner_program", localizedName: "Owner Program", value: toPubkey)
+          .init(name: "lamports", localizedName: "Lamports", value: "300", type: .uint64),
+          .init(name: "base", localizedName: "Base", value: toPubkey, type: .unknown),
+          .init(name: "seed", localizedName: "Seed", value: "", type: .unknown),
+          .init(name: "space", localizedName: "Space", value: "1", type: .unknown),
+          .init(name: "owner_program", localizedName: "Owner Program", value: toPubkey, type: .unknown)
         ]
       )
     )

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@mozilla/readability": "^0.4.2",
-        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.50.56/brave-core-ios-1.50.56.tgz",
+        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.50.83/brave-core-ios-1.50.83.tgz",
         "page-metadata-parser": "^1.1.3",
         "webpack-cli": "^4.8.0"
       },
@@ -355,9 +355,9 @@
       }
     },
     "node_modules/brave-core-ios": {
-      "version": "1.50.56",
-      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.50.56/brave-core-ios-1.50.56.tgz",
-      "integrity": "sha512-K+hsBWWuO83SFTXfjH6uV1dSD+yl1mli40V5ZmR9PnXPszuy0LEedS2sqfFHeH7i35Nmr2hJDHlq+OppteD+QQ==",
+      "version": "1.50.83",
+      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.50.83/brave-core-ios-1.50.83.tgz",
+      "integrity": "sha512-SsDhM5N3mmBEwTFTiuzkVck7crxB8kffRHlgJwg3X7EHhVcbgKX10tD+JW1StCbmZ7xQUElGG3+CG8E0YpQNYQ==",
       "license": "ISC"
     },
     "node_modules/browserslist": {
@@ -1731,8 +1731,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-browser/releases/download/v1.50.56/brave-core-ios-1.50.56.tgz",
-      "integrity": "sha512-K+hsBWWuO83SFTXfjH6uV1dSD+yl1mli40V5ZmR9PnXPszuy0LEedS2sqfFHeH7i35Nmr2hJDHlq+OppteD+QQ=="
+      "version": "https://github.com/brave/brave-browser/releases/download/v1.50.83/brave-core-ios-1.50.83.tgz",
+      "integrity": "sha512-SsDhM5N3mmBEwTFTiuzkVck7crxB8kffRHlgJwg3X7EHhVcbgKX10tD+JW1StCbmZ7xQUElGG3+CG8E0YpQNYQ=="
     },
     "browserslist": {
       "version": "4.17.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@mozilla/readability": "^0.4.2",
-        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.50.41/brave-core-ios-1.50.41.tgz",
+        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.50.56/brave-core-ios-1.50.56.tgz",
         "page-metadata-parser": "^1.1.3",
         "webpack-cli": "^4.8.0"
       },
@@ -355,9 +355,9 @@
       }
     },
     "node_modules/brave-core-ios": {
-      "version": "1.50.41",
-      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.50.41/brave-core-ios-1.50.41.tgz",
-      "integrity": "sha512-geeKf3Vl3ymKdOXFds3jnFyXC+dlcKnXyh1qCslYEVjyJX7384rTf4xaJ+MkHdMWVNxYMpnqgOOA/3PRI/VyGA==",
+      "version": "1.50.56",
+      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.50.56/brave-core-ios-1.50.56.tgz",
+      "integrity": "sha512-K+hsBWWuO83SFTXfjH6uV1dSD+yl1mli40V5ZmR9PnXPszuy0LEedS2sqfFHeH7i35Nmr2hJDHlq+OppteD+QQ==",
       "license": "ISC"
     },
     "node_modules/browserslist": {
@@ -1731,8 +1731,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-browser/releases/download/v1.50.41/brave-core-ios-1.50.41.tgz",
-      "integrity": "sha512-geeKf3Vl3ymKdOXFds3jnFyXC+dlcKnXyh1qCslYEVjyJX7384rTf4xaJ+MkHdMWVNxYMpnqgOOA/3PRI/VyGA=="
+      "version": "https://github.com/brave/brave-browser/releases/download/v1.50.56/brave-core-ios-1.50.56.tgz",
+      "integrity": "sha512-K+hsBWWuO83SFTXfjH6uV1dSD+yl1mli40V5ZmR9PnXPszuy0LEedS2sqfFHeH7i35Nmr2hJDHlq+OppteD+QQ=="
     },
     "browserslist": {
       "version": "4.17.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@mozilla/readability": "^0.4.2",
-        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.50.32/brave-core-ios-1.50.32.tgz",
+        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.50.41/brave-core-ios-1.50.41.tgz",
         "page-metadata-parser": "^1.1.3",
         "webpack-cli": "^4.8.0"
       },
@@ -355,9 +355,9 @@
       }
     },
     "node_modules/brave-core-ios": {
-      "version": "1.50.32",
-      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.50.32/brave-core-ios-1.50.32.tgz",
-      "integrity": "sha512-NBug6ak3o42Z+fdqFcutSxyihpwR760TbZD7B3dN3AMYeuHgd3sb1OT5/ndh/hqO3aIeIPP9z3i8ASW/AsjXyQ==",
+      "version": "1.50.41",
+      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.50.41/brave-core-ios-1.50.41.tgz",
+      "integrity": "sha512-geeKf3Vl3ymKdOXFds3jnFyXC+dlcKnXyh1qCslYEVjyJX7384rTf4xaJ+MkHdMWVNxYMpnqgOOA/3PRI/VyGA==",
       "license": "ISC"
     },
     "node_modules/browserslist": {
@@ -1731,8 +1731,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-browser/releases/download/v1.50.32/brave-core-ios-1.50.32.tgz",
-      "integrity": "sha512-NBug6ak3o42Z+fdqFcutSxyihpwR760TbZD7B3dN3AMYeuHgd3sb1OT5/ndh/hqO3aIeIPP9z3i8ASW/AsjXyQ=="
+      "version": "https://github.com/brave/brave-browser/releases/download/v1.50.41/brave-core-ios-1.50.41.tgz",
+      "integrity": "sha512-geeKf3Vl3ymKdOXFds3jnFyXC+dlcKnXyh1qCslYEVjyJX7384rTf4xaJ+MkHdMWVNxYMpnqgOOA/3PRI/VyGA=="
     },
     "browserslist": {
       "version": "4.17.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@mozilla/readability": "^0.4.2",
-        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.50.83/brave-core-ios-1.50.83.tgz",
+        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.50.85/brave-core-ios-1.50.85.tgz",
         "page-metadata-parser": "^1.1.3",
         "webpack-cli": "^4.8.0"
       },
@@ -355,9 +355,9 @@
       }
     },
     "node_modules/brave-core-ios": {
-      "version": "1.50.83",
-      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.50.83/brave-core-ios-1.50.83.tgz",
-      "integrity": "sha512-SsDhM5N3mmBEwTFTiuzkVck7crxB8kffRHlgJwg3X7EHhVcbgKX10tD+JW1StCbmZ7xQUElGG3+CG8E0YpQNYQ==",
+      "version": "1.50.85",
+      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.50.85/brave-core-ios-1.50.85.tgz",
+      "integrity": "sha512-Gd/QS0ZJTdVmSOrDpstAe+YjMRynMjrVb2NrHms1no2FIk3bVBF7lEO/ffU2HOkXYL2Hq7oEgTxI0/lCISsfsw==",
       "license": "ISC"
     },
     "node_modules/browserslist": {
@@ -1731,8 +1731,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-browser/releases/download/v1.50.83/brave-core-ios-1.50.83.tgz",
-      "integrity": "sha512-SsDhM5N3mmBEwTFTiuzkVck7crxB8kffRHlgJwg3X7EHhVcbgKX10tD+JW1StCbmZ7xQUElGG3+CG8E0YpQNYQ=="
+      "version": "https://github.com/brave/brave-browser/releases/download/v1.50.85/brave-core-ios-1.50.85.tgz",
+      "integrity": "sha512-Gd/QS0ZJTdVmSOrDpstAe+YjMRynMjrVb2NrHms1no2FIk3bVBF7lEO/ffU2HOkXYL2Hq7oEgTxI0/lCISsfsw=="
     },
     "browserslist": {
       "version": "4.17.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@mozilla/readability": "^0.4.2",
-        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.50.85/brave-core-ios-1.50.85.tgz",
+        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.50.93/brave-core-ios-1.50.93.tgz",
         "page-metadata-parser": "^1.1.3",
         "webpack-cli": "^4.8.0"
       },
@@ -355,9 +355,9 @@
       }
     },
     "node_modules/brave-core-ios": {
-      "version": "1.50.85",
-      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.50.85/brave-core-ios-1.50.85.tgz",
-      "integrity": "sha512-Gd/QS0ZJTdVmSOrDpstAe+YjMRynMjrVb2NrHms1no2FIk3bVBF7lEO/ffU2HOkXYL2Hq7oEgTxI0/lCISsfsw==",
+      "version": "1.50.93",
+      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.50.93/brave-core-ios-1.50.93.tgz",
+      "integrity": "sha512-F1IwkbmyKa07jXhfG81MJVX1+rFdoZFd+ccj24b9zTd6hIl6SLlvne947GKC6E1UEVu+wLSykHBmqaPmSX7cuA==",
       "license": "ISC"
     },
     "node_modules/browserslist": {
@@ -1731,8 +1731,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-browser/releases/download/v1.50.85/brave-core-ios-1.50.85.tgz",
-      "integrity": "sha512-Gd/QS0ZJTdVmSOrDpstAe+YjMRynMjrVb2NrHms1no2FIk3bVBF7lEO/ffU2HOkXYL2Hq7oEgTxI0/lCISsfsw=="
+      "version": "https://github.com/brave/brave-browser/releases/download/v1.50.93/brave-core-ios-1.50.93.tgz",
+      "integrity": "sha512-F1IwkbmyKa07jXhfG81MJVX1+rFdoZFd+ccj24b9zTd6hIl6SLlvne947GKC6E1UEVu+wLSykHBmqaPmSX7cuA=="
     },
     "browserslist": {
       "version": "4.17.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@mozilla/readability": "^0.4.2",
-        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.49.126/brave-core-ios-1.49.126.tgz",
+        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.50.32/brave-core-ios-1.50.32.tgz",
         "page-metadata-parser": "^1.1.3",
         "webpack-cli": "^4.8.0"
       },
@@ -355,9 +355,9 @@
       }
     },
     "node_modules/brave-core-ios": {
-      "version": "1.49.126",
-      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.49.126/brave-core-ios-1.49.126.tgz",
-      "integrity": "sha512-aNg+pRO+ef6bKZhvXSeEd8ehZloIx7Huham6wXZp7y/FnagvlNTMKhtGO/zHpBfbMse2jYC6JOe/hPN5U6YIyA==",
+      "version": "1.50.32",
+      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.50.32/brave-core-ios-1.50.32.tgz",
+      "integrity": "sha512-NBug6ak3o42Z+fdqFcutSxyihpwR760TbZD7B3dN3AMYeuHgd3sb1OT5/ndh/hqO3aIeIPP9z3i8ASW/AsjXyQ==",
       "license": "ISC"
     },
     "node_modules/browserslist": {
@@ -1731,8 +1731,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-browser/releases/download/v1.49.126/brave-core-ios-1.49.126.tgz",
-      "integrity": "sha512-aNg+pRO+ef6bKZhvXSeEd8ehZloIx7Huham6wXZp7y/FnagvlNTMKhtGO/zHpBfbMse2jYC6JOe/hPN5U6YIyA=="
+      "version": "https://github.com/brave/brave-browser/releases/download/v1.50.32/brave-core-ios-1.50.32.tgz",
+      "integrity": "sha512-NBug6ak3o42Z+fdqFcutSxyihpwR760TbZD7B3dN3AMYeuHgd3sb1OT5/ndh/hqO3aIeIPP9z3i8ASW/AsjXyQ=="
     },
     "browserslist": {
       "version": "4.17.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.50.41/brave-core-ios-1.50.41.tgz",
+    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.50.56/brave-core-ios-1.50.56.tgz",
     "page-metadata-parser": "^1.1.3",
     "@mozilla/readability": "^0.4.2",
     "webpack-cli": "^4.8.0"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.50.83/brave-core-ios-1.50.83.tgz",
+    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.50.85/brave-core-ios-1.50.85.tgz",
     "page-metadata-parser": "^1.1.3",
     "@mozilla/readability": "^0.4.2",
     "webpack-cli": "^4.8.0"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.50.32/brave-core-ios-1.50.32.tgz",
+    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.50.41/brave-core-ios-1.50.41.tgz",
     "page-metadata-parser": "^1.1.3",
     "@mozilla/readability": "^0.4.2",
     "webpack-cli": "^4.8.0"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.50.56/brave-core-ios-1.50.56.tgz",
+    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.50.83/brave-core-ios-1.50.83.tgz",
     "page-metadata-parser": "^1.1.3",
     "@mozilla/readability": "^0.4.2",
     "webpack-cli": "^4.8.0"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.49.126/brave-core-ios-1.49.126.tgz",
+    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.50.32/brave-core-ios-1.50.32.tgz",
     "page-metadata-parser": "^1.1.3",
     "@mozilla/readability": "^0.4.2",
     "webpack-cli": "^4.8.0"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.50.85/brave-core-ios-1.50.85.tgz",
+    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.50.93/brave-core-ios-1.50.93.tgz",
     "page-metadata-parser": "^1.1.3",
     "@mozilla/readability": "^0.4.2",
     "webpack-cli": "^4.8.0"


### PR DESCRIPTION
## Summary of Changes
Since `development` is ready for 1.50 work, this PR is bumping brave core to 1.50.93

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
