### PR TITLE
Fix #7089: Unstoppable Domains Navigation 

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Web3NameService.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Web3NameService.swift
@@ -38,6 +38,8 @@ extension BrowserViewController: Web3NameServiceScriptHandlerDelegate {
         rpcService.setEnsResolveMethod(proceed ? .enabled : .disabled)
       case .ethereumOffchain:
         rpcService.setEnsOffchainLookupResolveMethod(proceed ? .enabled : .disabled)
+      case .unstoppable:
+        rpcService.setUnstoppableDomainsResolveMethod(proceed ? .enabled : .disabled)
       }
       let result = await decentralizedDNSHelper.lookup(domain: originalURL.host ?? originalURL.absoluteString)
       switch result {

--- a/Sources/Brave/Frontend/Browser/Handlers/Web3DomainHandler.swift
+++ b/Sources/Brave/Frontend/Browser/Handlers/Web3DomainHandler.swift
@@ -18,6 +18,8 @@ extension Web3Service {
       return Strings.Wallet.ensDomainInterstitialPageTitle
     case .ethereumOffchain:
       return Strings.Wallet.ensOffchainDomainInterstitialPageTitle
+    case .unstoppable:
+      return Strings.Wallet.udDomainInterstitialPageTitle
     }
   }
   
@@ -47,6 +49,17 @@ extension Web3Service {
         Strings.Wallet.ensOffchainDomainInterstitialPageDescription,
         learnMore,
         Strings.Wallet.learnMoreButton)
+    case .unstoppable:
+      let termsOfUseUrl = WalletConstants.ensTermsOfUseURL.absoluteString
+      let privacyPolicyUrl = WalletConstants.ensPrivacyPolicyURL.absoluteString
+      let nonCryptoExtensions = WalletConstants.supportedUDExtensions.filter { $0 != ".crypto" }
+      return String.localizedStringWithFormat(
+        Strings.Wallet.udDomainInterstitialPageDescription,
+        nonCryptoExtensions.joined(separator: ", "),
+        termsOfUseUrl,
+        Strings.Wallet.web3DomainInterstitialPageTAndU,
+        privacyPolicyUrl,
+        Strings.Wallet.web3DomainInterstitialPagePrivacyPolicy)
     }
   }
   
@@ -62,6 +75,8 @@ extension Web3Service {
       return Strings.Wallet.ensDomainInterstitialPageButtonProceed
     case .ethereumOffchain:
       return Strings.Wallet.ensOffchainDomainInterstitialPageButtonProceed
+    case .unstoppable:
+      return Strings.Wallet.ensDomainInterstitialPageButtonProceed
     }
   }
 }

--- a/Sources/BraveWallet/Crypto/Stores/SettingsStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SettingsStore.swift
@@ -57,6 +57,14 @@ public class SettingsStore: ObservableObject {
       rpcService.setSnsResolveMethod(snsResolveMethod)
     }
   }
+  
+  /// The current Unstoppable Domains Resolve Method preference (Ask / Enabled / Disabled)
+  @Published var udResolveMethod: BraveWallet.ResolveMethod = .ask {
+    didSet {
+      guard oldValue != udResolveMethod else { return }
+      rpcService.setUnstoppableDomainsResolveMethod(udResolveMethod)
+    }
+  }
 
   private let keyringService: BraveWalletKeyringService
   private let walletService: BraveWalletBraveWalletService
@@ -95,6 +103,7 @@ public class SettingsStore: ObservableObject {
       self.snsResolveMethod = await rpcService.snsResolveMethod()
       self.ensResolveMethod = await rpcService.ensResolveMethod()
       self.ensOffchainResolveMethod = await rpcService.ensOffchainLookupResolveMethod()
+      self.udResolveMethod = await rpcService.unstoppableDomainsResolveMethod()
     }
   }
 

--- a/Sources/BraveWallet/Settings/Web3SettingsView.swift
+++ b/Sources/BraveWallet/Settings/Web3SettingsView.swift
@@ -316,6 +316,7 @@ private struct Web3DomainSettingsView: View {
         snsResolveMethodPreference
         ensResolveMethodPreference
         ensOffchainResolveMethodPreference
+        udResolveMethodPreference
       }
       .listRowBackground(Color(.secondaryBraveGroupedBackground))
     }
