### PR TITLE
Fix #7161: Cleanup resource downloader

### DIFF
--- a/App/iOS/Delegates/AppDelegate.swift
+++ b/App/iOS/Delegates/AppDelegate.swift
@@ -338,7 +338,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
       UrpLog.log("Failed to initialize user referral program")
     }
 
-    DebouncingResourceDownloader.shared.startLoading()
 #if canImport(BraveTalk)
     BraveTalkJitsiCoordinator.sendAppLifetimeEvent(
       .didFinishLaunching(options: launchOptions ?? [:])

--- a/App/iOS/Delegates/SceneDelegate.swift
+++ b/App/iOS/Delegates/SceneDelegate.swift
@@ -218,11 +218,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
   }
 
   func sceneWillEnterForeground(_ scene: UIScene) {
-    // The reason we need to call this method here instead of `applicationDidBecomeActive`
-    // is that this method is only invoked whenever the application is entering the foreground where as
-    // `applicationDidBecomeActive` will get called whenever the Touch ID authentication overlay disappears.
-    DebouncingResourceDownloader.shared.startLoading()
-
     if let scene = scene as? UIWindowScene {
       scene.browserViewController?.windowProtection = windowProtection
     }

--- a/Sources/Brave/Frontend/Settings/AdblockDebugMenuTableViewController.swift
+++ b/Sources/Brave/Frontend/Settings/AdblockDebugMenuTableViewController.swift
@@ -157,7 +157,7 @@ class AdblockDebugMenuTableViewController: TableViewController {
     
     func getEtag(from resource: Resource) -> String? {
       do {
-        return try resource.etag()
+        return try resource.createdEtag()
       } catch {
         return nil
       }

--- a/Sources/Brave/Frontend/Settings/AdblockDebugMenuTableViewController.swift
+++ b/Sources/Brave/Frontend/Settings/AdblockDebugMenuTableViewController.swift
@@ -32,7 +32,18 @@ class AdblockDebugMenuTableViewController: TableViewController {
         self.actionsSection,
         self.datesSection,
         self.bundledListsSection(names: listNames),
-        self.downloadedResourcesSection()
+        self.downloadedResourcesSection(
+          header: "Ad-Block Resources",
+          footer: "Files downloaded using the AdBlockResourceDownloader",
+          resources: AdblockResourceDownloader.handledResources
+        ),
+        self.downloadedResourcesSection(
+          header: "Filter lists",
+          footer: "Files downloaded using the FilterListResourceDownloader",
+          resources: FilterListResourceDownloader.shared.filterLists.map({ filterList in
+            return filterList.makeResource(componentId: filterList.entry.componentId)
+          })
+        )
       ]
     }
   }
@@ -137,30 +148,32 @@ class AdblockDebugMenuTableViewController: TableViewController {
     return section
   }
   
-  private func downloadedResourcesSection() -> Section {
-    func createRows(from resources: [ResourceDownloader.Resource]) -> [Row] {
+  private func downloadedResourcesSection<Resource: DownloadResourceInterface>(
+    header: Section.Extremity?, footer: Section.Extremity?, resources: [Resource]
+  ) -> Section {
+    func createRows(from resources: [Resource]) -> [Row] {
       resources.compactMap { createRow(from: $0) }
     }
     
-    func getEtag(from resource: ResourceDownloader.Resource) -> String? {
+    func getEtag(from resource: Resource) -> String? {
       do {
-        return try ResourceDownloader.etag(for: resource)
+        return try resource.etag()
       } catch {
         return nil
       }
     }
     
-    func getFileCreation(for resource: ResourceDownloader.Resource) -> String? {
+    func getFileCreation(for resource: Resource) -> String? {
       do {
-        guard let date = try ResourceDownloader.creationDate(for: resource) else { return nil }
+        guard let date = try resource.creationDate() else { return nil }
         return Self.fileDateFormatter.string(from: date)
       } catch {
         return nil
       }
     }
     
-    func createRow(from resource: ResourceDownloader.Resource) -> Row? {
-      guard let fileURL = ResourceDownloader.downloadedFileURL(for: resource) else {
+    func createRow(from resource: Resource) -> Row? {
+      guard let fileURL = resource.downloadedFileURL else {
         return nil
       }
       
@@ -173,18 +186,9 @@ class AdblockDebugMenuTableViewController: TableViewController {
       return Row(text: fileURL.lastPathComponent, detailText: detailText, cellClass: MultilineSubtitleCell.self)
     }
     
-    var resources = FilterListResourceDownloader.shared.filterLists.map { filterList -> ResourceDownloader.Resource in
-      return filterList.makeResource(componentId: filterList.entry.componentId)
-    }
-    
-    resources.append(contentsOf: [
-      .genericContentBlockingBehaviors, .genericFilterRules, .generalCosmeticFilters, .generalScriptletResources
-    ])
-    
     return Section(
-      header: "Downloaded resources",
-      rows: createRows(from: resources),
-      footer: "Lists downloaded from the internet at app launch using the ResourceDownloader."
+      header: header, rows: createRows(from: resources),
+      footer: footer
     )
   }
 }

--- a/Sources/Brave/WebFilters/AdblockResourceDownloader.swift
+++ b/Sources/Brave/WebFilters/AdblockResourceDownloader.swift
@@ -13,7 +13,7 @@ public actor AdblockResourceDownloader: Sendable {
   public static let shared = AdblockResourceDownloader()
   
   /// All the different resources this downloader handles
-  static let handledResources: [ResourceDownloader.Resource] = [
+  static let handledResources: [BraveS3Resource] = [
     .genericContentBlockingBehaviors, .generalCosmeticFilters
   ]
   
@@ -27,7 +27,7 @@ public actor AdblockResourceDownloader: Sendable {
   }()
   
   /// The resource downloader that will be used to download all our resoruces
-  private let resourceDownloader: ResourceDownloader
+  private let resourceDownloader: ResourceDownloader<BraveS3Resource>
 
   init(networkManager: NetworkManager = NetworkManager()) {
     self.resourceDownloader = ResourceDownloader(networkManager: networkManager)
@@ -92,7 +92,7 @@ public actor AdblockResourceDownloader: Sendable {
   }
   
   /// Start fetching the given resource at regular intervals
-  private func startFetching(resource: ResourceDownloader.Resource, every fetchInterval: TimeInterval) {
+  private func startFetching(resource: BraveS3Resource, every fetchInterval: TimeInterval) {
     Task { @MainActor in
       for try await result in await self.resourceDownloader.downloadStream(for: resource, every: fetchInterval) {
         switch result {
@@ -106,10 +106,10 @@ public actor AdblockResourceDownloader: Sendable {
   }
   
   /// Load cached data for the given resource. Ensures this is done on the MainActor
-  private func loadCachedOrBundledData(for resource: ResourceDownloader.Resource) async {
+  private func loadCachedOrBundledData(for resource: BraveS3Resource) async {
     do {
       // Check if we have cached results for the given resource
-      if let cachedResult = try ResourceDownloaderStream.cachedResult(for: resource) {
+      if let cachedResult = try resource.cachedResult() {
         await handle(downloadResult: cachedResult, for: resource)
       }
     } catch {
@@ -120,7 +120,7 @@ public actor AdblockResourceDownloader: Sendable {
   }
   
   /// Handle the downloaded file url for the given resource
-  private func handle(downloadResult: ResourceDownloaderStream.DownloadResult, for resource: ResourceDownloader.Resource) async {
+  private func handle(downloadResult: ResourceDownloader<BraveS3Resource>.DownloadResult, for resource: BraveS3Resource) async {
     let version = fileVersionDateFormatter.string(from: downloadResult.date)
     
     switch resource {
@@ -137,7 +137,7 @@ public actor AdblockResourceDownloader: Sendable {
       if !downloadResult.isModified {
         // If the file is not modified first we need to see if we already have a cached value loaded
         // We don't what to bother recompiling this file if we already loaded it
-        guard await !(ContentBlockerManager.shared.hasRuleList(for: blocklistType)) else {
+        guard await !ContentBlockerManager.shared.hasRuleList(for: blocklistType) else {
           // We don't want to recompile something that we alrady have loaded
           ContentBlockerManager.log.debug("Cached rule list exists for `\(blocklistType.identifier)`")
           return
@@ -145,7 +145,7 @@ public actor AdblockResourceDownloader: Sendable {
       }
       
       do {
-        guard let encodedContentRuleList = try ResourceDownloader.string(for: resource) else {
+        guard let encodedContentRuleList = try resource.downloadedString() else {
           assertionFailure("This file was downloaded successfully so it should not be nil")
           return
         }

--- a/Sources/Brave/WebFilters/AdblockResourceDownloader.swift
+++ b/Sources/Brave/WebFilters/AdblockResourceDownloader.swift
@@ -14,7 +14,7 @@ public actor AdblockResourceDownloader: Sendable {
   
   /// All the different resources this downloader handles
   static let handledResources: [BraveS3Resource] = [
-    .genericContentBlockingBehaviors, .generalCosmeticFilters
+    .genericContentBlockingBehaviors, .generalCosmeticFilters, .debounceRules
   ]
   
   /// A formatter that is used to format a version number
@@ -159,6 +159,23 @@ public actor AdblockResourceDownloader: Sendable {
         ContentBlockerManager.log.error(
           "Failed to compile downloaded content blocker resource: \(error.localizedDescription)"
         )
+      }
+      
+    case .debounceRules:
+      // We don't want to setup the debounce rules more than once for the same cached file
+      guard downloadResult.isModified || DebouncingResourceDownloader.shared.matcher == nil else {
+        return
+      }
+      
+      do {
+        guard let data = try resource.downloadedData() else {
+          assertionFailure("We just downloaded this file, how can it not be there?")
+          return
+        }
+        
+        try DebouncingResourceDownloader.shared.setup(withRulesJSON: data)
+      } catch {
+        ContentBlockerManager.log.error("Failed to setup debounce rules: \(error.localizedDescription)")
       }
       
     default:

--- a/Sources/Brave/WebFilters/BraveS3Resource.swift
+++ b/Sources/Brave/WebFilters/BraveS3Resource.swift
@@ -7,6 +7,8 @@ import Foundation
 import Shared
 
 enum BraveS3Resource: Hashable, DownloadResourceInterface {
+  /// Rules for debouncing links
+  case debounceRules
   /// Generic iOS only content blocking behaviours used for the iOS content blocker
   case genericContentBlockingBehaviors
   /// Cosmetic filter rules
@@ -32,6 +34,8 @@ enum BraveS3Resource: Hashable, DownloadResourceInterface {
   /// The folder name under which this data should be saved under
   var cacheFolderName: String {
     switch self {
+    case .debounceRules:
+      return "debounce-data"
     case .filterListContentBlockingBehaviors(_, let componentId):
       return ["filter-lists", componentId].joined(separator: "/")
     case .genericContentBlockingBehaviors:
@@ -44,6 +48,8 @@ enum BraveS3Resource: Hashable, DownloadResourceInterface {
   /// Get the file name that is stored on the device
   var cacheFileName: String {
     switch self {
+    case .debounceRules:
+      return "ios-debouce.json"
     case .filterListContentBlockingBehaviors(let uuid, _):
       return "\(uuid)-latest.json"
     case .genericContentBlockingBehaviors:
@@ -56,6 +62,8 @@ enum BraveS3Resource: Hashable, DownloadResourceInterface {
   /// Get the external path for the given filter list and this resource type
   var externalURL: URL {
     switch self {
+    case .debounceRules:
+      return Self.baseResourceURL.appendingPathComponent("/ios/debounce.json")
     case .filterListContentBlockingBehaviors(let uuid, _):
       return Self.baseResourceURL.appendingPathComponent("/ios/\(uuid)-latest.json")
     case .genericContentBlockingBehaviors:

--- a/Sources/Brave/WebFilters/BraveS3Resource.swift
+++ b/Sources/Brave/WebFilters/BraveS3Resource.swift
@@ -1,0 +1,77 @@
+// Copyright 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import Shared
+
+enum BraveS3Resource: Hashable, DownloadResourceInterface {
+  /// Generic iOS only content blocking behaviours used for the iOS content blocker
+  case genericContentBlockingBehaviors
+  /// Cosmetic filter rules
+  case generalCosmeticFilters
+  /// Adblock rules for a filter list
+  /// iOS only content blocking behaviours used for the iOS content blocker for a given filter list
+  case filterListContentBlockingBehaviors(uuid: String, componentId: String)
+  
+  /// The name of the info plist key that contains the service key
+  private static let servicesKeyName = "SERVICES_KEY"
+  /// The name of the header value that contains the service key
+  private static let servicesKeyHeaderValue = "BraveServiceKey"
+  /// The base s3 environment url that hosts the debouncing (and other) files.
+  /// Cannot be used as-is and must be combined with a path
+  private static var baseResourceURL: URL = {
+    if AppConstants.buildChannel.isPublic {
+      return URL(string: "https://adblock-data.s3.brave.com")!
+    } else {
+      return URL(string: "https://adblock-data-staging.s3.bravesoftware.com")!
+    }
+  }()
+  
+  /// The folder name under which this data should be saved under
+  var cacheFolderName: String {
+    switch self {
+    case .filterListContentBlockingBehaviors(_, let componentId):
+      return ["filter-lists", componentId].joined(separator: "/")
+    case .genericContentBlockingBehaviors:
+      return "abp-data"
+    case .generalCosmeticFilters:
+      return "cmf-data"
+    }
+  }
+  
+  /// Get the file name that is stored on the device
+  var cacheFileName: String {
+    switch self {
+    case .filterListContentBlockingBehaviors(let uuid, _):
+      return "\(uuid)-latest.json"
+    case .genericContentBlockingBehaviors:
+      return "latest.json"
+    case .generalCosmeticFilters:
+      return "ios-cosmetic-filters.dat"
+    }
+  }
+  
+  /// Get the external path for the given filter list and this resource type
+  var externalURL: URL {
+    switch self {
+    case .filterListContentBlockingBehaviors(let uuid, _):
+      return Self.baseResourceURL.appendingPathComponent("/ios/\(uuid)-latest.json")
+    case .genericContentBlockingBehaviors:
+      return Self.baseResourceURL.appendingPathComponent("/ios/latest.json")
+    case .generalCosmeticFilters:
+      return Self.baseResourceURL.appendingPathComponent("/ios/ios-cosmetic-filters.dat")
+    }
+  }
+  
+  var headers: [String: String] {
+    var headers = [String: String]()
+    
+    if let servicesKeyValue = Bundle.main.getPlistString(for: Self.servicesKeyName) {
+      headers[Self.servicesKeyHeaderValue] = servicesKeyValue
+    }
+    
+    return headers
+  }
+}

--- a/Sources/Brave/WebFilters/DownloadResourceInterface.swift
+++ b/Sources/Brave/WebFilters/DownloadResourceInterface.swift
@@ -104,7 +104,7 @@ extension DownloadResourceInterface {
   /// Get an existing etag for this resource..
   ///
   /// - Note: If no etag is created (i.e. the file is not downloaded) a nil is returned.
-  func etag() throws -> String? {
+  func createdEtag() throws -> String? {
     guard let fileURL = createdEtagURL else { return nil }
     guard let data = FileManager.default.contents(atPath: fileURL.path) else { return nil }
     return String(data: data, encoding: .utf8)

--- a/Sources/Brave/WebFilters/DownloadResourceInterface.swift
+++ b/Sources/Brave/WebFilters/DownloadResourceInterface.swift
@@ -1,0 +1,156 @@
+// Copyright 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+
+/// An object representing errors with the resource downloader
+enum ResourceFileError: Error {
+  case failedToCreateCacheFolder
+}
+
+/// An object providing the interface of a download resource which can be used with the `ResourceDownloader`.
+/// This provides a generic multi-purpose way of downloading any files.
+public protocol DownloadResourceInterface: Sendable {
+  /// The folder name under which this data should be saved under
+  var cacheFolderName: String { get }
+  var cacheFileName: String { get }
+  var externalURL: URL { get }
+  var headers: [String: String] { get }
+}
+
+extension DownloadResourceInterface {
+  /// The directory to which we should store all the dowloaded files into
+  private static var cacheFolderDirectory: FileManager.SearchPathDirectory {
+    return FileManager.SearchPathDirectory.applicationSupportDirectory
+  }
+  
+  /// The name of the etag save into the cache folder
+  var etagFileName: String {
+    return [cacheFileName, "etag"].joined(separator: ".")
+  }
+  
+  /// Get the downloaded file URL for this resource
+  ///
+  /// - Note: Returns nil if the file does not exist
+  var downloadedFileURL: URL? {
+    guard let cacheFolderURL = createdCacheFolderURL else {
+      return nil
+    }
+    
+    let fileURL = cacheFolderURL.appendingPathComponent(cacheFileName)
+    
+    if FileManager.default.fileExists(atPath: fileURL.path) {
+      return fileURL
+    } else {
+      return nil
+    }
+  }
+  
+  /// Get the file url for the downloaded file's etag
+  ///
+  /// - Note: Returns nil if the etag does not exist
+  var createdEtagURL: URL? {
+    guard let cacheFolderURL = createdCacheFolderURL else { return nil }
+    let fileURL = cacheFolderURL.appendingPathComponent(etagFileName)
+    
+    if FileManager.default.fileExists(atPath: fileURL.path) {
+      return fileURL
+    } else {
+      return nil
+    }
+  }
+  
+  /// Get the cache folder for this resource
+  ///
+  /// - Note: Returns nil if the cache folder does not exist
+  var createdCacheFolderURL: URL? {
+    guard let folderURL = Self.cacheFolderDirectory.url else { return nil }
+    let cacheFolderURL = folderURL.appendingPathComponent(cacheFolderName)
+    
+    if FileManager.default.fileExists(atPath: cacheFolderURL.path) {
+      return cacheFolderURL
+    } else {
+      return nil
+    }
+  }
+  
+  /// Load the data for this resource
+  ///
+  /// - Note: Return nil if the data does not exist
+  func downloadedData() throws -> Data? {
+    guard let fileUrl = downloadedFileURL else { return nil }
+    return FileManager.default.contents(atPath: fileUrl.path)
+  }
+  
+  /// Load the string for this resource.
+  ///
+  /// - Note: Return nil if the data does not exist or if the file is not in the correct encoding
+  func downloadedString(encoding: String.Encoding = .utf8) throws -> String? {
+    guard let data = try downloadedData() else { return nil }
+    return String(data: data, encoding: encoding)
+  }
+  
+  /// Get a creation date for the downloaded file
+  ///
+  /// - Note: Return nil if the data does not exist
+  func creationDate() throws -> Date? {
+    guard let fileURL = downloadedFileURL else { return nil }
+    let fileAttributes = try FileManager.default.attributesOfItem(atPath: fileURL.path)
+    return fileAttributes[.creationDate] as? Date
+  }
+  
+  /// Get an existing etag for this resource..
+  ///
+  /// - Note: If no etag is created (i.e. the file is not downloaded) a nil is returned.
+  func etag() throws -> String? {
+    guard let fileURL = createdEtagURL else { return nil }
+    guard let data = FileManager.default.contents(atPath: fileURL.path) else { return nil }
+    return String(data: data, encoding: .utf8)
+  }
+  
+  /// Removes file for the given `Resource`. The containing folder is not removed.
+  func removeFile() throws {
+    guard
+      let fileURL = downloadedFileURL
+    else {
+      return
+    }
+    
+    try FileManager.default.removeItem(atPath: fileURL.path)
+  }
+  
+  /// Removes all the data for the given `Resource`
+  func removeCacheFolder() throws {
+    guard
+      let folderURL = createdCacheFolderURL
+    else {
+      return
+    }
+    
+    try FileManager.default.removeItem(atPath: folderURL.path)
+  }
+  
+  /// Get or create a cache folder for the given `Resource`
+  ///
+  /// - Note: This technically can't really return nil as the location and folder are hard coded
+  func getOrCreateCacheFolder() throws -> URL {
+    guard let folderURL = FileManager.default.getOrCreateFolder(
+      name: cacheFolderName,
+      location: Self.cacheFolderDirectory
+    ) else {
+      throw ResourceFileError.failedToCreateCacheFolder
+    }
+    
+    return folderURL
+  }
+  
+  /// Get an object representing the cached download result.
+  /// If nothing is downloaded, nil is returned.
+  func cachedResult() throws -> ResourceDownloader<Self>.DownloadResult? {
+    guard let fileURL = downloadedFileURL else { return nil }
+    guard let creationDate = try creationDate() else { return nil }
+    return ResourceDownloader<Self>.DownloadResult(date: creationDate, fileURL: fileURL, isModified: false)
+  }
+}

--- a/Sources/Brave/WebFilters/FilterListInterface.swift
+++ b/Sources/Brave/WebFilters/FilterListInterface.swift
@@ -12,7 +12,7 @@ protocol FilterListInterface {
 }
 
 extension FilterListInterface {
-  @MainActor func makeResource(componentId: String) -> ResourceDownloader.Resource {
+  @MainActor func makeResource(componentId: String) -> BraveS3Resource {
     return .filterListContentBlockingBehaviors(
       uuid: uuid, componentId: componentId
     )

--- a/Sources/Brave/WebFilters/FilterListResourceDownloader.swift
+++ b/Sources/Brave/WebFilters/FilterListResourceDownloader.swift
@@ -108,11 +108,11 @@ public class FilterListResourceDownloader: ObservableObject {
   /// Manager that handles updates to filter list settings in core data
   private let settingsManager: FilterListSettingsManager
   /// The resource downloader that downloads our resources
-  private let resourceDownloader: ResourceDownloader
+  private let resourceDownloader: ResourceDownloader<BraveS3Resource>
   /// The filter list subscription
   private var filterListSubscription: AnyCancellable?
   /// Fetch content blocking tasks per filter list
-  private var fetchTasks: [ResourceDownloader.Resource: Task<Void, Error>]
+  private var fetchTasks: [BraveS3Resource: Task<Void, Error>]
   /// Ad block service tasks per filter list UUID
   private var adBlockServiceTasks: [String: Task<Void, Error>]
   /// A marker that says if fetching has started
@@ -358,7 +358,7 @@ public class FilterListResourceDownloader: ObservableObject {
   
   /// Start fetching the resource for the given filter list
   private func startFetchingGenericContentBlockingBehaviors(for filterList: FilterList) {
-    let resource = ResourceDownloader.Resource.filterListContentBlockingBehaviors(
+    let resource = BraveS3Resource.filterListContentBlockingBehaviors(
       uuid: filterList.entry.uuid,
       componentId: filterList.entry.componentId
     )
@@ -387,12 +387,12 @@ public class FilterListResourceDownloader: ObservableObject {
   }
   
   /// Cancel all fetching tasks for the given resource
-  private func stopFetching(resource: ResourceDownloader.Resource) {
+  private func stopFetching(resource: BraveS3Resource) {
     fetchTasks[resource]?.cancel()
     fetchTasks.removeValue(forKey: resource)
   }
   
-  private func handle(downloadResult: ResourceDownloaderStream.DownloadResult, for filterList: FilterListInterface) async {
+  private func handle(downloadResult: ResourceDownloader<BraveS3Resource>.DownloadResult, for filterList: FilterListInterface) async {
     if !downloadResult.isModified {
       // if the file is not modified first we need to see if we already have a cached value loaded
       guard await !ContentBlockerManager.shared.hasRuleList(for: .filterList(uuid: filterList.uuid)) else {

--- a/Sources/Brave/WebFilters/ResourceDownloader.swift
+++ b/Sources/Brave/WebFilters/ResourceDownloader.swift
@@ -8,104 +8,12 @@ import Shared
 import BraveCore
 
 /// A ganeric resource downloader class that is responsible for fetching resources
-actor ResourceDownloader: Sendable {
-  enum Resource: Hashable {
-    /// Rules for debouncing links
-    case debounceRules
-    /// Generic filter rules for any locale
-    case genericFilterRules
-    /// Generic iOS only content blocking behaviours used for the iOS content blocker
-    case genericContentBlockingBehaviors
-    /// Cosmetic filter rules
-    case generalCosmeticFilters
-    /// Resources for cosmetic filters
-    case generalScriptletResources
-    /// Adblock rules for a filter list
-    case filterListAdBlockRules(uuid: String, componentId: String)
-    /// iOS only content blocking behaviours used for the iOS content blocker for a given filter list
-    case filterListContentBlockingBehaviors(uuid: String, componentId: String)
-    /// General external file
-    case dataFile(URL, cacheFolderName: String, cacheFileName: String)
-    
-    /// The folder name under which this data should be saved under
-    var cacheFolderName: String {
-      switch self {
-      case .debounceRules:
-        return "debounce-data"
-      case .filterListContentBlockingBehaviors(_, let componentId), .filterListAdBlockRules(_, let componentId):
-        return ["filter-lists", componentId].joined(separator: "/")
-      case .genericFilterRules, .genericContentBlockingBehaviors:
-        return "abp-data"
-      case .generalCosmeticFilters, .generalScriptletResources:
-        return "cmf-data"
-      case .dataFile(_, let cacheFolderName, _):
-        return cacheFolderName
-      }
-    }
-    
-    /// The name of the etag save into the cache folder
-    fileprivate var etagFileName: String {
-      return [cacheFileName, "etag"].joined(separator: ".")
-    }
-    
-    /// Get the file name that is stored on the device
-    var cacheFileName: String {
-      switch self {
-      case .debounceRules:
-        return "ios-debouce.json"
-      case .filterListAdBlockRules(let uuid, _):
-        return "\(uuid)-latest.txt"
-      case .filterListContentBlockingBehaviors(let uuid, _):
-        return "\(uuid)-latest.json"
-      case .genericFilterRules:
-        return "latest.txt"
-      case .genericContentBlockingBehaviors:
-        return "latest.json"
-      case .generalCosmeticFilters:
-        return "ios-cosmetic-filters.dat"
-      case .generalScriptletResources:
-        return "scriptlet-resources.json"
-      case .dataFile(_, _, let cacheFileName):
-        return cacheFileName
-      }
-    }
-    
-    /// The base s3 environment url that hosts the debouncing (and other) files.
-    /// Cannot be used as-is and must be combined with a path
-    private static var baseResourceURL: URL = {
-      if AppConstants.buildChannel.isPublic {
-        return URL(string: "https://adblock-data.s3.brave.com")!
-      } else {
-        return URL(string: "https://adblock-data-staging.s3.bravesoftware.com")!
-      }
-    }()
-    
-    /// Get the external path for the given filter list and this resource type
-    var externalURL: URL {
-      switch self {
-      case .debounceRules:
-        return Self.baseResourceURL.appendingPathComponent("/ios/debounce.json")
-      case .filterListContentBlockingBehaviors(let uuid, _):
-        return Self.baseResourceURL.appendingPathComponent("/ios/\(uuid)-latest.json")
-      case .filterListAdBlockRules(let uuid, _):
-        return Self.baseResourceURL.appendingPathComponent("/ios/\(uuid)-latest.txt")
-      case .genericFilterRules:
-        return Self.baseResourceURL.appendingPathComponent("/ios/latest.txt")
-      case .genericContentBlockingBehaviors:
-        return Self.baseResourceURL.appendingPathComponent("/ios/latest.json")
-      case .generalCosmeticFilters:
-        return Self.baseResourceURL.appendingPathComponent("/ios/ios-cosmetic-filters.dat")
-      case .generalScriptletResources:
-        return Self.baseResourceURL.appendingPathComponent("/ios/scriptlet-resources.json")
-      case .dataFile(let url, _, _):
-        return url
-      }
-    }
-  }
-  
-  /// An object representing errors with the resource downloader
-  enum ResourceDownloaderError: Error {
-    case failedToCreateCacheFolder
+actor ResourceDownloader<Resource: DownloadResourceInterface>: Sendable {
+  /// An object representing the download
+  struct DownloadResult: Equatable {
+    let date: Date
+    let fileURL: URL
+    let isModified: Bool
   }
   
   /// An object representing errors during a resource download
@@ -114,24 +22,16 @@ actor ResourceDownloader: Sendable {
   }
   
   /// An object represening the download result
-  enum DownloadResult<Result> {
+  private enum DownloadResultStatus {
     case notModified(URL, Date)
-    case downloaded(Result, Date)
+    case downloaded(CachedNetworkResource, Date)
   }
   
-  /// The directory to which we should store all the dowloaded files into
-  private static var cacheFolderDirectory: FileManager.SearchPathDirectory {
-    return FileManager.SearchPathDirectory.applicationSupportDirectory
-  }
-  
+  /// The default fetch interval used by this resource downloaded. In production its 6 hours, whereas in debug it's every 10 minutes.
   private static var defaultFetchInterval: TimeInterval {
     return AppConstants.buildChannel.isPublic ? 6.hours : 10.minutes
   }
   
-  /// The name of the info plist key that contains the service key
-  private static let servicesKeyName = "SERVICES_KEY"
-  /// The name of the header value that contains the service key
-  private static let servicesKeyHeaderValue = "BraveServiceKey"
   /// The netowrk manager performing the requests
   private let networkManager: NetworkManager
   
@@ -140,199 +40,76 @@ actor ResourceDownloader: Sendable {
     self.networkManager = networkManager
   }
   
-  func downloadStream(for resource: Resource, every fetchInterval: TimeInterval = defaultFetchInterval) -> ResourceDownloaderStream {
+  /// Return a download stream for the given resource. The download stream will fetch data every interval given by the provided `fetchInterval`.
+  func downloadStream(for resource: Resource, every fetchInterval: TimeInterval = defaultFetchInterval) -> ResourceDownloaderStream<Resource> {
     return ResourceDownloaderStream(resource: resource, resourceDownloader: self, fetchInterval: fetchInterval)
   }
   
   /// Download the give resource type for the filter list and store it into the cache folder url
   @discardableResult
-  func download(resource: Resource) async throws -> DownloadResult<URL> {
+  func download(resource: Resource) async throws -> DownloadResult {
     let result = try await downloadInternal(resource: resource)
     
     switch result {
     case .downloaded(let networkResource, let date):
       // Clear any old data
-      try Self.removeFile(for: resource)
+      try resource.removeFile()
       // Make a cache folder if needed
-      let cacheFolderURL = try Self.getOrCreateCacheFolder(for: resource)
+      let cacheFolderURL = try resource.getOrCreateCacheFolder()
       // Save the data to file
       let fileURL = cacheFolderURL.appendingPathComponent(resource.cacheFileName)
-      try Self.writeDataToDisk(data: networkResource.data, toFileURL: fileURL)
+      try writeDataToDisk(data: networkResource.data, toFileURL: fileURL)
       // Save the etag to file
       if let data = networkResource.etag?.data(using: .utf8) {
-        try Self.writeDataToDisk(
+        try writeDataToDisk(
           data: data,
           toFileURL: cacheFolderURL.appendingPathComponent(resource.etagFileName)
         )
       }
       // Return the file URL
-      let creationDate = try? Self.creationDate(for: resource)
-      return .downloaded(fileURL, creationDate ?? date)
-    case .notModified(let url, let date):
-      let creationDate = try? Self.creationDate(for: resource)
-      return .notModified(url, creationDate ?? date)
+      let creationDate = try? resource.creationDate()
+      return DownloadResult(
+        date: creationDate ?? date, fileURL: fileURL, isModified: true
+      )
+    case .notModified(let fileURL, let date):
+      let creationDate = try? resource.creationDate()
+      return DownloadResult(
+        date: creationDate ?? date, fileURL: fileURL, isModified: false
+      )
     }
   }
   
-  private func downloadInternal(resource: Resource) async throws -> DownloadResult<CachedNetworkResource> {
-    var headers = [String: String]()
-    
-    if let servicesKeyValue = Bundle.main.getPlistString(for: Self.servicesKeyName) {
-      headers[Self.servicesKeyHeaderValue] = servicesKeyValue
-    }
-    
-    let etag = try? Self.etag(for: resource)
+  private func downloadInternal(resource: Resource) async throws -> DownloadResultStatus {
+    let etag = try? resource.etag()
     
     do {
       let networkResource = try await self.networkManager.downloadResource(
         with: resource.externalURL,
         resourceType: .cached(etag: etag),
         checkLastServerSideModification: !AppConstants.buildChannel.isPublic,
-        customHeaders: headers)
+        customHeaders: resource.headers)
       
       guard !networkResource.data.isEmpty else {
         throw DownloadResultError.noData
       }
       
-      return .downloaded(networkResource, Date())
+      let date = try resource.creationDate()
+      return .downloaded(networkResource, date ?? Date())
     } catch let error as NetworkManagerError {
-      if error == .fileNotModified, let fileURL = Self.downloadedFileURL(for: resource) {
-        return .notModified(fileURL, Date())
+      if error == .fileNotModified, let fileURL = resource.downloadedFileURL {
+        let date = try resource.creationDate()
+        return .notModified(fileURL, date ?? Date())
       } else {
         throw error
       }
     }
   }
   
-  /// Get or create a cache folder for the given `Resource`
-  ///
-  /// - Note: This technically can't really return nil as the location and folder are hard coded
-  private static func getOrCreateCacheFolder(for resource: Resource) throws -> URL {
-    guard let folderURL = FileManager.default.getOrCreateFolder(
-      name: resource.cacheFolderName,
-      location: Self.cacheFolderDirectory
-    ) else {
-      throw ResourceDownloaderError.failedToCreateCacheFolder
-    }
-    
-    return folderURL
-  }
-  
-  /// Load the data for the given `Resource` if it exists.
-  ///
-  /// - Note: Return nil if the data does not exist
-  static func data(for resource: Resource) throws -> Data? {
-    guard let fileUrl = downloadedFileURL(for: resource) else { return nil }
-    return FileManager.default.contents(atPath: fileUrl.path)
-  }
-  
-  /// Load the string for the given `Resource` if it exists.
-  ///
-  /// - Note: Return nil if the data does not exist
-  static func string(for resource: Resource) throws -> String? {
-    guard let data = try self.data(for: resource) else { return nil }
-    return String(data: data, encoding: .utf8)
-  }
-  
-  /// Get the downloaded file URL for the filter list and resource type
-  ///
-  /// - Note: Returns nil if the file does not exist
-  static func downloadedFileURL(for resource: Resource) -> URL? {
-    guard let cacheFolderURL = createdCacheFolderURL(for: resource) else {
-      return nil
-    }
-    
-    let fileURL = cacheFolderURL.appendingPathComponent(resource.cacheFileName)
-    
-    if FileManager.default.fileExists(atPath: fileURL.path) {
-      return fileURL
-    } else {
-      return nil
-    }
-  }
-  
-  /// Get the file url for the downloaded file's etag
-  ///
-  /// - Note: Returns nil if the etag does not exist
-  static func etagURL(for resource: Resource) -> URL? {
-    guard let cacheFolderURL = createdCacheFolderURL(for: resource) else { return nil }
-    let fileURL = cacheFolderURL.appendingPathComponent(resource.etagFileName)
-    
-    if FileManager.default.fileExists(atPath: fileURL.path) {
-      return fileURL
-    } else {
-      return nil
-    }
-  }
-  
-  /// Get an existing etag for the given `Resource`
-  static func creationDate(for resource: Resource) throws -> Date? {
-    guard let fileURL = downloadedFileURL(for: resource) else { return nil }
-    let fileAttributes = try FileManager.default.attributesOfItem(atPath: fileURL.path)
-    return fileAttributes[.creationDate] as? Date
-  }
-  
-  /// Get an existing etag for the given `Resource`
-  static func etag(for resource: Resource) throws -> String? {
-    guard let fileURL = etagURL(for: resource) else { return nil }
-    guard let data = FileManager.default.contents(atPath: fileURL.path) else { return nil }
-    return String(data: data, encoding: .utf8)
-  }
-  
-  /// Get the cache folder for the given `Resource`
-  ///
-  /// - Note: Returns nil if the cache folder does not exist
-  static func createdCacheFolderURL(for resource: Resource) -> URL? {
-    guard let folderURL = cacheFolderDirectory.url else { return nil }
-    let cacheFolderURL = folderURL.appendingPathComponent(resource.cacheFolderName)
-    
-    if FileManager.default.fileExists(atPath: cacheFolderURL.path) {
-      return cacheFolderURL
-    } else {
-      return nil
-    }
-  }
-  
-  /// Removes all the data for the given `Resource`
-  static func removeFile(for resource: Resource) throws {
-    guard
-      let fileURL = self.downloadedFileURL(for: resource)
-    else {
-      return
-    }
-    
-    try FileManager.default.removeItem(atPath: fileURL.path)
-  }
-
   /// Write the given `Data` to disk into to the specified file `URL`
   /// into the `applicationSupportDirectory` `SearchPathDirectory`.
   ///
   /// - Note: `fileName` must contain the full file name including the extension.
-  private static func writeDataToDisk(data: Data, toFileURL fileURL: URL) throws {
+  private func writeDataToDisk(data: Data, toFileURL fileURL: URL) throws {
     try data.write(to: fileURL, options: [.atomic])
   }
-  
-  /// Removes all the data for the given `Resource`
-  private static func removeCacheFolder(for resource: Resource) throws {
-    guard
-      let folderURL = self.createdCacheFolderURL(for: resource)
-    else {
-      return
-    }
-    
-    try FileManager.default.removeItem(atPath: folderURL.path)
-  }
-  
-  #if DEBUG
-  /// Convenience method for tests
-  public static func getMockResponse(
-    for resource: ResourceDownloader.Resource,
-    statusCode code: Int = 200,
-    headerFields: [String: String]? = nil
-  ) -> HTTPURLResponse {
-    return HTTPURLResponse(
-      url: resource.externalURL, statusCode: code,
-      httpVersion: "HTTP/1.1", headerFields: headerFields)!
-  }
-  #endif
 }

--- a/Sources/Brave/WebFilters/ResourceDownloader.swift
+++ b/Sources/Brave/WebFilters/ResourceDownloader.swift
@@ -80,7 +80,7 @@ actor ResourceDownloader<Resource: DownloadResourceInterface>: Sendable {
   }
   
   private func downloadInternal(resource: Resource) async throws -> DownloadResultStatus {
-    let etag = try? resource.etag()
+    let etag = try? resource.createdEtag()
     
     do {
       let networkResource = try await self.networkManager.downloadResource(

--- a/Tests/ClientTests/Web Filters/ResourceDownloaderStreamTests.swift
+++ b/Tests/ClientTests/Web Filters/ResourceDownloaderStreamTests.swift
@@ -11,8 +11,8 @@ class ResourceDownloaderStreamTests: XCTestCase {
     // Given
     let expectation = XCTestExpectation(description: "Test downloading resources")
     expectation.expectedFulfillmentCount = 2
-    let resource = ResourceDownloader.Resource.debounceRules
-    let downloader = ResourceDownloader(networkManager: NetworkManager.makeNetworkManager(
+    let resource = BraveS3Resource.genericContentBlockingBehaviors
+    let downloader = ResourceDownloader<BraveS3Resource>(networkManager: NetworkManager.makeNetworkManager(
       for: [resource], statusCode: 200
     ))
     
@@ -33,8 +33,8 @@ class ResourceDownloaderStreamTests: XCTestCase {
   func testSequenceWithErrorDownload() throws {
     // Given
     let expectation = XCTestExpectation(description: "Test downloading resources")
-    let resource = ResourceDownloader.Resource.debounceRules
-    let downloader = ResourceDownloader(networkManager: NetworkManager.makeNetworkManager(
+    let resource = BraveS3Resource.genericContentBlockingBehaviors
+    let downloader = ResourceDownloader<BraveS3Resource>(networkManager: NetworkManager.makeNetworkManager(
       for: [resource], statusCode: 404
     ))
     
@@ -52,7 +52,7 @@ class ResourceDownloaderStreamTests: XCTestCase {
     task.cancel()
   }
   
-  @MainActor private func ensureSuccessResult(result: Result<ResourceDownloaderStream.DownloadResult, Error>, file: StaticString = #filePath, line: UInt = #line) {
+  @MainActor private func ensureSuccessResult(result: Result<ResourceDownloader<BraveS3Resource>.DownloadResult, Error>, file: StaticString = #filePath, line: UInt = #line) {
     // Then
     switch result {
     case .success:
@@ -62,7 +62,7 @@ class ResourceDownloaderStreamTests: XCTestCase {
     }
   }
   
-  @MainActor private func ensureErrorResult(result: Result<ResourceDownloaderStream.DownloadResult, Error>, file: StaticString = #filePath, line: UInt = #line) {
+  @MainActor private func ensureErrorResult(result: Result<ResourceDownloader<BraveS3Resource>.DownloadResult, Error>, file: StaticString = #filePath, line: UInt = #line) {
     // Then
     switch result {
     case .success:

--- a/Tests/ClientTests/Web Filters/ResourceDownloaderTests.swift
+++ b/Tests/ClientTests/Web Filters/ResourceDownloaderTests.swift
@@ -10,45 +10,37 @@ class ResourceDownloaderTests: XCTestCase {
   func testSuccessfulResourceDownload() throws {
     // Given
     let expectation = XCTestExpectation(description: "Test downloading resources")
-    let resource = ResourceDownloader.Resource.debounceRules
-    let firstDownloader = ResourceDownloader(networkManager: NetworkManager.makeNetworkManager(
+    let resource = BraveS3Resource.genericContentBlockingBehaviors
+    let firstDownloader = ResourceDownloader<BraveS3Resource>(networkManager: NetworkManager.makeNetworkManager(
       for: [resource], statusCode: 200, etag: "123"
     ))
-    let secondDownloader = ResourceDownloader(networkManager: NetworkManager.makeNetworkManager(
+    let secondDownloader = ResourceDownloader<BraveS3Resource>(networkManager: NetworkManager.makeNetworkManager(
       for: [resource], statusCode: 304, etag: "123"
     ))
     
     Task {
       do {
         // When
+        // We do first download
         let result = try await firstDownloader.download(resource: resource)
         
         // Then
         // We get a download result
-        switch result {
-        case .downloaded:
-          XCTAssertNotNil(try ResourceDownloader.data(for: resource))
-          XCTAssertNotNil(try ResourceDownloader.etag(for: resource))
-        case .notModified:
-          XCTFail("Not modified recieved")
-        }
-      } catch {
-        XCTFail(error.localizedDescription)
-      }
-      
-      do {
+        XCTAssertNotNil(try resource.data())
+        XCTAssertNotNil(try resource.etag())
+        XCTAssertTrue(result.isModified)
+        
         // When
-        let result = try await secondDownloader.download(resource: resource)
+        // We re-download
+        let result2 = try await secondDownloader.download(resource: resource)
         
         // Then
-        // We get a not modified result
-        switch result {
-        case .downloaded:
-          XCTFail("Not modified recieved")
-        case .notModified:
-          XCTAssertNotNil(try ResourceDownloader.data(for: resource))
-          XCTAssertNotNil(try ResourceDownloader.etag(for: resource))
-        }
+        // We get a non modified result
+        XCTAssertNotNil(try resource.data())
+        XCTAssertNotNil(try resource.etag())
+        XCTAssertFalse(result2.isModified)
+        // Same download date
+        XCTAssertEqual(result2.date, result.date)
       } catch {
         XCTFail(error.localizedDescription)
       }
@@ -62,8 +54,8 @@ class ResourceDownloaderTests: XCTestCase {
   func testFailedResourceDownload() throws {
     // Given
     let expectation = XCTestExpectation(description: "Test downloading resource")
-    let resource = ResourceDownloader.Resource.debounceRules
-    let downloader = ResourceDownloader(networkManager: NetworkManager.makeNetworkManager(
+    let resource = BraveS3Resource.genericContentBlockingBehaviors
+    let downloader = ResourceDownloader<BraveS3Resource>(networkManager: NetworkManager.makeNetworkManager(
       for: [resource], statusCode: 404
     ))
     

--- a/Tests/ClientTests/Web Filters/ResourceDownloaderTests.swift
+++ b/Tests/ClientTests/Web Filters/ResourceDownloaderTests.swift
@@ -26,8 +26,8 @@ class ResourceDownloaderTests: XCTestCase {
         
         // Then
         // We get a download result
-        XCTAssertNotNil(try resource.data())
-        XCTAssertNotNil(try resource.etag())
+        XCTAssertNotNil(try resource.downloadedData())
+        XCTAssertNotNil(try resource.createdEtag())
         XCTAssertTrue(result.isModified)
         
         // When
@@ -36,8 +36,8 @@ class ResourceDownloaderTests: XCTestCase {
         
         // Then
         // We get a non modified result
-        XCTAssertNotNil(try resource.data())
-        XCTAssertNotNil(try resource.etag())
+        XCTAssertNotNil(try resource.downloadedData())
+        XCTAssertNotNil(try resource.createdEtag())
         XCTAssertFalse(result2.isModified)
         // Same download date
         XCTAssertEqual(result2.date, result.date)


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7161 

1. This PR prepares the `ResourceDownloader` so that we can download resources outside of S3. This is done by using generics in resource downloader so I can use whatever class/struct as a resource. 
2. It also has some outstanding cleanups so the code is less verbose. For example, `resource.etag()` vs `ResourceDownloader<BraveS3Resource>.etag(for: resource)`.
3. Debounce has custom download logic where I can just simply use all the logic in AdBlockResourceDownloader for downloading debounce files with just the need to add a new enum type. So a lot of that duplicate logic is removed.

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
