### PR TITLE
Fix #7170: Do not double encode Brave Search fallback query.

### DIFF
--- a/Sources/Brave/Frontend/Browser/Search/BraveSearchManager.swift
+++ b/Sources/Brave/Frontend/Browser/Search/BraveSearchManager.swift
@@ -177,7 +177,7 @@ class BraveSearchManager: NSObject {
     guard var components = URLComponents(string: fallbackProviderURLString) else { return }
 
     var queryItems: [URLQueryItem] = [
-      .init(name: "q", value: query.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed))
+      .init(name: "q", value: query)
     ]
 
     if let language = backupQuery.language {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7170 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Query to use for test: `truitt white hinges berkeley`.

1. Enable "Google fallback query" from BraveSearch website settings.
2. Search for `truitt white hinges berkeley` from the app's url bar
3. Search for `truitt white hinges berkeley` from website's search bar
4. Verify that both search results are the same.

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
