### PR TITLE
Fix #7034: fixing activation of tabs when moving them around

### DIFF
--- a/Sources/Brave/Frontend/Browser/Tabs/TabBar/TabBarCell.swift
+++ b/Sources/Brave/Frontend/Browser/Tabs/TabBar/TabBarCell.swift
@@ -14,7 +14,7 @@ class TabBarCell: UICollectionViewCell {
     return label
   }()
 
-  private lazy var closeButton: UIButton = {
+  lazy var closeButton: UIButton = {
     let button = UIButton()
     button.addTarget(self, action: #selector(closeTab), for: .touchUpInside)
     button.setImage(UIImage(named: "close_tab_bar", in: .module, compatibleWith: nil)!.template, for: .normal)
@@ -44,7 +44,7 @@ class TabBarCell: UICollectionViewCell {
   var closeTabCallback: ((Tab) -> Void)?
   private var cancellables: Set<AnyCancellable> = []
 
-  private let deselectedOverlayView = UIView().then {
+  let deselectedOverlayView = UIView().then {
     $0.backgroundColor = UIColor {
       if $0.userInterfaceStyle == .dark {
         return UIColor.black.withAlphaComponent(0.25)

--- a/Sources/Brave/Frontend/Browser/Tabs/TabBar/TabsBarViewController.swift
+++ b/Sources/Brave/Frontend/Browser/Tabs/TabBar/TabsBarViewController.swift
@@ -414,6 +414,17 @@ extension TabsBarViewController: UICollectionViewDataSource {
     updateData()
 
     guard let selectedTab = tabList[destinationIndexPath.row] else { return }
+      
+    // Deselects all tabBarCells before selecting the one that was moved
+    for i in 0...tabs.count - 1 where i != destinationIndexPath.row {
+    if let cell = collectionView.cellForItem(at: IndexPath(row: i, section: 0)) as? TabBarCell {
+      cell.closeButton.isHidden = true
+      cell.deselectedOverlayView.isHidden = false
+      cell.isSelected = false
+      cell.configure()
+    }
+    }
+      
     manager.selectTab(selectedTab)
   }
 }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes brave/brave-browser#36102. I explicitly changed attributes of all unselected cells (like hiding the close button) inside the method that gets called when moving around a tab.

## Submitter Checklist:

- [X] New or updated UI has been tested across:
  - [X] Light & dark mode
  - [X] Different size classes (iPhone, landscape, iPad)
  - [X] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
1. Open two or more tabs
2. Move one of the unselected tabs to another position
3. Move unselected tabs to all possible positions
4. Verify that only the moved tab gets selected. All the other tabs appear unselected (tab label font is not bold, close button is hidden, darker background color)

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
