### PR TITLE
Ref #7086: Adding Playlist Folder creation into SceneDelegate

### DIFF
--- a/App/iOS/Delegates/SceneDelegate.swift
+++ b/App/iOS/Delegates/SceneDelegate.swift
@@ -100,8 +100,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     // Setup Playlist
     // This restores the playlist incomplete downloads. So if a download was started
     // and interrupted on application death, we restart it on next launch.
-    PlaylistManager.shared.restoreSession()
     PlaylistManager.shared.setupPlaylistFolder()
+    PlaylistManager.shared.restoreSession()
 
     // Setup Playlist Car-Play
     // TODO: Decide what to do if we have multiple windows

--- a/App/iOS/Delegates/SceneDelegate.swift
+++ b/App/iOS/Delegates/SceneDelegate.swift
@@ -101,6 +101,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     // This restores the playlist incomplete downloads. So if a download was started
     // and interrupted on application death, we restart it on next launch.
     PlaylistManager.shared.restoreSession()
+    PlaylistManager.shared.setupPlaylistFolder()
 
     // Setup Playlist Car-Play
     // TODO: Decide what to do if we have multiple windows

--- a/Sources/Brave/Frontend/Browser/Playlist/Managers & Cache/PlaylistManager.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/Managers & Cache/PlaylistManager.swift
@@ -241,6 +241,14 @@ public class PlaylistManager: NSObject {
       }
     }
   }
+  
+  public func setupPlaylistFolder() {
+    if PlaylistFolder.getFolder(uuid: PlaylistFolder.savedFolderUUID) == nil {
+      PlaylistFolder.addFolder(title: Strings.PlaylistFolders.playlistSavedFolderTitle, uuid: PlaylistFolder.savedFolderUUID) { uuid in
+        Logger.module.debug("Created Playlist Folder: \(uuid)")
+      }
+    }
+  }
 
   func download(item: PlaylistInfo) {
     guard downloadManager.downloadTask(for: item.tagId) == nil, let assetUrl = URL(string: item.src) else { return }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request references #7086

This Pr is adding back the folder creation for Playlist - it is accidentally removed while removal of V2 migration.

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
