### PR TITLE
Fix #7213, #4187: Block Playlist from showing up on Brave-Talk

### DIFF
--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/PlaylistScriptHandler.swift
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/PlaylistScriptHandler.swift
@@ -100,6 +100,11 @@ class PlaylistScriptHandler: NSObject, TabContentScript {
       return
     }
     
+    // If this URL is blocked from Playlist support, do nothing
+    if url?.isPlaylistBlockedSiteURL == true {
+      return
+    }
+    
     if ReadyState.from(message: message) != nil {
       return
     }
@@ -216,6 +221,12 @@ extension PlaylistScriptHandler: UIGestureRecognizerDelegate {
     if gestureRecognizer.state == .began,
       let webView = tab?.webView,
       Preferences.Playlist.enableLongPressAddToPlaylist.value {
+      
+      // If this URL is blocked from Playlist support, do nothing
+      if url?.isPlaylistBlockedSiteURL == true {
+        return
+      }
+      
       let touchPoint = gestureRecognizer.location(in: webView)
 
       webView.evaluateSafeJavaScript(functionName: "window.__firefox__.\(PlaylistScriptHandler.playlistLongPressed)",

--- a/Sources/Shared/Extensions/URLExtensions.swift
+++ b/Sources/Shared/Extensions/URLExtensions.swift
@@ -434,6 +434,11 @@ extension URL {
 
     return siteList.contains(where: urlHost.contains)
   }
+  
+  public var isPlaylistBlockedSiteURL: Bool {
+    let urlHost = self.host ?? self.hostSLD
+    return urlHost == "talk.brave.com"
+  }
 
   public func uniquePathForFilename(_ filename: String) throws -> URL {
     let basePath = self.appendingPathComponent(filename)


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Block playlist from showing up entirely, on Brave-Talk

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7213, #4187
## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
