### PR TITLE
Fix #7146: Crash when creating sync chain after attempting to join deleted chain [Same profile]

### DIFF
--- a/Sources/Brave/Frontend/Sync/SyncWelcomeViewController.swift
+++ b/Sources/Brave/Frontend/Sync/SyncWelcomeViewController.swift
@@ -227,8 +227,6 @@ class SyncWelcomeViewController: SyncViewController {
         view.navigationItem.hidesBackButton = true
         self.navigationController?.pushViewController(view, animated: true)
       }
-
-      self.syncAPI.leaveSyncGroup()
       
       if self.syncAPI.isInSyncGroup {
         pushAddDeviceVC()


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

Adding DidJoinSynChain result successful when creating a new chain.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7146

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
Actually crash can happen without involving other devices.

-Create a Sync Chain and record the code
-Delete that Sync Chain
-Try to join the same sync chain with deleted words
-Create a new chain

## Screenshots:


https://user-images.githubusercontent.com/6643505/228028982-c8f17afc-83a5-487b-b7b5-7cf2dc39ff58.mp4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
