### PR TITLE
Fix #7200: Tx Confirmation auto-dismisses after creating tx via asset details

### DIFF
--- a/Sources/BraveWallet/WalletPromptView.swift
+++ b/Sources/BraveWallet/WalletPromptView.swift
@@ -6,6 +6,7 @@
 import SwiftUI
 import BraveUI
 import DesignSystem
+import Shared
 
 struct WalletPromptContentView<Content, Footer>: View where Content: View, Footer: View {
   let content: () -> Content
@@ -82,12 +83,23 @@ struct WalletPromptView<Content, Footer>: UIViewControllerRepresentable where Co
           footer: footer
         )
       )
+      context.coordinator.presentedViewController = .init(controller)
       uiViewController.present(controller, animated: true)
     } else {
-      if buySendSwapDestination.wrappedValue == nil {
+      if buySendSwapDestination.wrappedValue == nil,
+         let presentedViewController = context.coordinator.presentedViewController?.value,
+         presentedViewController == uiViewController.presentedViewController {
         uiViewController.presentedViewController?.dismiss(animated: true)
       }
     }
+  }
+  
+  class Coordinator {
+    var presentedViewController: WeakRef<UIViewController>?
+  }
+  
+  func makeCoordinator() -> Coordinator {
+    Coordinator()
   }
 }
 

--- a/Sources/BraveWallet/WalletPromptView.swift
+++ b/Sources/BraveWallet/WalletPromptView.swift
@@ -57,8 +57,6 @@ struct WalletPromptView<Content, Footer>: UIViewControllerRepresentable where Co
   var action: (Bool, UINavigationController?) -> Bool
   var content: () -> Content
   var footer: () -> Footer
-  @Environment(\.buySendSwapDestination)
-  private var buySendSwapDestination: Binding<BuySendSwapDestination?>
   
   func makeUIViewController(context: Context) -> UIViewController {
     .init()
@@ -86,8 +84,7 @@ struct WalletPromptView<Content, Footer>: UIViewControllerRepresentable where Co
       context.coordinator.presentedViewController = .init(controller)
       uiViewController.present(controller, animated: true)
     } else {
-      if buySendSwapDestination.wrappedValue == nil,
-         let presentedViewController = context.coordinator.presentedViewController?.value,
+      if let presentedViewController = context.coordinator.presentedViewController?.value,
          presentedViewController == uiViewController.presentedViewController {
         uiViewController.presentedViewController?.dismiss(animated: true)
       }


### PR DESCRIPTION
## Summary of Changes
- Fix Transaction Confirmation automatically dismissing after creating a send/swap transaction from asset details

This pull request fixes #7200

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
Verify no regressions with popup (Aurora bridge, Biometrics popup):
1. Create a new wallet and verify 'Enable' toggle works on Biometrics prompt (dismisses the popup).
2. Restore wallet and verify 'Enable' toggle works on Biometrics prompt (dismisses the popup).
3. Open Portfolio and tap an Aurora Bridge supported asset (ex. Ethereum on Etheruem Mainnet).
4. Tap Bridge to Aurora
5. Verify the popup closes and opens the Rainbow Bridge url.
6. Open Portfolio and tap an Aurora Bridge supported asset  (ex. Ethereum on Etheruem Mainnet).
7. Tap 'Do not show again' and verify the popup closes.

Verify no regression with https://github.com/brave/brave-ios/issues/6460
1. Open Portfolio
2. Select any asset and tap Buy/Send/Swap on asset details
3. Change network or selected account and verify Buy/Send/Swap is not dismissed automatically

Verify bug fix:
1. Open Portfolio and tap an asset with a balance on one of your accounts
4. Tap send or swap
5. Tap `Send` or `Swap` the send or swap transaction
9. Verify Transaction Confirmation modal is displayed as expected, does not auto-dismiss.


## Screenshots:

https://user-images.githubusercontent.com/5314553/229905914-e1e1d81e-1c44-4d79-af97-9d4d8ebbf391.mp4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
