### PR TITLE
Fix #7227: open IPNS links from other apps

### DIFF
--- a/App/iOS/Supporting Files/Info.plist
+++ b/App/iOS/Supporting Files/Info.plist
@@ -40,6 +40,7 @@
 				<string>http</string>
 				<string>https</string>
 				<string>ipfs</string>
+				<string>ipns</string>
 				<string>$(BRAVE_URL_SCHEME)</string>
 			</array>
 		</dict>


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
Register `ipns` scheme so that users can open `ipns` scheme url from other apps.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7227

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
1. Copy and paste an ipns scheme url (for example: ipns://en.wikipedia-on-ipfs.org/wiki/) to any apps other than Brave browser
2. Click this link 
3. check if brave browser will be opened and try to load this url (3 ways resolved/disabled(error)/ask to resolve) 


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
