### PR TITLE
Fix #7012: Make `IpfsAPI` non-optional in Wallet

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
@@ -16,7 +16,7 @@ import Growth
 
 extension WalletStore {
   /// Creates a WalletStore based on whether or not the user is in Private Mode
-  static func from(ipfsApi: IpfsAPI?, privateMode: Bool) -> WalletStore? {
+  static func from(ipfsApi: IpfsAPI, privateMode: Bool) -> WalletStore? {
     guard
       let keyringService = BraveWallet.KeyringServiceFactory.get(privateMode: privateMode),
       let rpcService = BraveWallet.JsonRpcServiceFactory.get(privateMode: privateMode),
@@ -47,7 +47,7 @@ extension WalletStore {
 
 extension CryptoStore {
   /// Creates a CryptoStore based on whether or not the user is in Private Mode
-  static func from(ipfsApi: IpfsAPI?, privateMode: Bool) -> CryptoStore? {
+  static func from(ipfsApi: IpfsAPI, privateMode: Bool) -> CryptoStore? {
     guard
       let keyringService = BraveWallet.KeyringServiceFactory.get(privateMode: privateMode),
       let rpcService = BraveWallet.JsonRpcServiceFactory.get(privateMode: privateMode),
@@ -201,7 +201,7 @@ extension Tab: BraveWalletProviderDelegate {
             completion(.internal, nil)
             return
           }
-        case .fil:
+        case .fil, .btc:
           // not supported
           fallthrough
         @unknown default:
@@ -210,7 +210,7 @@ extension Tab: BraveWalletProviderDelegate {
         }
       }
       
-      guard WalletStore.from(ipfsApi: nil, privateMode: isPrivate) != nil else {
+      guard !isPrivate else {
         completion(.internal, nil)
         return
       }

--- a/Sources/Brave/Frontend/Settings/SettingsViewController.swift
+++ b/Sources/Brave/Frontend/Settings/SettingsViewController.swift
@@ -744,8 +744,7 @@ class SettingsViewController: TableViewController {
               let web3SettingsView = Web3SettingsView(
                 settingsStore: settingsStore,
                 networkStore: cryptoStore?.networkStore,
-                keyringStore: keyringStore,
-                ipfsAPI: ipfsAPI
+                keyringStore: keyringStore
               ).environment(\.openURL, .init(handler: { [weak self] url in
                 guard let self = self else { return .discarded }
                 (self.presentingViewController ?? self).dismiss(animated: true) { [self] in

--- a/Sources/BraveWallet/Crypto/Stores/AccountActivityStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/AccountActivityStore.swift
@@ -32,7 +32,7 @@ class AccountActivityStore: ObservableObject {
   private let txService: BraveWalletTxService
   private let blockchainRegistry: BraveWalletBlockchainRegistry
   private let solTxManagerProxy: BraveWalletSolanaTxManagerProxy
-  private let ipfsApi: IpfsAPI?
+  private let ipfsApi: IpfsAPI
   /// Cache for storing `BlockchainToken`s that are not in user assets or our token registry.
   /// This could occur with a dapp creating a transaction.
   private var tokenInfoCache: [String: BraveWallet.BlockchainToken] = [:]
@@ -47,7 +47,7 @@ class AccountActivityStore: ObservableObject {
     txService: BraveWalletTxService,
     blockchainRegistry: BraveWalletBlockchainRegistry,
     solTxManagerProxy: BraveWalletSolanaTxManagerProxy,
-    ipfsApi: IpfsAPI?
+    ipfsApi: IpfsAPI
   ) {
     self.account = account
     self.observeAccountUpdates = observeAccountUpdates

--- a/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -90,7 +90,7 @@ public class CryptoStore: ObservableObject {
   private let txService: BraveWalletTxService
   private let ethTxManagerProxy: BraveWalletEthTxManagerProxy
   private let solTxManagerProxy: BraveWalletSolanaTxManagerProxy
-  private let ipfsApi: IpfsAPI?
+  private let ipfsApi: IpfsAPI
   
   public init(
     keyringService: BraveWalletKeyringService,
@@ -102,7 +102,7 @@ public class CryptoStore: ObservableObject {
     txService: BraveWalletTxService,
     ethTxManagerProxy: BraveWalletEthTxManagerProxy,
     solTxManagerProxy: BraveWalletSolanaTxManagerProxy,
-    ipfsApi: IpfsAPI?
+    ipfsApi: IpfsAPI
   ) {
     self.keyringService = keyringService
     self.rpcService = rpcService
@@ -278,7 +278,8 @@ public class CryptoStore: ObservableObject {
     keyringService: keyringService,
     walletService: walletService,
     rpcService: rpcService,
-    txService: txService
+    txService: txService,
+    ipfsApi: ipfsApi
   )
   
   private var nftDetailStore: NFTDetailStore?

--- a/Sources/BraveWallet/Crypto/Stores/NFTDetailStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/NFTDetailStore.swift
@@ -33,9 +33,8 @@ struct NFTMetadata: Codable, Equatable {
     self.description = description
   }
 
-  func httpfyIpfsUrl(ipfsApi: IpfsAPI?) -> NFTMetadata {
-    guard let ipfsApi,
-          let imageURLString,
+  func httpfyIpfsUrl(ipfsApi: IpfsAPI) -> NFTMetadata {
+    guard let imageURLString,
           imageURLString.hasPrefix("ipfs://"),
           let url = URL(string: imageURLString) else {
       return NFTMetadata(imageURLString: self.imageURLString, name: self.name, description: self.description)
@@ -51,7 +50,7 @@ struct NFTMetadata: Codable, Equatable {
 
 class NFTDetailStore: ObservableObject {
   private let rpcService: BraveWalletJsonRpcService
-  private let ipfsApi: IpfsAPI?
+  private let ipfsApi: IpfsAPI
   let nft: BraveWallet.BlockchainToken
   @Published var isLoading: Bool = false
   @Published var nftMetadata: NFTMetadata?
@@ -59,7 +58,7 @@ class NFTDetailStore: ObservableObject {
 
   init(
     rpcService: BraveWalletJsonRpcService,
-    ipfsApi: IpfsAPI?,
+    ipfsApi: IpfsAPI,
     nft: BraveWallet.BlockchainToken,
     nftMetadata: NFTMetadata?
   ) {

--- a/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
@@ -122,7 +122,7 @@ public class PortfolioStore: ObservableObject {
   private let walletService: BraveWalletBraveWalletService
   private let assetRatioService: BraveWalletAssetRatioService
   private let blockchainRegistry: BraveWalletBlockchainRegistry
-  private let ipfsApi: IpfsAPI?
+  private let ipfsApi: IpfsAPI
 
   public init(
     keyringService: BraveWalletKeyringService,
@@ -130,7 +130,7 @@ public class PortfolioStore: ObservableObject {
     walletService: BraveWalletBraveWalletService,
     assetRatioService: BraveWalletAssetRatioService,
     blockchainRegistry: BraveWalletBlockchainRegistry,
-    ipfsApi: IpfsAPI?
+    ipfsApi: IpfsAPI
   ) {
     self.keyringService = keyringService
     self.rpcService = rpcService

--- a/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
@@ -134,7 +134,7 @@ public class SendTokenStore: ObservableObject {
   private var sendAmountUpdatedTimer: Timer?
   private var prefilledToken: BraveWallet.BlockchainToken?
   private var metadataCache: [String: NFTMetadata] = [:]
-  private let ipfsApi: IpfsAPI?
+  private let ipfsApi: IpfsAPI
 
   public init(
     keyringService: BraveWalletKeyringService,
@@ -145,7 +145,7 @@ public class SendTokenStore: ObservableObject {
     ethTxManagerProxy: BraveWalletEthTxManagerProxy,
     solTxManagerProxy: BraveWalletSolanaTxManagerProxy,
     prefilledToken: BraveWallet.BlockchainToken?,
-    ipfsApi: IpfsAPI?
+    ipfsApi: IpfsAPI
   ) {
     self.keyringService = keyringService
     self.rpcService = rpcService

--- a/Sources/BraveWallet/Crypto/Stores/SettingsStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SettingsStore.swift
@@ -54,6 +54,7 @@ public class SettingsStore: ObservableObject {
   private let walletService: BraveWalletBraveWalletService
   private let rpcService: BraveWalletJsonRpcService
   private let txService: BraveWalletTxService
+  let ipfsApi: IpfsAPI
   private let keychain: KeychainType
 
   public init(
@@ -61,12 +62,14 @@ public class SettingsStore: ObservableObject {
     walletService: BraveWalletBraveWalletService,
     rpcService: BraveWalletJsonRpcService,
     txService: BraveWalletTxService,
+    ipfsApi: IpfsAPI,
     keychain: KeychainType = Keychain()
   ) {
     self.keyringService = keyringService
     self.walletService = walletService
     self.rpcService = rpcService
     self.txService = txService
+    self.ipfsApi = ipfsApi
     self.keychain = keychain
 
     keyringService.add(self)

--- a/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
@@ -29,7 +29,7 @@ public class AssetStore: ObservableObject, Equatable {
 
   private let walletService: BraveWalletBraveWalletService
   private let rpcService: BraveWalletJsonRpcService
-  private let ipfsApi: IpfsAPI?
+  private let ipfsApi: IpfsAPI
   private(set) var isCustomToken: Bool
 
   init(
@@ -37,7 +37,7 @@ public class AssetStore: ObservableObject, Equatable {
     rpcService: BraveWalletJsonRpcService,
     network: BraveWallet.NetworkInfo,
     token: BraveWallet.BlockchainToken,
-    ipfsApi: IpfsAPI?,
+    ipfsApi: IpfsAPI,
     isCustomToken: Bool,
     isVisible: Bool
   ) {
@@ -68,7 +68,7 @@ public class UserAssetsStore: ObservableObject {
   private let rpcService: BraveWalletJsonRpcService
   private let keyringService: BraveWalletKeyringService
   private let assetRatioService: BraveWalletAssetRatioService
-  private let ipfsApi: IpfsAPI?
+  private let ipfsApi: IpfsAPI
   private var allTokens: [BraveWallet.BlockchainToken] = []
   private var timer: Timer?
 
@@ -78,7 +78,7 @@ public class UserAssetsStore: ObservableObject {
     rpcService: BraveWalletJsonRpcService,
     keyringService: BraveWalletKeyringService,
     assetRatioService: BraveWalletAssetRatioService,
-    ipfsApi: IpfsAPI?
+    ipfsApi: IpfsAPI
   ) {
     self.walletService = walletService
     self.blockchainRegistry = blockchainRegistry

--- a/Sources/BraveWallet/Crypto/Stores/WalletStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/WalletStore.swift
@@ -30,7 +30,7 @@ public class WalletStore {
     txService: BraveWalletTxService,
     ethTxManagerProxy: BraveWalletEthTxManagerProxy,
     solTxManagerProxy: BraveWalletSolanaTxManagerProxy,
-    ipfsApi: IpfsAPI?
+    ipfsApi: IpfsAPI
   ) {
     self.keyringStore = .init(keyringService: keyringService, walletService: walletService, rpcService: rpcService)
     self.setUp(
@@ -57,7 +57,7 @@ public class WalletStore {
     txService: BraveWalletTxService,
     ethTxManagerProxy: BraveWalletEthTxManagerProxy,
     solTxManagerProxy: BraveWalletSolanaTxManagerProxy,
-    ipfsApi: IpfsAPI?
+    ipfsApi: IpfsAPI
   ) {
     self.cancellable = self.keyringStore.$defaultKeyring
       .map(\.isKeyringCreated)

--- a/Sources/BraveWallet/Extensions/RpcServiceExtensions.swift
+++ b/Sources/BraveWallet/Extensions/RpcServiceExtensions.swift
@@ -278,7 +278,7 @@ extension BraveWalletJsonRpcService {
   }
   
   /// Returns a nullable NFT metadata
-  @MainActor func fetchNFTMetadata(for token: BraveWallet.BlockchainToken, ipfsApi: IpfsAPI?) async -> NFTMetadata? {
+  @MainActor func fetchNFTMetadata(for token: BraveWallet.BlockchainToken, ipfsApi: IpfsAPI) async -> NFTMetadata? {
     var metaDataString = ""
     if token.isErc721 {
       let (_, metaData, result, errMsg) = await self.erc721Metadata(token.contractAddress, tokenId: token.tokenId, chainId: token.chainId)
@@ -302,7 +302,7 @@ extension BraveWalletJsonRpcService {
   }
   
   /// Returns a map of Token.id with its NFT metadata
-  @MainActor func fetchNFTMetadata(tokens: [BraveWallet.BlockchainToken], ipfsApi: IpfsAPI?) async -> [String: NFTMetadata] {
+  @MainActor func fetchNFTMetadata(tokens: [BraveWallet.BlockchainToken], ipfsApi: IpfsAPI) async -> [String: NFTMetadata] {
     await withTaskGroup(of: [String: NFTMetadata].self) {  @MainActor [weak self] group -> [String: NFTMetadata] in
       guard let self = self else { return [:] }
       for token in tokens {

--- a/Sources/BraveWallet/Extensions/TestIpfsAPI.swift
+++ b/Sources/BraveWallet/Extensions/TestIpfsAPI.swift
@@ -1,0 +1,30 @@
+// Copyright 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import BraveCore
+
+#if DEBUG
+
+class TestIpfsAPI: IpfsAPI {
+  var ipfsGateway: URL?
+  var nftIpfsGateway: URL?
+
+  var _resolveGatewayUrl: ((_ input: URL) -> URL?)?
+  func resolveGatewayUrl(for input: URL) -> URL? {
+    _resolveGatewayUrl?(input)
+  }
+
+  var _resolveGatewayUrlForNft: ((_ input: URL) -> URL?)?
+  func resolveGatewayUrl(forNft input: URL) -> URL? {
+    _resolveGatewayUrlForNft?(input)
+  }
+
+  var _contentHashToCIDv1URL: ((_ contentHash: [NSNumber]) -> URL?)?
+  func contentHashToCIDv1URL(for contentHash: [NSNumber]) -> URL? {
+    _contentHashToCIDv1URL?(contentHash)
+  }
+}
+
+#endif

--- a/Sources/BraveWallet/Preview Content/MockStores.swift
+++ b/Sources/BraveWallet/Preview Content/MockStores.swift
@@ -21,7 +21,7 @@ extension WalletStore {
       txService: MockTxService(),
       ethTxManagerProxy: MockEthTxManagerProxy(),
       solTxManagerProxy: BraveWallet.TestSolanaTxManagerProxy.previewProxy,
-      ipfsApi: nil
+      ipfsApi: TestIpfsAPI()
     )
   }
 }
@@ -38,7 +38,7 @@ extension CryptoStore {
       txService: MockTxService(),
       ethTxManagerProxy: MockEthTxManagerProxy(),
       solTxManagerProxy: BraveWallet.TestSolanaTxManagerProxy.previewProxy,
-      ipfsApi: nil
+      ipfsApi: TestIpfsAPI()
     )
   }
 }
@@ -111,7 +111,7 @@ extension SendTokenStore {
       ethTxManagerProxy: MockEthTxManagerProxy(),
       solTxManagerProxy: BraveWallet.TestSolanaTxManagerProxy.previewProxy,
       prefilledToken: .previewToken,
-      ipfsApi: nil
+      ipfsApi: TestIpfsAPI()
     )
   }
 }
@@ -156,7 +156,7 @@ extension UserAssetsStore {
       rpcService: MockJsonRpcService(),
       keyringService: MockKeyringService(),
       assetRatioService: MockAssetRatioService(),
-      ipfsApi: nil
+      ipfsApi: TestIpfsAPI()
     )
   }
 }
@@ -173,7 +173,7 @@ extension AccountActivityStore {
       txService: MockTxService(),
       blockchainRegistry: MockBlockchainRegistry(),
       solTxManagerProxy: BraveWallet.TestSolanaTxManagerProxy.previewProxy,
-      ipfsApi: nil
+      ipfsApi: TestIpfsAPI()
     )
   }
 }
@@ -204,6 +204,7 @@ extension SettingsStore {
       walletService: MockBraveWalletService(),
       rpcService: MockJsonRpcService(),
       txService: MockTxService(),
+      ipfsApi: TestIpfsAPI(),
       keychain: TestableKeychain()
     )
   }

--- a/Sources/BraveWallet/Settings/Web3SettingsView.swift
+++ b/Sources/BraveWallet/Settings/Web3SettingsView.swift
@@ -14,8 +14,6 @@ public struct Web3SettingsView: View {
   var networkStore: NetworkStore?
   var keyringStore: KeyringStore?
   
-  private let ipfsAPI: IpfsAPI?
-  
   @State private var isShowingResetWalletAlert = false
   @State private var isShowingResetTransactionAlert = false
   /// If we are showing the modal so the user can enter their password to enable unlock via biometrics.
@@ -25,33 +23,31 @@ public struct Web3SettingsView: View {
   public init(
     settingsStore: SettingsStore? = nil,
     networkStore: NetworkStore? = nil,
-    keyringStore: KeyringStore? = nil,
-    ipfsAPI: IpfsAPI? = nil
+    keyringStore: KeyringStore? = nil
   ) {
     self.settingsStore = settingsStore
     self.networkStore = networkStore
     self.keyringStore = keyringStore
-    self.ipfsAPI = ipfsAPI
   }
   
   public var body: some View {
     List {
-      if let settingsStore = settingsStore, let networkStore = networkStore, let keyringStore = keyringStore, keyringStore.isDefaultKeyringCreated {
-        WalletSettingsView(
-          settingsStore: settingsStore,
-          networkStore: networkStore,
-          keyringStore: keyringStore,
-          isShowingResetWalletAlert: $isShowingResetWalletAlert,
-          isShowingResetTransactionAlert: $isShowingResetTransactionAlert,
-          isShowingBiometricsPasswordEntry: $isShowingBiometricsPasswordEntry
-        )
-      }
-      if let ipfsAPI { // means users come from the browser not the wallet
+      if let settingsStore = settingsStore {
+        if let networkStore = networkStore, let keyringStore = keyringStore, keyringStore.isDefaultKeyringCreated {
+          WalletSettingsView(
+            settingsStore: settingsStore,
+            networkStore: networkStore,
+            keyringStore: keyringStore,
+            isShowingResetWalletAlert: $isShowingResetWalletAlert,
+            isShowingResetTransactionAlert: $isShowingResetTransactionAlert,
+            isShowingBiometricsPasswordEntry: $isShowingBiometricsPasswordEntry
+          )
+        }
         Section(
           header: Text(Strings.Wallet.ipfsSettingsHeader),
           footer: Text(Strings.Wallet.ipfsSettingsFooter)
         ) {
-          NavigationLink(destination: IPFSCustomGatewayView(ipfsAPI: ipfsAPI)) {
+          NavigationLink(destination: IPFSCustomGatewayView(ipfsAPI: settingsStore.ipfsApi)) {
             VStack(alignment: .leading, spacing: 4) {
               Text(Strings.Wallet.nftGatewayTitle)
                 .foregroundColor(Color(.braveLabel))
@@ -111,7 +107,7 @@ public struct Web3SettingsView: View {
         }
     )
     .onAppear {
-      if let urlString = ipfsAPI?.nftIpfsGateway?.absoluteString, urlString != ipfsNFTGatewayURL {
+      if let urlString = settingsStore?.ipfsApi.nftIpfsGateway?.absoluteString, urlString != ipfsNFTGatewayURL {
         ipfsNFTGatewayURL = urlString
       }
       settingsStore?.setup()

--- a/Tests/BraveWalletTests/AccountActivityStoreTests.swift
+++ b/Tests/BraveWalletTests/AccountActivityStoreTests.swift
@@ -45,7 +45,7 @@ class AccountActivityStoreTests: XCTestCase {
     mockLamportBalance: UInt64 = 0,
     mockSplTokenBalances: [String: String] = [:], // [tokenMintAddress: balance]
     selectedNetwork: BraveWallet.NetworkInfo
-  ) -> (BraveWallet.TestKeyringService, BraveWallet.TestJsonRpcService, BraveWallet.TestBraveWalletService, BraveWallet.TestBlockchainRegistry, BraveWallet.TestAssetRatioService, BraveWallet.TestTxService, BraveWallet.TestSolanaTxManagerProxy) {
+  ) -> (BraveWallet.TestKeyringService, BraveWallet.TestJsonRpcService, BraveWallet.TestBraveWalletService, BraveWallet.TestBlockchainRegistry, BraveWallet.TestAssetRatioService, BraveWallet.TestTxService, BraveWallet.TestSolanaTxManagerProxy, IpfsAPI) {
     let keyringService = BraveWallet.TestKeyringService()
     keyringService._addObserver = { _ in }
     keyringService._keyringInfo = { _, completion in
@@ -122,8 +122,10 @@ class AccountActivityStoreTests: XCTestCase {
     
     let solTxManagerProxy = BraveWallet.TestSolanaTxManagerProxy()
     solTxManagerProxy._estimatedTxFee = { $1(0, .success, "") }
+    
+    let ipfsApi = TestIpfsAPI()
 
-    return (keyringService, rpcService, walletService, blockchainRegistry, assetRatioService, txService, solTxManagerProxy)
+    return (keyringService, rpcService, walletService, blockchainRegistry, assetRatioService, txService, solTxManagerProxy, ipfsApi)
   }
   
   func testUpdateEthereumAccount() {
@@ -139,7 +141,7 @@ class AccountActivityStoreTests: XCTestCase {
     
     let mockERC721Metadata: NFTMetadata = .init(imageURLString: "mock.image.url", name: "mock nft name", description: "mock nft description")
     
-    let (keyringService, rpcService, walletService, blockchainRegistry, assetRatioService, txService, solTxManagerProxy) = setupServices(
+    let (keyringService, rpcService, walletService, blockchainRegistry, assetRatioService, txService, solTxManagerProxy, ipfsApi) = setupServices(
       mockEthBalanceWei: mockEthBalanceWei,
       mockERC20BalanceWei: mockERC20BalanceWei,
       mockERC721BalanceWei: mockERC721BalanceWei,
@@ -156,7 +158,7 @@ class AccountActivityStoreTests: XCTestCase {
       txService: txService,
       blockchainRegistry: blockchainRegistry,
       solTxManagerProxy: solTxManagerProxy,
-      ipfsApi: nil
+      ipfsApi: ipfsApi
     )
     
     let userVisibleAssetsException = expectation(description: "accountActivityStore-assetStores")
@@ -238,7 +240,7 @@ class AccountActivityStoreTests: XCTestCase {
     
     let mockSolMetadata: NFTMetadata = .init(imageURLString: "sol.mock.image.url", name: "sol mock nft name", description: "sol mock nft description")
     
-    let (keyringService, rpcService, walletService, blockchainRegistry, assetRatioService, txService, solTxManagerProxy) = setupServices(
+    let (keyringService, rpcService, walletService, blockchainRegistry, assetRatioService, txService, solTxManagerProxy, ipfsApi) = setupServices(
       mockLamportBalance: mockLamportBalance,
       mockSplTokenBalances: mockSplTokenBalances,
       selectedNetwork: .mockMainnet
@@ -254,7 +256,7 @@ class AccountActivityStoreTests: XCTestCase {
       txService: txService,
       blockchainRegistry: blockchainRegistry,
       solTxManagerProxy: solTxManagerProxy,
-      ipfsApi: nil
+      ipfsApi: ipfsApi
     )
     
     let userVisibleAssetsExpectation = expectation(description: "accountActivityStore-assetStores")

--- a/Tests/BraveWalletTests/PortfolioStoreTests.swift
+++ b/Tests/BraveWalletTests/PortfolioStoreTests.swift
@@ -162,7 +162,7 @@ class PortfolioStoreTests: XCTestCase {
       walletService: walletService,
       assetRatioService: assetRatioService,
       blockchainRegistry: BraveWallet.TestBlockchainRegistry(),
-      ipfsApi: nil
+      ipfsApi: TestIpfsAPI()
     )
     // test that `update()` will assign new value to `userVisibleAssets` publisher
     let userVisibleAssetsException = expectation(description: "update-userVisibleAssets")

--- a/Tests/BraveWalletTests/SendTokenStoreTests.swift
+++ b/Tests/BraveWalletTests/SendTokenStoreTests.swift
@@ -94,7 +94,7 @@ class SendTokenStoreTests: XCTestCase {
       ethTxManagerProxy: MockEthTxManagerProxy(),
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: nil,
-      ipfsApi: nil
+      ipfsApi: TestIpfsAPI()
     )
     XCTAssertNil(store.selectedSendToken)
 
@@ -107,7 +107,7 @@ class SendTokenStoreTests: XCTestCase {
       ethTxManagerProxy: MockEthTxManagerProxy(),
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: .previewToken,
-      ipfsApi: nil
+      ipfsApi: TestIpfsAPI()
     )
     let sendTokenExpectation = expectation(description: "update-sendTokenExpectation")
     store.$selectedSendToken
@@ -153,7 +153,7 @@ class SendTokenStoreTests: XCTestCase {
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: .mockSolToken,
-      ipfsApi: nil
+      ipfsApi: TestIpfsAPI()
     )
     let sendTokenExpectation = expectation(description: "update-sendTokenExpectation")
     store.$selectedSendToken
@@ -188,7 +188,7 @@ class SendTokenStoreTests: XCTestCase {
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: nil,
-      ipfsApi: nil
+      ipfsApi: TestIpfsAPI()
     )
     let selectedSendTokenExpectation = expectation(description: "update-selectedSendToken")
     XCTAssertNil(store.selectedSendToken)  // Initial state
@@ -232,7 +232,7 @@ class SendTokenStoreTests: XCTestCase {
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: .previewToken,
-      ipfsApi: nil
+      ipfsApi: TestIpfsAPI()
     )
     store.selectedSendToken = .previewToken
     let ex = expectation(description: "send-eth-eip1559-transaction")
@@ -257,7 +257,7 @@ class SendTokenStoreTests: XCTestCase {
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: .previewToken,
-      ipfsApi: nil
+      ipfsApi: TestIpfsAPI()
     )
     store.selectedSendToken = .previewToken
     let ex = expectation(description: "send-eth-transaction")
@@ -282,7 +282,7 @@ class SendTokenStoreTests: XCTestCase {
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: nil,
-      ipfsApi: nil
+      ipfsApi: TestIpfsAPI()
     )
     let token: BraveWallet.BlockchainToken = .init(contractAddress: "0x0d8775f648430679a709e98d2b0cb6250d2887ef", name: "Basic Attention Token", logo: "", isErc20: true, isErc721: false, isNft: false, symbol: batSymbol, decimals: 18, visible: true, tokenId: "", coingeckoId: "", chainId: "", coin: .eth)
     store.selectedSendToken = token
@@ -309,7 +309,7 @@ class SendTokenStoreTests: XCTestCase {
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: .previewToken,
-      ipfsApi: nil
+      ipfsApi: TestIpfsAPI()
     )
     store.selectedSendToken = .previewToken
     let ex = expectation(description: "send-bat-transaction")
@@ -337,7 +337,7 @@ class SendTokenStoreTests: XCTestCase {
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: .mockERC721NFTToken,
-      ipfsApi: nil
+      ipfsApi: TestIpfsAPI()
     )
     store.selectedSendToken = .mockERC721NFTToken
     let ex = expectation(description: "send-NFT-transaction")
@@ -387,7 +387,7 @@ class SendTokenStoreTests: XCTestCase {
       ethTxManagerProxy: MockEthTxManagerProxy(),
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: .previewToken,
-      ipfsApi: nil
+      ipfsApi: TestIpfsAPI()
     )
     store.selectedSendToken = .previewToken
     let fetchSelectedTokenBalanceEx = expectation(description: "fetchSelectedTokenBalance")
@@ -438,7 +438,7 @@ class SendTokenStoreTests: XCTestCase {
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: BraveWallet.NetworkInfo.mockSolana.nativeToken,
-      ipfsApi: nil
+      ipfsApi: TestIpfsAPI()
     )
     store.selectedSendToken = BraveWallet.NetworkInfo.mockSolana.nativeToken
     let ex = expectation(description: "send-sol-transaction")
@@ -475,7 +475,7 @@ class SendTokenStoreTests: XCTestCase {
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: .mockSpdToken,
-      ipfsApi: nil
+      ipfsApi: TestIpfsAPI()
     )
     store.selectedSendToken = .mockSpdToken
     let ex = expectation(description: "send-sol-transaction")
@@ -515,7 +515,7 @@ class SendTokenStoreTests: XCTestCase {
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: .mockSolToken,
-      ipfsApi: nil
+      ipfsApi: TestIpfsAPI()
     )
     store.selectedSendToken = .mockSolToken
     let ex = expectation(description: "send-sol-transaction")
@@ -556,7 +556,7 @@ class SendTokenStoreTests: XCTestCase {
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: .mockSpdToken,
-      ipfsApi: nil
+      ipfsApi: TestIpfsAPI()
     )
     store.selectedSendToken = .mockSpdToken
     let ex = expectation(description: "send-spl-transaction")
@@ -588,7 +588,7 @@ class SendTokenStoreTests: XCTestCase {
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: nil,
-      ipfsApi: nil
+      ipfsApi: TestIpfsAPI()
     )
     
     let selectedSendNFTMetadataERC721Exception = expectation(description: "sendTokenStore-selectedSendTokenERC721MetadataException")
@@ -630,7 +630,7 @@ class SendTokenStoreTests: XCTestCase {
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: nil,
-      ipfsApi: nil
+      ipfsApi: TestIpfsAPI()
     )
     
     let selectedSendNFTMetadataSolNFTException = expectation(description: "sendTokenStore-selectedSendNFTMetadataSolNFTException")
@@ -675,7 +675,7 @@ class SendTokenStoreTests: XCTestCase {
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: nil,
-      ipfsApi: nil
+      ipfsApi: TestIpfsAPI()
     )
     
     let resolvedAddressExpectation = expectation(description: "sendTokenStore-resolvedAddress")
@@ -712,7 +712,7 @@ class SendTokenStoreTests: XCTestCase {
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: nil,
-      ipfsApi: nil
+      ipfsApi: TestIpfsAPI()
     )
     
     let resolvedAddressExpectation = expectation(description: "sendTokenStore-resolvedAddress")
@@ -763,7 +763,7 @@ class SendTokenStoreTests: XCTestCase {
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: nil,
-      ipfsApi: nil
+      ipfsApi: TestIpfsAPI()
     )
     store.selectedSendToken = .mockSolToken
     
@@ -810,7 +810,7 @@ class SendTokenStoreTests: XCTestCase {
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: nil,
-      ipfsApi: nil
+      ipfsApi: TestIpfsAPI()
     )
     
     let resolvedAddressExpectation = expectation(description: "sendTokenStore-resolvedAddress")
@@ -851,7 +851,7 @@ class SendTokenStoreTests: XCTestCase {
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: nil,
-      ipfsApi: nil
+      ipfsApi: TestIpfsAPI()
     )
     
     let isOffchainResolveRequiredExpectation = expectation(description: "sendTokenStore-isOffchainResolveRequired")
@@ -889,7 +889,7 @@ class SendTokenStoreTests: XCTestCase {
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: nil,
-      ipfsApi: nil
+      ipfsApi: TestIpfsAPI()
     )
     
     let resolvedAddressExpectation = expectation(description: "sendTokenStore-resolvedAddress")
@@ -940,7 +940,7 @@ class SendTokenStoreTests: XCTestCase {
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: nil,
-      ipfsApi: nil
+      ipfsApi: TestIpfsAPI()
     )
     store.selectedSendToken = .mockSolToken
 
@@ -987,7 +987,7 @@ class SendTokenStoreTests: XCTestCase {
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: .previewToken,
-      ipfsApi: nil
+      ipfsApi: TestIpfsAPI()
     )
     
     let waitForPrefilledTokenExpectation = expectation(description: "waitForPrefilledToken")
@@ -1040,7 +1040,7 @@ class SendTokenStoreTests: XCTestCase {
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: .previewToken,
-      ipfsApi: nil
+      ipfsApi: TestIpfsAPI()
     )
     
     let waitForPrefilledTokenExpectation = expectation(description: "waitForPrefilledToken")
@@ -1103,7 +1103,7 @@ class SendTokenStoreTests: XCTestCase {
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: .mockSolToken,
-      ipfsApi: nil
+      ipfsApi: TestIpfsAPI()
     )
     
     let waitForPrefilledTokenExpectation = expectation(description: "waitForPrefilledToken")
@@ -1163,7 +1163,7 @@ class SendTokenStoreTests: XCTestCase {
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: .previewToken,
-      ipfsApi: nil
+      ipfsApi: TestIpfsAPI()
     )
     
     let waitForPrefilledTokenExpectation = expectation(description: "waitForPrefilledToken")

--- a/Tests/BraveWalletTests/SettingsStoreTests.swift
+++ b/Tests/BraveWalletTests/SettingsStoreTests.swift
@@ -15,7 +15,7 @@ class SettingsStoreTests: XCTestCase {
   private var cancellables: Set<AnyCancellable> = .init()
   
   /// Sets up TestKeyringService, TestBraveWalletService and TestTxService with some default values.
-  private func setupServices() -> (BraveWallet.TestKeyringService, BraveWallet.TestBraveWalletService, BraveWallet.TestJsonRpcService, BraveWallet.TestTxService) {
+  private func setupServices() -> (BraveWallet.TestKeyringService, BraveWallet.TestBraveWalletService, BraveWallet.TestJsonRpcService, BraveWallet.TestTxService, IpfsAPI) {
     let mockAccountInfos: [BraveWallet.AccountInfo] = [.previewAccount]
     let mockUserAssets: [BraveWallet.BlockchainToken] = [.previewToken.then { $0.visible = true }]
     
@@ -50,12 +50,14 @@ class SettingsStoreTests: XCTestCase {
     
     let txService = BraveWallet.TestTxService()
     
-    return (keyringService, walletService, rpcService, txService)
+    let ipfsApi = TestIpfsAPI()
+    
+    return (keyringService, walletService, rpcService, txService, ipfsApi)
   }
   
   /// Test `setup` will populate default values from keyring service / wallet service
   func testSetup() {
-    let (keyringService, walletService, rpcService, txService) = setupServices()
+    let (keyringService, walletService, rpcService, txService, ipfsApi) = setupServices()
     keyringService._autoLockMinutes = { $0(1) }
     walletService._defaultBaseCurrency = { $0(CurrencyCode.cad.code) }
     rpcService._ensOffchainLookupResolveMethod = { $0(.disabled) }
@@ -66,6 +68,7 @@ class SettingsStoreTests: XCTestCase {
       walletService: walletService,
       rpcService: rpcService,
       txService: txService,
+      ipfsApi: ipfsApi,
       keychain: TestableKeychain()
     )
     
@@ -114,7 +117,7 @@ class SettingsStoreTests: XCTestCase {
 
   /// Test `reset()` will call `reset()` on wallet service, update web3 preferences to default values, and update autolock & currency code values.
   func testReset() {
-    let (keyringService, walletService, rpcService, txService) = setupServices()
+    let (keyringService, walletService, rpcService, txService, ipfsApi) = setupServices()
     var keyringServiceAutolockMinutes: Int32 = 1
     keyringService._autoLockMinutes = { $0(keyringServiceAutolockMinutes) }
     walletService._defaultBaseCurrency = { $0(CurrencyCode.cad.code) }
@@ -170,6 +173,7 @@ class SettingsStoreTests: XCTestCase {
       walletService: walletService,
       rpcService: rpcService,
       txService: txService,
+      ipfsApi: ipfsApi,
       keychain: keychain
     )
     
@@ -221,7 +225,7 @@ class SettingsStoreTests: XCTestCase {
 
   /// Test `resetTransaction()` will call `reset()` on TxService
   func testResetTransaction() {
-    let (keyringService, walletService, rpcService, txService) = setupServices()
+    let (keyringService, walletService, rpcService, txService, ipfsApi) = setupServices()
     var txServiceResetCalled = false
     txService._reset = {
       txServiceResetCalled = true
@@ -232,6 +236,7 @@ class SettingsStoreTests: XCTestCase {
       walletService: walletService,
       rpcService: rpcService,
       txService: txService,
+      ipfsApi: ipfsApi,
       keychain: TestableKeychain()
     )
     

--- a/Tests/BraveWalletTests/UserAssetsStoreTests.swift
+++ b/Tests/BraveWalletTests/UserAssetsStoreTests.swift
@@ -62,7 +62,7 @@ class UserAssetsStoreTests: XCTestCase {
       rpcService: rpcService,
       keyringService: keyringService,
       assetRatioService: assetRatioService,
-      ipfsApi: nil
+      ipfsApi: TestIpfsAPI()
     )
     
     let assetStoresException = expectation(description: "userAssetsStore-assetStores")
@@ -114,7 +114,7 @@ class UserAssetsStoreTests: XCTestCase {
       rpcService: rpcService,
       keyringService: keyringService,
       assetRatioService: assetRatioService,
-      ipfsApi: nil
+      ipfsApi: TestIpfsAPI()
     )
     
     let assetStoresException = expectation(description: "userAssetsStore-assetStores")


### PR DESCRIPTION
## Summary of Changes
- Made `IpfsAPI` non-optional in Wallet. Added a `TestIpfsAPI` for unit tests + previews.

This pull request fixes #7012

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
Verify wallet still works as expected; IPFS gateway setting still works as expected.


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
