### PR TITLE
Fix #7229: Added 'presearch' to 'searchSiteList' to block injection of night mode

### DIFF
--- a/Sources/Shared/Extensions/URLExtensions.swift
+++ b/Sources/Shared/Extensions/URLExtensions.swift
@@ -372,7 +372,7 @@ extension URL {
                          "imdb"]
     
     let searchSiteList = ["search.brave", "google", "qwant",
-                          "startpage", "duckduckgo"]
+                          "startpage", "duckduckgo", "presearch"]
     
     let devSiteList = ["macrumors", "9to5mac", "developer.apple"]
                     


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7229 

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
