### PR TITLE
NoBug: Add flags to build script to disable goma

### DIFF
--- a/BraveCore/build_in_core.sh
+++ b/BraveCore/build_in_core.sh
@@ -12,6 +12,7 @@ clean=0
 build_simulator=0
 build_device=0
 release_flag="Release"
+other_flags=""
 brave_browser_dir="${@: -1}"
 
 sim_dir="out/ios_Release_"$current_arch"_simulator"
@@ -23,6 +24,7 @@ function usage() {
   echo " --debug:           Builds a debug instead of release framework. (Should not be pushed with the repo)"
   echo " --build-simulator: Build only for simulator"
   echo " --build-device:    Build only for device"
+  echo " --no-goma:         Builds without goma"
   exit 1
 }
 
@@ -52,6 +54,10 @@ case $i in
     ;;
     --build-device)
     build_device=1
+    shift
+    ;;
+    --no-goma)
+    other_flags+=" --goma_offline"
     shift
     ;;
 esac
@@ -99,13 +105,13 @@ bc_framework_args=""
 mc_framework_args=""
 
 if [ "$build_simulator" = 1 ]; then
-  npm run build -- $release_flag --target_os=ios --target_arch=$target_architecture --target_environment=simulator
+  npm run build -- $release_flag --target_os=ios --target_arch=$target_architecture --target_environment=simulator $other_flags
   bc_framework_args="-framework $sim_dir/BraveCore.framework -debug-symbols $(pwd)/$sim_dir/BraveCore.dSYM"
   mc_framework_args="-framework $sim_dir/MaterialComponents.framework"
 fi
 
 if [ "$build_device" = 1 ]; then
-  npm run build -- $release_flag --target_os=ios --target_arch=arm64
+  npm run build -- $release_flag --target_os=ios --target_arch=arm64 $other_flags
   bc_framework_args="$bc_framework_args -framework $device_dir/BraveCore.framework -debug-symbols $(pwd)/$device_dir/BraveCore.dSYM"
   mc_framework_args="$mc_framework_args -framework $device_dir/MaterialComponents.framework"
 fi


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Add `--no-goma` flag to disable goma in the Brave-Core build script

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #N/A

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
