### PR TITLE
Fix #6967: Use constants provided by core for Solana Instruction Decoding

### DIFF
--- a/Sources/BraveWallet/Crypto/Transactions/TransactionParser.swift
+++ b/Sources/BraveWallet/Crypto/Transactions/TransactionParser.swift
@@ -419,7 +419,7 @@ enum TransactionParser {
           symbol = "SOL"
           switch instructionType {
           case .transfer, .transferWithSeed:
-            if let instructionLamports = instruction.decodedData?.paramFor(.lamports)?.value,
+            if let instructionLamports = instruction.decodedData?.paramFor(BraveWallet.Lamports)?.value,
                let instructionLamportsValue = BDouble(instructionLamports),
                let fromPubkey = instruction.accountMetas[safe: 0]?.pubkey,
                let toPubkey = instruction.accountMetas[safe: 1]?.pubkey,
@@ -427,7 +427,7 @@ enum TransactionParser {
               valueFromInstructions += instructionLamportsValue
             }
           case .withdrawNonceAccount:
-            if let instructionLamports = instruction.decodedData?.paramFor(.lamports)?.value,
+            if let instructionLamports = instruction.decodedData?.paramFor(BraveWallet.Lamports)?.value,
                let instructionLamportsValue = BDouble(instructionLamports) {
               if let nonceAccount = instruction.accountMetas[safe: 0]?.pubkey,
                  nonceAccount == fromAddress {
@@ -437,7 +437,7 @@ enum TransactionParser {
               }
             }
           case .createAccount, .createAccountWithSeed:
-            if let instructionLamports = instruction.decodedData?.paramFor(.lamports)?.value,
+            if let instructionLamports = instruction.decodedData?.paramFor(BraveWallet.Lamports)?.value,
                let instructionLamportsValue = BDouble(instructionLamports) {
               if let fromPubkey = instruction.accountMetas[safe: 0]?.pubkey,
                  fromPubkey == fromAddress {
@@ -445,7 +445,7 @@ enum TransactionParser {
               }
             }
           default:
-            if let instructionLamports = instruction.decodedData?.paramFor(.lamports)?.value,
+            if let instructionLamports = instruction.decodedData?.paramFor(BraveWallet.Lamports)?.value,
                let instructionLamportsValue = BDouble(instructionLamports) {
               valueFromInstructions += instructionLamportsValue
             }
@@ -528,7 +528,7 @@ enum TransactionParser {
       }
       details.append(contentsOf: accounts)
       
-      if let lamportsParam = decodedData.paramFor(.lamports),
+      if let lamportsParam = decodedData.paramFor(BraveWallet.Lamports),
          let lamportsValue = formatter.decimalString(for: lamportsParam.value, radix: .decimal, decimals: 9)?.trimmingTrailingZeros {
         details.append(.init(key: Strings.Wallet.solanaAmount, value: "\(lamportsValue) SOL"))
       }
@@ -543,7 +543,7 @@ enum TransactionParser {
       
     } else if instruction.isTokenProgram {
       let accounts = decodedData.accountParams.enumerated().compactMap { (index, param) -> SolanaTxDetails.ParsedSolanaInstruction.KeyValue? in
-        if param.name == "signers" { // special case
+        if param.name == BraveWallet.Signers { // special case
           // the signers are the `accountMetas` from this index to the end of the array
           // its possible to have any number of signers, including 0
           if instruction.accountMetas[safe: index] != nil {
@@ -561,8 +561,8 @@ enum TransactionParser {
       }
       details.append(contentsOf: accounts)
       
-      if let amountParam = decodedData.paramFor(.amount),
-         let decimalsParam = decodedData.paramFor(.decimals),
+      if let amountParam = decodedData.paramFor(BraveWallet.Amount),
+         let decimalsParam = decodedData.paramFor(BraveWallet.Decimals),
          let decimals = Int(decimalsParam.value),
          let amountValue = formatter.decimalString(for: amountParam.value, radix: .decimal, decimals: decimals)?.trimmingTrailingZeros {
         details.append(.init(key: Strings.Wallet.solanaAmount, value: amountValue))

--- a/Sources/BraveWallet/Extensions/SolanaInstruction+Extensions.swift
+++ b/Sources/BraveWallet/Extensions/SolanaInstruction+Extensions.swift
@@ -40,13 +40,13 @@ extension BraveWallet.SolanaInstruction {
   
   /// Returns the `to_account` pubkey for the instruction if available
   var toPubkey: String? {
-    guard let index = decodedData?.accountParams.firstIndex(where: { $0.name == "to_account" }) else { return nil }
+    guard let index = decodedData?.accountParams.firstIndex(where: { $0.name == BraveWallet.ToAccount }) else { return nil }
     return accountMetas[safe: index]?.pubkey
   }
   
   /// Returns the `from_account` pubkey for the instruction if available
   var fromPubkey: String? {
-    guard let index = decodedData?.accountParams.firstIndex(where: { $0.name == "from_account" }) else { return nil }
+    guard let index = decodedData?.accountParams.firstIndex(where: { $0.name == BraveWallet.FromAccount }) else { return nil }
     return accountMetas[safe: index]?.pubkey
   }
 }
@@ -138,27 +138,7 @@ extension BraveWallet.SolanaTokenInstruction {
 }
 
 extension BraveWallet.DecodedSolanaInstructionData {
-  func paramFor(_ paramKey: ParamKey) -> BraveWallet.SolanaInstructionParam? {
-    params.first(where: { $0.name == paramKey.rawValue })
-  }
-  
-  // brave-core/components/brave_wallet/browser/solana_instruction_data_decoder.cc
-  // GetSystemInstructionParams() / GetTokenInstructionParams()
-  enum ParamKey: String {
-    case lamports
-    case amount
-    case decimals
-    case space
-    case owner
-    case base
-    case seed
-    case fromSeed = "from_seed"
-    case fromOwner = "from_owner"
-    case nonceAccount = "nonce_account"
-    case authorityType = "authority_type"
-    case newAuthority = "new_authority"
-    case mintAuthority = "mint_authority"
-    case freezeAuthority = "freeze_authority"
-    case numOfSigners = "num_of_signers"
+  func paramFor(_ paramName: String) -> BraveWallet.SolanaInstructionParam? {
+    params.first(where: { $0.name == paramName })
   }
 }

--- a/Tests/BraveWalletTests/TransactionParserTests.swift
+++ b/Tests/BraveWalletTests/TransactionParserTests.swift
@@ -895,9 +895,9 @@ class TransactionParserTests: XCTestCase {
       decodedData: .init(
         instructionType: UInt32(BraveWallet.SolanaSystemInstruction.transfer.rawValue),
         accountParams: [
-          .init(name: "from_account", localizedName: "From Account"),
-          .init(name: "to_account", localizedName: "To Account"),],
-        params: [.init(name: "lamports", localizedName: "Lamports", value: "10000", type: .uint64)]
+          .init(name: BraveWallet.FromAccount, localizedName: "From Account"),
+          .init(name: BraveWallet.ToAccount, localizedName: "To Account"),],
+        params: [.init(name: BraveWallet.Lamports, localizedName: "Lamports", value: "10000", type: .uint64)]
       )
     )
     let expectedParsedTransfer = SolanaTxDetails.ParsedSolanaInstruction(
@@ -925,14 +925,14 @@ class TransactionParserTests: XCTestCase {
       decodedData: .init(
         instructionType: UInt32(BraveWallet.SolanaSystemInstruction.withdrawNonceAccount.rawValue),
         accountParams: [
-          .init(name: "nonce_account", localizedName: "Nonce Account"),
-          .init(name: "to_account", localizedName: "To Account"),
+          .init(name: BraveWallet.NonceAccount, localizedName: "Nonce Account"),
+          .init(name: BraveWallet.ToAccount, localizedName: "To Account"),
           .init(name: "recentblockhashes_sysvar", localizedName: "RecentBlockhashes sysvar"),
           .init(name: "rent_sysvar", localizedName: "Rent sysvar"),
           .init(name: "nonce_authority", localizedName: "Nonce Authority")
         ],
         params: [
-          .init(name: "lamports", localizedName: "Lamports", value: "40", type: .uint64)
+          .init(name: BraveWallet.Lamports, localizedName: "Lamports", value: "40", type: .uint64)
         ]
       )
     )
@@ -961,11 +961,11 @@ class TransactionParserTests: XCTestCase {
       decodedData: .init(
         instructionType: UInt32(BraveWallet.SolanaSystemInstruction.createAccount.rawValue),
         accountParams: [
-          .init(name: "from_account", localizedName: "From Account"),
-          .init(name: "new_account", localizedName: "New Account"),
+          .init(name: BraveWallet.FromAccount, localizedName: "From Account"),
+          .init(name: BraveWallet.NewAccount, localizedName: "New Account"),
         ],
         params: [
-          .init(name: "lamports", localizedName: "Lamports", value: "2000", type: .uint64),
+          .init(name: BraveWallet.Lamports, localizedName: "Lamports", value: "2000", type: .uint64),
           .init(name: "space", localizedName: "Space", value: "1", type: .unknown),
           .init(name: "owner_program", localizedName: "Owner Program", value: toPubkey, type: .unknown)
         ]
@@ -995,11 +995,11 @@ class TransactionParserTests: XCTestCase {
       decodedData: .init(
         instructionType: UInt32(BraveWallet.SolanaSystemInstruction.createAccountWithSeed.rawValue),
         accountParams: [
-          .init(name: "from_account", localizedName: "From Account"),
+          .init(name: BraveWallet.FromAccount, localizedName: "From Account"),
           .init(name: "created_account", localizedName: "Created Account"),
         ],
         params: [
-          .init(name: "lamports", localizedName: "Lamports", value: "300", type: .uint64),
+          .init(name: BraveWallet.Lamports, localizedName: "Lamports", value: "300", type: .uint64),
           .init(name: "base", localizedName: "Base", value: toPubkey, type: .unknown),
           .init(name: "seed", localizedName: "Seed", value: "", type: .unknown),
           .init(name: "space", localizedName: "Space", value: "1", type: .unknown),


### PR DESCRIPTION
## Summary of Changes
- Small code re-use now that these `String` constants are available via core.

This pull request fixes #6967

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
Verify code changes matches up with new constants: https://github.com/brave/brave-core/blob/master/components/brave_wallet/common/brave_wallet.mojom#L1678-L1685


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
