### PR TITLE
Fix #7132: Update URL clipping fade when trait collection changes

### DIFF
--- a/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
+++ b/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
@@ -522,6 +522,16 @@ class DisplayTextField: UITextField {
   required init(coder: NSCoder) {
     fatalError()
   }
+  
+  override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    super.traitCollectionDidChange(previousTraitCollection)
+    leadingClippingFade.gradientLayer.colors = [
+      UIColor.braveBackground,
+      UIColor.braveBackground.withAlphaComponent(0.0)
+    ].map {
+      $0.resolvedColor(with: traitCollection).cgColor
+    }
+  }
 
   override var accessibilityCustomActions: [UIAccessibilityCustomAction]? {
     get {


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #7132 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
