### PR TITLE
Fix #7147: Cleanup ContentBlockerManager and all related files

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -350,9 +350,8 @@ extension BrowserViewController: WKNavigationDelegate {
         let domainForShields = Domain.getOrCreate(forUrl: mainDocumentURL, persistent: !isPrivateBrowsing)
         
         // Load rule lists
-        tab?.contentBlocker.ruleListTypes = ContentBlockerManager.shared.compiledRuleTypes(
-          for: domainForShields
-        )
+        let ruleLists = await ContentBlockerManager.shared.ruleLists(for: domainForShields)
+        tab?.contentBlocker.set(ruleLists: ruleLists)
         
         let isScriptsEnabled = !domainForShields.isShieldExpected(.NoScript, considerAllShieldsOption: true)
         preferences.allowsContentJavaScript = isScriptsEnabled

--- a/Sources/Brave/Frontend/Browser/Helpers/LaunchHelper.swift
+++ b/Sources/Brave/Frontend/Browser/Helpers/LaunchHelper.swift
@@ -27,6 +27,10 @@ public actor LaunchHelper {
     
     // Otherwise prepare the services and await the task
     let task = Task {
+      #if DEBUG
+      let startTime = CFAbsoluteTimeGetCurrent()
+      #endif
+      
       // Load cached data
       // This is done first because compileResources need their results
       async let filterListCache: Void = FilterListResourceDownloader.shared.loadCachedData()
@@ -36,6 +40,10 @@ public actor LaunchHelper {
       // Compile some engines
       await AdBlockEngineManager.shared.compileResources()
       
+      #if DEBUG
+      let timeElapsed = CFAbsoluteTimeGetCurrent() - startTime
+      ContentBlockerManager.log.debug("Adblock loaded: \(timeElapsed)s")
+      #endif
       // This one is non-blocking
       performPostLoadTasks(adBlockService: adBlockService)
       areAdBlockServicesReady = true

--- a/Sources/Brave/Frontend/Browser/LinkPreviewViewController.swift
+++ b/Sources/Brave/Frontend/Browser/LinkPreviewViewController.swift
@@ -44,11 +44,11 @@ class LinkPreviewViewController: UIViewController {
       return
     }
 
+    // Add rule lists for this page
     let domain = Domain.getOrCreate(forUrl: url, persistent: !PrivateBrowsingManager.shared.isPrivateBrowsing)
-    let compiledRuleTypes = ContentBlockerManager.shared.compiledRuleTypes(for: domain)
     
     Task(priority: .userInitiated) {
-      let ruleLists = await ContentBlockerManager.shared.loadRuleLists(for: Set(compiledRuleTypes.map({ $0.ruleType })))
+      let ruleLists = await ContentBlockerManager.shared.ruleLists(for: domain)
       for ruleList in ruleLists {
         webView.configuration.userContentController.add(ruleList)
       }

--- a/Sources/Brave/Frontend/Browser/Playlist/Managers & Cache/PlaylistCacheLoader.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/Managers & Cache/PlaylistCacheLoader.swift
@@ -584,8 +584,8 @@ extension PlaylistWebLoader: WKNavigationDelegate {
         domainForShields.shield_adblockAndTp = true
         
         // Load block lists
-        let enabledRuleTypes = ContentBlockerManager.shared.compiledRuleTypes(for: domainForShields)
-        tab.contentBlocker.ruleListTypes = enabledRuleTypes
+        let ruleLists = await ContentBlockerManager.shared.ruleLists(for: domainForShields)
+        tab.contentBlocker.set(ruleLists: ruleLists)
 
         let isScriptsEnabled = !domainForShields.isShieldExpected(.NoScript, considerAllShieldsOption: true)
         preferences.allowsContentJavaScript = isScriptsEnabled

--- a/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
+++ b/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
@@ -185,7 +185,7 @@ class TopToolbarView: UIView, ToolbarProtocol {
     if let currentURL = currentURL {
       let isPrivateBrowsing = PrivateBrowsingManager.shared.isPrivateBrowsing
       let domain = Domain.getOrCreate(forUrl: currentURL, persistent: !isPrivateBrowsing)
-      if domain.shield_allOff == 1 {
+      if domain.areAllShieldsOff {
         shieldIcon = shieldsOffIcon
       }
       if currentURL.isLocal || currentURL.isLocalUtility {

--- a/Sources/Brave/Frontend/Browser/UserScriptManager.swift
+++ b/Sources/Brave/Frontend/Browser/UserScriptManager.swift
@@ -192,6 +192,16 @@ class UserScriptManager {
       return
     }
     
+    #if DEBUG
+    ContentBlockerManager.log.debug("Loaded \(userScripts.count + customScripts.count) scripts:")
+    userScripts.sorted(by: { $0.rawValue < $1.rawValue}).forEach { scriptType in
+      ContentBlockerManager.log.debug(" \(scriptType.debugDescription)")
+    }
+    customScripts.sorted(by: { $0.order < $1.order}).forEach { scriptType in
+      ContentBlockerManager.log.debug(" #\(scriptType.order) \(scriptType.debugDescription)")
+    }
+    #endif
+    
     loadScripts(into: tab, scripts: userScripts)
     
     webView.configuration.userContentController.do { scriptController in
@@ -309,3 +319,28 @@ class UserScriptManager {
     }
   }
 }
+
+#if DEBUG
+extension UserScriptType: CustomDebugStringConvertible {
+  var debugDescription: String {
+    switch self {
+    case .domainUserScript(let domainUserScript):
+      return "domainUserScript(\(domainUserScript.associatedDomains.joined(separator: ", ")))"
+    case .engineScript(let configuration):
+      return "engineScript(\(configuration.frameURL))"
+    case .farblingProtection(let etld):
+      return "farblingProtection(\(etld))"
+    case .nacl:
+      return "nacl"
+    case .siteStateListener:
+      return "siteStateListener"
+    }
+  }
+}
+
+extension UserScriptManager.ScriptType: CustomDebugStringConvertible {
+  var debugDescription: String {
+    return rawValue
+  }
+}
+#endif

--- a/Sources/Brave/Frontend/Settings/AdblockDebugMenuTableViewController.swift
+++ b/Sources/Brave/Frontend/Settings/AdblockDebugMenuTableViewController.swift
@@ -44,7 +44,7 @@ class AdblockDebugMenuTableViewController: TableViewController {
         text: "Recompile Content Blockers",
         selection: {
           Task { @MainActor in
-            await ContentBlockerManager.shared.compilePendingResources()
+            await AdblockResourceDownloader.shared.reloadBundledOnlyData()
             self.showCompiledBlockListAlert()
           }
         }, cellClass: ButtonCell.self)
@@ -173,12 +173,12 @@ class AdblockDebugMenuTableViewController: TableViewController {
       return Row(text: fileURL.lastPathComponent, detailText: detailText, cellClass: MultilineSubtitleCell.self)
     }
     
-    var resources = FilterListResourceDownloader.shared.filterLists.flatMap { filterList -> [ResourceDownloader.Resource] in
-      return filterList.resources
+    var resources = FilterListResourceDownloader.shared.filterLists.map { filterList -> ResourceDownloader.Resource in
+      return filterList.makeResource(componentId: filterList.entry.componentId)
     }
     
     resources.append(contentsOf: [
-      .debounceRules, .genericContentBlockingBehaviors, .genericFilterRules, .generalCosmeticFilters, .generalScriptletResources
+      .genericContentBlockingBehaviors, .genericFilterRules, .generalCosmeticFilters, .generalScriptletResources
     ])
     
     return Section(

--- a/Sources/Brave/Frontend/Settings/BraveShieldsAndPrivacySettingsController.swift
+++ b/Sources/Brave/Frontend/Settings/BraveShieldsAndPrivacySettingsController.swift
@@ -66,7 +66,7 @@ class BraveShieldsAndPrivacySettingsController: TableViewController {
         Task { @MainActor in
           // Check if we need to update the cookie consent switch
           if let filterList = filterLists.first(where: { filterList in
-            filterList.componentId == FilterList.cookieConsentNoticesComponentID
+            filterList.entry.componentId == FilterList.cookieConsentNoticesComponentID
           }) {
             // Toggle only if it's needed or an endless loop might be created
             self.toggleSwitchIfNeeded(
@@ -77,7 +77,7 @@ class BraveShieldsAndPrivacySettingsController: TableViewController {
           
           // Check if we need to update the block mobile notifications switch
           if let filterList = filterLists.first(where: { filterList in
-            filterList.componentId == FilterList.mobileAnnoyancesComponentID
+            filterList.entry.componentId == FilterList.mobileAnnoyancesComponentID
           }) {
             // Toggle only if it's needed or an endless loop might be created
             self.toggleSwitchIfNeeded(

--- a/Sources/Brave/Frontend/Settings/FilterListsView.swift
+++ b/Sources/Brave/Frontend/Settings/FilterListsView.swift
@@ -1,4 +1,4 @@
-// Copyright 2022 The Brave Authors. All rights reserved.
+// Copyright 2023 The Brave Authors. All rights reserved.
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -11,17 +11,17 @@ import BraveUI
 
 /// A view showing enabled and disabled community filter lists
 struct FilterListsView: View {
-  @ObservedObject private var downloader = FilterListResourceDownloader.shared
+  @ObservedObject private var filterListDownloader = FilterListResourceDownloader.shared
   
   var body: some View {
     List {
       Section {
-        ForEach($downloader.filterLists) { $filterList in
+        ForEach($filterListDownloader.filterLists) { $filterList in
           Toggle(isOn: $filterList.isEnabled) {
             VStack(alignment: .leading) {
-              Text(filterList.title)
+              Text(filterList.entry.title)
                 .foregroundColor(Color(.bravePrimary))
-              Text(filterList.description)
+              Text(filterList.entry.desc)
                 .font(.caption)
                 .foregroundColor(Color(.secondaryBraveLabel))
             }

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/ContentBlockerScriptHandler.swift
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/ContentBlockerScriptHandler.swift
@@ -82,12 +82,12 @@ extension ContentBlockerHelper: TabContentScript {
         guard let requestURL = NSURL(idnString: dto.data.resourceURL) as URL? else { return }
         guard let sourceURL = NSURL(idnString: dto.data.sourceURL) as URL? else { return }
         guard let domainURLString = domain.url else { return }
-        let loadedRuleTypes = Set(self.loadedRuleTypeWithSourceTypes.map({ $0.ruleType }))
+        let genericTypes = ContentBlockerManager.shared.validGenericTypes(for: domain)
         
         let blockedType = await TPStatsBlocklistChecker.shared.blockedTypes(
           requestURL: requestURL,
           sourceURL: sourceURL,
-          loadedRuleTypes: loadedRuleTypes,
+          enabledRuleTypes: genericTypes,
           resourceType: dto.data.resourceType
         )
         

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/ContentBlockerScriptHandler.swift
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/ContentBlockerScriptHandler.swift
@@ -66,7 +66,7 @@ extension ContentBlockerHelper: TabContentScript {
       Task { @MainActor in
         let isPrivateBrowsing = PrivateBrowsingManager.shared.isPrivateBrowsing
         let domain = Domain.getOrCreate(forUrl: currentTabURL, persistent: !isPrivateBrowsing)
-        if let shieldsAllOff = domain.shield_allOff, Bool(truncating: shieldsAllOff) {
+        guard !domain.areAllShieldsOff else {
           // if domain is "all_off", can just skip
           return
         }

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/ContentBlockerScriptHandler.swift
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/ContentBlockerScriptHandler.swift
@@ -66,7 +66,7 @@ extension ContentBlockerHelper: TabContentScript {
       Task { @MainActor in
         let isPrivateBrowsing = PrivateBrowsingManager.shared.isPrivateBrowsing
         let domain = Domain.getOrCreate(forUrl: currentTabURL, persistent: !isPrivateBrowsing)
-        guard !domain.areAllShieldsOff else {
+        if domain.areAllShieldsOff {
           // if domain is "all_off", can just skip
           return
         }

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/SiteStateListenerScriptHandler.swift
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/SiteStateListenerScriptHandler.swift
@@ -65,7 +65,7 @@ class SiteStateListenerScriptHandler: TabContentScript {
         Task { @MainActor in
           let domain = pageData.domain(persistent: !tab.isPrivate)
           
-          guard domain.shield_allOff?.boolValue != true else {
+          guard !domain.areAllShieldsOff else {
             return
           }
           

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/SiteStateListenerScriptHandler.swift
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/SiteStateListenerScriptHandler.swift
@@ -64,10 +64,7 @@ class SiteStateListenerScriptHandler: TabContentScript {
       if let pageData = tab.currentPageData {
         Task { @MainActor in
           let domain = pageData.domain(persistent: !tab.isPrivate)
-          
-          guard !domain.areAllShieldsOff else {
-            return
-          }
+          if domain.areAllShieldsOff { return }
           
           let models = await AdBlockStats.shared.cosmeticFilterModels(forFrameURL: frameURL, domain: domain)
           let args = try await self.makeArgs(from: models, frameURL: frameURL)

--- a/Sources/Brave/WebFilters/AdBlockEngineManager.swift
+++ b/Sources/Brave/WebFilters/AdBlockEngineManager.swift
@@ -61,7 +61,7 @@ public actor AdBlockEngineManager: Sendable {
     }
   }
   
-  /// An aboject containing the resource and version.
+  /// An object containing the resource and version.
   ///
   /// Stored in this way so we can replace resources with an older version
   public struct ResourceWithVersion: Hashable {

--- a/Sources/Brave/WebFilters/AdBlockEngineManager.swift
+++ b/Sources/Brave/WebFilters/AdBlockEngineManager.swift
@@ -184,41 +184,39 @@ public actor AdBlockEngineManager: Sendable {
 }
 
 #if DEBUG
-extension AdBlockEngineManager {
+private extension AdBlockEngineManager {
   /// A method that logs info on the given resources
-  fileprivate func debug(compiledResults: [ResourceWithVersion: Result<Void, Error>]) {
-    let resourcesString = compiledResults.sorted(by: { $0.key.order < $1.key.order })
-      .map { (resourceWithVersion, compileResult) -> String in
+  func debug(compiledResults: [ResourceWithVersion: Result<Void, Error>]) {
+    log.debug("Loaded \(compiledResults.count) (total) engine resources:")
+    
+    compiledResults.sorted(by: { $0.key.order < $1.key.order })
+      .forEach { (resourceWithVersion, compileResult) in
         let resultString: String
         
         switch compileResult {
         case .success:
-          resultString = "success"
+          resultString = "✔︎"
         case .failure(let error):
-          resultString = error.localizedDescription
+          resultString = "\(error)"
         }
         
         let sourceDebugString = [
-          resourceWithVersion.debugDescription,
-          "result: \(resultString)",
-        ].joined(separator: ", ")
+          "", resourceWithVersion.debugDescription,
+          "\(resultString)",
+        ].joined(separator: " ")
         
-        return ["{", sourceDebugString, "}"].joined()
-      }.joined(separator: ", ")
-
-    log.debug("Loaded \(self.enabledResources.count, privacy: .public) (total) engine resources: \(resourcesString, privacy: .public)")
+        log.debug("\(sourceDebugString)")
+      }
   }
 }
 
 extension AdBlockEngineManager.ResourceWithVersion: CustomDebugStringConvertible {
   public var debugDescription: String {
     return [
-      "order: \(order)",
-      "fileName: \(fileURL.lastPathComponent)",
-      "source: \(resource.source.debugDescription)",
-      "version: \(version ?? "nil")",
-      "type: \(resource.type.debugDescription)"
-    ].joined(separator: ", ")
+      "#\(order)",
+      "\(resource.source.debugDescription).\(resource.type.debugDescription)",
+      "v\(version ?? "nil")",
+    ].joined(separator: " ")
   }
 }
 

--- a/Sources/Brave/WebFilters/ContentBlocker/ContentBlockerHelper.swift
+++ b/Sources/Brave/WebFilters/ContentBlocker/ContentBlockerHelper.swift
@@ -45,12 +45,8 @@ enum BlockingStrength: String {
 class ContentBlockerHelper {
   private(set) weak var tab: Tab?
   
-  /// The rule types and source types that are currently loaded in this tab
-  private(set) var loadedRuleTypeWithSourceTypes: Set<ContentBlockerManager.RuleTypeWithSourceType> = []
-  /// The rule types with their source types that should be  loaded in this tab
-  var ruleListTypes: Set<ContentBlockerManager.RuleTypeWithSourceType> = [] {
-    didSet { reloadNeededRuleLists() }
-  }
+  /// The rule lists that are loaded into the current tab
+  private var setRuleLists: Set<WKContentRuleList> = []
 
   var stats: TPPageStats = TPPageStats() {
     didSet {
@@ -69,58 +65,31 @@ class ContentBlockerHelper {
     self.tab = tab
   }
   
-  private func reloadNeededRuleLists() {
-    // Remove old values that were previously added
-    for loadedRuleTypeWithSourceType in loadedRuleTypeWithSourceTypes {
-      // Check if should be removed or if the source type doesn't match, otherwise don't do anything
-      guard !ruleListTypes.contains(loadedRuleTypeWithSourceType) else {
-        continue
-      }
-      
-      guard let ruleList = ContentBlockerManager.shared.cachedRuleList(for: loadedRuleTypeWithSourceType.ruleType) else {
-        // For some reason the rule is not cached. Shouldn't happen.
-        // But if it does we have to remove all the rule lists
-        // We will add back all the necessary ones below
-        tab?.webView?.configuration.userContentController.removeAllContentRuleLists()
-        loadedRuleTypeWithSourceTypes = []
-        assertionFailure("This shouldn't happen!")
-        break
-      }
-      
-      // Since either it shouldn't be included or the source type doesn't match, we remove it
-      tab?.webView?.configuration.userContentController.remove(ruleList)
-      loadedRuleTypeWithSourceTypes.remove(loadedRuleTypeWithSourceType)
-    }
-    
-    // Add new values that are not yet added (or were removed above because the source type didn't match)
-    for ruleTypeWithSourceType in ruleListTypes {
-      // Only add rule lists that are missing
-      guard !loadedRuleTypeWithSourceTypes.contains(ruleTypeWithSourceType) else { continue }
-      guard let ruleList = ContentBlockerManager.shared.cachedRuleList(for: ruleTypeWithSourceType.ruleType) else { continue }
-      tab?.webView?.configuration.userContentController.add(ruleList)
-      loadedRuleTypeWithSourceTypes.insert(ruleTypeWithSourceType)
-    }
-    
+  @MainActor func set(ruleLists: Set<WKContentRuleList>) {
+    guard ruleLists != setRuleLists else { return }
     #if DEBUG
-    let rulesString = loadedRuleTypeWithSourceTypes.map { ruleTypeWithSourceType -> String in
-      let ruleTypeString: String
-      
-      switch ruleTypeWithSourceType.ruleType {
-      case .general(let type):
-        ruleTypeString = type.rawValue
-      case .filterList(let uuid):
-        ruleTypeString = "filterList(\(uuid))"
-      }
-      
-      let rulesDebugString = [
-        "ruleType: \(ruleTypeString)",
-        "sourceType: \(ruleTypeWithSourceType.sourceType)"
-      ].joined(separator: ", ")
-      
-      return ["{", rulesDebugString, "}"].joined()
-    }.joined(separator: ", ")
-    
-    log.debug("Loaded \(self.loadedRuleTypeWithSourceTypes.count, privacy: .public) tab rules: \(rulesString, privacy: .public)")
+    ContentBlockerManager.log.debug("Set rule lists:")
     #endif
+    
+    // Remove unwanted rule lists
+    for ruleList in setRuleLists.subtracting(ruleLists) {
+      // It's added but we don't want it. So we remove it.
+      tab?.webView?.configuration.userContentController.remove(ruleList)
+      setRuleLists.remove(ruleList)
+      
+      #if DEBUG
+      ContentBlockerManager.log.debug(" - \(ruleList.identifier)")
+      #endif
+    }
+    
+    // Add missing rule lists
+    for ruleList in ruleLists.subtracting(setRuleLists) {
+      tab?.webView?.configuration.userContentController.add(ruleList)
+      setRuleLists.insert(ruleList)
+      
+      #if DEBUG
+      ContentBlockerManager.log.debug(" + \(ruleList.identifier)")
+      #endif
+    }
   }
 }

--- a/Sources/Brave/WebFilters/ContentBlocker/ContentBlockerManager.swift
+++ b/Sources/Brave/WebFilters/ContentBlocker/ContentBlockerManager.swift
@@ -10,460 +10,319 @@ import Shared
 import BraveShared
 import os.log
 
-// TODO: Convert this class to `actor`(#6018)
-/// A class responsible for compiling content blocker lists
-final public class ContentBlockerManager: Sendable {
+/// A class that aids in the managment of rule lists on the rule store.
+actor ContentBlockerManager {
   // TODO: Use a proper logger system once implemented and adblock files are moved to their own module(#5928).
   /// Logger to use for debugging.
   static let log = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "adblock")
   
-  /// An object representing a rule type and a source type.
-  public struct RuleTypeWithSourceType: Hashable {
-    let ruleType: BlocklistRuleType
-    let sourceType: BlocklistSourceType
-  }
-  
-  /// An object representing the source of a block-list
-  public enum BlocklistSourceType: Hashable, Sendable {
-    /// A block list that is bundled with this application
-    case bundled
-    /// A block list that is downloaded from a server
-    case downloaded(version: String?)
-  }
-  
-  /// An object representing the type of block list
-  public enum GeneralBlocklistTypes: String, CaseIterable {
-    case blockAds = "block-ads"
-    case blockCookies = "block-cookies"
-    case blockTrackers = "block-trackers"
+  struct CompileOptions: OptionSet {
+    let rawValue: Int
     
-    var fileName: String {
-      return rawValue
-    }
-    
-    /// List of all bundled content blockers.
-    /// Regional lists are downloaded on fly and not included here.
-    static var validLists: Set<GeneralBlocklistTypes> {
-      return Set(allCases)
-    }
-  }
-  
-  /// Represents the rule type
-  public enum BlocklistRuleType: Hashable {
-    case general(GeneralBlocklistTypes)
-    case filterList(uuid: String)
-    
-    var identifier: String {
-      switch self {
-      case .general(let storedType):
-        return ["stored-type", storedType.fileName].joined(separator: "-")
-      case .filterList(let uuid):
-        return ["filter-list", uuid].joined(separator: "-")
-      }
-    }
+    static let stripContentBlockers = CompileOptions(rawValue: 1 << 0)
+    static let punycodeDomains = CompileOptions(rawValue: 1 << 1)
+    static let all: CompileOptions = [.stripContentBlockers, .punycodeDomains]
   }
   
   enum CompileError: Error {
-    case fileNotFound(identifier: String)
     case noRuleListReturned(identifier: String)
-    case invalidResourceString(identifier: String)
   }
   
-  /// Represents a resource that needs to be compiled
-  struct Resource: Hashable {
-    /// The local url of this resource
-    let url: URL
-    /// The source type of this resource
-    let sourceType: BlocklistSourceType
-  }
-  
-  private actor SyncData {
-    /// The resources that need to be compiled
-    private(set) var enabledResources: [String: Resource]
-    private(set) var compiledResources: [String: Resource]
+  public enum GenericBlocklistType: Hashable, CaseIterable {
+    case blockAds
+    case blockCookies
+    case blockTrackers
     
-    var pendingResources: [String: Resource] {
-      var results: [String: Resource] = [:]
-      
-      enabledResources.forEach { key, resource in
-        guard compiledResources[key] == nil || compiledResources[key] != resource else { return }
-        results[key] = resource
+    var bundledFileName: String {
+      switch self {
+      case .blockAds: return "block-ads"
+      case .blockCookies: return "block-cookies"
+      case .blockTrackers: return "block-trackers"
       }
-      
-      return results
     }
+  }
+  
+  /// An object representing the type of block list
+  public enum BlocklistType: Hashable {
+    fileprivate static let genericPrifix = "stored-type"
+    fileprivate static let filterListPrefix = "filter-list"
+    fileprivate static let customFilterListPrefix = "custom-filter-list"
     
-    init() {
-      self.enabledResources = [:]
-      self.compiledResources = [:]
-    }
+    case generic(GenericBlocklistType)
+    case filterList(uuid: String)
+    case customFilterList(uuid: String)
     
-    var isSynced: Bool {
-      return pendingResources.isEmpty
-    }
-    
-    /// Set a resource for the given rule type
-    func set(enabledResource: Resource, for ruleType: BlocklistRuleType) {
-      enabledResources[ruleType.identifier] = enabledResource
-    }
-    
-    /// Remove all resources for the given rule and source type
-    func removeEnabledResource(for ruleType: BlocklistRuleType) {
-      enabledResources.removeValue(forKey: ruleType.identifier)
-    }
-    
-    /// Remove all resources for the given rule and source type
-    func movePendingResource(forIdentifier identifier: String) {
-      compiledResources[identifier] = enabledResources[identifier]
+    var identifier: String {
+      switch self {
+      case .generic(let type):
+        return [Self.genericPrifix, type.bundledFileName].joined(separator: "-")
+      case .filterList(let uuid):
+        return [Self.filterListPrefix, uuid].joined(separator: "-")
+      case .customFilterList(let uuid):
+        return [Self.customFilterListPrefix, uuid].joined(separator: "-")
+      }
     }
   }
   
   public static var shared = ContentBlockerManager()
   /// The store in which these rule lists should be compiled
   let ruleStore: WKContentRuleListStore
-  /// Compile results
-  private var cachedCompileResults: [String: (sourceType: BlocklistSourceType, result: Result<WKContentRuleList, Error>)]
-  /// The actor in which all of our sync data is stored on
-  private var data: SyncData
-  /// The repeating task that contnually compiles new blocklists as they come in
-  private var endlessCompileTask: Task<(), Error>?
-  /// The amount of time to wait before checking if new entries came in
-  private static let compileSleepTime: TimeInterval = {
-    #if DEBUG
-    return 10
-    #else
-    return 1.minutes
-    #endif
-  }()
+  /// We cached the rule lists so that we can return them quicker if we need to
+  private var cachedRuleLists: [String: Result<WKContentRuleList, Error>]
   
   init(ruleStore: WKContentRuleListStore = .default()) {
     self.ruleStore = ruleStore
-    self.cachedCompileResults = [:]
-    self.data = SyncData()
+    self.cachedRuleLists = [:]
   }
   
-  public func cleanupDeadRuleLists() async {
-    guard let identifiers = await ruleStore.availableIdentifiers() else { return }
-    let enabledResources = await data.enabledResources
+  /// Remove all rule lists minus the given valid types.
+  /// Should be used only as a cleanup once during launch to get rid of unecessary/old data.
+  /// This is mostly for custom filter lists a user may have added.
+  public func cleaupInvalidRuleLists(validTypes: Set<BlocklistType>) async {
+    let availableIdentifiers = await ruleStore.availableIdentifiers() ?? []
     
-    await remove(identifiers: identifiers.filter({ identifier in
-      !enabledResources.contains(where: { $0.key == identifier })
-    }))
-  }
-  
-  private func remove(identifiers: [String]) async {
-    return await withTaskGroup(of: Void.self) { group in
-      for identifier in identifiers {
-        group.addTask {
-          do {
-            try await self.ruleStore.removeContentRuleList(forIdentifier: identifier)
-          } catch {
-            Self.log.error("\(error.localizedDescription)")
-          }
-        }
+    await availableIdentifiers.asyncConcurrentForEach { identifier in
+      guard !validTypes.contains(where: { $0.identifier == identifier }) else { return }
+      
+      // Only allow certain prefixed identifiers to be removed so as not to remove something apple adds
+      let prefixes = [BlocklistType.genericPrifix, BlocklistType.filterListPrefix, BlocklistType.customFilterListPrefix]
+      guard prefixes.contains(where: { identifier.hasPrefix($0) }) else { return }
+      
+      do {
+        try await self.removeRuleList(forIdentifier: identifier)
+      } catch {
+        assertionFailure()
       }
     }
   }
-  private func load(identifiers: [String]) async -> [(String, Result<WKContentRuleList, Error>)] {
-    return await withTaskGroup(of: (identifier: String, result: Result<WKContentRuleList, Error>?).self, returning: [(String, Result<WKContentRuleList, Error>)].self) { group in
-      for identifier in identifiers {
-        group.addTask {
-          do {
-            guard let ruleList = try await self.ruleStore.contentRuleList(forIdentifier: identifier) else {
-              return (identifier, nil)
-            }
-            
-            return (identifier, .success(ruleList))
-          } catch {
-            return (identifier, .failure(error))
-          }
-        }
+  
+  /// Compile the given resource and store it in cache for the given blocklist type
+  func compile(encodedContentRuleList: String, for type: BlocklistType, options: CompileOptions = []) async throws {
+    do {
+      let cleanedRuleList = try await performOperations(encodedContentRuleList: encodedContentRuleList, options: options)
+      let ruleList = try await ruleStore.compileContentRuleList(forIdentifier: type.identifier, encodedContentRuleList: cleanedRuleList)
+      
+      guard let ruleList = ruleList else {
+        throw CompileError.noRuleListReturned(identifier: type.identifier)
       }
       
-      return await group.reduce([(String, Result<WKContentRuleList, Error>)](), { partialResult, nextResult in
-        guard let result = nextResult.result else { return partialResult }
-        var partialResult = partialResult
-        partialResult.append((nextResult.identifier, result))
-        return partialResult
-      })
-    }
-  }
-  
-  public func loadBundledResources() async {
-    await withTaskGroup(of: Void.self) { group in
-      for type in GeneralBlocklistTypes.validLists {
-        group.addTask(operation: {
-          guard let resource = await self.getBundledResource(for: type) else { return }
-          await self.data.set(enabledResource: resource, for: .general(type))
-        })
-      }
-    }
-  }
-  
-  /// Start the timer that will continually compile new resources
-  public func startTimer() {
-    guard endlessCompileTask == nil else { return }
-    
-    self.endlessCompileTask = Task.detached {
-      try await withTaskCancellationHandler(operation: {
-        while true {
-          try await Task.sleep(seconds: Self.compileSleepTime)
-          guard await !self.data.isSynced else { return }
-          await self.compilePendingResources()
-        }
-      }, onCancel: {
-        Task { @MainActor in
-          self.endlessCompileTask = nil
-        }
-      })
-    }
-  }
-  
-  /// Set a resource for the given rule type
-  func set(resource: Resource, for ruleType: BlocklistRuleType) async {
-    await self.data.set(enabledResource: resource, for: ruleType)
-  }
-  
-  /// Remove all resources for the given rule and source type
-  func removeResource(for ruleType: BlocklistRuleType) async {
-    await self.data.removeEnabledResource(for: ruleType)
-    
-    switch ruleType {
-    case .general(let generalBlocklistTypes):
-      // Add back the bundled rule type if we need to. We always want at least the bundled resource type
-      switch cachedCompileResults[ruleType.identifier]?.sourceType {
-      case .downloaded, .none:
-        guard let resource = await getBundledResource(for: generalBlocklistTypes) else { return }
-        await self.data.set(enabledResource: resource, for: ruleType)
-      case .bundled:
-        // We're good
-        break
-      }
-    case .filterList:
-      break
-    }
-  }
-  
-  /// Compile all the resources
-  public func compilePendingResources() async {
-    let resources = await self.data.pendingResources
-    
-    await withTaskGroup(of: Void.self) { group in
-      for (identifier, resource) in resources {
-        group.addTask { @MainActor in
-          do {
-            let ruleList = try await self.compile(resource: resource, forIdentifier: identifier)
-            self.cachedCompileResults[identifier] = (resource.sourceType, .success(ruleList))
-          } catch {
-            Self.log.error("Failed to compile rule list `\(identifier)`: \(error)")
-            self.cachedCompileResults[identifier] = (resource.sourceType, .failure(error))
-          }
-          await self.data.movePendingResource(forIdentifier: identifier)
-        }
-      }
+      self.cachedRuleLists[type.identifier] = .success(ruleList)
+    } catch {
+      self.cachedRuleLists[type.identifier] = .failure(error)
+      throw error
     }
     
     #if DEBUG
-    debug(resources: resources)
+    ContentBlockerManager.log.debug("Compiled rule list `\(type.identifier)`")
     #endif
   }
   
-  /// This method goes through all the resources and loads any available from the rule store so they are ready when displaying the page
-  public func loadCachedRuleLists() async {
-    await withTaskGroup(of: Void.self) { group in
-      for (identifier, resource) in await data.pendingResources {
-        group.addTask { @MainActor in
-          do {
-            guard let ruleList = try await self.ruleStore.contentRuleList(forIdentifier: identifier) else {
-              await self.data.movePendingResource(forIdentifier: identifier)
-              return
-            }
-            
-            self.cachedCompileResults[identifier] = (resource.sourceType, .success(ruleList))
-          } catch {
-            self.cachedCompileResults[identifier] = (resource.sourceType, .failure(error))
-          }
-        }
+  /// Check if a rule list is compiled for this type
+  func hasRuleList(for type: BlocklistType) async -> Bool {
+    do {
+      return try await ruleList(for: type) != nil
+    } catch {
+      return false
+    }
+  }
+  
+  /// Remove the rule list for the blocklist type
+  func removeRuleList(for type: BlocklistType) async throws {
+    try await removeRuleList(forIdentifier: type.identifier)
+  }
+  
+  /// Load a rule list from the rule store and return it. Will use cached results if they exist
+  func ruleList(for type: BlocklistType) async throws -> WKContentRuleList? {
+    if let result = cachedRuleLists[type.identifier] { return try result.get() }
+    return try await loadRuleList(for: type)
+  }
+  
+  /// Load a rule list from the rule store and return it. Will not use cached results
+  private func loadRuleList(for type: BlocklistType) async throws -> WKContentRuleList? {
+    do {
+      guard let ruleList = try await ruleStore.contentRuleList(forIdentifier: type.identifier) else {
+        return nil
       }
+      
+      self.cachedRuleLists[type.identifier] = .success(ruleList)
+      return ruleList
+    } catch {
+      throw error
     }
   }
   
-  /// Compile the given resource
-  private func compile(resource: Resource, forIdentifier identifier: String) async throws -> WKContentRuleList {
-    guard let jsonData = FileManager.default.contents(atPath: resource.url.path) else {
-      throw CompileError.fileNotFound(identifier: identifier)
+  /// Compiles the bundled file for the given generic type
+  /// - Warning: This may replace any downloaded versions with the bundled ones in the rulestore
+  /// for example, the `adBlock` rule type may replace the `genericContentBlockingBehaviors` downloaded version.
+  func compileBundledRuleList(for genericType: GenericBlocklistType) async throws {
+    guard let fileURL = Bundle.module.url(forResource: genericType.bundledFileName, withExtension: "json") else {
+      assertionFailure("A bundled file shouldn't fail to load")
+      return
     }
     
-    guard let json = String(data: jsonData, encoding: .utf8) else {
-      throw CompileError.invalidResourceString(identifier: identifier)
-    }
-                
-    let ruleList = try await ruleStore.compileContentRuleList(forIdentifier: identifier, encodedContentRuleList: json)
-    
-    guard let ruleList = ruleList else {
-      throw CompileError.noRuleListReturned(identifier: identifier)
-    }
-    
-    return ruleList
+    let encodedContentRuleList = try String(contentsOf: fileURL)
+    try await compile(encodedContentRuleList: encodedContentRuleList, for: .generic(genericType))
   }
   
-  /// Return the enabled rule types for this domain and the enabled settings
-  @MainActor public func compiledRuleTypes(for domain: Domain) -> Set<RuleTypeWithSourceType> {
-    let filterLists = FilterListResourceDownloader.shared.filterLists
-    
-    if domain.shield_allOff == 1 {
-      return []
-    }
-    
-    var results = Set<RuleTypeWithSourceType>()
+  /// Return the valid generic types for the given domain
+  @MainActor public func validGenericTypes(for domain: Domain) -> Set<GenericBlocklistType> {
+    guard !domain.areAllShieldsOff else { return [] }
+    var results = Set<GenericBlocklistType>()
 
     // Get domain specific rule types
     if domain.isShieldExpected(.AdblockAndTp, considerAllShieldsOption: true) {
-      if let sourceType = self.sourceType(for: .general(.blockAds)) {
-        results.insert(RuleTypeWithSourceType(ruleType: .general(.blockAds), sourceType: sourceType))
-      }
-      
-      if let sourceType = self.sourceType(for: .general(.blockTrackers)) {
-        results.insert(RuleTypeWithSourceType(ruleType: .general(.blockTrackers), sourceType: sourceType))
-      }
-    }
-    
-    // Get filter list specific rule types
-    filterLists.forEach { filterList in
-      guard filterList.isEnabled else { return }
-      let ruleType = filterList.makeRuleType()
-      
-      guard let sourceType = self.sourceType(for: ruleType) else {
-        return
-      }
-      
-      guard cachedRuleList(for: ruleType) != nil else {
-        return
-      }
-      
-      results.insert(RuleTypeWithSourceType(ruleType: ruleType, sourceType: sourceType))
+      results = results.union([.blockAds, .blockTrackers])
     }
     
     // Get global rule types
     if Preferences.Privacy.blockAllCookies.value {
-      if let sourceType = sourceType(for: .general(.blockCookies)) {
-        results.insert(RuleTypeWithSourceType(ruleType: .general(.blockCookies), sourceType: sourceType))
-      }
+      results.insert(.blockCookies)
     }
     
     return results
   }
   
-  /// Return a source type for the given rule type
-  public func sourceType(for ruleType: BlocklistRuleType) -> BlocklistSourceType? {
-    guard let compileResult = cachedCompileResults[ruleType.identifier] else { return nil }
+  /// Return the enabled blocklist types for the given domain
+  @MainActor func validBlocklistTypes(for domain: Domain) -> Set<BlocklistType> {
+    guard !domain.areAllShieldsOff else { return [] }
     
-    switch compileResult.result {
-    case .success:
-      return compileResult.sourceType
-    case .failure:
-      return nil
+    // Get the generic types
+    let genericTypes = validGenericTypes(for: domain)
+    
+    let genericRuleLists = genericTypes.map { genericType -> BlocklistType in
+      return .generic(genericType)
     }
+    
+    // Get rule lists for filter lists
+    let filterLists = FilterListResourceDownloader.shared.filterLists
+    let additionalRuleLists = filterLists.compactMap { filterList -> BlocklistType? in
+      guard filterList.isEnabled else { return nil }
+      return .filterList(uuid: filterList.uuid)
+    }
+    
+    return Set(genericRuleLists).union(additionalRuleLists)
   }
   
-  /// Get the cached rule list for this rule type. Returns nil if it's either not compiled or there were errors during compilation
-  public func cachedRuleList(for ruleType: BlocklistRuleType) -> WKContentRuleList? {
-    guard let compileResult = cachedCompileResults[ruleType.identifier] else { return nil }
+  /// Return the enabled rule types for this domain and the enabled settings.
+  /// It will attempt to return cached results if they exist otherwise it will attempt to load results from the rule store
+  public func ruleLists(for domain: Domain) async -> Set<WKContentRuleList> {
+    let validBlocklistTypes = await self.validBlocklistTypes(for: domain)
     
-    switch compileResult.result {
-    case .success(let ruleList): return ruleList
-    case .failure: return nil
-    }
+    return await Set(validBlocklistTypes.asyncConcurrentCompactMap({ blocklistType -> WKContentRuleList? in
+      do {
+        return try await self.ruleList(for: blocklistType)
+      } catch {
+        return nil
+      }
+    }))
   }
   
-  /// Load the rule lists for the given rule types
-  public func loadRuleLists(for ruleTypes: Set<BlocklistRuleType>) async -> [WKContentRuleList] {
-    return await withTaskGroup(of: WKContentRuleList?.self) { group in
-      for ruleType in ruleTypes {
-        group.addTask {
-          do {
-            return try await self.loadRuleList(for: ruleType)
-          } catch {
-            Self.log.error("\(error.localizedDescription)")
-            return nil
-          }
-        }
+  /// Remove the rule list for the given identifier. This will remove them from this local cache and from the rule store.
+  private func removeRuleList(forIdentifier identifier: String) async throws {
+    self.cachedRuleLists.removeValue(forKey: identifier)
+    try await ruleStore.removeContentRuleList(forIdentifier: identifier)
+    Self.log.debug("Removed rule list for `\(identifier)`")
+  }
+  
+  /// Perform operations of the rule list given by the provided options
+  private func performOperations(encodedContentRuleList: String, options: CompileOptions) async throws -> String {
+    guard !options.isEmpty else { return encodedContentRuleList }
+    
+    guard let blocklistData = encodedContentRuleList.data(using: .utf8) else {
+      assertionFailure()
+      return encodedContentRuleList
+    }
+    
+    guard var jsonArray = try JSONSerialization.jsonObject(with: blocklistData) as? [[String: Any]] else {
+      return encodedContentRuleList
+    }
+    
+    #if DEBUG
+    let originalCount = jsonArray.count
+    ContentBlockerManager.log.debug("Cleanining up \(originalCount) rules")
+    #endif
+    
+    if options.contains(.stripContentBlockers) {
+      jsonArray = await stripCosmeticFilters(jsonArray: jsonArray)
+    }
+    
+    if options.contains(.punycodeDomains) {
+      jsonArray = await punycodeDomains(jsonArray: jsonArray)
+    }
+    
+    #if DEBUG
+    let count = originalCount - jsonArray.count
+    ContentBlockerManager.log.debug("Filtered out \(count) rules")
+    #endif
+    
+    let modifiedData = try JSONSerialization.data(withJSONObject: jsonArray)
+    return String(bytes: modifiedData, encoding: .utf8) ?? encodedContentRuleList
+  }
+  
+  /// This will remove cosmetic filters from the provided encoded rule list. These are any rules that have a `selector` in the `action` field.
+  /// We do this because our cosmetic filtering is handled via the `SelectorsPoller.js` file and these selectors come from the engine directly.
+  private func stripCosmeticFilters(jsonArray: [[String: Any]]) async -> [[String: Any]] {
+    let updatedArray = await jsonArray.asyncConcurrentCompactMap { dictionary in
+      guard let actionDictionary = dictionary["action"] as? [String: Any] else {
+        return dictionary
       }
       
-      var results: [WKContentRuleList] = []
-      for await ruleList in group {
-        guard let ruleList = ruleList else { continue }
-        results.append(ruleList)
+      // Filter out with any dictionaries with `selector` actions
+      if actionDictionary["selector"] != nil {
+        return nil
+      } else {
+        return dictionary
       }
-      return results
     }
+    
+    return updatedArray
   }
   
-  /// Load the rule list for the given rule type
-  public func loadRuleList(for ruleType: BlocklistRuleType) async throws -> WKContentRuleList? {
-    return try await ruleStore.contentRuleList(forIdentifier: ruleType.identifier)
-  }
-
-  /// Compile the data and set it for the given general type.
-  private func getBundledResource(for type: GeneralBlocklistTypes) async -> Resource? {
-    guard let url = await loadBundledURL(for: type) else { return nil }
-    return Resource(url: url, sourceType: .bundled)
-  }
-
-  /// Get the bundled URL for the given type
-  private func loadBundledURL(for type: GeneralBlocklistTypes) async -> URL? {
-    return await withCheckedContinuation { continuation in
-      guard let fileURL = Bundle.module.url(forResource: type.rawValue, withExtension: "json") else {
-        continuation.resume(returning: nil)
+  /// Convert all domain in the `if-domain` and `unless-domain` fields.
+  ///
+  /// Sometimes we get non-punycoded domans in our JSON and apple does not allow non-punycoded domains to be passed to the rule store.
+  private func punycodeDomains(jsonArray: [[String: Any]]) async -> [[String: Any]] {
+    var jsonArray = jsonArray
+    
+    await jsonArray.enumerated().asyncConcurrentForEach({ index, dictionary in
+      guard var triggerObject = dictionary["trigger"] as? [String: Any] else {
         return
       }
       
-      continuation.resume(returning: fileURL)
-    }
+      if let domainArray = triggerObject["if-domain"] as? [String] {
+        triggerObject["if-domain"] = self.punycodeConversion(domains: domainArray)
+      }
+      
+      if let domainArray = triggerObject["unless-domain"] as? [String] {
+        triggerObject["unless-domain"] = self.punycodeConversion(domains: domainArray)
+      }
+      
+      jsonArray[index]["trigger"] = triggerObject
+    })
+    
+    return jsonArray
   }
   
-  #if DEBUG
-  /// A method that logs info on the given resources
-  private func debug(resources: [String: Resource]) {
-    let resourcesString = resources
-      .sorted(by: { lhs, rhs in
-        lhs.value.url.absoluteString < rhs.value.url.absoluteString
-      })
-      .map { identifier, compiledResource -> String in
-        let sourceString: String
-        let versionString: String
-        let resultString: String
-        
-        switch compiledResource.sourceType {
-        case .bundled:
-          sourceString = "bundled"
-          versionString = "nil"
-        case .downloaded(let version):
-          sourceString = "downloaded"
-          versionString = version ?? "nil"
+  /// Punycode an array of `domains` and return the punycoded results.
+  /// The array size shoud be unchanged but this is not guarantted.
+  private func punycodeConversion(domains: [String]) -> [String] {
+    return domains.compactMap { domain -> String? in
+      guard domain.allSatisfy({ $0.isASCII }) else {
+        if let result = NSURL(idnString: domain)?.absoluteString {
+          #if DEBUG
+          Self.log.debug("Punycoded domain: \(domain) -> \(result)")
+          #endif
+          return result
+        } else {
+          #if DEBUG
+          Self.log.debug("Could not punycode domain: \(domain)")
+          #endif
+          
+          return nil
         }
-        
-        switch self.cachedCompileResults[identifier]?.result {
-        case .failure(let error):
-          resultString = error.localizedDescription
-        case .success:
-          resultString = "success"
-        case .none:
-          resultString = "nil"
-        }
-        
-        let resourcesDebugString = [
-          "identifier: \(identifier)",
-          "fileName: \(compiledResource.url.lastPathComponent)",
-          "source: \(sourceString)",
-          "version: \(versionString)",
-          "result: \(resultString)"
-        ].joined(separator: ", ")
-        
-        return ["{", resourcesDebugString, "}"].joined()
-      }.joined(separator: ", ")
-
-    Self.log.debug("Compiled \(resources.count, privacy: .public) additional block list resources: \(resourcesString, privacy: .public))")
+      }
+      
+      return domain
+    }
   }
-  #endif
 }

--- a/Sources/Brave/WebFilters/ContentBlocker/TrackingProtectionPageStats.swift
+++ b/Sources/Brave/WebFilters/ContentBlocker/TrackingProtectionPageStats.swift
@@ -46,7 +46,7 @@ class TPStatsBlocklistChecker {
     case ad
   }
 
-  @MainActor func blockedTypes(requestURL: URL, sourceURL: URL, loadedRuleTypes: Set<ContentBlockerManager.BlocklistRuleType>, resourceType: AdblockEngine.ResourceType) async -> BlockedType? {
+  @MainActor func blockedTypes(requestURL: URL, sourceURL: URL, enabledRuleTypes: Set<ContentBlockerManager.GenericBlocklistType>, resourceType: AdblockEngine.ResourceType) async -> BlockedType? {
     guard let host = requestURL.host, !host.isEmpty else {
       // TP Stats init isn't complete yet
       return nil
@@ -56,7 +56,7 @@ class TPStatsBlocklistChecker {
       return .image
     }
 
-    if loadedRuleTypes.contains(.general(.blockAds)) || loadedRuleTypes.contains(.general(.blockTrackers)) {
+    if enabledRuleTypes.contains(.blockAds) || enabledRuleTypes.contains(.blockTrackers) {
       if await AdBlockStats.shared.shouldBlock(requestURL: requestURL, sourceURL: sourceURL, resourceType: resourceType) {
         return .ad
       }

--- a/Sources/Brave/WebFilters/FilterList.swift
+++ b/Sources/Brave/WebFilters/FilterList.swift
@@ -35,27 +35,12 @@ struct FilterList: Identifiable {
     ]
   }
   
-  let uuid: String
-  let title: String
-  let description: String
-  let componentId: String
-  let urlString: String
+  var id: String { return entry.uuid }
+  let entry: AdblockFilterListCatalogEntry
   var isEnabled: Bool = false
-  let languages: [String]
   
-  var id: String { return uuid }
-  
-  init(from filterList: AdblockFilterListCatalogEntry, isEnabled: Bool) {
-    self.uuid = filterList.uuid
-    self.title = filterList.title
-    self.description = filterList.desc
-    self.componentId = filterList.componentId
+  init(from entry: AdblockFilterListCatalogEntry, isEnabled: Bool) {
+    self.entry = entry
     self.isEnabled = isEnabled
-    self.urlString = filterList.url
-    self.languages = filterList.languages
-  }
-  
-  func makeRuleType() -> ContentBlockerManager.BlocklistRuleType {
-    return .filterList(uuid: uuid)
   }
 }

--- a/Sources/Brave/WebFilters/FilterListInterface.swift
+++ b/Sources/Brave/WebFilters/FilterListInterface.swift
@@ -8,23 +8,27 @@ import Data
 
 protocol FilterListInterface {
   @MainActor var uuid: String { get }
-  @MainActor var filterListComponentId: String? { get }
+  @MainActor var debugTitle: String { get }
 }
- 
+
 extension FilterListInterface {
-  @MainActor var resources: [ResourceDownloader.Resource] {
-    guard let filterListComponentId = self.filterListComponentId else { return [] }
-    
-    return [
-      .filterListContentBlockingBehaviors(uuid: uuid, componentId: filterListComponentId)
-    ]
+  @MainActor func makeResource(componentId: String) -> ResourceDownloader.Resource {
+    return .filterListContentBlockingBehaviors(
+      uuid: uuid, componentId: componentId
+    )
   }
 }
 
 extension FilterListSetting: FilterListInterface {
-  @MainActor var filterListComponentId: String? { return componentId }
+  var debugTitle: String {
+    return "\(uuid) \(componentId ?? "unknown")"
+  }
 }
 
 extension FilterList: FilterListInterface {
-  @MainActor var filterListComponentId: String? { return componentId }
+  var uuid: String { entry.uuid }
+  
+  var debugTitle: String {
+    return "\(entry.title) \(entry.componentId)"
+  }
 }

--- a/Sources/Brave/WebFilters/FilterListResourceDownloader.swift
+++ b/Sources/Brave/WebFilters/FilterListResourceDownloader.swift
@@ -32,13 +32,6 @@ public class FilterListResourceDownloader: ObservableObject {
       self.inMemory = inMemory
     }
     
-    /// Get the enabled status of a filter list setting without modifying any other property
-    ///
-    /// - Warning: Do not call this before we load core data
-    @MainActor public func isEnabled(forUUID uuid: String) -> Bool {
-      return allFilterListSettings.first(where: { $0.uuid == uuid })?.isEnabled ?? false
-    }
-    
     /// - Warning: Do not call this before we load core data
     @MainActor public func isEnabled(for componentID: String) -> Bool {
       guard let setting = allFilterListSettings.first(where: { $0.componentId == componentID }) else {
@@ -52,12 +45,12 @@ public class FilterListResourceDownloader: ObservableObject {
     /// Otherwise it will create a new setting with the specified properties
     ///
     /// - Warning: Do not call this before we load core data
-    @MainActor public func upsertSetting(uuid: String, isEnabled: Bool, componentId: String?, allowCreation: Bool) {
+    @MainActor public func upsertSetting(uuid: String, componentId: String?, isEnabled: Bool, allowCreation: Bool) {
       if allFilterListSettings.contains(where: { $0.uuid == uuid }) {
         updateSetting(
           uuid: uuid,
-          isEnabled: isEnabled,
-          componentId: componentId
+          componentId: componentId,
+          isEnabled: isEnabled
         )
       } else if allowCreation {
         create(
@@ -81,7 +74,7 @@ public class FilterListResourceDownloader: ObservableObject {
       FilterListSetting.save(inMemory: inMemory)
     }
     
-    @MainActor private func updateSetting(uuid: String, isEnabled: Bool, componentId: String?) {
+    @MainActor private func updateSetting(uuid: String, componentId: String?, isEnabled: Bool) {
       guard let index = allFilterListSettings.firstIndex(where: { $0.uuid == uuid }) else {
         return
       }
@@ -147,46 +140,23 @@ public class FilterListResourceDownloader: ObservableObject {
   }
   
   public func loadCachedData() async {
-    async let cachedFilterLists: Void = self.loadCachedFilterLists()
+    async let cachedFilterLists: Void = self.addEngineResourcesFromCachedFilterLists()
     async let cachedDefaultFilterList: Void = self.loadCachedDefaultFilterList()
     _ = await (cachedFilterLists, cachedDefaultFilterList)
   }
   
-  /// Tells us if the filter list is enabled for the given `UUID`
-  @MainActor public func isEnabled(filterListUUID uuid: String) -> Bool {
-    return settingsManager.isEnabled(forUUID: uuid)
-  }
-  
-  private func loadCachedFilterLists() async {
-    let settingsInfo: [(index: Int, uuid: String, folderURL: URL?, resources: [ResourceDownloader.Resource])] = await MainActor.run {
-      let filterListSettings = settingsManager.allFilterListSettings
+  /// This function adds engine resources to `AdBlockManager` for the cached filter lists
+  @MainActor private func addEngineResourcesFromCachedFilterLists() async {
+    let filterListSettings = settingsManager.allFilterListSettings
       
-      return filterListSettings.enumerated().compactMap { (index, setting) in
-        guard setting.isEnabled else { return nil }
-        return (index, setting.uuid, setting.folderURL, setting.resources)
-      }
-    }
-    
-    return await withTaskGroup(of: Void.self) { group in
-      for settingInfo in settingsInfo {
-        group.addTask {
-          // Load cached component updater files
-          if let folderURL = settingInfo.folderURL, FileManager.default.fileExists(atPath: folderURL.path) {
-            await self.handle(downloadedFolderURL: folderURL, forFilterListUUID: settingInfo.uuid, index: settingInfo.index)
-          }
-          
-          // Load cached download resources
-          await withTaskGroup(of: Void.self) { group in
-            for resource in settingInfo.resources {
-              group.addTask {
-                guard let fileURL = ResourceDownloader.downloadedFileURL(for: resource) else { return }
-                let date = try? ResourceDownloader.creationDate(for: resource)
-                await self.handle(downloadedFileURL: fileURL, for: resource, filterListUUID: settingInfo.uuid, date: date, index: settingInfo.index)
-              }
-            }
-          }
-        }
-        
+    await filterListSettings.asyncConcurrentForEach { setting in
+      guard setting.isEnabled == true else { return }
+      
+      // Try to load the filter list folder. We always have to compile this at start
+      if let folderURL = setting.folderURL, FileManager.default.fileExists(atPath: folderURL.path) {
+        await self.addEngineResources(
+          forFilterListUUID: setting.uuid, downloadedFolderURL: folderURL, relativeOrder: 0
+        )
       }
     }
   }
@@ -198,7 +168,7 @@ public class FilterListResourceDownloader: ObservableObject {
       return
     }
     
-    await loadShields(fromFolderURL: folderURL)
+    await loadShields(fromDefaultFilterListFolderURL: folderURL)
   }
   
   /// Start the resource subscriber.
@@ -225,7 +195,7 @@ public class FilterListResourceDownloader: ObservableObject {
     // Enable the setting
     defer { self.recordP3ACookieListEnabled() }
     
-    if let index = filterLists.firstIndex(where: { $0.componentId == componentID }) {
+    if let index = filterLists.firstIndex(where: { $0.entry.componentId == componentID }) {
       // Only update the value if it has changed
       guard filterLists[index].isEnabled != isEnabled else { return }
       filterLists[index].isEnabled = isEnabled
@@ -233,7 +203,7 @@ public class FilterListResourceDownloader: ObservableObject {
       let defaultToggle = FilterList.defaultOnComponentIds.contains(componentID)
       
       settingsManager.upsertSetting(
-        uuid: uuid, isEnabled: isEnabled, componentId: componentID,
+        uuid: uuid, componentId: componentID, isEnabled: isEnabled,
         allowCreation: defaultToggle != isEnabled
       )
     } else {
@@ -263,17 +233,19 @@ public class FilterListResourceDownloader: ObservableObject {
       self.registerAllEnabledFilterLists()
     }
     
+    // Store the folder path so we can load it from cache next time we launch quicker
+    // than waiting for the component updater to respond, which may take a few seconds
     let folderURL = URL(fileURLWithPath: folderPath)
     let folderSubPath = FilterListSetting.extractFolderPath(fromFilterListFolderURL: folderURL)
     Preferences.AppState.lastDefaultFilterListFolderPath.value = folderSubPath
     
     Task {
-      await self.loadShields(fromFolderURL: folderURL)
+      await self.loadShields(fromDefaultFilterListFolderURL: folderURL)
     }
   }
   
   /// Load shields with the given `AdblockService` folder `URL`
-  private func loadShields(fromFolderURL folderURL: URL) async {
+  private func loadShields(fromDefaultFilterListFolderURL folderURL: URL) async {
     let version = folderURL.lastPathComponent
     
     // Lets add these new resources
@@ -325,9 +297,9 @@ public class FilterListResourceDownloader: ObservableObject {
     //    (in order to respect the users preference if the default were to change in the future)
     settingsManager.upsertSetting(
       uuid: filterList.uuid,
+      componentId: filterList.entry.componentId,
       isEnabled: filterList.isEnabled,
-      componentId: filterList.componentId,
-      allowCreation: filterList.defaultToggle != filterList.isEnabled
+      allowCreation: filterList.entry.defaultToggle != filterList.isEnabled || filterList.isEnabled
     )
     
     // Register or unregister the filter list depending on its toggle state
@@ -350,17 +322,16 @@ public class FilterListResourceDownloader: ObservableObject {
   @MainActor private func register(filterList: FilterList) {
     guard adBlockServiceTasks[filterList.uuid] == nil else { return }
     guard let adBlockService = adBlockService else { return }
-    guard let index = filterLists.firstIndex(where: { $0.uuid == filterList.uuid }) else { return }
-    
-    for resource in filterList.resources {
-      startFetching(resource: resource, for: filterList, index: index)
-    }
+    guard let index = filterLists.firstIndex(where: { $0.id == filterList.id }) else { return }
+    startFetchingGenericContentBlockingBehaviors(for: filterList)
 
     adBlockServiceTasks[filterList.uuid] = Task { @MainActor in
-      for await folderURL in await adBlockService.register(filterListUUID: filterList.uuid) {
+      for await folderURL in await adBlockService.register(filterList: filterList) {
         guard let folderURL = folderURL else { continue }
-        guard self.isEnabled(filterListUUID: filterList.uuid) else { return }
-        await self.handle(downloadedFolderURL: folderURL, forFilterListUUID: filterList.uuid, index: index)
+        guard self.isEnabled(for: filterList.entry.componentId) else { return }
+        await self.addEngineResources(
+          forFilterListUUID: filterList.uuid, downloadedFolderURL: folderURL, relativeOrder: index
+        )
         
         // Save the downloaded folder for later (caching) purposes
         self.settingsManager.set(folderURL: folderURL, forUUID: filterList.uuid)
@@ -372,39 +343,38 @@ public class FilterListResourceDownloader: ObservableObject {
   @MainActor private func unregister(filterList: FilterList) {
     adBlockServiceTasks[filterList.uuid]?.cancel()
     adBlockServiceTasks.removeValue(forKey: filterList.uuid)
-    
-    for resource in filterList.resources {
-      stopFetching(resource: resource)
-    }
+    stopFetching(resource: .filterListContentBlockingBehaviors(uuid: filterList.uuid, componentId: filterList.entry.componentId))
     
     Task {
-      async let removeContentBlockerResource: Void = ContentBlockerManager.shared.removeResource(for: .filterList(uuid: filterList.uuid))
-      async let removeAdBlockEngineResource: Void = AdBlockEngineManager.shared.removeResources(for: .filterList(uuid: filterList.uuid))
-      _ = await (removeContentBlockerResource, removeAdBlockEngineResource)
+      async let removeContentBlockerResource: Void = ContentBlockerManager.shared.removeRuleList(
+        for: .filterList(uuid: filterList.uuid)
+      )
+      async let removeAdBlockEngineResource: Void = AdBlockEngineManager.shared.removeResources(
+        for: .filterList(uuid: filterList.uuid)
+      )
+      _ = try await (removeContentBlockerResource, removeAdBlockEngineResource)
     }
   }
   
   /// Start fetching the resource for the given filter list
-  private func startFetching(resource: ResourceDownloader.Resource, for filterList: FilterList, index: Int) {
+  private func startFetchingGenericContentBlockingBehaviors(for filterList: FilterList) {
+    let resource = ResourceDownloader.Resource.filterListContentBlockingBehaviors(
+      uuid: filterList.entry.uuid,
+      componentId: filterList.entry.componentId
+    )
+    
     guard fetchTasks[resource] == nil else {
       // We're already fetching for this filter list
       return
     }
     
     fetchTasks[resource] = Task { @MainActor in
-      if let fileURL = ResourceDownloader.downloadedFileURL(for: resource) {
-        await self.handle(downloadedFileURL: fileURL, for: resource, filterListUUID: filterList.uuid, index: index)
-      }
-      
       try await withTaskCancellationHandler(operation: {
         for try await result in await self.resourceDownloader.downloadStream(for: resource) {
           switch result {
           case .success(let downloadResult):
-            await self.handle(
-              downloadedFileURL: downloadResult.fileURL,
-              for: resource, filterListUUID: filterList.uuid,
-              date: downloadResult.date,
-              index: index
+            await handle(
+              downloadResult: downloadResult, for: filterList
             )
           case .failure(let error):
             Logger.module.error("\(error.localizedDescription)")
@@ -422,48 +392,46 @@ public class FilterListResourceDownloader: ObservableObject {
     fetchTasks.removeValue(forKey: resource)
   }
   
-  /// Handle resource downloads for the given filter list
-  private func handle(downloadedFileURL: URL, for resource: ResourceDownloader.Resource, filterListUUID uuid: String, date: Date? = nil, index: Int) async {
-    guard await isEnabled(filterListUUID: uuid) else {
-      return
+  private func handle(downloadResult: ResourceDownloaderStream.DownloadResult, for filterList: FilterListInterface) async {
+    if !downloadResult.isModified {
+      // if the file is not modified first we need to see if we already have a cached value loaded
+      guard await !ContentBlockerManager.shared.hasRuleList(for: .filterList(uuid: filterList.uuid)) else {
+        // We don't want to recompile something that we alrady have loaded
+        return
+      }
     }
     
-    let version = date != nil ? self.fileVersionDateFormatter.string(from: date!) : nil
-    
-    switch resource {
-    case .filterListContentBlockingBehaviors:
-      await ContentBlockerManager.shared.set(resource: ContentBlockerManager.Resource(
-        url: downloadedFileURL,
-        sourceType: .downloaded(version: version)
-      ), for: .filterList(uuid: uuid))
+    do {
+      let encodedContentRuleList = try String(contentsOf: downloadResult.fileURL, encoding: .utf8)
       
-    case .filterListAdBlockRules:
-      // TODO: Compile rulelist to blocklist
-      await AdBlockEngineManager.shared.add(
-        resource: AdBlockEngineManager.Resource(type: .ruleList, source: .filterList(uuid: uuid)),
-        fileURL: downloadedFileURL,
-        version: version,
-        relativeOrder: index
+      // We only want to compile cached values if they are not already loaded
+      try await ContentBlockerManager.shared.compile(
+        encodedContentRuleList: encodedContentRuleList,
+        for: .filterList(uuid: filterList.uuid),
+        options: .all
       )
-    default:
-      assertionFailure("Should not be handling this resource")
+    } catch {
+      let debugTitle = await filterList.debugTitle
+      ContentBlockerManager.log.error(
+        "Failed to compile rule list for \(debugTitle) (`\(downloadResult.fileURL.absoluteString)`): \(error)"
+      )
     }
   }
   
   /// Handle the downloaded folder url for the given filter list. The folder URL should point to a `AdblockFilterList` resource
   /// This will also start fetching any additional resources for the given filter list given it is still enabled.
-  private func handle(downloadedFolderURL: URL, forFilterListUUID uuid: String, index: Int) async {
+  private func addEngineResources(forFilterListUUID uuid: String, downloadedFolderURL: URL, relativeOrder: Int) async {
     // Let's add the new ones in
     await AdBlockEngineManager.shared.add(
       resource: AdBlockEngineManager.Resource(type: .dat, source: .filterList(uuid: uuid)),
       fileURL: downloadedFolderURL.appendingPathComponent("rs-\(uuid).dat"),
-      version: downloadedFolderURL.lastPathComponent, relativeOrder: index
+      version: downloadedFolderURL.lastPathComponent, relativeOrder: relativeOrder
     )
     await AdBlockEngineManager.shared.add(
       resource: AdBlockEngineManager.Resource(type: .jsonResources, source: .filterList(uuid: uuid)),
       fileURL: downloadedFolderURL.appendingPathComponent("resources.json"),
       version: downloadedFolderURL.lastPathComponent,
-      relativeOrder: index
+      relativeOrder: relativeOrder
     )
   }
   
@@ -485,14 +453,9 @@ private extension AdblockService {
   /// Register the filter list given by the uuid and streams its updates
   ///
   /// - Note: Cancelling this task will unregister this filter list from recieving any further updates
-  @MainActor func register(filterListUUID uuid: String) async -> AsyncStream<URL?> {
+  @MainActor func register(filterList: FilterList) async -> AsyncStream<URL?> {
     return AsyncStream { continuation in
-      guard let filterList = regionalFilterLists?.first(where: { $0.uuid == uuid }) else {
-        continuation.finish()
-        return
-      }
-
-      registerFilterListComponent(filterList, useLegacyComponent: true) { folderPath in
+      registerFilterListComponent(filterList.entry, useLegacyComponent: true) { folderPath in
         guard let folderPath = folderPath else {
           continuation.yield(nil)
           return
@@ -503,7 +466,7 @@ private extension AdblockService {
       }
       
       continuation.onTermination = { @Sendable _ in
-        self.unregisterFilterListComponent(filterList, useLegacyComponent: true)
+        self.unregisterFilterListComponent(filterList.entry, useLegacyComponent: true)
       }
     }
   }
@@ -511,15 +474,7 @@ private extension AdblockService {
 
 // MARK: - FilterListLanguageProvider - A way to share `defaultToggle` logic between multiple structs/classes
 
-private protocol FilterListLanguageProvider {
-  var languages: [String] { get }
-  var componentId: String { get }
-}
-
-extension FilterList: FilterListLanguageProvider {}
-extension AdblockFilterListCatalogEntry: FilterListLanguageProvider {}
-
-private extension FilterListLanguageProvider {
+private extension AdblockFilterListCatalogEntry {
   @available(iOS 16, *)
   /// A list of regions that this filter list focuses on.
   /// An empty set means this filter list doesn't focus on any specific region.

--- a/Sources/Brave/WebFilters/FilterListResourceDownloader.swift
+++ b/Sources/Brave/WebFilters/FilterListResourceDownloader.swift
@@ -377,7 +377,7 @@ public class FilterListResourceDownloader: ObservableObject {
               downloadResult: downloadResult, for: filterList
             )
           case .failure(let error):
-            Logger.module.error("\(error.localizedDescription)")
+            ContentBlockerManager.log.error("Failed to download resource \(resource.cacheFolderName): \(error)")
           }
         }
       }, onCancel: {

--- a/Sources/Data/models/Domain.swift
+++ b/Sources/Data/models/Domain.swift
@@ -38,6 +38,10 @@ public final class Domain: NSManagedObject, CRUD {
   
   private static let containsEthereumPermissionsPredicate = NSPredicate(format: "wallet_permittedAccounts != nil && wallet_permittedAccounts != ''")
   private static let containsSolanaPermissionsPredicate = NSPredicate(format: "wallet_solanaPermittedAcccounts != nil && wallet_solanaPermittedAcccounts != ''")
+  
+  @MainActor public var areAllShieldsOff: Bool {
+    return shield_allOff == 1
+  }
 
   /// A domain can be created in many places,
   /// different save strategies are used depending on its relationship(eg. attached to a Bookmark) or browsing mode.

--- a/Sources/Data/models/Domain.swift
+++ b/Sources/Data/models/Domain.swift
@@ -40,7 +40,7 @@ public final class Domain: NSManagedObject, CRUD {
   private static let containsSolanaPermissionsPredicate = NSPredicate(format: "wallet_solanaPermittedAcccounts != nil && wallet_solanaPermittedAcccounts != ''")
   
   @MainActor public var areAllShieldsOff: Bool {
-    return shield_allOff == 1
+    return shield_allOff?.boolValue ?? false
   }
 
   /// A domain can be created in many places,

--- a/Tests/ClientTests/ContentBlockerManagerTests.swift
+++ b/Tests/ClientTests/ContentBlockerManagerTests.swift
@@ -14,59 +14,64 @@ class ContentBlockerManagerTests: XCTestCase {
     return WKContentRuleListStore(url: bundleURL)!
   }()
   
-  func testCompilePendingResources() throws {
+  func testContentBlockerManager() throws {
     // Given
     let bundle = Bundle.module
     let resourceURL = bundle.url(forResource: "content-blocking", withExtension: "json")!
-    let downloadedRuleType = ContentBlockerManager.BlocklistRuleType.general(.blockAds)
-    let downloadedSourceType = ContentBlockerManager.BlocklistSourceType.downloaded(version: "123")
+    let encodedContentRuleList = try String(contentsOf: resourceURL, encoding: .utf8)
     let expectation = XCTestExpectation(description: "Test loading resources")
     let manager = ContentBlockerManager(ruleStore: ruleStore)
+    let filterListUUID = UUID().uuidString
+    let filterListCustomUUID = UUID().uuidString
     
-    Task.detached {
+    Task { @MainActor in
       // When
-      await manager.loadBundledResources()
-      await manager.set(resource: ContentBlockerManager.Resource(
-        url: resourceURL,
-        sourceType: downloadedSourceType
-      ), for: downloadedRuleType)
-      
-      await manager.compilePendingResources()
-      
-      await MainActor.run {
-        // Then
-        // Check for the correct source and cached rule list
-        for generalType in ContentBlockerManager.GeneralBlocklistTypes.allCases {
-          let returnedSourceType = manager.sourceType(for: .general(generalType))
-          let returnedCachedRuleList = manager.cachedRuleList(for: .general(generalType))
-          switch generalType {
-          case .blockAds:
-            // Check for downloaded rule type
-            XCTAssertEqual(returnedSourceType, downloadedSourceType)
-            XCTAssertNotNil(returnedCachedRuleList)
-          case .blockCookies, .blockTrackers:
-            // Check for bundled rule type
-            XCTAssertEqual(returnedSourceType, .bundled)
-            XCTAssertNotNil(returnedCachedRuleList)
-          }
+      for generalType in ContentBlockerManager.GenericBlocklistType.allCases {
+        do {
+          try await manager.compileBundledRuleList(for: generalType)
+        } catch {
+          XCTFail(error.localizedDescription)
         }
       }
       
-      // Check we go back to the bundled rule type if we remove the downloaded one
-      await manager.removeResource(for: downloadedRuleType)
-      await manager.compilePendingResources()
-      
-      Task { @MainActor in
-        XCTAssertEqual(
-          manager.sourceType(for: downloadedRuleType), .bundled
-        )
-        
-        XCTAssertNotNil(
-          manager.cachedRuleList(for: .general(.blockAds))
-        )
-        
-        expectation.fulfill()
+      do {
+        try await manager.compile(encodedContentRuleList: encodedContentRuleList, for: .filterList(uuid: filterListUUID))
+        try await manager.compile(encodedContentRuleList: encodedContentRuleList, for: .customFilterList(uuid: filterListCustomUUID))
+      } catch {
+        XCTFail(error.localizedDescription)
       }
+      
+      // Then
+      // Check for loading the cached results
+      for generalType in ContentBlockerManager.GenericBlocklistType.allCases {
+        do {
+          let cachedType = try await manager.ruleList(for: .generic(generalType))
+          XCTAssertNotNil(cachedType)
+        } catch {
+          XCTFail(error.localizedDescription)
+        }
+      }
+      
+      // Then
+      // Check for loading the uncached result from the rule store
+      for generalType in ContentBlockerManager.GenericBlocklistType.allCases {
+        do {
+          let cachedType = try await manager.ruleList(for: .generic(generalType))
+          XCTAssertNotNil(cachedType)
+        } catch {
+          XCTFail(error.localizedDescription)
+        }
+      }
+      
+      // Check removing the filter lists
+      do {
+        try await manager.removeRuleList(for: .filterList(uuid: filterListUUID))
+        try await manager.removeRuleList(for: .customFilterList(uuid: filterListCustomUUID))
+      } catch {
+        XCTFail(error.localizedDescription)
+      }
+      
+      expectation.fulfill()
     }
     
     wait(for: [expectation], timeout: 10)

--- a/Tests/ClientTests/PageDataTests.swift
+++ b/Tests/ClientTests/PageDataTests.swift
@@ -45,7 +45,7 @@ final class PageDataTests: XCTestCase {
       pageData.addSubframeURL(forRequestURL: subFrameURL, isForMainFrame: false)
       
       // Then
-      // We get an aditional scripts for sub-frame
+      // We get no aditional scripts for sub-frame
       // NOTE: This is because we have no engines on AdBlockStats.
       // If we were to add some engines we might see additional types
       let addedSubFrameFrameRequestTypes = pageData.makeUserScriptTypes(domain: domain)

--- a/Tests/ClientTests/Web Filters/NetworkManager+Tests.swift
+++ b/Tests/ClientTests/Web Filters/NetworkManager+Tests.swift
@@ -40,7 +40,6 @@ extension NetworkManager {
         let resourceURL = bundle.url(forResource: "debouncing", withExtension: "json")
         let data = try Data(contentsOf: resourceURL!)
         return data
-        
       case .genericContentBlockingBehaviors, .filterListContentBlockingBehaviors:
         let bundle = Bundle.module
         let resourceURL = bundle.url(forResource: "content-blocking", withExtension: "json")


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7147

1. Now I compile more blocklists. To prevent from adding extra delays, I no longer compile cached blocklists during re-launch (it's not needed). This also meant I can remove much of the syncing logic as it is completely unnecessary.
2. The code is increasingly more difficult to maintain as I load more content. I struggled not breaking bundled content blockers several times (and almost broke it couple of times). Simplifying the logic helps to maintain it.
3. Punycode domains that are not puny coded. Because this adds extra work on compiling blocklists, it's important that we don't compile blocklists during launch. While things from s3 or bundled blocklists should not require puny coding there is no guarantee of this for custom blocklists. However I still puny code domains for things coming from s3 because as we've seen this has been an issue recently.
4. Removed multiple states on filter lists. Instead of having copies of the fields on filter lists entries from core data, I just use the entries themselves to display the data in the UI. Helps with syncing things especially when I will have different sources of content blockers (brave core and custom urls)
5. Rule lists are loaded lazily from the rule store (except for the bundled ones which need to be compiled at first launch). This improves launch time, especially when a lot of filter lists are enabled.
6. Added some better debugging logs because it's difficult to test if ad-blocking is working properly. something being blocked doesn't mean everything is working properly as we have multiple ways of blocking content: CF, engine blocking and rule lists. Depending on the rule lists a mistake in loading Adblock content could only reveal itself later when a rule is added. Logs tell me that everything is loaded (or unloaded) properly so when I make code changes (or a webcompat issue occurs) I know that everything is loaded properly. 

### Launch metrics: 
#### iPhone 14 (sim)
Adblock loaded: 0.175008s (0.194461s on development)
With all filter lists enabled: 0.870092s

#### iPad mini (6th gen) (sim)
Adblock loaded: 0.219583s (0.259748s on development)
With all filter lists enabled: 0.903977s

#### iPhone 14 Pro (device):
Adblock loaded: 0.281288s (0.291682s on development)
With all filter lists enabled: 1.036126s

**Note:** these values have a bit of variation. Sometimes they are higher and sometimes lower but the variation is usually not that large. Perhaps ~0.04

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
We need to test 
1. ad-blocking by going to https://test-pages.privacytests.org/tracking_content.html. We want to test first launch and re-launches. This page should have `passed: true` for all values.
2. Launch time for both first launch and subsequent launches. Try to enable more filter lists. This will surely add more delays to launch time because more engine dat files need to be loaded. This is unavoidable. But the 
3. Cosmetic filtering. Best way to do this is by enabling blocking in app notices and going to pages like reddit.com
4. Script loading. Best way to do this is by going to https://dev-pages.brave.software/filtering/scriptlets.html. All values should be true with shields on and nil with shields off. Note the values will be nil on first launch.

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
