### PR TITLE
Fix #6953: Fix filter list toggle states

### DIFF
--- a/Sources/Brave/WebFilters/FilterList.swift
+++ b/Sources/Brave/WebFilters/FilterList.swift
@@ -20,6 +20,21 @@ struct FilterList: Identifiable {
     "llgjaaddopeckcifdceaaadmemagkepi" // Japanese filter lists
   ]
   
+  /// All the component ids that should be set to on by default.
+  public static var defaultOnComponentIds: Set<String> {
+    return [mobileAnnoyancesComponentID]
+  }
+  
+  /// This is a list of component to UUID for some filter lists that have special toggles
+  /// (which are availble before filter lists are downloaded)
+  /// To save these values before filter lists are downloaded we need to also have the UUID
+  public static var componentToUUID: [String: String] {
+    return [
+      mobileAnnoyancesComponentID: "2F3DCE16-A19A-493C-A88F-2E110FBD37D6",
+      cookieConsentNoticesComponentID: "AC023D22-AE88-4060-A978-4FEEEC4221693"
+    ]
+  }
+  
   let uuid: String
   let title: String
   let description: String


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6953

Make sure the toggle is in sync with the filter list and settings are stored even before filter lists are downloaded

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
1. Disable internet connection:
2. Launch the app for the first time. Verify that "Block cookie consent notices'' is **off** and "Block 'Switch to App' Notices" is **on** in the Shields menu.
3. Enable "Block cookie consent notices' and disable "Block 'Switch to App' Notices"
4. Enable internet connection
 Note: The filter lists will not download until you enable the internet and restart the application. I don't know why component updater doesn't retry the download until you restart the app. This is an issue I'll look into but for now you have to restart the app to retry the downloads. The two toggles will not do anything until filter lists are downloaded.
6.  Relaunch the app. Verify the settings are preserved.  
7. Verify that filter lists also reflect these toggles. The filter lists that represent these two settings are: "Easylist-Cookie List - Filer Obtrusive Cookie Notices" and "Fanboy's Mobile Notifications List" respectively. 
8. Now you test that things are blocked. For example reddit.com. (be aware that some sites have some blocking issues, e.x. twitter.com)
9. Delete the app, re-install and launch the app for the first time. Verify that "Block cookie consent notices'' is **off** and "Block 'Switch to App' Notices" is **on**on the Shields menu. Ensure that the filter list screen also reflect these settings once they are downloaded.
 d. Switch the toggles and ensure the changes are reflected on the filter lists (you can try to repeat this several times)
 e. Switch the toggles on the filter lists and ensure the toggles are reflected on the Shields screen (you can also repeat this several times)
10. See STR in ticket for additional steps (Note: Ensure filter lists are downloaded before testing blocking and be aware of sites that have broken cosmetic filtering (such as twitter.com which does not block all content))

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
