### PR TITLE
Fix #7183: Use MutationObserver for JitsiSDK iframe's src attribute.

### DIFF
--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/DomainSpecific/Paged/BraveTalkScript.js
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/DomainSpecific/Paged/BraveTalkScript.js
@@ -32,8 +32,18 @@ window.__firefox__.includeOnce("BraveTalkScript", function($) {
   if (document.location.host === "talk.brave.com") {
     const postRoom = $((event) => {
       if (event.target.tagName !== undefined && event.target.tagName.toLowerCase() == "iframe") {
-        launchNativeBraveTalk(event.target.src);
-        window.removeEventListener("DOMNodeInserted", postRoom)
+        const srcObserver = new MutationObserver((mutationsList) => {
+          mutationsList.forEach((mutation) => {
+            if (mutation.type === 'attributes') {
+              launchNativeBraveTalk(event.target.src);
+              srcObserver.disconnect();
+              return;
+            }
+          });
+        });
+
+        srcObserver.observe(event.target, { attributes: true, attributeFilter: ['src'] });
+        window.removeEventListener("DOMNodeInserted", postRoom);
       }
     });
     window.addEventListener("DOMNodeInserted", postRoom);


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7183 

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
