### PR TITLE
Fix #7136: Send button disabled when address missing checksum

### DIFF
--- a/Sources/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
+++ b/Sources/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
@@ -30,7 +30,7 @@ struct SendTokenView: View {
           !sendTokenStore.isMakingTx,
           !sendTokenStore.sendAddress.isEmpty,
           !sendTokenStore.isResolvingAddress,
-          sendTokenStore.addressError == nil,
+          sendTokenStore.addressError?.shouldBlockSend != true,
           sendTokenStore.sendError == nil else {
       return true
     }

--- a/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
@@ -101,6 +101,15 @@ public class SendTokenStore: ObservableObject {
         return String.localizedStringWithFormat(Strings.Wallet.sendErrorDomainNotRegistered, BraveWallet.CoinType.eth.localizedTitle)
       }
     }
+    
+    var shouldBlockSend: Bool {
+      switch self {
+      case .missingChecksum:
+        return false
+      default:
+        return true
+      }
+    }
   }
   
   enum SendError: LocalizedError {


### PR DESCRIPTION
## Summary of Changes
- Added a new computed property to `AddressError` to determine if it should disable the send button. Only the `missingChecksum` error will allow transaction to be created

This pull request fixes #7136

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
Verify error cases from [#4744](https://github.com/brave/brave-ios/issues/4744)
- If an address has each alphabetic character as lowercase, give a warning that the address has no checksum information and might be invalid.
    - Verify user can proceed with creating the transaction
- If an address has each alphabetic character as uppercase, give a warning that the address has no checksum information and might be invalid.
    - Verify user can proceed with creating the transaction
- If an address has both lowercase and uppercase alphabetic characters, and it doesn't match the checksum address, give an error and don't allow the user to send.


## Screenshots:

https://user-images.githubusercontent.com/5314553/227235787-19251ac6-7927-4e8d-a890-c779d612caf6.mp4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
