### PR TITLE
No Bug: Remove Xcode 14.3 strict concurrency workaround

### DIFF
--- a/App/Configuration/Base.xcconfig
+++ b/App/Configuration/Base.xcconfig
@@ -11,9 +11,7 @@
 #include "Local/Version.xcconfig"
 #include "Local/Keys.xcconfig"
 
-// Xcode 14.3b1 uses `-strict-concurrency=targeted` as the default. This can be removed when a Xcode build
-// moves this back to `minimal`. See https://github.com/apple/swift/pull/63786
-OTHER_SWIFT_FLAGS_BASE=-DMOZ_TARGET_$(TARGET_NAME:upper) -Xfrontend -strict-concurrency=minimal
+OTHER_SWIFT_FLAGS_BASE=-DMOZ_TARGET_$(TARGET_NAME:upper)
 
 FRAMEWORK_BASE_BUNDLE_ID = com.brave
 BASE_BUNDLE_ID = $(FRAMEWORK_BASE_BUNDLE_ID).ios

--- a/Package.swift
+++ b/Package.swift
@@ -448,15 +448,3 @@ if ProcessInfo.processInfo.environment["BRAVE_APPSTORE_BUILD"] == nil {
 }
 
 package.targets.append(braveTarget)
-
-#if swift(>=5.8)
-// Xcode 14.3b1 uses `-strict-concurrency=targeted` as the default. This can be removed when a Xcode build
-// moves this back to `minimal`. See https://github.com/apple/swift/pull/63786
-for i in package.targets.indices {
-  let type = package.targets[i].type
-  if type == .binary || type == .plugin { continue }
-  package.targets[i].swiftSettings = [
-    .unsafeFlags(["-Xfrontend", "-strict-concurrency=minimal"])
-  ]
-}
-#endif


### PR DESCRIPTION
This is fixed as of Xcode 14.3 RC1 (14E222a)

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
