### PR TITLE
Fix #6093: Update wallet password policy

### DIFF
--- a/Sources/BraveWallet/Crypto/Stores/KeyringStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/KeyringStore.swift
@@ -210,7 +210,15 @@ public class KeyringStore: ObservableObject {
   }
 
   func isStrongPassword(_ password: String, completion: @escaping (Bool) -> Void) {
-    keyringService.isStrongPassword(password, completion: completion)
+    completion(password.count >= 8)
+  }
+  
+  @MainActor func isStrongPassword(_ password: String) async -> Bool {
+    await withCheckedContinuation { continuation in
+      isStrongPassword(password) { isStrong in
+        continuation.resume(returning: isStrong)
+      }
+    }
   }
 
   func createWallet(password: String, completion: ((String) -> Void)? = nil) {

--- a/Sources/BraveWallet/Preview Content/MockKeyringService.swift
+++ b/Sources/BraveWallet/Preview Content/MockKeyringService.swift
@@ -263,35 +263,7 @@ class MockKeyringService: BraveWalletKeyringService {
   }
 
   func isStrongPassword(_ password: String, completion: @escaping (Bool) -> Void) {
-    do {
-      // Should match shared logic for testing, however this may not always be the case
-      let range = NSRange(location: 0, length: password.count)
-      if password.count < 7 {
-        completion(false)
-        return
-      }
-      // Has at least one letter
-      if (try NSRegularExpression(pattern: "[a-zA-Z]", options: []))
-        .numberOfMatches(in: password, options: [], range: range) < 1 {
-        completion(false)
-        return
-      }
-      // Has at least one number
-      if (try NSRegularExpression(pattern: "[0-9]", options: []))
-        .numberOfMatches(in: password, options: [], range: range) < 1 {
-        completion(false)
-        return
-      }
-      // Has at least one non-alphanumeric
-      if (try NSRegularExpression(pattern: "[^0-9a-zA-Z]", options: []))
-        .numberOfMatches(in: password, options: [], range: range) < 1 {
-        completion(false)
-        return
-      }
-      completion(true)
-    } catch {
-      completion(false)
-    }
+    completion(password.count >= 8)
   }
 
   func checksumEthAddress(_ address: String, completion: @escaping (String) -> Void) {

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -635,7 +635,7 @@ extension Strings {
       "wallet.passwordDoesNotMeetRequirementsError",
       tableName: "BraveWallet",
       bundle: .module,
-      value: "Passwords must be at least 7 characters, and contain at least one letter, one number, and one special character.",
+      value: "Passwords must be at least 8 characters.",
       comment: "The error message displayed when a user enters a password that does not meet the requirements"
     )
     public static let passwordsDontMatchError = NSLocalizedString(

--- a/Tests/BraveWalletTests/KeyringStoreTests.swift
+++ b/Tests/BraveWalletTests/KeyringStoreTests.swift
@@ -107,4 +107,35 @@ class KeyringStoreTests: XCTestCase {
       XCTAssertNil(error)
     }
   }
+  
+  @MainActor func testIsStrongPassword() async {
+    let (keyringService, rpcService, walletService) = setupServices()
+    let store = KeyringStore(
+      keyringService: keyringService,
+      walletService: walletService,
+      rpcService: rpcService
+    )
+    
+    let invalidPassword1 = ""
+    var isStrongPassword = await store.isStrongPassword(invalidPassword1)
+    XCTAssertFalse(isStrongPassword)
+    
+    let invalidPassword2 = "1234"
+    isStrongPassword = await store.isStrongPassword(invalidPassword2)
+    XCTAssertFalse(isStrongPassword)
+    
+    let validPassword = "12345678"
+    isStrongPassword = await store.isStrongPassword(validPassword)
+    XCTAssertTrue(isStrongPassword)
+    
+    let uuid = UUID().uuidString
+    // first 30 characters of uuid
+    let validPassword2 = String(uuid[uuid.startIndex..<uuid.index(uuid.startIndex, offsetBy: 30)])
+    isStrongPassword = await store.isStrongPassword(validPassword2)
+    XCTAssertTrue(isStrongPassword)
+    
+    let strongPassword = "LDKH66BJbLsHQPEAK@4_zak*"
+    isStrongPassword = await store.isStrongPassword(strongPassword)
+    XCTAssertTrue(isStrongPassword)
+  }
 }


### PR DESCRIPTION
## Summary of Changes
- Updates the requirements for wallet password to require at least 8 characters

This pull request fixes #6093

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Setup a new Brave Wallet.
2. Verify new password requirements (>= 8 characters).
3. Reset your Brave Wallet.
4. Restore / Import an existing Brave Wallet.
5. Verify new password requirements (>= 8 characters).


## Screenshots:

https://user-images.githubusercontent.com/5314553/229208293-3f05cec4-71ea-405f-8ecd-d572ce34a28b.mp4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
