### PR TITLE
Fix #7207: Add a minimum size limit to favicon. Fix playlist thumbnail rendering

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Widgets.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Widgets.swift
@@ -38,6 +38,10 @@ extension BrowserViewController: NSFetchedResultsControllerDelegate {
             let title = fav.title
             
             group.addTask {
+              if let favicon = FaviconFetcher.getIconFromCache(for: url) {
+                return IndexedWidgetFavorite(index: index, favorite: .init(url: url, title: title, favicon: favicon))
+              }
+              
               let favicon = try? await FaviconFetcher.loadIcon(url: url, kind: .largeIcon, persistent: true)
               return IndexedWidgetFavorite(index: index, favorite: .init(url: url, title: title, favicon: favicon))
             }

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/FaviconScriptHandler.swift
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/FaviconScriptHandler.swift
@@ -57,9 +57,18 @@ class FaviconScriptHandler: NSObject, TabContentScript {
           Logger.module.debug("Fetched Favicon for page: \(url.absoluteString)")
         }
         
+        // If the icon is too small, we don't want to cache it.
+        // It's better to show monogram or bundled icons.
+        if icon.size.width < CGFloat(FaviconLoader.Sizes.desiredMedium.rawValue) ||
+           icon.size.height < CGFloat(FaviconLoader.Sizes.desiredMedium.rawValue) {
+          return
+        }
+        
         Task { @MainActor in
           let favicon = await Favicon.renderImage(icon, backgroundColor: .clear, shouldScale: true)
-          FaviconFetcher.updateCache(favicon, for: url, persistent: !isPrivate)  // We can only cache favicons for non-private tabs
+
+          // We can only cache favicons for non-private tabs
+          FaviconFetcher.updateCache(favicon, for: url, persistent: !isPrivate)
           
           guard let tab = tab else { return }
           tab.favicon = favicon

--- a/Sources/Favicon/FaviconRenderer.swift
+++ b/Sources/Favicon/FaviconRenderer.swift
@@ -13,7 +13,7 @@ class FaviconRenderer {
   static func loadIcon(for url: URL, persistent: Bool) async throws -> Favicon {
     // Load the Favicon from Brave-Core
     let attributes: FaviconAttributes = await withCheckedContinuation { continuation in
-      FaviconLoader.getForPrivateMode(!persistent).favicon(forPageURLOrHost: url, sizeInPoints: .desiredLargest, minSizeInPoints: .desiredSmallest) { _, attributes in
+      FaviconLoader.getForPrivateMode(!persistent).favicon(forPageURLOrHost: url, sizeInPoints: .desiredLargest, minSizeInPoints: .desiredMedium /*32x32*/) { _, attributes in
 
         // If the completion block was called with the `default` image, do nothing
         if attributes.usesDefaultImage {


### PR DESCRIPTION
## Summary of Changes
- Fix so that we have a minimum size icon of 32x32.
- Anything smaller is extremely blurry and doesn't look good.
- Fix playlist icon rendering so it can pull from the Favicon cache without asking the Chromium cache for the icon.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7207

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