@@ -366,6 +367,26 @@ private struct Web3DomainSettingsView: View {
       Text(Strings.Wallet.snsResolveMethodTitle)
         .foregroundColor(Color(.braveLabel))
         .padding(.vertical, 4)
+    }
+  }
+  
+  @ViewBuilder private var udResolveMethodPreference: some View {
+    Picker(selection: $settingsStore.udResolveMethod) {
+      ForEach(BraveWallet.ResolveMethod.allCases) { option in
+        Text(option.name)
+          .foregroundColor(Color(.secondaryBraveLabel))
+          .tag(option)
+      }
+    } label: {
+      VStack(alignment: .leading, spacing: 6) {
+        Text(Strings.Wallet.udResolveMethodTitle)
+          .foregroundColor(Color(.braveLabel))
+        Text(LocalizedStringKey(String.localizedStringWithFormat(Strings.Wallet.udResolveMethodDescription, WalletConstants.braveWalletUnstoppableDomainsURL.absoluteDisplayString)))
+          .foregroundColor(Color(.secondaryBraveLabel))
+          .tint(Color(.braveBlurpleTint))
+          .font(.footnote)
+      }
+      .padding(.vertical, 4)
     }
   }
 }

--- a/Sources/BraveWallet/WalletConstants.swift
+++ b/Sources/BraveWallet/WalletConstants.swift
@@ -41,6 +41,9 @@ public struct WalletConstants {
   /// The url to learn more about ENS off-chain lookups
   public static let braveWalletENSOffchainURL = URL(string: "https://github.com/brave/brave-browser/wiki/ENS-offchain-lookup")!
   
+  /// The url to learn more about Unstoppable Domains resolve methods.
+  public static let braveWalletUnstoppableDomainsURL = URL(string: "https://github.com/brave/brave-browser/wiki/Resolve-Methods-for-Unstoppable-Domains")!
+  
   /// The url to the privacy policy for 0x swaps
   static let zeroXPrivacyPolicy = URL(string: "https://www.0x.org/privacy")!
   
@@ -74,7 +77,7 @@ public struct WalletConstants {
   /// The supported Solana Name Service (SNS) extensions
   static let supportedSNSExtensions = [".sol"]
   /// The supported Unstoppable Domain (UD) extensions
-  static let supportedUDExtensions = [".crypto", ".x", ".nft", ".dao", ".wallet", ".888", ".blockchain", ".bitcoin"]
+  public static let supportedUDExtensions = [".crypto", ".x", ".nft", ".dao", ".wallet", ".888", ".blockchain", ".bitcoin"]
   
   /// The supported IPFS schemes
   static let supportedIPFSSchemes = ["ipfs", "ipns"]

--- a/Sources/BraveWallet/WalletConstants.swift
+++ b/Sources/BraveWallet/WalletConstants.swift
@@ -77,7 +77,7 @@ public struct WalletConstants {
   /// The supported Solana Name Service (SNS) extensions
   static let supportedSNSExtensions = [".sol"]
   /// The supported Unstoppable Domain (UD) extensions
-  public static let supportedUDExtensions = [".crypto", ".x", ".nft", ".dao", ".wallet", ".888", ".blockchain", ".bitcoin"]
+  public static let supportedUDExtensions = [".crypto", ".x", ".nft", ".dao", ".wallet", ".blockchain", ".bitcoin", ".zil"]
   
   /// The supported IPFS schemes
   static let supportedIPFSSchemes = ["ipfs", "ipns"]

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -3571,6 +3571,20 @@ extension Strings {
       value: "Resolve Solana Name Service (SNS) Domain Names",
       comment: "The title for the options to resolve Solana Name service domain names."
     )
+    public static let udResolveMethodTitle = NSLocalizedString(
+      "wallet.udResolveMethodTitle",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Resolve Unstoppable Domains Domain Names",
+      comment: "The title for the options to resolve Unstoppable Domains domain names."
+    )
+    public static let udResolveMethodDescription = NSLocalizedString(
+      "wallet.udResolveMethodDescription",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "[Learn more](%@) about Unstoppable Domains privacy considerations.",
+      comment: "The description for the options to allow Unstoppable Domain domain names. '%@' will be replaced with a url to explain more about Unstoppable Domains."
+    )
     public static let web3DomainOptionsHeader = NSLocalizedString(
       "wallet.web3DomainOptionsHeader",
       tableName: "BraveWallet",
@@ -3888,6 +3902,21 @@ extension Strings {
       bundle: .module,
       value: "Proceed with offchain lookup",
       comment: "Title on the button that users can click to enable Brave to resolve the ENS offchain lookup for the domain they entered."
+    )
+    // Unstoppable Domains
+    public static let udDomainInterstitialPageTitle = NSLocalizedString(
+      "wallet.udDomainInterstitialPageTitle",
+      tableName: "BraveShared",
+      bundle: .module,
+      value: "Enable support of Unstoppable Domains in Brave?",
+      comment: "Title displayed when users chose Brave to ask them if they want the Unstoppable Domains domain to be resolved every time they enter one."
+    )
+    public static let udDomainInterstitialPageDescription = NSLocalizedString(
+      "wallet.udDomainInterstitialPageDescription",
+      tableName: "BraveShared",
+      bundle: .module,
+      value: "Brave will be using Infura to resolve .crypto (and also %@) domain names that are on Unstoppable Domains. Brave hides your IP address. If you enable this, Infura will see that someone is trying to visit these domains but nothing else. See Infura's <a href=%@>%@</a> and <a href=%@>%@</a>.",
+      comment: "Description displayed when users chose Brave to ask them if they want the Unstoppable Domains to be resolved every time they enter one. The first '%@' will be replaced with a list of supported TLDs like '.x' or '.bitcoin'. The second '%@' be replaced with a link to Infura's terms of use page. The third '%@' will be replaced with the value of 'Web3DomainInterstitialPageTAndU'. The fourth '%@' will be replaced with a link to Infura's privacy policy page. The last '%@' will be replaced with the value of 'Web3DomainInterstitialPagePrivacyPolicy'."
     )
   }
 }

--- a/Tests/BraveWalletTests/SettingsStoreTests.swift
+++ b/Tests/BraveWalletTests/SettingsStoreTests.swift
@@ -49,6 +49,8 @@ class SettingsStoreTests: XCTestCase {
     rpcService._setEnsOffchainLookupResolveMethod = { _ in }
     rpcService._snsResolveMethod = { $0(.ask) }
     rpcService._setSnsResolveMethod = { _ in }
+    rpcService._unstoppableDomainsResolveMethod = { $0(.ask) }
+    rpcService._setUnstoppableDomainsResolveMethod = { _ in }
     
     let txService = BraveWallet.TestTxService()
     
@@ -65,6 +67,7 @@ class SettingsStoreTests: XCTestCase {
     rpcService._ensResolveMethod = { $0(.disabled) }
     rpcService._ensOffchainLookupResolveMethod = { $0(.disabled) }
     rpcService._snsResolveMethod = { $0(.disabled) }
+    rpcService._unstoppableDomainsResolveMethod = { $0(.disabled) }
 
     let sut = SettingsStore(
       keyringService: keyringService,
@@ -117,6 +120,15 @@ class SettingsStoreTests: XCTestCase {
       .sink { snsResolveMethod in
         defer { snsResolveMethodExpectation.fulfill() }
         XCTAssertEqual(snsResolveMethod, .disabled)
+      }
+      .store(in: &cancellables)
+    
+    let udResolveMethodExpectation = expectation(description: "setup-udResolveMethod")
+    sut.$udResolveMethod
+      .dropFirst()
+      .sink { udResolveMethod in
+        defer { udResolveMethodExpectation.fulfill() }
+        XCTAssertEqual(udResolveMethod, .disabled)
       }
       .store(in: &cancellables)
     


### PR DESCRIPTION
## Summary of Changes
- Update `DecentralizedDNSHelper` to support UD domains with TLDs: `.crypto`, `.x`, `.nft`, `.dao`, `.wallet`, `.blockchain`, `.bitcoin`, `.zil`
- Added UD support using `DecentralizedDNSHelper`. Unstoppable Domains resolve method defaults to 'Ask' similar to existing ENS / SNS resolve method. When set to 'Ask' an interstitial page is shown before proceeding with the lookup.
- Security/privacy review: https://github.com/brave/security/issues/1234

This pull request fixes #7089

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Open Web3 / Wallet settings and set 
    - `Resolve Unstoppable Domains Domain Names` to `Ask`
    - `Resolve IPFS Resources` to ask (optional, IPFS out of scope for this PR); must be either `Ask` or `Enabled`
2. Navigate to any UD domain via the omnibox. Ex. `jim-unstoppable.crypto`
3. Verify interstitial to enable Ethereum Name Service is shown.
    - Verify privacy policy and terms of use links open to expected pages for Consensys (Infura)
4. Tap `Disable`
5. Navigate to Web3 / Wallet settings and verify `Resolve Unstoppable Domains Domain Names` is set to Disabled
6. Change `Resolve Unstoppable Domains Domain Names` back to `Ask`
7. Navigate to any UD domain via the omnibox. Ex. `jim-unstoppable.crypto`
8. Tap `Proceed using Infura server`
9. Verify either IPFS interstitial is shown, IPFS public gateway url is loaded, or IPFS disabled page shown (note: IPFS out of scope for this PR).


## Screenshots:


https://user-images.githubusercontent.com/5314553/228329594-ca43ec77-f286-4010-9ce7-54be83c770da.mp4

![Simulator Screen Shot - iPhone 12 Pro - 2023-03-28 at 14 11 43](https://user-images.githubusercontent.com/5314553/228329936-8162deab-0a7c-4ed4-a341-21f8c6ffbd4b.png) | ![Simulator Screenshot - iPhone 12 Pro - 2023-04-05 at 15 46 45](https://user-images.githubusercontent.com/5314553/230189664-bc895f9e-54cc-4380-a723-6b421470e27b.png)
--|--


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
