### PR TITLE
Fix #7166: Use WebKit Session Restore (InteractionState)

### DIFF
--- a/App/iOS/Delegates/SceneDelegate.swift
+++ b/App/iOS/Delegates/SceneDelegate.swift
@@ -50,6 +50,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     // initialization. This is because Database container may change. See bugs #3416, #3377.
     DataController.shared.initializeOnce()
     Migration.postCoreDataInitMigrations()
+    Migration.migrateTabStateToWebkitState(diskImageStore: sceneInfo.diskImageStore)
     
     Task(priority: .high) {
       // Start preparing the ad-block services right away

--- a/Sources/Brave/Frontend/Browser/BraveWebView.swift
+++ b/Sources/Brave/Frontend/Browser/BraveWebView.swift
@@ -61,3 +61,14 @@ class BraveWebView: WKWebView {
     return super.hitTest(point, with: event)
   }
 }
+
+extension WKWebView {
+  public var sessionData: Data? {
+    get {
+      interactionState as? Data
+    }
+    set {
+      interactionState = newValue
+    }
+  }
+}

--- a/Sources/Brave/Frontend/Browser/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController.swift
@@ -2276,9 +2276,9 @@ public class BrowserViewController: UIViewController {
           if let visitType = typedNavigation.first(where: {
             $0.key.typedDisplayString == url.typedDisplayString
           })?.value, visitType == .typed {
-            braveCore.historyAPI.add(url: url, title: tab.title ?? "", dateAdded: Date())
+            braveCore.historyAPI.add(url: url, title: tab.title, dateAdded: Date())
           } else {
-            braveCore.historyAPI.add(url: url, title: tab.title ?? "", dateAdded: Date(), isURLTyped: false)
+            braveCore.historyAPI.add(url: url, title: tab.title, dateAdded: Date(), isURLTyped: false)
           }
           
           // Saving Tab. Private Mode - not supported yet.

--- a/Sources/Brave/Frontend/Browser/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController.swift
@@ -303,7 +303,6 @@ public class BrowserViewController: UIViewController {
     // Initialize TabManager
     self.tabManager = TabManager(
       prefs: profile.prefs,
-      imageStore: diskImageStore,
       rewards: rewards,
       tabGeneratorAPI: braveCore.tabGeneratorAPI)
     
@@ -745,6 +744,10 @@ public class BrowserViewController: UIViewController {
     }
   }
   
+  @objc func appWillTerminateNotification() {
+    tabManager.saveAllTabs()
+  }
+  
   @objc private func tappedCollapsedURLBar() {
     if keyboardState != nil && isUsingBottomBar && !topToolbar.inOverlayMode {
       view.endEditing(true)
@@ -758,6 +761,8 @@ public class BrowserViewController: UIViewController {
   }
 
   @objc func appWillResignActiveNotification() {
+    tabManager.saveAllTabs()
+    
     // Dismiss any popovers that might be visible
     displayedPopoverController?.dismiss(animated: false) {
       self.updateDisplayedPopoverProperties = nil
@@ -874,6 +879,9 @@ public class BrowserViewController: UIViewController {
       $0.addObserver(
         self, selector: #selector(appDidEnterBackgroundNotification),
         name: UIApplication.didEnterBackgroundNotification, object: nil)
+      $0.addObserver(
+        self, selector: #selector(appWillTerminateNotification),
+        name: UIApplication.willTerminateNotification, object: nil)
       $0.addObserver(
         self, selector: #selector(resetNTPNotification),
         name: .adsOrRewardsToggledInSettings, object: nil)
@@ -1154,7 +1162,7 @@ public class BrowserViewController: UIViewController {
         self.setupTabs()
       },
       noCallback: { _ in
-        TabMO.deleteAll()
+        SessionTab.deleteAll()
         self.tabManager.addTabAndSelect(isPrivate: PrivateBrowsingManager.shared.isPrivateBrowsing)
       }
     )
@@ -1163,7 +1171,7 @@ public class BrowserViewController: UIViewController {
 
   fileprivate func canRestoreTabs() -> Bool {
     // Make sure there's at least one real tab open
-    return !TabMO.getAll().compactMap({ $0.url }).isEmpty
+    return !SessionTab.all().compactMap({ $0.url }).isEmpty
   }
 
   override public func viewDidAppear(_ animated: Bool) {
@@ -1871,7 +1879,7 @@ public class BrowserViewController: UIViewController {
     }
   }
   
-  func switchToTabOrOpen(id: String?, url: URL) {
+  func switchToTabOrOpen(id: UUID?, url: URL) {
     popToBVC()
     
     if let tabID = id, let tab = tabManager.getTabForID(tabID) {
@@ -2737,7 +2745,7 @@ extension BrowserViewController: SearchViewControllerDelegate {
     finishEditingAndSubmit(url, visitType: .typed)
   }
 
-  func searchViewController(_ searchViewController: SearchViewController, didSelectOpenTab tabInfo: (id: String?, url: URL)) {
+  func searchViewController(_ searchViewController: SearchViewController, didSelectOpenTab tabInfo: (id: UUID?, url: URL)) {
     switchToTabOrOpen(id: tabInfo.id, url: tabInfo.url)
   }
   

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -133,7 +133,8 @@ extension BrowserViewController: WKNavigationDelegate {
     }
 
     if InternalURL.isValid(url: url) {
-      if navigationAction.navigationType != .backForward, navigationAction.isInternalUnprivileged {
+      if navigationAction.navigationType != .backForward, navigationAction.isInternalUnprivileged,
+          (navigationAction.sourceFrame != nil || navigationAction.targetFrame?.isMainFrame == false || navigationAction.request.cachePolicy == .useProtocolCachePolicy) {
         Logger.module.warning("Denying unprivileged request: \(navigationAction.request)")
         return (.cancel, preferences)
       }

--- a/Sources/Brave/Frontend/Browser/FrequencyQuery.swift
+++ b/Sources/Brave/Frontend/Browser/FrequencyQuery.swift
@@ -83,32 +83,27 @@ class FrequencyQuery {
       if PrivateBrowsingManager.shared.isPrivateBrowsing {
         if let url = tab.url, url.isWebPage(), !(InternalURL(url)?.isAboutHomeURL ?? false) {
           
-          if let selectedTabID = tabManager.selectedTab?.id, let tabID = tab.id, selectedTabID == tabID {
+          if let selectedTabID = tabManager.selectedTab?.id, selectedTabID == tab.id {
             continue
           }
           
-          tabList.append(Site(url: url.absoluteString, title: tab.displayTitle, siteType: .tab, tabID: tab.id))
+          tabList.append(Site(url: url.absoluteString, title: tab.displayTitle, siteType: .tab, tabID: tab.id.uuidString))
         }
       } else {
         var tabURL: URL?
         
         if let url = tab.url {
           tabURL = url
-        } else if let tabID = tab.id {
-          let fetchedTab = TabMO.get(fromId: tabID)
-          
-          if let urlString = fetchedTab?.url, let url = URL(string: urlString) {
-            tabURL = url
-          }
+        } else if let fetchedTab = SessionTab.from(tabId: tab.id){
+          tabURL = fetchedTab.url
         }
         
         if let url = tabURL, url.isWebPage(), !(InternalURL(url)?.isAboutHomeURL ?? false) {
-          
-          if let selectedTabID = tabManager.selectedTab?.id, let tabID = tab.id, selectedTabID == tabID {
+          if let selectedTabID = tabManager.selectedTab?.id, selectedTabID == tab.id {
             continue
           }
           
-          tabList.append(Site(url: url.absoluteString, title: tab.title ?? tab.displayTitle, siteType: .tab, tabID: tab.id))
+          tabList.append(Site(url: url.absoluteString, title: tab.title, siteType: .tab, tabID: tab.id.uuidString))
         }
       }
     }

--- a/Sources/Brave/Frontend/Browser/Interstitial Pages/InternalSchemeHandler.swift
+++ b/Sources/Brave/Frontend/Browser/Interstitial Pages/InternalSchemeHandler.swift
@@ -93,7 +93,9 @@ public class InternalSchemeHandler: NSObject, WKURLSchemeHandler {
       return
     }
 
-    if !urlSchemeTask.request.isPrivileged {
+    // Need a better way to detect when WebKit is making a request from interactionState vs. a regular request by the user
+    // instead of having to check the cache policy
+    if !urlSchemeTask.request.isPrivileged && urlSchemeTask.request.cachePolicy == .useProtocolCachePolicy {
       urlSchemeTask.didFailWithError(InternalPageSchemeHandlerError.notAuthorized)
       return
     }

--- a/Sources/Brave/Frontend/Browser/Search/SearchViewController.swift
+++ b/Sources/Brave/Frontend/Browser/Search/SearchViewController.swift
@@ -14,7 +14,7 @@ import Favicon
 protocol SearchViewControllerDelegate: AnyObject {
   func searchViewController(_ searchViewController: SearchViewController, didSubmit query: String, braveSearchPromotion: Bool)
   func searchViewController(_ searchViewController: SearchViewController, didSelectURL url: URL)
-  func searchViewController(_ searchViewController: SearchViewController, didSelectOpenTab tabInfo: (id: String?, url: URL))
+  func searchViewController(_ searchViewController: SearchViewController, didSelectOpenTab tabInfo: (id: UUID?, url: URL))
   func searchViewController(_ searchViewController: SearchViewController, didLongPressSuggestion suggestion: String)
   func presentSearchSettingsController()
   func searchViewController(_ searchViewController: SearchViewController, didHighlightText text: String, search: Bool)
@@ -400,7 +400,11 @@ public class SearchViewController: SiteTableViewController, LoaderListener {
       let site = data[indexPath.row]
       if let url = URL(string: site.url) {
         if site.siteType == .tab {
-          searchDelegate?.searchViewController(self, didSelectOpenTab: (site.tabID, url))
+          var tabId: UUID?
+          if let siteId = site.tabID {
+            tabId = UUID(uuidString: siteId)
+          }
+          searchDelegate?.searchViewController(self, didSelectOpenTab: (tabId, url))
         } else {
           searchDelegate?.searchViewController(self, didSelectURL: url)
         }

--- a/Sources/Brave/Frontend/Browser/Tab.swift
+++ b/Sources/Brave/Frontend/Browser/Tab.swift
@@ -235,6 +235,10 @@ class Tab: NSObject {
   
   var webStateDebounceTimer: Timer?
   var onPageReadyStateChanged: ((ReadyState.State) -> Void)?
+  
+  private var webViewScrollViewObserver: NSObjectProtocol?
+  var webViewScrollDebounceTimer: Timer?
+  var onWebViewScrolled: ((_ tab: Tab, _ contentOffset: CGPoint) -> Void)?
 
   // If this tab has been opened from another, its parent will point to the tab from which it was opened
   var parent: Tab?
@@ -331,6 +335,11 @@ class Tab: NSObject {
 
       self.webView = webView
       self.webView?.addObserver(self, forKeyPath: KVOConstants.URL.rawValue, options: .new, context: nil)
+      self.webViewScrollViewObserver = webView.scrollView.observe(\.contentOffset, options: [.new]) { [weak self] _, change in
+        guard let self = self, let value = change.newValue else { return }
+        self.onWebViewScrolled?(self, value)
+      }
+      
       tabDelegate?.tab(self, didCreateWebView: webView)
       
       let scriptPreferences: [UserScriptManager.ScriptType: Bool] = [

--- a/Sources/Brave/Frontend/Browser/Tab.swift
+++ b/Sources/Brave/Frontend/Browser/Tab.swift
@@ -235,10 +235,6 @@ class Tab: NSObject {
   
   var webStateDebounceTimer: Timer?
   var onPageReadyStateChanged: ((ReadyState.State) -> Void)?
-  
-  private var webViewScrollViewObserver: NSObjectProtocol?
-  var webViewScrollDebounceTimer: Timer?
-  var onWebViewScrolled: ((_ tab: Tab, _ contentOffset: CGPoint) -> Void)?
 
   // If this tab has been opened from another, its parent will point to the tab from which it was opened
   var parent: Tab?
@@ -335,10 +331,6 @@ class Tab: NSObject {
 
       self.webView = webView
       self.webView?.addObserver(self, forKeyPath: KVOConstants.URL.rawValue, options: .new, context: nil)
-      self.webViewScrollViewObserver = webView.scrollView.observe(\.contentOffset, options: [.new]) { [weak self] _, change in
-        guard let self = self, let value = change.newValue else { return }
-        self.onWebViewScrolled?(self, value)
-      }
       
       tabDelegate?.tab(self, didCreateWebView: webView)
       

--- a/Sources/Brave/Frontend/Browser/Tab.swift
+++ b/Sources/Brave/Frontend/Browser/Tab.swift
@@ -63,7 +63,7 @@ enum TabSecureContentState {
 }
 
 class Tab: NSObject {
-  var id: String?
+  let id: UUID
   let rewardsId: UInt32
 
   var onScreenshotUpdated: (() -> Void)?
@@ -134,7 +134,7 @@ class Tab: NSObject {
   var bars = [SnackBar]()
   var favicon: Favicon
   var lastExecutedTime: Timestamp?
-  var sessionData: SessionData?
+  var sessionData: (title: String, interactionState: Data)?
   fileprivate var lastRequest: URLRequest?
   var restoring: Bool = false
   var pendingScreenshot = false
@@ -170,14 +170,7 @@ class Tab: NSObject {
       }
     }
   }
-  var lastKnownUrl: URL? {
-    // Tab url can be nil when user cold starts the app
-    // thus we check session data for last known url
-    guard self.url != nil else {
-      return self.sessionData?.urls.last
-    }
-    return self.url
-  }
+
   var mimeType: String?
   var isEditing: Bool = false
   var shouldClassifyLoadsForAds = true
@@ -239,9 +232,6 @@ class Tab: NSObject {
   }
 
   fileprivate(set) var screenshot: UIImage?
-  var screenshotUUID: UUID? {
-    didSet { TabMO.saveScreenshotUUID(screenshotUUID, tabId: id) }
-  }
   
   var webStateDebounceTimer: Timer?
   var onPageReadyStateChanged: ((ReadyState.State) -> Void)?
@@ -275,9 +265,10 @@ class Tab: NSObject {
     }
   }
 
-  init(configuration: WKWebViewConfiguration, type: TabType = .regular, tabGeneratorAPI: BraveTabGeneratorAPI? = nil) {
+  init(configuration: WKWebViewConfiguration, id: UUID = UUID(), type: TabType = .regular, tabGeneratorAPI: BraveTabGeneratorAPI? = nil) {
     self.configuration = configuration
     self.favicon = Favicon.default
+    self.id = id
     rewardsId = UInt32.random(in: 1...UInt32.max)
     nightMode = Preferences.General.nightModeEnabled.value
     syncTab = tabGeneratorAPI?.createBraveSyncTab(isOffTheRecord: type == .private)
@@ -336,7 +327,7 @@ class Tab: NSObject {
       webView.scrollView.layer.masksToBounds = false
       webView.navigationDelegate = navigationDelegate
 
-      restore(webView, restorationData: self.sessionData?.savedTabData)
+      restore(webView, restorationData: self.sessionData)
 
       self.webView = webView
       self.webView?.addObserver(self, forKeyPath: KVOConstants.URL.rawValue, options: .new, context: nil)
@@ -362,12 +353,9 @@ class Tab: NSObject {
   }
 
   func clearHistory(config: WKWebViewConfiguration) {
-    guard let webView = webView, let tabID = id else {
+    guard let webView = webView else {
       return
     }
-
-    // Remove the tab history from saved tabs
-    TabMO.removeHistory(with: tabID)
 
     /*
      * Clear selector is used on WKWebView backForwardList because backForwardList list is only exposed with a getter
@@ -384,45 +372,27 @@ class Tab: NSObject {
     if webView.backForwardList.responds(to: selector) {
       webView.backForwardList.performSelector(onMainThread: selector, with: nil, waitUntilDone: true)
     }
+    
+    // Remove the tab history from saved tabs
+    SessionTab.update(tabId: id, interactionState: webView.sessionData ?? Data(), title: title, url: webView.url ?? TabManager.ntpInteralURL)
   }
 
-  func restore(_ webView: WKWebView, restorationData: SavedTab?) {
+  func restore(_ webView: WKWebView, restorationData: (title: String, interactionState: Data)?) {
     // Pulls restored session data from a previous SavedTab to load into the Tab. If it's nil, a session restore
     // has already been triggered via custom URL, so we use the last request to trigger it again; otherwise,
     // we extract the information needed to restore the tabs and create a NSURLRequest with the custom session restore URL
     // to trigger the session restore via custom handlers
-    if let sessionData = restorationData {
+    if let sessionInfo = restorationData {
       restoring = true
-
-      lastTitle = sessionData.title
-
-      var urls = [String]()
-      for url in sessionData.history {
-        guard let url = URL(string: url) else { continue }
-        urls.append(url.absoluteString)
-      }
-
-      let currentPage = sessionData.historyIndex
+      lastTitle = sessionInfo.title
+      webView.interactionState = sessionInfo.interactionState
+      restoring = false
       self.sessionData = nil
-      var jsonDict = [String: AnyObject]()
-      jsonDict["history"] = urls as AnyObject?
-      jsonDict["currentPage"] = currentPage as AnyObject?
-      guard let json = JSON(jsonDict).rawString()?.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else {
-        return
-      }
-
-      if let restoreURL = URL(string: "\(InternalURL.baseUrl)/\(SessionRestoreHandler.path)?history=\(json)") {
-        let request = PrivilegedRequest(url: restoreURL) as URLRequest
-        webView.load(request)
-        lastRequest = request
-        restoring = false
-      }
     } else if let request = lastRequest {
       webView.load(request)
     } else {
       Logger.module.warning("creating webview with no lastRequest and no session data: \(self.url?.absoluteString ?? "nil")")
     }
-
   }
 
   func deleteWebView() {
@@ -464,8 +434,8 @@ class Tab: NSObject {
     return tabs
   }
 
-  var title: String? {
-    return webView?.title
+  var title: String {
+    return webView?.title ?? ""
   }
 
   var displayTitle: String {
@@ -481,12 +451,6 @@ class Tab: NSObject {
       return Strings.Hotkey.newTabTitle
     }
 
-    // lets double check the sessionData in case this is a non-restored new tab
-    if let firstURL = sessionData?.urls.first, sessionData?.urls.count == 1, InternalURL(firstURL)?.isAboutHomeURL ?? false {
-      syncTab?.setTitle(Strings.Hotkey.newTabTitle)
-      return Strings.Hotkey.newTabTitle
-    }
-
     if let url = self.url, !InternalURL.isValid(url: url), let shownUrl = url.displayURL?.absoluteString {
       syncTab?.setTitle(shownUrl)
       return shownUrl
@@ -498,10 +462,9 @@ class Tab: NSObject {
       if let title = url?.absoluteString {
         syncTab?.setTitle(title)
         return title
-      } else if let tab = TabMO.get(fromId: id) {
-        let title = tab.title ?? tab.url ?? ""
-        syncTab?.setTitle(title)
-        return title
+      } else if let tab = SessionTab.from(tabId: id) {
+        syncTab?.setTitle(tab.title)
+        return tab.title
       }
       
       syncTab?.setTitle("")
@@ -540,12 +503,8 @@ class Tab: NSObject {
     } else {
       if let tabUrl = url, tabUrl.isWebPage() {
         return tabUrl
-      } else if let tabID = id {
-        let fetchedTab = TabMO.get(fromId: tabID)
-        
-        if let urlString = fetchedTab?.url, let url = URL(string: urlString), url.isWebPage() {
-          return url
-        }
+      } else if let fetchedTab = SessionTab.from(tabId: id), fetchedTab.url.isWebPage() {
+        return url
       }
     }
     
@@ -638,7 +597,7 @@ class Tab: NSObject {
 
     if let webView = self.webView {
       Logger.module.debug("restoring webView from scratch")
-      restore(webView, restorationData: sessionData?.savedTabData)
+      restore(webView, restorationData: sessionData)
     }
   }
 
@@ -713,19 +672,15 @@ class Tab: NSObject {
     bars.reversed().filter({ !$0.shouldPersist(self) }).forEach({ removeSnackbar($0) })
   }
 
-  func setScreenshot(_ screenshot: UIImage?, revUUID: Bool = true) {
+  func setScreenshot(_ screenshot: UIImage?) {
     self.screenshot = screenshot
-    if revUUID {
-      self.screenshotUUID = UUID()
-    }
-
     onScreenshotUpdated?()
   }
 
   /// Switches user agent Desktop -> Mobile or Mobile -> Desktop.
   func switchUserAgent() {
     if let urlString = webView?.url?.baseDomain {
-      // The website was changed once already, need to flip the override.
+      // The website was changed once already, need to flip the override.onScreenshotUpdated
       if let siteOverride = userAgentOverrides[urlString] {
         userAgentOverrides[urlString] = !siteOverride
       } else {

--- a/Sources/Brave/Frontend/Browser/TabManager.swift
+++ b/Sources/Brave/Frontend/Browser/TabManager.swift
@@ -51,7 +51,7 @@ class TabManager: NSObject {
   weak var stateDelegate: TabManagerStateDelegate?
   
   /// Internal url to access the new tab page.
-  private let ntpInteralURL = URL(string: "\(InternalURL.baseUrl)/\(AboutHomeHandler.path)#panel=0")!
+  static let ntpInteralURL = URL(string: "\(InternalURL.baseUrl)/\(AboutHomeHandler.path)#panel=0")!
 
   func addDelegate(_ delegate: TabManagerDelegate) {
     assert(Thread.isMainThread)
@@ -78,8 +78,6 @@ class TabManager: NSObject {
   lazy fileprivate var configuration: WKWebViewConfiguration = {
     return TabManager.getNewConfiguration()
   }()
-
-  fileprivate let imageStore: DiskImageStore?
 
   fileprivate let prefs: Prefs
   var selectedIndex: Int {
@@ -109,12 +107,11 @@ class TabManager: NSObject {
     }
   }
 
-  init(prefs: Prefs, imageStore: DiskImageStore?, rewards: BraveRewards?, tabGeneratorAPI: BraveTabGeneratorAPI?) {
+  init(prefs: Prefs, rewards: BraveRewards?, tabGeneratorAPI: BraveTabGeneratorAPI?) {
     assert(Thread.isMainThread)
 
     self.prefs = prefs
     self.navDelegate = TabManagerNavDelegate()
-    self.imageStore = imageStore
     self.rewards = rewards
     self.tabGeneratorAPI = tabGeneratorAPI
     self.tabEventHandlers = TabEventHandlers.create(with: prefs)
@@ -330,7 +327,7 @@ class TabManager: NSObject {
     }
 
     if let tabId = tab?.id {
-      TabMO.selectTabAndDeselectOthers(selectedTabId: tabId)
+      SessionTab.setSelected(tabId: tabId)
     }
 
     UIImpactFeedbackGenerator(style: .light).bzzt()
@@ -346,7 +343,7 @@ class TabManager: NSObject {
     }
 
     if let tabID = tab?.id {
-      TabMO.touch(tabID: tabID)
+      SessionTab.touch(tabId: tabID)
     }
 
     guard let newSelectedTab = tab, let previousTab = previous, let newTabUrl = newSelectedTab.url, let previousTabUrl = previousTab.url else { return }
@@ -391,7 +388,7 @@ class TabManager: NSObject {
   }
 
   func addPopupForParentTab(_ parentTab: Tab, configuration: WKWebViewConfiguration) -> Tab {
-    let popup = Tab(configuration: configuration, type: parentTab.type, tabGeneratorAPI: tabGeneratorAPI)
+    let popup = Tab(configuration: configuration, id: UUID(), type: parentTab.type, tabGeneratorAPI: tabGeneratorAPI)
     configureTab(popup, request: nil, afterTab: parentTab, flushToDisk: true, zombie: false, isPopup: true)
 
     // Wait momentarily before selecting the new tab, otherwise the parent tab
@@ -405,8 +402,8 @@ class TabManager: NSObject {
   }
 
   @discardableResult
-  func addTabAndSelect(_ request: URLRequest! = nil, configuration: WKWebViewConfiguration! = nil, afterTab: Tab? = nil, isPrivate: Bool) -> Tab {
-    let tab = addTab(request, configuration: configuration, afterTab: afterTab, isPrivate: isPrivate)
+  func addTabAndSelect(_ request: URLRequest! = nil, afterTab: Tab? = nil, isPrivate: Bool) -> Tab {
+    let tab = addTab(request, afterTab: afterTab, isPrivate: isPrivate)
     selectTab(tab)
     return tab
   }
@@ -431,16 +428,13 @@ class TabManager: NSObject {
   }
 
   @discardableResult
-  func addTab(_ request: URLRequest? = nil, configuration: WKWebViewConfiguration? = nil, afterTab: Tab? = nil, flushToDisk: Bool = true, zombie: Bool = false, id: String? = nil, isPrivate: Bool) -> Tab {
+  func addTab(_ request: URLRequest? = nil, afterTab: Tab? = nil, flushToDisk: Bool = true, zombie: Bool = false, id: UUID? = nil, isPrivate: Bool) -> Tab {
     assert(Thread.isMainThread)
 
-    // Take the given configuration. Or if it was nil, take our default configuration for the current browsing mode.
-    let configuration: WKWebViewConfiguration = configuration ?? self.configuration
-
+    let tabId = id ?? UUID()
     let type: TabType = isPrivate ? .private : .regular
-    let tab = Tab(configuration: configuration, type: type, tabGeneratorAPI: tabGeneratorAPI)
-
-    configureTab(tab, request: request, afterTab: afterTab, flushToDisk: flushToDisk, zombie: zombie, id: id)
+    let tab = Tab(configuration: configuration, id: tabId, type: type, tabGeneratorAPI: tabGeneratorAPI)
+    configureTab(tab, request: request, afterTab: afterTab, flushToDisk: flushToDisk, zombie: zombie)
     return tab
   }
 
@@ -471,18 +465,39 @@ class TabManager: NSObject {
   private func saveTabOrder() {
     if PrivateBrowsingManager.shared.isPrivateBrowsing { return }
     let allTabIds = allTabs.compactMap { $0.id }
-    TabMO.saveTabOrder(tabIds: allTabIds)
+    SessionTab.saveTabOrder(tabIds: allTabIds)
   }
 
-  func configureTab(_ tab: Tab, request: URLRequest?, afterTab parent: Tab? = nil, flushToDisk: Bool, zombie: Bool, id: String? = nil, isPopup: Bool = false) {
+  func configureTab(_ tab: Tab, request: URLRequest?, afterTab parent: Tab? = nil, flushToDisk: Bool, zombie: Bool, isPopup: Bool = false) {
     assert(Thread.isMainThread)
 
     let isPrivate = tab.type == .private
-    if isPrivate {
-      // Creating random tab id for private mode, as we don't want to save to database.
-      tab.id = UUID().uuidString
-    } else {
-      tab.id = id ?? TabMO.create()
+    if !isPrivate {
+      let tabUrl = TabManager.ntpInteralURL
+      
+      if !SessionTab.exists(tabId: tab.id) {
+        DataController.performOnMainContext { context in
+          guard let window = SessionWindow.getActiveWindow(context: context) else { return }
+          _ = SessionTab(context: context,
+                         sessionWindow: window,
+                         sessionTabGroup: nil,
+                         index: Int32(window.sessionTabs.count),
+                         interactionState: Data(),
+                         isPrivate: false,
+                         isSelected: false,
+                         lastUpdated: .now,
+                         screenshotData: Data(),
+                         title: Strings.newTab,
+                         url: tabUrl,
+                         tabId: tab.id)
+          
+          do {
+            try context.save()
+          } catch {
+            Logger.module.error("performTask save error: \(error.localizedDescription, privacy: .public)")
+          }
+        }
+      }
       
       if let (provider, js) = makeWalletEthProvider?(tab) {
         let providerJS = """
@@ -530,9 +545,8 @@ class TabManager: NSObject {
     if let request = request {
       tab.loadRequest(request)
     } else if !isPopup {
-      
-      tab.loadRequest(PrivilegedRequest(url: ntpInteralURL) as URLRequest)
-      tab.url = ntpInteralURL
+      tab.loadRequest(PrivilegedRequest(url: TabManager.ntpInteralURL) as URLRequest)
+      tab.url = TabManager.ntpInteralURL
     }
 
     // Ignore on restore.
@@ -574,59 +588,18 @@ class TabManager: NSObject {
 
     return nil
   }
+  
+  func saveAllTabs() {
+    if PrivateBrowsingManager.shared.isPrivateBrowsing { return }
+    SessionTab.updateAll(tabs: tabs(withType: .regular).map({ ($0.id, $0.webView?.sessionData ?? Data(), $0.title, $0.webView?.url ?? $0.url ?? TabManager.ntpInteralURL) }))
+  }
 
   func saveTab(_ tab: Tab, saveOrder: Bool = false) {
     if PrivateBrowsingManager.shared.isPrivateBrowsing { return }
-    guard let data = savedTabData(tab: tab) else { return }
-
-    TabMO.update(tabData: data)
+    SessionTab.update(tabId: tab.id, interactionState: tab.webView?.sessionData ?? Data(), title: tab.title, url: tab.url ?? TabManager.ntpInteralURL)
     if saveOrder {
       saveTabOrder()
     }
-  }
-
-  private func savedTabData(tab: Tab) -> SavedTab? {
-
-    guard let webView = tab.webView, let order = indexOfWebView(webView) else { return nil }
-
-    // Ignore session restore data.
-    guard let url = tab.url,
-      !InternalURL.isValid(url: url),
-      !(InternalURL(url)?.isSessionRestore ?? false)
-    else { return nil }
-
-    var urls = [URL]()
-    var currentPage = 0
-
-    if let currentItem = webView.backForwardList.currentItem {
-      // Freshly created web views won't have any history entries at all.
-      let backList = webView.backForwardList.backList
-      let forwardList = webView.backForwardList.forwardList
-      let backListMap = backList.map { $0.url }
-      let forwardListMap = forwardList.map { $0.url }
-      let currentItem = currentItem.url
-
-      // Business as usual.
-      urls = backListMap + [currentItem] + forwardListMap
-      currentPage = -forwardList.count
-    }
-    if let id = TabMO.get(fromId: tab.id)?.syncUUID {
-      let displayTitle = tab.displayTitle
-      let title = displayTitle != "" ? displayTitle : ""
-
-      let isSelected = selectedTab === tab
-
-      let urls = SessionData.updateSessionURLs(urls: urls).map({ $0.absoluteString })
-      let data = SavedTab(
-        id: id, title: title, url: url.absoluteString,
-        isSelected: isSelected, order: Int16(order),
-        screenshot: nil, history: urls,
-        historyIndex: Int16(currentPage),
-        isPrivate: tab.isPrivate)
-      return data
-    }
-
-    return nil
   }
 
   func removeTab(_ tab: Tab) {
@@ -667,7 +640,7 @@ class TabManager: NSObject {
     let prevCount = count
     allTabs.remove(at: removalIndex)
 
-    if let tab = TabMO.get(fromId: tab.id) {
+    if let tab = SessionTab.from(tabId: tab.id) {
       tab.delete()
     }
 
@@ -858,9 +831,8 @@ class TabManager: NSObject {
     return tab
   }
   
-  func getTabForID(_ id: String) -> Tab? {
+  func getTabForID(_ id: UUID) -> Tab? {
     assert(Thread.isMainThread)
-
     return allTabs.filter { $0.id == id }.first
   }
 
@@ -919,64 +891,40 @@ class TabManager: NSObject {
     if isRestoring { return }
 
     Task { @MainActor in
-      var savedUUIDs = Set<String>()
-      
       for tab in allTabs {
-        guard let screenshot = tab.screenshot, let screenshotUUID = tab.screenshotUUID else { continue }
-        savedUUIDs.insert(screenshotUUID.uuidString)
-        try? await imageStore?.put(screenshotUUID.uuidString, image: screenshot)
+        guard let screenshot = tab.screenshot else { continue }
+        SessionTab.updateScreenshot(tabId: tab.id, screenshot: screenshot)
       }
-      
-      // Clean up any screenshots that are no longer associated with a tab.
-      await imageStore?.clearExcluding(savedUUIDs)
     }
   }
 
   fileprivate var restoreTabsInternal: Tab? {
-    var savedTabs = [TabMO]()
+    var savedTabs = [SessionTab]()
 
     if let autocloseTime = Preferences.AutoCloseTabsOption(
       rawValue: Preferences.General.autocloseTabs.value)?.timeInterval {
       // To avoid db problems, we first retrieve fresh tabs(on main thread context)
       // then delete old tabs(background thread context)
-      savedTabs = TabMO.all(noOlderThan: autocloseTime)
-      TabMO.deleteAll(olderThan: autocloseTime)
+      savedTabs = SessionTab.all(noOlderThan: autocloseTime)
+      SessionTab.deleteAll(olderThan: autocloseTime)
     } else {
-      savedTabs = TabMO.getAll()
+      savedTabs = SessionTab.all()
     }
 
     if savedTabs.isEmpty { return nil }
 
     var tabToSelect: Tab?
     for savedTab in savedTabs {
-      guard let urlString = savedTab.url else {
-        savedTab.delete()
-        continue
-      }
-
+      let tabURL = savedTab.url
       // Provide an empty request to prevent a new tab from loading the home screen
-      let tab = addTab(
-        nil, configuration: nil, afterTab: nil, flushToDisk: false, zombie: true,
-        id: savedTab.syncUUID, isPrivate: false)
-
-      // Since this is a restored tab, reset the URL to be loaded as that will be handled by the SessionRestoreHandler
-      tab.url = nil
+      let tab = addTab(URLRequest(url: tabURL), flushToDisk: false, zombie: true, id: savedTab.tabId, isPrivate: false)
+      // tab.sessionData = (savedTab.title, savedTab.interactionState)
+      
       let isPrivateBrowsing = PrivateBrowsingManager.shared.isPrivateBrowsing
-      if let url = URL(string: urlString) {
-        tab.favicon = FaviconFetcher.getIconFromCache(for: url) ?? Favicon.default
-        Task { @MainActor in
-          tab.favicon = try await FaviconFetcher.loadIcon(url: url, kind: .smallIcon, persistent: !isPrivateBrowsing)
-        }
-      }
-
-      // Set the UUID for the tab, asynchronously fetch the UIImage, then store
-      // the screenshot in the tab as long as long as a newer one hasn't been taken.
-      if let screenshotUUID = savedTab.screenshotUUID, let imageStore = imageStore {
-        tab.screenshotUUID = UUID(uuidString: screenshotUUID)
-        Task { @MainActor in
-          let screenshot = try await imageStore.get(screenshotUUID)
-          tab.setScreenshot(screenshot, revUUID: false)
-        }
+      tab.favicon = FaviconFetcher.getIconFromCache(for: tabURL) ?? Favicon.default
+      Task { @MainActor in
+        tab.favicon = try await FaviconFetcher.loadIcon(url: tabURL, kind: .smallIcon, persistent: !isPrivateBrowsing)
+        tab.setScreenshot(savedTab.screenshot)
       }
 
       if savedTab.isSelected {
@@ -1002,13 +950,12 @@ class TabManager: NSObject {
 
   func restoreTab(_ tab: Tab) {
     // Tab was created with no active webview or session data. Restore tab data from CD and configure.
-    guard let savedTab = TabMO.get(fromId: tab.id) else { return }
+    guard let sessionTab = SessionTab.from(tabId: tab.id) else { return }
 
-    if let history = savedTab.urlHistorySnapshot as? [String], let tabUUID = savedTab.syncUUID, let url = savedTab.url {
-      let data = SavedTab(id: tabUUID, title: savedTab.title, url: url, isSelected: savedTab.isSelected, order: savedTab.order, screenshot: nil, history: history, historyIndex: savedTab.urlHistoryCurrentIndex, isPrivate: tab.isPrivate)
+    if !sessionTab.interactionState.isEmpty {
       if let webView = tab.webView {
         tab.navigationDelegate = navDelegate
-        tab.restore(webView, restorationData: data)
+        tab.restore(webView, restorationData: (sessionTab.title, sessionTab.interactionState))
       }
     }
   }
@@ -1085,30 +1032,17 @@ class TabManager: NSObject {
   
   /// Function invoked when a Recently Closed item is selected
   /// This function adss a new tab, populates this tab with necessary information
-  /// Also executes restore function on this tab to load History Snapshot to teh webview
+  /// Also executes restore function on this tab to load History Snapshot to the webview
   /// - Parameter recentlyClosed: Recently Closed item to be processed
   func addAndSelectRecentlyClosed(_ recentlyClosed: RecentlyClosed) {
-    guard let url = URL(string: recentlyClosed.url) else {
-      return
-    }
+    guard let url = NSURL(idnString: recentlyClosed.url) as? URL ?? URL(string: recentlyClosed.url) else { return }
     
     let tab = addTab(URLRequest(url: url), isPrivate: false)
-    guard let webView = tab.webView, let order = indexOfWebView(webView) else { return }
+    guard let webView = tab.webView else { return }
 
-    if let history = recentlyClosed.historyList as? [String], let tabUUID = tab.id {
-      let data = SavedTab(
-        id: tabUUID,
-        title: recentlyClosed.title,
-        url: recentlyClosed.url,
-        isSelected: false,
-        order: Int16(order),
-        screenshot: nil,
-        history: history,
-        historyIndex: recentlyClosed.historyIndex,
-        isPrivate: false)
-      
+    if !recentlyClosed.interactionState.isEmpty {
       tab.navigationDelegate = navDelegate
-      tab.restore(webView, restorationData: data)
+      tab.restore(webView, restorationData: (recentlyClosed.title, recentlyClosed.interactionState))
     }
     
     selectTab(tab)
@@ -1133,36 +1067,15 @@ class TabManager: NSObject {
     }
     
     // Fetching the Managed Object using the tab id
-    guard let tabID = tab.id,
-          let fetchedTab = TabMO.get(fromId: tabID),
-          let urlString = fetchedTab.url else {
+    guard let fetchedTab = SessionTab.from(tabId: tab.id) else {
       return nil
     }
     
-    // Gathering History Snaphot from Tab Managed Object
-    let urlHistorySnapshot: [String] = fetchedTab.urlHistorySnapshot as? [String] ?? []
-    
-    let recentlyClosedHistoryList = urlHistorySnapshot.compactMap {
-      // Session Restore URLs should be converted into extracted URL
-      // before being passed as backforward history
-      if let _url = URL(string: $0), let url = InternalURL(_url) {
-        return url.extractedUrlParam
-      }
-      return URL(string: $0)
-    }
-    
-    // NTP should not be passed as Recently Closed item if there are no items in History Snapshot
-    if let url = URL(string: urlString), InternalURL(url)?.isAboutHomeURL == true, urlHistorySnapshot.count > 1 {
-      return nil
-    }
-    
-    let savedItem = SavedRecentlyClosed(
-      url: urlString,
+    return SavedRecentlyClosed(
+      url: fetchedTab.url,
       title: fetchedTab.title,
-      historyList: recentlyClosedHistoryList.map({ $0.absoluteString }),
-      historyIndex: fetchedTab.urlHistoryCurrentIndex)
-    
-    return savedItem
+      interactionState: fetchedTab.interactionState,
+      order: fetchedTab.index)
   }
 }
 

--- a/Sources/Brave/Frontend/Browser/Tabs/RecentlyClosedTabs/RecentlyClosedTabsView.swift
+++ b/Sources/Brave/Frontend/Browser/Tabs/RecentlyClosedTabs/RecentlyClosedTabsView.swift
@@ -59,7 +59,7 @@ struct RecentlyClosedTabsView: View {
             HStack {
               FaviconImage(url: recentlyClosed.url)  
               VStack(alignment: .leading) {
-                Text(recentlyClosed.title ?? "")
+                Text(recentlyClosed.title)
                   .font(.footnote.weight(.semibold))
                   .foregroundColor(Color(.bravePrimary))
                   .lineLimit(1)
@@ -74,7 +74,7 @@ struct RecentlyClosedTabsView: View {
           .frame(maxWidth: .infinity)
           .padding(.vertical, 6)
           .accessibilityElement()
-          .accessibilityLabel(recentlyClosed.title ?? "")
+          .accessibilityLabel(recentlyClosed.title)
         }
         .onDelete { indexSet in
           // Delete an individual info from recently closed

--- a/Sources/Brave/Frontend/Browser/Tabs/RecentlyClosedTabs/RecentlyClosedTabsView.swift
+++ b/Sources/Brave/Frontend/Browser/Tabs/RecentlyClosedTabs/RecentlyClosedTabsView.swift
@@ -59,7 +59,7 @@ struct RecentlyClosedTabsView: View {
             HStack {
               FaviconImage(url: recentlyClosed.url)  
               VStack(alignment: .leading) {
-                Text(recentlyClosed.title)
+                Text(recentlyClosed.title ?? "")
                   .font(.footnote.weight(.semibold))
                   .foregroundColor(Color(.bravePrimary))
                   .lineLimit(1)
@@ -74,7 +74,7 @@ struct RecentlyClosedTabsView: View {
           .frame(maxWidth: .infinity)
           .padding(.vertical, 6)
           .accessibilityElement()
-          .accessibilityLabel(recentlyClosed.title)
+          .accessibilityLabel(recentlyClosed.title ?? "")
         }
         .onDelete { indexSet in
           // Delete an individual info from recently closed

--- a/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/AddEditBookmarkTableViewController.swift
+++ b/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/AddEditBookmarkTableViewController.swift
@@ -374,16 +374,12 @@ class AddEditBookmarkTableViewController: UITableViewController {
         if let url = tab.url, url.isWebPage(), !(InternalURL(url)?.isAboutHomeURL ?? false) {
           bookmarkManager.add(url: url, title: tab.title, parentFolder: parentFolder)
         }
-      } else {
-        if let tabID = tab.id {
-          let fetchedTab = TabMO.get(fromId: tabID)
-
-          if let urlString = fetchedTab?.url, let url = URL(string: urlString), url.isWebPage(), !(InternalURL(url)?.isAboutHomeURL ?? false) {
-            bookmarkManager.add(
-              url: url,
-              title: fetchedTab?.title ?? tab.title ?? tab.lastTitle,
-              parentFolder: parentFolder)
-          }
+      } else if let fetchedTab = SessionTab.from(tabId: tab.id) {
+        if fetchedTab.url.isWebPage(), !(InternalURL(fetchedTab.url)?.isAboutHomeURL ?? false) {
+          bookmarkManager.add(
+            url: fetchedTab.url,
+            title: fetchedTab.title,
+            parentFolder: parentFolder)
         }
       }
     }

--- a/Sources/BraveWallet/Preview Content/MockJsonRpcService.swift
+++ b/Sources/BraveWallet/Preview Content/MockJsonRpcService.swift
@@ -105,8 +105,8 @@ class MockJsonRpcService: BraveWalletJsonRpcService {
   }
   
   func removeChain(_ chainId: String, coin: BraveWallet.CoinType, completion: @escaping (Bool) -> Void) {
-    if let index = networks.firstIndex(where: { $0.chainId == chainId }) {
-      networks.remove(at: index)
+    if let historyIndex = networks.firstIndex(where: { $0.chainId == chainId }) {
+      networks.remove(at: historyIndex)
       completion(true)
     } else {
       completion(false)

--- a/Sources/Data/models/Model.xcdatamodeld/.xccurrentversion
+++ b/Sources/Data/models/Model.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>Model19.xcdatamodel</string>
+	<string>Model20.xcdatamodel</string>
 </dict>
 </plist>

--- a/Sources/Data/models/Model.xcdatamodeld/Model19.xcdatamodel/contents
+++ b/Sources/Data/models/Model.xcdatamodeld/Model19.xcdatamodel/contents
@@ -173,6 +173,35 @@
             </uniquenessConstraint>
         </uniquenessConstraints>
     </entity>
+    <entity name="SessionTab" representedClassName="Data.SessionTab" syncable="YES">
+        <attribute name="groupID" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="index" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="interactionState" attributeType="Binary"/>
+        <attribute name="isPrivate" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="isSelected" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="lastUpdated" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="screenshotData" attributeType="Binary"/>
+        <attribute name="tabId" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="title" attributeType="String"/>
+        <attribute name="url" attributeType="URI"/>
+        <relationship name="sessionTabGroup" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SessionTabGroup" inverseName="sessionTabs" inverseEntity="SessionTabGroup"/>
+        <relationship name="sessionWindow" maxCount="1" deletionRule="Nullify" destinationEntity="SessionWindow" inverseName="sessionTabs" inverseEntity="SessionWindow"/>
+    </entity>
+    <entity name="SessionTabGroup" representedClassName="Data.SessionTabGroup" syncable="YES">
+        <attribute name="groupId" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="index" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="title" attributeType="String"/>
+        <relationship name="sessionTabs" toMany="YES" deletionRule="Nullify" destinationEntity="SessionTab" inverseName="sessionTabGroup" inverseEntity="SessionTab"/>
+        <relationship name="sessionWindow" maxCount="1" deletionRule="Nullify" destinationEntity="SessionWindow" inverseName="sessionTabGroups" inverseEntity="SessionWindow"/>
+    </entity>
+    <entity name="SessionWindow" representedClassName="Data.SessionWindow" syncable="YES">
+        <attribute name="index" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="isPrivate" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="isSelected" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="windowId" attributeType="UUID" usesScalarValueType="NO"/>
+        <relationship name="sessionTabGroups" toMany="YES" deletionRule="Cascade" destinationEntity="SessionTabGroup" inverseName="sessionWindow" inverseEntity="SessionTabGroup"/>
+        <relationship name="sessionTabs" toMany="YES" deletionRule="Cascade" destinationEntity="SessionTab" inverseName="sessionWindow" inverseEntity="SessionTab"/>
+    </entity>
     <entity name="TabMO" representedClassName="Data.TabMO" syncable="YES">
         <attribute name="color" optional="YES" attributeType="String"/>
         <attribute name="isPrivate" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>

--- a/Sources/Data/models/Model.xcdatamodeld/Model20.xcdatamodel/contents
+++ b/Sources/Data/models/Model.xcdatamodeld/Model20.xcdatamodel/contents
@@ -72,15 +72,6 @@
             </uniquenessConstraint>
         </uniquenessConstraints>
     </entity>
-    <entity name="Device" representedClassName="Data.Device" syncable="YES">
-        <attribute name="created" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
-        <attribute name="deviceDisplayId" optional="YES" attributeType="String"/>
-        <attribute name="isCurrentDevice" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
-        <attribute name="isSynced" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
-        <attribute name="name" optional="YES" attributeType="String"/>
-        <attribute name="syncDisplayUUID" optional="YES" attributeType="String"/>
-        <relationship name="tabs" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="TabMO" inverseName="device" inverseEntity="TabMO"/>
-    </entity>
     <entity name="Domain" representedClassName="Data.Domain" syncable="YES">
         <attribute name="blockedFromTopSites" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="shield_adblockAndTp" optional="YES" attributeType="Boolean" usesScalarValueType="NO"/>
@@ -141,7 +132,7 @@
         <attribute name="cachedData" optional="YES" attributeType="Binary"/>
         <attribute name="dateAdded" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="duration" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
-        <attribute name="lastPlayedOffset" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="lastPlayedOffset" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
         <attribute name="mediaSrc" attributeType="String"/>
         <attribute name="mimeType" attributeType="String"/>
         <attribute name="name" attributeType="String"/>
@@ -153,8 +144,9 @@
     </entity>
     <entity name="RecentlyClosed" representedClassName="Data.RecentlyClosed" syncable="YES">
         <attribute name="dateAdded" attributeType="Date" usesScalarValueType="NO"/>
-        <attribute name="historyIndex" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="historyIndex" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="historyList" optional="YES" attributeType="Transformable"/>
+        <attribute name="interactionState" optional="YES" attributeType="Binary"/>
         <attribute name="title" optional="YES" attributeType="String"/>
         <attribute name="url" attributeType="String"/>
     </entity>
@@ -173,6 +165,35 @@
             </uniquenessConstraint>
         </uniquenessConstraints>
     </entity>
+    <entity name="SessionTab" representedClassName="Data.SessionTab" syncable="YES">
+        <attribute name="groupID" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="index" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="interactionState" attributeType="Binary"/>
+        <attribute name="isPrivate" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="isSelected" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="lastUpdated" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="screenshotData" attributeType="Binary"/>
+        <attribute name="tabId" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="title" attributeType="String"/>
+        <attribute name="url" attributeType="URI"/>
+        <relationship name="sessionTabGroup" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SessionTabGroup" inverseName="sessionTabs" inverseEntity="SessionTabGroup"/>
+        <relationship name="sessionWindow" maxCount="1" deletionRule="Nullify" destinationEntity="SessionWindow" inverseName="sessionTabs" inverseEntity="SessionWindow"/>
+    </entity>
+    <entity name="SessionTabGroup" representedClassName="Data.SessionTabGroup" syncable="YES">
+        <attribute name="groupId" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="index" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="title" attributeType="String"/>
+        <relationship name="sessionTabs" toMany="YES" deletionRule="Nullify" destinationEntity="SessionTab" inverseName="sessionTabGroup" inverseEntity="SessionTab"/>
+        <relationship name="sessionWindow" maxCount="1" deletionRule="Nullify" destinationEntity="SessionWindow" inverseName="sessionTabGroups" inverseEntity="SessionWindow"/>
+    </entity>
+    <entity name="SessionWindow" representedClassName="Data.SessionWindow" syncable="YES">
+        <attribute name="index" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="isPrivate" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="isSelected" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="windowId" attributeType="UUID" usesScalarValueType="NO"/>
+        <relationship name="sessionTabGroups" toMany="YES" deletionRule="Cascade" destinationEntity="SessionTabGroup" inverseName="sessionWindow" inverseEntity="SessionTabGroup"/>
+        <relationship name="sessionTabs" toMany="YES" deletionRule="Cascade" destinationEntity="SessionTab" inverseName="sessionWindow" inverseEntity="SessionTab"/>
+    </entity>
     <entity name="TabMO" representedClassName="Data.TabMO" syncable="YES">
         <attribute name="color" optional="YES" attributeType="String"/>
         <attribute name="isPrivate" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
@@ -186,6 +207,5 @@
         <attribute name="url" optional="YES" attributeType="String"/>
         <attribute name="urlHistoryCurrentIndex" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="urlHistorySnapshot" optional="YES" attributeType="Transformable"/>
-        <relationship name="device" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Device" inverseName="tabs" inverseEntity="Device"/>
     </entity>
 </model>

--- a/Sources/Data/models/RecentlyClosed.swift
+++ b/Sources/Data/models/RecentlyClosed.swift
@@ -10,26 +10,26 @@ import os.log
 
 public struct SavedRecentlyClosed {
   public let url: String
-  public let title: String?
-  public let dateAdded: Date?
-  public let historyList: [String]
-  public let historyIndex: Int16
+  public let title: String
+  public let dateAdded: Date
+  public let interactionState: Data
+  public let index: Int32
 
-  public init(url: String, title: String?, dateAdded: Date? = Date(), historyList: [String], historyIndex: Int16) {
-    self.url = url
+  public init(url: URL, title: String, dateAdded: Date = .now, interactionState: Data, order: Int32) {
+    self.url = url.absoluteString
     self.title = title
     self.dateAdded = dateAdded
-    self.historyList = historyList
-    self.historyIndex = historyIndex
+    self.interactionState = interactionState
+    self.index = order
   }
 }
 
 public final class RecentlyClosed: NSManagedObject, CRUD {
   @NSManaged public var url: String
-  @NSManaged public var title: String?
-  @NSManaged public var dateAdded: Date?
-  @NSManaged public var historyList: NSArray?  // List of urls for back forward navigation
-  @NSManaged public var historyIndex: Int16
+  @NSManaged public var title: String
+  @NSManaged public var dateAdded: Date
+  @NSManaged public var interactionState: Data
+  @NSManaged public var index: Int32
   
   public class func get(with url: String) -> RecentlyClosed? {
     return getInternal(with: url)
@@ -53,20 +53,7 @@ public final class RecentlyClosed: NSManagedObject, CRUD {
   }
   
   public class func insert(_ saved: SavedRecentlyClosed) {
-    DataController.perform { context in
-      guard let entity = entity(in: context) else {
-        Logger.module.error("Error fetching the entity 'Recently Closed' from Managed Object-Model")
-  
-        return
-      }
-  
-      let source = RecentlyClosed(entity: entity, insertInto: context)
-      source.url = saved.url
-      source.title = saved.title
-      source.dateAdded = saved.dateAdded
-      source.historyList = saved.historyList as NSArray
-      source.historyIndex = saved.historyIndex
-    }
+    Self.insertAll([saved])
   }
   
   public class func insertAll(_ savedList: [SavedRecentlyClosed]) {
@@ -77,8 +64,8 @@ public final class RecentlyClosed: NSManagedObject, CRUD {
           source.url = saved.url
           source.title = saved.title
           source.dateAdded = saved.dateAdded
-          source.historyList = saved.historyList as NSArray
-          source.historyIndex = saved.historyIndex
+          source.interactionState = saved.interactionState
+          source.index = saved.index
         }
       }
     }
@@ -102,7 +89,7 @@ public final class RecentlyClosed: NSManagedObject, CRUD {
   private class func getInternal(
     with url: String,
     context: NSManagedObjectContext = DataController.viewContext) -> RecentlyClosed? {
-    let predicate = NSPredicate(format: "\(#keyPath(RecentlyClosed.url)) == %@", url)
+      let predicate = NSPredicate(format: "\(#keyPath(RecentlyClosed.url)) == %@", argumentArray: [url])
 
     return first(where: predicate, context: context)
   }

--- a/Sources/Data/models/RecentlyClosed.swift
+++ b/Sources/Data/models/RecentlyClosed.swift
@@ -26,10 +26,10 @@ public struct SavedRecentlyClosed {
 
 public final class RecentlyClosed: NSManagedObject, CRUD {
   @NSManaged public var url: String
-  @NSManaged public var title: String
+  @NSManaged public var title: String?
   @NSManaged public var dateAdded: Date
-  @NSManaged public var interactionState: Data
-  @NSManaged public var index: Int32
+  @NSManaged public var interactionState: Data?
+  @NSManaged public var historyIndex: Int32
   
   public class func get(with url: String) -> RecentlyClosed? {
     return getInternal(with: url)
@@ -65,7 +65,7 @@ public final class RecentlyClosed: NSManagedObject, CRUD {
           source.title = saved.title
           source.dateAdded = saved.dateAdded
           source.interactionState = saved.interactionState
-          source.index = saved.index
+          source.historyIndex = saved.index
         }
       }
     }

--- a/Sources/Data/models/SessionTab.swift
+++ b/Sources/Data/models/SessionTab.swift
@@ -1,0 +1,207 @@
+// Copyright 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import UIKit
+import CoreData
+import os.log
+
+public final class SessionTab: NSManagedObject, CRUD {
+  @NSManaged public var index: Int32
+  @NSManaged public var interactionState: Data
+  @NSManaged private(set) public var isPrivate: Bool
+  @NSManaged private(set) public var isSelected: Bool
+  @NSManaged public var lastUpdated: Date
+  @NSManaged public var screenshotData: Data
+  @NSManaged public var title: String
+  @NSManaged public var url: URL
+  @NSManaged private(set) public var tabId: UUID
+  
+  @NSManaged private(set) public var sessionTabGroup: SessionTabGroup?
+  @NSManaged private(set) public var sessionWindow: SessionWindow
+  
+  @available(*, unavailable)
+  public init() {
+    fatalError("No Such Initializer: init()")
+  }
+
+  @available(*, unavailable)
+  public init(context: NSManagedObjectContext) {
+    fatalError("No Such Initializer: init(context:)")
+  }
+  
+  @objc
+  private override init(entity: NSEntityDescription, insertInto context: NSManagedObjectContext?) {
+    super.init(entity: entity, insertInto: context)
+  }
+  
+  public init(context: NSManagedObjectContext,
+              sessionWindow: SessionWindow,
+              sessionTabGroup: SessionTabGroup?,
+              index: Int32,
+              interactionState: Data,
+              isPrivate: Bool,
+              isSelected: Bool,
+              lastUpdated: Date,
+              screenshotData: Data,
+              title: String,
+              url: URL,
+              tabId: UUID = UUID()) {
+    guard let entity = Self.entity(context) else {
+      fatalError("No such Entity: SessionTab")
+    }
+    
+    if let sessionTabGroup = sessionTabGroup, sessionTabGroup.sessionWindow.windowId != sessionWindow.windowId {
+      fatalError("Cannot add a tab to a different window and group. The group must belong to the same window as the tab")
+    }
+    
+    super.init(entity: entity, insertInto: context)
+    self.sessionWindow = sessionWindow
+    self.sessionTabGroup = sessionTabGroup
+    self.index = index
+    self.interactionState = interactionState
+    self.isPrivate = isPrivate
+    self.isSelected = isSelected
+    self.lastUpdated = lastUpdated
+    self.screenshotData = screenshotData
+    self.title = title
+    self.url = url
+    self.tabId = tabId
+  }
+}
+
+// MARK: - Public
+
+extension SessionTab {
+  public var screenshot: UIImage? {
+    get {
+      return screenshotData.isEmpty ? nil : UIImage(data: screenshotData)
+    }
+    
+    set {
+      self.screenshotData = newValue?.jpegData(compressionQuality: 0.3) ?? Data()
+    }
+  }
+  
+  public static func exists(tabId: UUID) -> Bool {
+    let predicate = NSPredicate(format: "\(#keyPath(SessionTab.tabId)) == %@", argumentArray: [tabId])
+    return Self.count(predicate: predicate, context: DataController.viewContext) != 0
+  }
+  
+  /// Returns the tab with the specificed tabId
+  public static func from(tabId: UUID) -> SessionTab? {
+    return Self.from(tabId: tabId, in: DataController.viewContext)
+  }
+  
+  public static func all() -> [SessionTab] {
+    let sortDescriptors = [NSSortDescriptor(key: #keyPath(SessionTab.index), ascending: true)]
+    return all(sortDescriptors: sortDescriptors) ?? []
+  }
+  
+  public static func all(noOlderThan timeInterval: TimeInterval) -> [SessionTab] {
+    let lastUpdatedKeyPath = #keyPath(SessionTab.lastUpdated)
+    let date = Date().advanced(by: -timeInterval) as NSDate
+  
+    let sortDescriptors = [NSSortDescriptor(key: #keyPath(SessionTab.index), ascending: true)]
+    let predicate = NSPredicate(format: "\(lastUpdatedKeyPath) = nil OR \(lastUpdatedKeyPath) > %@", date)
+    return all(where: predicate, sortDescriptors: sortDescriptors) ?? []
+  }
+  
+  public func delete() {
+    delete(context: .new(inMemory: false))
+  }
+  
+  public static func deleteAll() {
+    deleteAll(context: .new(inMemory: false))
+  }
+  
+  public static func deleteAll(olderThan timeInterval: TimeInterval) {
+    let lastUpdatedKeyPath = #keyPath(SessionTab.lastUpdated)
+    let date = Date().advanced(by: -timeInterval) as NSDate
+    let predicate = NSPredicate(format: "\(lastUpdatedKeyPath) != nil AND \(lastUpdatedKeyPath) < %@", date)
+    self.deleteAll(predicate: predicate)
+  }
+  
+  /// Marks the specified tab as selected
+  /// Since only one tab can be active at a time, all other tabs are marked as deselected
+  public static func setSelected(tabId: UUID) {
+    DataController.perform { context in
+      guard let tab = Self.from(tabId: tabId, in: context) else { return }
+
+      let predicate = NSPredicate(format: "isSelected == true")
+      all(where: predicate, context: context)?.forEach {
+        $0.isSelected = false
+      }
+
+      tab.isSelected = true
+    }
+  }
+  
+  public static func touch(tabId: UUID) {
+    DataController.perform { context in
+      Self.from(tabId: tabId, in: context)?.lastUpdated = .now
+    }
+  }
+  
+  public static func update(tabId: UUID, interactionState: Data, title: String, url: URL) {
+    DataController.perform { context in
+      guard let sessionTab = Self.from(tabId: tabId, in: context) else { return }
+      sessionTab.interactionState = interactionState
+      sessionTab.title = title
+      sessionTab.url = url
+      sessionTab.lastUpdated = .now
+    }
+  }
+  
+  public static func updateScreenshot(tabId: UUID, screenshot: UIImage?) {
+    DataController.perform { context in
+      guard let sessionTab = Self.from(tabId: tabId, in: context) else { return }
+      sessionTab.screenshot = screenshot
+    }
+  }
+  
+  public static func saveTabOrder(tabIds: [UUID]) {
+    DataController.perform { context in
+      for (index, tabId) in tabIds.enumerated() {
+        guard let tab = Self.from(tabId: tabId, in: context) else {
+          Logger.module.error("Error: SessionTab missing managed object")
+          continue
+        }
+        tab.index = Int32(index)
+      }
+    }
+  }
+  
+  public static func updateAll(tabs: [(tabId: UUID, interactionState: Data, title: String, url: URL)]) {
+    DataController.performOnMainContext { context in
+      for (index, tab) in tabs.enumerated() {
+        guard let sessionTab = Self.from(tabId: tab.tabId, in: context) else { return }
+        sessionTab.interactionState = tab.interactionState
+        sessionTab.title = tab.title
+        sessionTab.url = tab.url
+        sessionTab.index = Int32(index)
+      }
+      
+      do {
+        try context.save()
+      } catch {
+        Logger.module.error("Error: SessionTabs not saved!")
+      }
+    }
+  }
+}
+
+// MARK: - Private
+
+extension SessionTab {
+  private static func from(tabId: UUID, in context: NSManagedObjectContext) -> SessionTab? {
+    let predicate = NSPredicate(format: "\(#keyPath(SessionTab.tabId)) == %@", argumentArray: [tabId])
+    return first(where: predicate, context: context)
+  }
+  
+  private static func entity(_ context: NSManagedObjectContext) -> NSEntityDescription? {
+    return NSEntityDescription.entity(forEntityName: "SessionTab", in: context)
+  }
+}

--- a/Sources/Data/models/SessionTab.swift
+++ b/Sources/Data/models/SessionTab.swift
@@ -191,6 +191,32 @@ extension SessionTab {
       }
     }
   }
+  
+  public static func createIfNeeded(tabId: UUID, title: String, tabURL: URL) {
+    if !SessionTab.exists(tabId: tabId) {
+      DataController.performOnMainContext { context in
+        guard let window = SessionWindow.getActiveWindow(context: context) else { return }
+        _ = SessionTab(context: context,
+                       sessionWindow: window,
+                       sessionTabGroup: nil,
+                       index: Int32(window.sessionTabs.count),
+                       interactionState: Data(),
+                       isPrivate: false,
+                       isSelected: false,
+                       lastUpdated: .now,
+                       screenshotData: Data(),
+                       title: title,
+                       url: tabURL,
+                       tabId: tabId)
+        
+        do {
+          try context.save()
+        } catch {
+          Logger.module.error("performTask save error: \(error.localizedDescription, privacy: .public)")
+        }
+      }
+    }
+  }
 }
 
 // MARK: - Private

--- a/Sources/Data/models/SessionTabGroup.swift
+++ b/Sources/Data/models/SessionTabGroup.swift
@@ -1,0 +1,45 @@
+// Copyright 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import UIKit
+import CoreData
+import os.log
+
+public final class SessionTabGroup: NSManagedObject, CRUD {
+  @NSManaged public var title: String
+  @NSManaged public var index: Int32
+  @NSManaged private(set) public var groupId: UUID
+  
+  @NSManaged private(set) public var sessionWindow: SessionWindow
+  @NSManaged private(set) public var sessionTabs: Set<SessionTab>
+  
+  @available(*, unavailable)
+  public init() {
+    fatalError("No Such Initializer: init()")
+  }
+
+  @available(*, unavailable)
+  public init(context: NSManagedObjectContext) {
+    fatalError("No Such Initializer: init(context:)")
+  }
+  
+  public init(context: NSManagedObjectContext,
+              sessionWindow: SessionWindow,
+              index: Int32,
+              title: String) {
+    guard let entity = NSEntityDescription.entity(forEntityName: "SessionTabGroup", in: context) else {
+      fatalError("No such Entity: SessionTabGroup")
+    }
+    
+    super.init(entity: entity, insertInto: context)
+    
+    self.sessionWindow = sessionWindow
+    self.sessionTabs = Set()
+    self.index = index
+    self.groupId = groupId
+    self.title = title
+  }
+}

--- a/Sources/Data/models/SessionWindow.swift
+++ b/Sources/Data/models/SessionWindow.swift
@@ -1,0 +1,93 @@
+// Copyright 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import UIKit
+import CoreData
+import os.log
+
+public final class SessionWindow: NSManagedObject, CRUD {
+  @NSManaged public var index: Int32
+  @NSManaged private(set) public var isPrivate: Bool
+  @NSManaged public var isSelected: Bool
+  @NSManaged private(set) public var windowId: UUID
+  @NSManaged private(set) public var sessionTabs: Set<SessionTab>
+  @NSManaged private(set) public var sessionTabGroups: Set<SessionTabGroup>
+  
+  @available(*, unavailable)
+  public init() {
+    fatalError("No Such Initializer: init()")
+  }
+
+  @available(*, unavailable)
+  public init(context: NSManagedObjectContext) {
+    fatalError("No Such Initializer: init(context:)")
+  }
+  
+  @objc
+  private override init(entity: NSEntityDescription, insertInto context: NSManagedObjectContext?) {
+    super.init(entity: entity, insertInto: context)
+  }
+  
+  public init(context: NSManagedObjectContext,
+              index: Int32,
+              isPrivate: Bool,
+              isSelected: Bool) {
+    guard let entity = NSEntityDescription.entity(forEntityName: "SessionWindow", in: context) else {
+      fatalError("No such Entity: SessionWindow")
+    }
+    
+    super.init(entity: entity, insertInto: context)
+    self.sessionTabs = Set()
+    self.sessionTabGroups = Set()
+    self.index = index
+    self.isPrivate = isPrivate
+    self.isSelected = isSelected
+    self.windowId = UUID()
+  }
+}
+
+// MARK: - Public
+
+extension SessionWindow {
+  /// Returns the active window
+  public static func getActiveWindow(context: NSManagedObjectContext) -> SessionWindow? {
+    let predicate = NSPredicate(format: "\(#keyPath(SessionWindow.isSelected)) == true")
+    return first(where: predicate, context: DataController.viewContext)
+  }
+  
+  /// Returns the tab with the specificed windowId
+  public static func from(windowId: UUID) -> SessionWindow? {
+    return Self.from(windowId: windowId, in: DataController.viewContext)
+  }
+  
+  /// Marks the specified window as selected
+  /// Since only one window can be active at a time, all other windows are marked as deselected
+  public static func setSelected(windowId: UUID) {
+    DataController.perform { context in
+      guard let window = Self.from(windowId: windowId) else { return }
+
+      let predicate = NSPredicate(format: "isSelected == true")
+      all(where: predicate, context: context)?.forEach {
+        $0.isSelected = false
+      }
+
+      window.isSelected = true
+    }
+  }
+}
+
+// MARK: - Private
+
+extension SessionWindow {
+  private static func from(windowId: UUID, in context: NSManagedObjectContext) -> SessionWindow? {
+    let predicate = NSPredicate(format: "\(#keyPath(SessionWindow.windowId)) == %@", windowId.uuidString)
+    return first(where: predicate, context: context)
+  }
+  
+  private static func entity(_ context: NSManagedObjectContext) -> NSEntityDescription? {
+    return NSEntityDescription.entity(forEntityName: "SessionWindow", in: context)
+  }
+}

--- a/Sources/Data/models/TabMO.swift
+++ b/Sources/Data/models/TabMO.swift
@@ -60,6 +60,12 @@ public final class TabMO: NSManagedObject, CRUD {
   }
 
   // MARK: - Public interface
+  
+  public static func migrate(_ block: @escaping (NSManagedObjectContext) -> Void) {
+    DataController.perform(save: true) { context in
+      block(context)
+    }
+  }
 
   // MARK: Create
 
@@ -102,22 +108,6 @@ public final class TabMO: NSManagedObject, CRUD {
 
   public class func get(fromId id: String?) -> TabMO? {
     return getInternal(fromId: id)
-  }
-
-  public class func insertRecentlyClosed(uuidString: String, _ saved: SavedRecentlyClosed) {
-    DataController.perform { context in
-      guard let entity = entity(context) else {
-        Logger.module.error("Error fetching the entity 'Tab' from Managed Object-Model")
-        return
-      }
-  
-      let tab = TabMO(entity: entity, insertInto: context)
-      tab.syncUUID = uuidString
-      tab.url = saved.url
-      tab.title = saved.title
-      tab.urlHistorySnapshot = saved.historyList as NSArray
-      tab.urlHistoryCurrentIndex = saved.historyIndex
-    }
   }
   
   // MARK: Update

--- a/Sources/DesignSystem/Views/BraveButtonStyle.swift
+++ b/Sources/DesignSystem/Views/BraveButtonStyle.swift
@@ -101,11 +101,11 @@ struct BraveButtonStyle_Previews: PreviewProvider {
       HStack {
         ForEach([false, true], id: \.self) { disabled in
           VStack {
-            ForEach(defaultSizes.indices, id: \.self) { index in
+            ForEach(defaultSizes.indices, id: \.self) { historyIndex in
               Button(action: {}) {
                 Text(verbatim: "Button text")
               }
-              .buttonStyle(BraveFilledButtonStyle(size: defaultSizes[index]))
+              .buttonStyle(BraveFilledButtonStyle(size: defaultSizes[historyIndex]))
               .disabled(disabled)
             }
           }
@@ -115,11 +115,11 @@ struct BraveButtonStyle_Previews: PreviewProvider {
       HStack {
         ForEach([false, true], id: \.self) { disabled in
           VStack {
-            ForEach(defaultSizes.indices, id: \.self) { index in
+            ForEach(defaultSizes.indices, id: \.self) { historyIndex in
               Button(action: {}) {
                 Text(verbatim: "Button text")
               }
-              .buttonStyle(BraveOutlineButtonStyle(size: defaultSizes[index]))
+              .buttonStyle(BraveOutlineButtonStyle(size: defaultSizes[historyIndex]))
               .disabled(disabled)
             }
           }

--- a/Sources/Storage/DiskImageStore.swift
+++ b/Sources/Storage/DiskImageStore.swift
@@ -57,6 +57,22 @@ open class DiskImageStore {
       }
     }
   }
+  
+  /// Gets an image for the given key if it is in the store.
+  open func getSynchronously(_ key: String) throws -> UIImage {
+    try queue.sync {
+      if !self.keys.contains(key) {
+        throw DiskImageStoreErrorType(description: "Image key not found")
+      }
+      let imagePath = URL(fileURLWithPath: self.filesDir).appendingPathComponent(key)
+      if let data = try? Data(contentsOf: imagePath),
+         let image = UIImage.imageFromDataThreadSafe(data) {
+        return image
+      }
+      
+      throw DiskImageStoreErrorType(description: "Invalid image data")
+    }
+  }
 
   /// Adds an image for the given key.
   /// This put is asynchronous; the image is not recorded in the cache until the write completes.

--- a/Tests/ClientTests/TabManagerTests.swift
+++ b/Tests/ClientTests/TabManagerTests.swift
@@ -113,7 +113,7 @@ class TabManagerTests: XCTestCase {
 
     DataController.shared.initializeOnce()
     let profile = MockProfile()
-    manager = TabManager(prefs: profile.prefs, imageStore: nil, rewards: nil, tabGeneratorAPI: nil)
+    manager = TabManager(prefs: profile.prefs, rewards: nil, tabGeneratorAPI: nil)
     PrivateBrowsingManager.shared.isPrivateBrowsing = false
   }
 
@@ -513,8 +513,8 @@ class TabManagerTests: XCTestCase {
     wait(1)
     delegate.verify("Not all delegate methods were called")
 
-    let storedTabs = TabMO.getAll()
-    XCTAssertNotNil(storedTabs.first(where: { $0.syncUUID == tab.id }))
+    let storedTabs = SessionTab.all()
+    XCTAssertNotNil(storedTabs.first(where: { $0.tabId == tab.id }))
     XCTAssertEqual(storedTabs.count, 1)
   }
 
@@ -529,7 +529,7 @@ class TabManagerTests: XCTestCase {
     manager.addTab(isPrivate: true)
     delegate.verify("Not all delegate methods were called")
 
-    let storedTabs = TabMO.getAll()
+    let storedTabs = SessionTab.all()
     // Shouldn't be storing any private tabs
     XCTAssertTrue(storedTabs.isEmpty)
   }
@@ -547,8 +547,8 @@ class TabManagerTests: XCTestCase {
     wait(1)
     delegate.verify("Not all delegate methods were called")
 
-    let storedTabs = TabMO.getAll()
-    XCTAssertNotNil(storedTabs.first(where: { $0.syncUUID == tab.id }), "Couldn't find added tab: \(tab) in stored tabs: \(storedTabs)")
+    let storedTabs = SessionTab.all()
+    XCTAssertNotNil(storedTabs.first(where: { $0.tabId == tab.id }), "Couldn't find added tab: \(tab) in stored tabs: \(storedTabs)")
     // Shouldn't be storing any private tabs
     XCTAssertEqual(storedTabs.count, 1)
   }

--- a/Tests/ClientTests/TabSessionTests.swift
+++ b/Tests/ClientTests/TabSessionTests.swift
@@ -89,7 +89,7 @@ class TabSessionTests: XCTestCase {
     DataController.shared.initializeOnce()
     tabManager = { () -> TabManager in
       let profile = BrowserProfile(localName: "profile")
-      return TabManager(prefs: profile.prefs, imageStore: nil, rewards: nil, tabGeneratorAPI: nil)
+      return TabManager(prefs: profile.prefs, rewards: nil, tabGeneratorAPI: nil)
     }()
   }
 

--- a/Tests/DataTests/RecentlyClosedTests.swift
+++ b/Tests/DataTests/RecentlyClosedTests.swift
@@ -19,19 +19,16 @@ class RecentlyClosedTests: CoreDataTestCase {
 
     XCTAssertEqual(object1.url, url1.absoluteString)
     XCTAssertEqual(object1.title, title1)
-    XCTAssertEqual(object1.historyList?.count, 0)
     
     let url2 = URL(string: "https://www.wikipedia.org")!
     let title2 = "Wikipedia"
     
     let object2 = createAndWait(
-      url: url2, title: title2,
-      historyList: ["https://brave.com", "https://www.wikipedia.org"])
+      url: url2, title: title2)
     XCTAssertEqual(try! DataController.viewContext.count(for: fetchRequest), 2)
 
     XCTAssertEqual(object2.url, url2.absoluteString)
     XCTAssertEqual(object2.title, title2)
-    XCTAssertEqual(object2.historyList?.count, 2)
   }
   
   func testInsertAll() {
@@ -39,21 +36,21 @@ class RecentlyClosedTests: CoreDataTestCase {
     let title1 = "Brave"
     
     let savedObject1 = SavedRecentlyClosed(
-      url: url1.absoluteString,
+      url: url1,
       title: title1,
       dateAdded: Date(),
-      historyList: [],
-      historyIndex: Int16(0))
+      interactionState: Data(),
+      order: 0)
     
     let url2 = URL(string: "https://www.wikipedia.org")!
     let title2 = "Wikipedia"
     
     let savedObject2 = SavedRecentlyClosed(
-      url: url2.absoluteString,
+      url: url2,
       title: title2,
       dateAdded: Date(),
-      historyList: [],
-      historyIndex: Int16(0))
+      interactionState: Data(),
+      order: 0)
     
     let savedRecentlyClosedList = [savedObject1, savedObject2]
     
@@ -69,8 +66,7 @@ class RecentlyClosedTests: CoreDataTestCase {
     let savedUrl = URL(string: "https://brave.com")!
 
     let title1 = "Brave"
-
-    let object1 = createAndWait(url: savedUrl, title: title1)
+    createAndWait(url: savedUrl, title: title1)
 
     XCTAssertNil(RecentlyClosed.get(with: unsavedUrl.absoluteString))
     XCTAssertNotNil(RecentlyClosed.get(with: savedUrl.absoluteString))
@@ -133,14 +129,13 @@ class RecentlyClosedTests: CoreDataTestCase {
   }
   
   @discardableResult
-  private func createAndWait(url: URL, title: String, date: Date = Date(), historyList: [String] = [], historyIndex: Int = 0) -> RecentlyClosed {
+  private func createAndWait(url: URL, title: String, date: Date = Date(), historyIndex: Int = 0) -> RecentlyClosed {
     backgroundSaveAndWaitForExpectation {
       RecentlyClosed.insert(SavedRecentlyClosed(
-        url: url.absoluteString,
+        url: url,
         title: title,
-        dateAdded: date,
-        historyList: historyList,
-        historyIndex: Int16(historyIndex)))
+        interactionState: Data(),
+        order: Int32(historyIndex)))
     }
 
     let predicate = NSPredicate(format: "\(#keyPath(RecentlyClosed.url)) == %@", url.absoluteString)


### PR DESCRIPTION
## Summary of Changes
- Add SessionRestore from WebKit
- Store state on background and terminate :)
- Update database version.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7166

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
- Test Session Restore
- Test restoring reader-mode
- Test restoring error pages
- Test recently closed


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
