### PR TITLE
Fix #7175: Only allow json importing for eth account

### DIFF
--- a/Sources/BraveWallet/Crypto/Accounts/Add/AddAccountView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/Add/AddAccountView.swift
@@ -125,6 +125,11 @@ struct AddAccountView: View {
             tag: coin,
             selection: $selectedCoin) {
               addAccountView
+                .onDisappear {
+                  name = ""
+                  originPassword = ""
+                  privateKey = ""
+                }
             } label: {
               HStack(spacing: 10) {
                 Image(coin.iconName, bundle: .module)

--- a/Sources/BraveWallet/Crypto/Accounts/Add/AddAccountView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/Add/AddAccountView.swift
@@ -61,7 +61,7 @@ struct AddAccountView: View {
   }
 
   private var isJSONImported: Bool {
-    guard let data = privateKey.data(using: .utf8) else {
+    guard selectedCoin == .eth, let data = privateKey.data(using: .utf8) else {
       return false
     }
     do {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7175

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
1. open Brave wallet 
2. go to Accounts tab
3. click `+` button to add a new account
4. choose Solana
5. input any json formatted string in the text box
6. observe that `Original Password` will not show up. 
7. user should be able to add a new account if the input is a valid private key

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
