### PR TITLE
Fix #6682 - Added playback rate 2.5x

### DIFF
--- a/Sources/Brave/Frontend/Browser/Playlist/Controllers/PlaylistViewController.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/Controllers/PlaylistViewController.swift
@@ -364,8 +364,10 @@ class PlaylistViewController: UIViewController {
         button.setTitle("1x", for: .normal)
       } else if playbackRate == 1.5 {
         button.setTitle("1.5x", for: .normal)
+      } else if playbackRate == 2.0 {
+        button.setTitle("2.0x", for: .normal)
       } else {
-        button.setTitle("2x", for: .normal)
+        button.setTitle("2.5x", for: .normal)
       }
 
       if !PlaylistCarplayManager.shared.isCarPlayAvailable {

--- a/Sources/Brave/Frontend/Browser/Playlist/VideoPlayer/UI/VideoPlayer.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/VideoPlayer/UI/VideoPlayer.swift
@@ -429,6 +429,9 @@ class VideoView: UIView, VideoTrackerBarDelegate {
     } else if playbackRate == 1.5 {
       playbackRate = 2.0
       button.setTitle("2x", for: .normal)
+    } else if playbackRate == 2.0 {
+        playbackRate = 2.5
+        button.setTitle("2.5x", for: .normal)
     } else {
       playbackRate = 1.0
       button.setTitle("1x", for: .normal)


### PR DESCRIPTION
Added playback rate of 2.5x following #6682 

Being a user who consumes much podcasts, I couldn't agree more with #6682 I tend to always set playback rate to 2.5x

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes #6682

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
