### PR TITLE
Fix #7139: Fetch all favicons from cache always

### DIFF
--- a/Sources/Brave/Frontend/Browser/FaviconHandler.swift
+++ b/Sources/Brave/Frontend/Browser/FaviconHandler.swift
@@ -24,37 +24,30 @@ class FaviconHandler {
   }
 
   @MainActor func loadFaviconURL(
-    _ faviconURL: String,
+    _ url: URL,
     forTab tab: Tab
   ) async throws -> Favicon {
-    guard let currentURL = tab.url else {
-      throw FaviconError.noImagesFound
-    }
-    
-    let favicon = try await FaviconFetcher.loadIcon(url: currentURL, kind: .smallIcon, persistent: !tab.isPrivate)
-    tab.favicons.append(favicon)
+    let favicon = try await FaviconFetcher.loadIcon(url: url, kind: .smallIcon, persistent: !tab.isPrivate)
+    tab.favicon = favicon
     return favicon
   }
 }
 
 extension FaviconHandler: TabEventHandler {
   func tab(_ tab: Tab, didLoadPageMetadata metadata: PageMetadata) {
-    tab.favicons.removeAll(keepingCapacity: false)
-    Task { @MainActor in
-      if let iconURL = metadata.largeIconURL {
-        let favicon = try await loadFaviconURL(iconURL, forTab: tab)
-        TabEvent.post(.didLoadFavicon(favicon), for: tab)
-      } else if let iconURL = metadata.faviconURL {
-        let favicon = try await loadFaviconURL(iconURL, forTab: tab)
+    if let currentURL = tab.url {
+      if let favicon = FaviconFetcher.getIconFromCache(for: currentURL) {
+        tab.favicon = favicon
+        return
+      }
+      
+      tab.favicon = Favicon.default
+      Task { @MainActor in
+        let favicon = try await loadFaviconURL(currentURL, forTab: tab)
         TabEvent.post(.didLoadFavicon(favicon), for: tab)
       }
-      // No favicon fetched from metadata, trying base domain's standard favicon location.
-      else if let baseURL = tab.url?.domainURL {
-        let favicon = try await loadFaviconURL(
-          baseURL.appendingPathComponent("favicon.ico").absoluteString,
-          forTab: tab)
-        TabEvent.post(.didLoadFavicon(favicon), for: tab)
-      }
+    } else {
+      tab.favicon = Favicon.default
     }
   }
 }

--- a/Sources/Brave/Frontend/Browser/FaviconHandler.swift
+++ b/Sources/Brave/Frontend/Browser/FaviconHandler.swift
@@ -38,10 +38,10 @@ extension FaviconHandler: TabEventHandler {
     if let currentURL = tab.url {
       if let favicon = FaviconFetcher.getIconFromCache(for: currentURL) {
         tab.favicon = favicon
-        return
+      } else {
+        tab.favicon = Favicon.default
       }
       
-      tab.favicon = Favicon.default
       Task { @MainActor in
         let favicon = try await loadFaviconURL(currentURL, forTab: tab)
         TabEvent.post(.didLoadFavicon(favicon), for: tab)

--- a/Sources/Brave/Frontend/Browser/Favicons/LargeFaviconView.swift
+++ b/Sources/Brave/Frontend/Browser/Favicons/LargeFaviconView.swift
@@ -13,11 +13,27 @@ import Favicon
 class LargeFaviconView: UIView {
   func loadFavicon(siteURL: URL, monogramFallbackCharacter: Character? = nil) {
     faviconTask?.cancel()
+    if let favicon = FaviconFetcher.getIconFromCache(for: siteURL) {
+      faviconTask = nil
+      
+      self.imageView.image = favicon.image ?? Favicon.defaultImage
+      self.backgroundColor = favicon.backgroundColor
+      self.imageView.contentMode = .scaleAspectFit
+      
+      if let image = favicon.image {
+        self.backgroundView.isHidden = !favicon.isMonogramImage && !image.hasTransparentEdges
+      } else {
+        self.backgroundView.isHidden = !favicon.hasTransparentBackground && !favicon.isMonogramImage
+      }
+      return
+    }
+    
     faviconTask = Task { @MainActor in
+      let isPersistent = !PrivateBrowsingManager.shared.isPrivateBrowsing
       do {
         let favicon = try await FaviconFetcher.loadIcon(url: siteURL,
                                                         kind: .largeIcon,
-                                                        persistent: !PrivateBrowsingManager.shared.isPrivateBrowsing)
+                                                        persistent: isPersistent)
         
         self.imageView.image = favicon.image
         self.backgroundColor = favicon.backgroundColor
@@ -29,7 +45,7 @@ class LargeFaviconView: UIView {
           self.backgroundView.isHidden = !favicon.hasTransparentBackground && !favicon.isMonogramImage
         }
       } catch {
-        self.imageView.image = try? await FaviconFetcher.monogramIcon(url: siteURL).image ?? Favicon.defaultImage
+        self.imageView.image = try? await FaviconFetcher.monogramIcon(url: siteURL, persistent: isPersistent).image ?? Favicon.defaultImage
         self.backgroundColor = nil
         self.imageView.contentMode = .scaleAspectFit
         self.backgroundView.isHidden = false

--- a/Sources/Brave/Frontend/Browser/Favicons/LargeFaviconView.swift
+++ b/Sources/Brave/Frontend/Browser/Favicons/LargeFaviconView.swift
@@ -45,7 +45,7 @@ class LargeFaviconView: UIView {
           self.backgroundView.isHidden = !favicon.hasTransparentBackground && !favicon.isMonogramImage
         }
       } catch {
-        self.imageView.image = try? await FaviconFetcher.monogramIcon(url: siteURL, persistent: isPersistent).image ?? Favicon.defaultImage
+        self.imageView.image = Favicon.defaultImage
         self.backgroundColor = nil
         self.imageView.contentMode = .scaleAspectFit
         self.backgroundView.isHidden = false

--- a/Sources/Brave/Frontend/Browser/Favorites/FavoritesViewController.swift
+++ b/Sources/Brave/Frontend/Browser/Favorites/FavoritesViewController.swift
@@ -668,8 +668,7 @@ extension FavoritesViewController: NSFetchedResultsControllerDelegate {
 
       cell.textLabel.text = favorite.displayTitle ?? favorite.url
       if let url = favorite.url?.asURL {
-        cell.imageView.loadFavicon(siteURL: url,
-                                   monogramFallbackCharacter: favorite.title?.first)
+        cell.imageView.loadFavicon(siteURL: url)
       }
       cell.accessibilityLabel = cell.textLabel.text
 

--- a/Sources/Brave/Frontend/Browser/New Tab Page/Sections/FavoritesSectionProvider.swift
+++ b/Sources/Brave/Frontend/Browser/New Tab Page/Sections/FavoritesSectionProvider.swift
@@ -110,7 +110,7 @@ class FavoritesSectionProvider: NSObject, NTPObservableSectionProvider {
     cell.imageView.cancelLoading()
 
     if let url = fav.url?.asURL {
-      cell.imageView.loadFavicon(siteURL: url, monogramFallbackCharacter: fav.title?.first)
+      cell.imageView.loadFavicon(siteURL: url)
     }
     cell.accessibilityLabel = cell.textLabel.text
   }

--- a/Sources/Brave/Frontend/Browser/Search/SearchViewController.swift
+++ b/Sources/Brave/Frontend/Browser/Search/SearchViewController.swift
@@ -618,7 +618,6 @@ public class SearchViewController: SiteTableViewController, LoaderListener {
         cell.imageView?.contentMode = .scaleAspectFit
         cell.imageView?.layer.borderColor = SearchViewControllerUX.iconBorderColor.cgColor
         cell.imageView?.layer.borderWidth = SearchViewControllerUX.iconBorderWidth
-        cell.imageView?.image = FaviconFetcher.getIconFromCache(for: site.tileURL)?.image ?? Favicon.defaultImage
         cell.imageView?.loadFavicon(for: site.tileURL)
         cell.backgroundColor = .secondaryBraveBackground
       }

--- a/Sources/Brave/Frontend/Browser/Tab.swift
+++ b/Sources/Brave/Frontend/Browser/Tab.swift
@@ -594,23 +594,6 @@ class Tab: NSObject {
         if url.isSecureWebPage(), !isPrivate {
           ActivityShortcutManager.shared.donateCustomIntent(for: .openWebsite, with: url.absoluteString)
         }
-
-        Task { @MainActor in
-          if let favicon = FaviconFetcher.getIconFromCache(for: url) {
-            self.favicon = favicon
-          } else if url.scheme == "http" {  // Attempt to upgrade http to https favicons if the original doesn't exist due to a redirect
-            var components = URLComponents(string: url.absoluteString)
-            components?.scheme = "https"
-
-            if let url = components?.url, let favicon = FaviconFetcher.getIconFromCache(for: url) {
-              self.favicon = favicon
-            } else {
-              self.favicon = Favicon.default
-            }
-          } else {
-            self.favicon = Favicon.default
-          }
-        }
       }
 
       return webView.load(request)

--- a/Sources/Brave/Frontend/Browser/TabManager.swift
+++ b/Sources/Brave/Frontend/Browser/TabManager.swift
@@ -963,9 +963,9 @@ class TabManager: NSObject {
       tab.url = nil
       let isPrivateBrowsing = PrivateBrowsingManager.shared.isPrivateBrowsing
       if let url = URL(string: urlString) {
+        tab.favicon = FaviconFetcher.getIconFromCache(for: url) ?? Favicon.default
         Task { @MainActor in
-          let favicon = try await FaviconFetcher.loadIcon(url: url, kind: .smallIcon, persistent: !isPrivateBrowsing)
-          tab.favicons.append(favicon)
+          tab.favicon = try await FaviconFetcher.loadIcon(url: url, kind: .smallIcon, persistent: !isPrivateBrowsing)
         }
       }
 

--- a/Sources/Brave/Frontend/Browser/Tabs/TabTray/TabTrayController+TableViewDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/Tabs/TabTray/TabTrayController+TableViewDelegate.swift
@@ -45,17 +45,12 @@ extension TabTrayController: UITableViewDataSource, UITableViewDelegate {
     
     cell.imageIconView.do {
       $0.contentMode = .scaleAspectFit
-      $0.image = Favicon.defaultImage
       $0.layer.borderColor = BraveUX.faviconBorderColor.cgColor
       $0.layer.borderWidth = BraveUX.faviconBorderWidth
       $0.layer.cornerRadius = 6
       $0.layer.cornerCurve = .continuous
       $0.layer.masksToBounds = true
-      
-      // TODO: Remove Domain creation and load FavIcon method swap the method with brave-core fetch #5312
-      $0.loadFavicon(
-        for: distantTab.url,
-        monogramFallbackCharacter: distantTab.title?.first)
+      $0.loadFavicon(for: distantTab.url)
     }
   }
   

--- a/Sources/Brave/Frontend/Browser/Tabs/TabTray/Views/TabTrayCell.swift
+++ b/Sources/Brave/Frontend/Browser/Tabs/TabTray/Views/TabTrayCell.swift
@@ -44,7 +44,15 @@ class TabCell: UICollectionViewCell {
   func configure(with tab: Tab) {
     self.tab = tab
     tab.onScreenshotUpdated = { [weak self, weak tab] in
-      self?.screenshotView.image = tab?.screenshot
+      guard let self = self, let tab = tab else { return }
+      
+      if !tab.displayTitle.isEmpty {
+        self.accessibilityLabel = tab.displayTitle
+      }
+      
+      self.titleLabel.text = tab.displayTitle
+      self.favicon.image = tab.displayFavicon?.image ?? Favicon.defaultImage
+      self.screenshotView.image = tab.screenshot
     }
 
     titleLabel.text = tab.displayTitle

--- a/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarksViewController.swift
+++ b/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarksViewController.swift
@@ -415,8 +415,7 @@ class BookmarksViewController: SiteTableViewController, ToolbarUrlActionsProtoco
           cell.imageView?.clearMonogramFavicon()
 
           if let urlString = item.url, let url = URL(string: urlString) {
-            cell.imageView?.image = FaviconFetcher.getIconFromCache(for: url)?.image ?? Favicon.defaultImage
-            cell.imageView?.loadFavicon(for: url, monogramFallbackCharacter: item.title?.first) { [weak cell] favicon in
+            cell.imageView?.loadFavicon(for: url) { [weak cell] favicon in
               if favicon?.isMonogramImage == true, let icon = item.bookmarkNode.icon {
                 cell?.imageView?.image = icon
               }

--- a/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/HistoryViewController.swift
+++ b/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/HistoryViewController.swift
@@ -236,14 +236,13 @@ class HistoryViewController: SiteTableViewController, ToolbarUrlActionsProtocol 
       $0.imageView?.layer.cornerRadius = 6
       $0.imageView?.layer.cornerCurve = .continuous
       $0.imageView?.layer.masksToBounds = true
-      $0.imageView?.image = FaviconFetcher.getIconFromCache(for: historyItem.url)?.image ?? Favicon.defaultImage
 
       let domain = Domain.getOrCreate(
         forUrl: historyItem.url,
         persistent: !PrivateBrowsingManager.shared.isPrivateBrowsing)
 
       if domain.url?.asURL != nil {
-        cell.imageView?.loadFavicon(for: historyItem.url, monogramFallbackCharacter: historyItem.title?.first)
+        cell.imageView?.loadFavicon(for: historyItem.url)
       } else {
         cell.imageView?.clearMonogramFavicon()
         cell.imageView?.image = Favicon.defaultImage

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/FaviconScriptHandler.swift
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/FaviconScriptHandler.swift
@@ -37,15 +37,16 @@ class FaviconScriptHandler: NSObject, TabContentScript {
 
   func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage, replyHandler: (Any?, String?) -> Void) {
     defer { replyHandler(nil, nil) }
-    
-    tab?.favicons.removeAll(keepingCapacity: false)
+    guard let tab = tab else { return }
+    tab.favicon = Favicon.default
     
     guard let webView = message.webView,
           let url = webView.url,
           !InternalURL.isValid(url: url),
           !(InternalURL(url)?.isSessionRestore ?? false) else { return }
     
-    tab?.faviconDriver?.webView(webView, scriptMessage: message) { [weak tab] iconUrl, icon in
+    tab.favicon = FaviconFetcher.getIconFromCache(for: url) ?? Favicon.default
+    tab.faviconDriver?.webView(webView, scriptMessage: message) { [weak tab] iconUrl, icon in
       if let icon = icon, let tab = tab {
         if let iconUrl = iconUrl {
           Logger.module.debug("Fetched Favicon: \(iconUrl.absoluteString), for page: \(url.absoluteString)")
@@ -56,16 +57,23 @@ class FaviconScriptHandler: NSObject, TabContentScript {
         Task { @MainActor in
           let favicon = await Favicon.renderImage(icon, backgroundColor: .clear, shouldScale: true)
           FaviconFetcher.updateCache(favicon, for: url, persistent: !tab.isPrivate)  // We can only cache favicons for non-private tabs
-          
-          tab.favicons.append(favicon)
+          tab.favicon = favicon
           TabEvent.post(.didLoadFavicon(favicon), for: tab)
         }
       } else if let iconUrl = iconUrl {
         Logger.module.error("Failed fetching Favicon: \(iconUrl.absoluteString), for page: \(url.absoluteString)")
         FaviconFetcher.updateCache(nil, for: url, persistent: true)  // We can delete cache always
+        
+        if let tab = tab {
+          TabEvent.post(.didLoadFavicon(nil), for: tab)
+        }
       } else {
         Logger.module.error("Website: \(url.absoluteString), has no Favicon")
         FaviconFetcher.updateCache(nil, for: url, persistent: true)  // We can delete cache always
+        
+        if let tab = tab {
+          TabEvent.post(.didLoadFavicon(nil), for: tab)
+        }
       }
     }
   }

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/FaviconScriptHandler.swift
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/FaviconScriptHandler.swift
@@ -45,9 +45,12 @@ class FaviconScriptHandler: NSObject, TabContentScript {
           !InternalURL.isValid(url: url),
           !(InternalURL(url)?.isSessionRestore ?? false) else { return }
     
+    let isPrivate = tab.isPrivate
     tab.favicon = FaviconFetcher.getIconFromCache(for: url) ?? Favicon.default
+    
     tab.faviconDriver?.webView(webView, scriptMessage: message) { [weak tab] iconUrl, icon in
-      if let icon = icon, let tab = tab {
+      let tab = tab
+      if let icon = icon {
         if let iconUrl = iconUrl {
           Logger.module.debug("Fetched Favicon: \(iconUrl.absoluteString), for page: \(url.absoluteString)")
         } else {
@@ -56,22 +59,25 @@ class FaviconScriptHandler: NSObject, TabContentScript {
         
         Task { @MainActor in
           let favicon = await Favicon.renderImage(icon, backgroundColor: .clear, shouldScale: true)
-          FaviconFetcher.updateCache(favicon, for: url, persistent: !tab.isPrivate)  // We can only cache favicons for non-private tabs
+          FaviconFetcher.updateCache(favicon, for: url, persistent: !isPrivate)  // We can only cache favicons for non-private tabs
+          
+          guard let tab = tab else { return }
           tab.favicon = favicon
           TabEvent.post(.didLoadFavicon(favicon), for: tab)
         }
-      } else if let iconUrl = iconUrl {
-        Logger.module.error("Failed fetching Favicon: \(iconUrl.absoluteString), for page: \(url.absoluteString)")
-        FaviconFetcher.updateCache(nil, for: url, persistent: true)  // We can delete cache always
-        
-        if let tab = tab {
-          TabEvent.post(.didLoadFavicon(nil), for: tab)
-        }
       } else {
-        Logger.module.error("Website: \(url.absoluteString), has no Favicon")
-        FaviconFetcher.updateCache(nil, for: url, persistent: true)  // We can delete cache always
+        if let iconUrl = iconUrl {
+          Logger.module.error("Failed fetching Favicon: \(iconUrl.absoluteString), for page: \(url.absoluteString)")
+        } else {
+          Logger.module.error("Website: \(url.absoluteString), has no Favicon")
+        }
         
-        if let tab = tab {
+        Task { @MainActor in
+          let favicon = try await FaviconFetcher.monogramIcon(url: url, persistent: !isPrivate)
+          FaviconFetcher.updateCache(favicon, for: url, persistent: true)
+          
+          guard let tab = tab else { return }
+          tab.favicon = favicon
           TabEvent.post(.didLoadFavicon(nil), for: tab)
         }
       }

--- a/Sources/BraveWallet/FaviconReader.swift
+++ b/Sources/BraveWallet/FaviconReader.swift
@@ -29,6 +29,15 @@ struct FaviconReader<Content: View>: View {
   private func load(_ url: URL?, transaction: Transaction) {
     guard let url = url else { return }
     faviconTask?.cancel()
+    if let favicon = FaviconFetcher.getIconFromCache(for: url) {
+      faviconTask = nil
+      
+      withTransaction(transaction) {
+        self.image = favicon.image
+      }
+      return
+    }
+    
     faviconTask = Task { @MainActor in
       do {
         let favicon = try await FaviconFetcher.loadIcon(url: url, kind: .largeIcon, persistent: true)

--- a/Sources/Favicon/FaviconFetcher.swift
+++ b/Sources/Favicon/FaviconFetcher.swift
@@ -72,7 +72,13 @@ public class FaviconFetcher {
   /// 1. If `monogramString` is not null, it is used to render the Favicon image.
   /// 2. If `monogramString` is null, the first character of the URL's domain is used to render the Favicon image.
   @MainActor
-  public static func monogramIcon(url: URL, monogramString: Character? = nil) async throws -> Favicon {
+  public static func monogramIcon(url: URL, monogramString: Character? = nil, persistent: Bool) async throws -> Favicon {
+    try Task.checkCancellation()
+    
+    if let favicon = getFromCache(for: url) {
+      return favicon
+    }
+    
     // Render the Monogram on a UIImage
     guard let attributes = BraveCore.FaviconAttributes.withDefaultImage() else {
       throw FaviconError.noImagesFound
@@ -81,23 +87,48 @@ public class FaviconFetcher {
     let textColor = !attributes.isDefaultBackgroundColor ? attributes.textColor : nil
     let backColor = !attributes.isDefaultBackgroundColor ? attributes.backgroundColor : nil
     var monogramText = attributes.monogramString
-    if let monogramString = monogramString {
+    if let monogramString = monogramString ?? url.baseDomain?.first {
       monogramText = String(monogramString)
     }
     
     let favicon = await UIImage.renderMonogram(url, textColor: textColor, backgroundColor: backColor, monogramString: monogramText)
+    storeInCache(favicon, for: url, persistent: persistent)
     try Task.checkCancellation()
     return favicon
   }
   
   /// Retrieves a Favicon from the cache
   public static func getIconFromCache(for url: URL) -> Favicon? {
-    getFromCache(for: url)
+    // Handle internal URLs
+    var url = url
+    if let internalURL = InternalURL(url), let realUrl = internalURL.originalURLFromErrorPage ?? internalURL.extractedUrlParam {
+      url = realUrl
+    }
+    
+    // Fetch from cache
+    if let favicon = getFromCache(for: url) {
+      return favicon
+    }
+    
+    // When we search for a domain in the URL bar,
+    // it automatically makes the scheme `http`
+    // Even if the website loads/redirects as `https`
+    // Attempt to use `https` favicons if they exist
+    if url.scheme == "http", var components = URLComponents(string: url.absoluteString) {
+      components.scheme = "https"
+
+      // Fetch from cache
+      if let url = components.url, let favicon = FaviconFetcher.getIconFromCache(for: url) {
+        return favicon
+      }
+    }
+    
+    return nil
   }
   
   /// Stores a Favicon in the cache if not persistent, and not a monogram image.
   public static func updateCache(_ favicon: Favicon?, for url: URL, persistent: Bool) {
-    guard let favicon, !favicon.isMonogramImage else {
+    guard let favicon else {
       let cachedURL = cacheURL(for: url)
       SDImageCache.shared.memoryCache.removeObject(forKey: cachedURL.absoluteString)
       SDImageCache.shared.diskCache.removeData(forKey: cachedURL.absoluteString)
@@ -116,13 +147,21 @@ public class FaviconFetcher {
   }
 
   private static func storeInCache(_ favicon: Favicon, for url: URL, persistent: Bool) {
-    // Do not cache non-persistent icons
+    // Do not cache non-persistent icons to disk
     if persistent {
       do {
         let data = try JSONEncoder().encode(favicon)
         let cachedURL = cacheURL(for: url)
         SDImageCache.shared.memoryCache.setObject(data, forKey: cachedURL.absoluteString, cost: UInt(data.count))
         SDImageCache.shared.diskCache.setData(data, forKey: cachedURL.absoluteString)
+      } catch {
+        Logger.module.error("Error Caching Favicon: \(error)")
+      }
+    } else {
+      // Cache non-persistent icons to memory only
+      do {
+        let data = try JSONEncoder().encode(favicon)
+        SDImageCache.shared.memoryCache.setObject(data, forKey: cacheURL(for: url).absoluteString, cost: UInt(data.count))
       } catch {
         Logger.module.error("Error Caching Favicon: \(error)")
       }


### PR DESCRIPTION
## Summary of Changes
- Fetch icons synchronously from cache first.
- Only fetch icons async from Brave-Core when an icon has changed. 
- All monogram icons are now based on the URL instead of the title.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7139

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
