### PR TITLE
Fix #5481: Limit account name to 30 characters

### DIFF
--- a/Sources/BraveWallet/Crypto/Accounts/Add/AddAccountView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/Add/AddAccountView.swift
@@ -31,9 +31,11 @@ struct AddAccountView: View {
   var onDismiss: (() -> Void)?
 
   private func addAccount(for coin: BraveWallet.CoinType) {
+    let accountName = name.isEmpty ? defaultAccountName(for: coin, isPrimary: privateKey.isEmpty) : name
+    guard accountName.isValidAccountName else { return }
+    
     if privateKey.isEmpty {
       // Add normal account
-      let accountName = name.isEmpty ? defaultAccountName(for: coin, isPrimary: true) : name
       keyringStore.addPrimaryAccount(accountName, coin: coin) { success in
         if success {
           onCreate?()
@@ -51,7 +53,6 @@ struct AddAccountView: View {
           failedToImport = true
         }
       }
-      let accountName = name.isEmpty ? defaultAccountName(for: coin, isPrimary: false) : name
       if isJSONImported {
         keyringStore.addSecondaryAccount(accountName, json: privateKey, password: originPassword, completion: handler)
       } else {
@@ -103,6 +104,7 @@ struct AddAccountView: View {
         Text(Strings.Wallet.add)
       }
         .buttonStyle(BraveFilledButtonStyle(size: .small))
+        .disabled(!name.isValidAccountName)
     )
     .alert(isPresented: $failedToImport) {
       Alert(
@@ -198,15 +200,29 @@ struct AddAccountView: View {
 
   private var accountNameSection: some View {
     Section(
-      header: WalletListHeaderView(
-        title: Text(Strings.Wallet.accountDetailsNameTitle)
-          .font(.subheadline.weight(.semibold))
-          .foregroundColor(Color(.bravePrimary))
-      )
-    ) {
-      TextField(Strings.Wallet.accountDetailsNamePlaceholder, text: $name)
-        .listRowBackground(Color(.secondaryBraveGroupedBackground))
-    }
+      content: {
+        Group {
+          if #available(iOS 16, *) {
+            TextField(Strings.Wallet.accountDetailsNamePlaceholder, text: $name, axis: .vertical)
+          } else {
+            TextField(Strings.Wallet.accountDetailsNamePlaceholder, text: $name)
+          }
+        }
+          .listRowBackground(Color(.secondaryBraveGroupedBackground))
+      },
+      header: {
+        WalletListHeaderView(
+          title: Text(Strings.Wallet.accountDetailsNameTitle)
+            .font(.subheadline.weight(.semibold))
+            .foregroundColor(Color(.bravePrimary))
+        )
+      },
+      footer: {
+        SectionFooterErrorView(
+          errorMessage: name.isValidAccountName ? nil : Strings.Wallet.accountNameLengthError
+        )
+      }
+    )
   }
 
   private var originPasswordSection: some View {

--- a/Sources/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
+++ b/Sources/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
@@ -140,33 +140,10 @@ struct SendTokenView: View {
         }
         Section(
           header: WalletListHeaderView(title: Text(Strings.Wallet.sendCryptoToTitle)),
-          footer: Group {
-            if let error = sendTokenStore.addressError {
-              HStack(alignment: .firstTextBaseline, spacing: 4) {
-                Image(systemName: "exclamationmark.circle.fill")
-                Text(error.localizedDescription)
-                  .fixedSize(horizontal: false, vertical: true)
-                  .animation(nil, value: error.localizedDescription)
-              }
-              .transition(
-                .asymmetric(
-                  insertion: .opacity.animation(.default),
-                  removal: .identity
-                )
-              )
-              .font(.footnote)
-              .foregroundColor(Color(.braveErrorLabel))
-              .padding(.bottom)
-            } else {
-              // SwiftUI will add/remove this Section footer when addressError
-              // optionality is changed. This can cause keyboard to dismiss.
-              // By using clear square, the footer remains and section is not
-              // redrawn, so the keyboard does not dismiss as user types.
-              Color.clear.frame(width: 1, height: 1)
-                .accessibility(hidden: true)
-                .transition(.identity)
-            }
-          }
+          footer:
+            SectionFooterErrorView(
+              errorMessage: sendTokenStore.addressError?.localizedDescription
+            )
         ) {
           VStack {
             HStack(spacing: 14.0) {

--- a/Sources/BraveWallet/Extensions/BraveWalletExtensions.swift
+++ b/Sources/BraveWallet/Extensions/BraveWalletExtensions.swift
@@ -317,4 +317,9 @@ public extension String {
   var endsWithSupportedUDExtension: Bool {
     WalletConstants.supportedUDExtensions.contains(where: hasSuffix)
   }
+  
+  /// Returns true if `Self` is a valid account name
+  var isValidAccountName: Bool {
+    self.count <= 30
+  }
 }

--- a/Sources/BraveWallet/SectionFooterErrorView.swift
+++ b/Sources/BraveWallet/SectionFooterErrorView.swift
@@ -1,0 +1,39 @@
+// Copyright 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import SwiftUI
+
+struct SectionFooterErrorView: View {
+  
+  var errorMessage: String?
+  
+  var body: some View {
+    if let errorMessage {
+      HStack(alignment: .firstTextBaseline, spacing: 4) {
+        Image(systemName: "exclamationmark.circle.fill")
+        Text(errorMessage)
+          .fixedSize(horizontal: false, vertical: true)
+          .animation(nil, value: errorMessage)
+      }
+      .transition(
+        .asymmetric(
+          insertion: .opacity.animation(.default),
+          removal: .identity
+        )
+      )
+      .font(.footnote)
+      .foregroundColor(Color(.braveErrorLabel))
+      .padding(.bottom)
+    } else {
+      // SwiftUI will add/remove this Section footer when addressError
+      // optionality is changed. This can cause keyboard to dismiss.
+      // By using clear square, the footer remains and section is not
+      // redrawn, so the keyboard does not dismiss as user types.
+      Color.clear.frame(width: 1, height: 1)
+        .accessibility(hidden: true)
+        .transition(.identity)
+    }
+  }
+}

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -155,6 +155,13 @@ extension Strings {
       value: "Enter account name",
       comment: "The placeholder of the text field which allows the user to edit the account's name"
     )
+    public static let accountNameLengthError = NSLocalizedString(
+      "wallet.accountNameLengthError",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Account name must be at most 30 characters long",
+      comment: "The error shown below the account name field when adding or renaming a wallet account if the length is longer than 30 characters."
+    )
     public static let accountPrivateKey = NSLocalizedString(
       "wallet.accountPrivateKey",
       tableName: "BraveWallet",


### PR DESCRIPTION
## Summary of Changes
- Add 30 character limit to account name
- Updated name field to drop to multiline if needed on iOS 16+; minor UX tweak (nice with accessibility text sizes).

This pull request fixes #5481

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Open wallet, switch to Accounts tab and tap the `+` button
2. Select a coin type, then try entering a name > 30 characters long. 
3. Verify error message is shown and `add` button is disabled
4. Navigate back to Accounts tab and select an account
5. Tap `Rename`
6. Try entering an account name > 30 characters long
7. Verify error message is shown and `done` button is disabled

## Screenshots:

Add Account | Add Account multiline (iOS 16+) | Rename Account | Rename Account multiline (iOS 16+)
--|--|--|--
![5481 - add account](https://user-images.githubusercontent.com/5314553/228894802-4a7b9a38-00fe-475d-ab15-e6f15439a1d1.png) | ![5481 - add account multiline](https://user-images.githubusercontent.com/5314553/228894822-c20d2cf7-3134-4bb6-944e-13ae47658c31.png) | ![5481 - rename account](https://user-images.githubusercontent.com/5314553/228894828-04c6718d-953a-4a98-94d3-7c8c9ad5d73a.png) | ![5481 - rename account multiline](https://user-images.githubusercontent.com/5314553/228894837-b75b4370-86f2-41bf-a56b-b72a9b372b76.png)


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
