### PR TITLE
Fix #7238: Use built-in find interaction for find in page on iOS 16

### DIFF
--- a/Sources/Brave/Frontend/Browser/BraveWebView.swift
+++ b/Sources/Brave/Frontend/Browser/BraveWebView.swift
@@ -35,6 +35,10 @@ class BraveWebView: WKWebView {
 
     super.init(frame: frame, configuration: configuration)
 
+    if #available(iOS 16.0, *) {
+      isFindInteractionEnabled = true
+    }
+    
     customUserAgent = UserAgent.userAgentForDesktopMode
 #if compiler(>=5.8)
     if #available(iOS 16.4, *) {

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
@@ -58,7 +58,12 @@ extension BrowserViewController {
     updateRewardsButtonState()
 
     guard let tab = tabManager.selectedTab else { return }
-
+    
+    if #available(iOS 16.0, *) {
+      // System components sit on top so we want to dismiss it
+      tab.webView?.findInteraction?.dismissFindNavigator()
+    }
+    
     let braveRewardsPanel = BraveRewardsViewController(
       tab: tab,
       rewards: rewards,

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+FindInPageDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+FindInPageDelegate.swift
@@ -10,6 +10,7 @@ import os.log
 
 /// List of Find Options used by WebKit to `Find-In-Page`
 /// Typically we use `caseInsensitive`, `wrapAround`, `backwards`, `showHighlight`
+@available(iOS, obsoleted: 16.0, message: "Replaced by UIFindInteraction")
 private struct WKFindOptions: OptionSet {
   let rawValue: UInt
 
@@ -38,6 +39,7 @@ private struct WKFindOptions: OptionSet {
 
 /// A Delegate used to invoke `Find-In-Page` internally in WebKit
 /// This is used to allow WebKit to do Find-In-Page on PDFs and all Web-Content
+@available(iOS, obsoleted: 16.0, message: "Replaced by UIFindInteraction")
 @objc
 class WKWebViewFindStringFindDelegate: NSObject {
   /// Set to true when the constructor hasn't failed
@@ -183,6 +185,7 @@ class WKWebViewFindStringFindDelegate: NSObject {
 
 // MARK: FindInPageBarDelegate - FindInPageScriptHandlerDelegate
 
+@available(iOS, obsoleted: 16.0, message: "Replaced by UIFindInteraction")
 extension BrowserViewController: FindInPageBarDelegate, FindInPageScriptHandlerDelegate {
   
   enum TextSearchDirection: String {

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -266,15 +266,18 @@ extension BrowserViewController {
       UIKeyCommand(title: Strings.Hotkey.findInPageTitle, action: #selector(findInPageKeyCommand), input: "f", modifierFlags: .command)
     ]
 
-    let findTextUtilitiesCommands = [
-      UIKeyCommand(title: Strings.Hotkey.findNextTitle, action: #selector(findNextCommand), input: "g", modifierFlags: [.command]),
-      UIKeyCommand(title: Strings.Hotkey.findPreviousTitle, action: #selector(findPreviousCommand), input: "g", modifierFlags: [.command, .shift]),
-    ]
-
-    let isFindingText = !(findInPageBar?.text?.isEmpty ?? true)
-
-    if isFindingText {
-      findTextCommands.append(contentsOf: findTextUtilitiesCommands)
+    // These are automatically handled in iOS 16's UIFindInteraction
+    if #unavailable(iOS 16.0) {
+      let findTextUtilitiesCommands = [
+        UIKeyCommand(title: Strings.Hotkey.findNextTitle, action: #selector(findNextCommand), input: "g", modifierFlags: [.command]),
+        UIKeyCommand(title: Strings.Hotkey.findPreviousTitle, action: #selector(findPreviousCommand), input: "g", modifierFlags: [.command, .shift]),
+      ]
+      
+      let isFindingText = !(findInPageBar?.text?.isEmpty ?? true)
+      
+      if isFindingText {
+        findTextCommands.append(contentsOf: findTextUtilitiesCommands)
+      }
     }
 
     // Share With Key Command

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+TabManagerDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+TabManagerDelegate.swift
@@ -107,7 +107,9 @@ extension BrowserViewController: TabManagerDelegate {
       }
     }
 
-    updateFindInPageVisibility(visible: false, tab: previous)
+    if #unavailable(iOS 16.0) {
+      updateFindInPageVisibility(visible: false, tab: previous)
+    }
     displayPageZoom(visible: false)
     updateTabsBarVisibility()
     selected?.updatePullToRefreshVisibility()

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
@@ -22,7 +22,9 @@ extension BrowserViewController: TopToolbarDelegate {
     if tabManager.tabsForCurrentMode.isEmpty {
       return
     }
-    updateFindInPageVisibility(visible: false)
+    if #unavailable(iOS 16.0) {
+      updateFindInPageVisibility(visible: false)
+    }
     displayPageZoom(visible: false)
 
     if tabManager.selectedTab == nil {
@@ -97,6 +99,10 @@ extension BrowserViewController: TopToolbarDelegate {
         }
         
         await MainActor.run { [errorDescription] in
+          if #available(iOS 16.0, *) {
+            // System components sit on top so we want to dismiss it
+            webView.findInteraction?.dismissFindNavigator()
+          }
           let certificateViewController = CertificateViewController(certificate: certificate, evaluationError: errorDescription)
           let popover = PopoverController(contentController: certificateViewController, contentSizeBehavior: .preferredContentSize)
           popover.addsConvenientDismissalMargins = true
@@ -393,6 +399,11 @@ extension BrowserViewController: TopToolbarDelegate {
       return
     }
 
+    if #available(iOS 16.0, *) {
+      // System components sit on top so we want to dismiss it
+      selectedTab.webView?.findInteraction?.dismissFindNavigator()
+    }
+    
     let shields = ShieldsViewController(tab: selectedTab)
     shields.shieldsSettingsChanged = { [unowned self] _, shield in
       // Update the shields status immediately
@@ -462,6 +473,10 @@ extension BrowserViewController: TopToolbarDelegate {
   func topToolbarDidTapWalletButton(_ urlBar: TopToolbarView) {
     guard let selectedTab = tabManager.selectedTab else {
       return
+    }
+    if #available(iOS 16.0, *) {
+      // System components sit on top so we want to dismiss it
+      selectedTab.webView?.findInteraction?.dismissFindNavigator()
     }
     presentWalletPanel(from: selectedTab.getOrigin(), with: selectedTab.tabDappStore)
   }

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -66,7 +66,9 @@ extension BrowserViewController: WKNavigationDelegate {
       }
     }
 
-    updateFindInPageVisibility(visible: false)
+    if #unavailable(iOS 16.0) {
+      updateFindInPageVisibility(visible: false)
+    }
     displayPageZoom(visible: false)
 
     // If we are going to navigate to a new page, hide the reader mode button. Unless we

--- a/Sources/Brave/Frontend/Browser/FindInPageBar.swift
+++ b/Sources/Brave/Frontend/Browser/FindInPageBar.swift
@@ -5,6 +5,7 @@
 import UIKit
 import Shared
 
+@available(iOS, obsoleted: 16.0, message: "Replaced by UIFindInteraction")
 protocol FindInPageBarDelegate: AnyObject {
   func findInPage(_ findInPage: FindInPageBar, didTextChange text: String)
   func findInPage(_ findInPage: FindInPageBar, didFindPreviousWithText text: String)
@@ -12,11 +13,13 @@ protocol FindInPageBarDelegate: AnyObject {
   func findInPageDidPressClose(_ findInPage: FindInPageBar)
 }
 
+@available(iOS, obsoleted: 16.0, message: "Replaced by UIFindInteraction")
 private struct FindInPageUX {
   static let matchCountFont = UIConstants.defaultChromeFont
   static let searchTextFont = UIConstants.defaultChromeFont
 }
 
+@available(iOS, obsoleted: 16.0, message: "Replaced by UIFindInteraction")
 class FindInPageBar: UIView {
   weak var delegate: FindInPageBarDelegate?
   fileprivate let searchText = UITextField()

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/FindInPageScriptHandler.swift
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/FindInPageScriptHandler.swift
@@ -7,11 +7,13 @@ import Shared
 import WebKit
 import os.log
 
+@available(iOS, obsoleted: 16.0, message: "Replaced by UIFindInteraction")
 protocol FindInPageScriptHandlerDelegate: AnyObject {
   func findInPageHelper(_ findInPageScriptHandler: FindInPageScriptHandler, didUpdateCurrentResult currentResult: Int)
   func findInPageHelper(_ findInPageScriptHandler: FindInPageScriptHandler, didUpdateTotalResults totalResults: Int)
 }
 
+@available(iOS, obsoleted: 16.0, message: "Replaced by UIFindInteraction")
 class FindInPageScriptHandler: TabContentScript {
   weak var delegate: FindInPageScriptHandlerDelegate?
   fileprivate weak var tab: Tab?


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #7238

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

- Ensure Find In Page works as normal in iOS 15
- Ensure Find In Page works correctly using the new built-in system find component on iOS 16
  - Since this is a system component it lives outside of Brave's UI, which means we should make sure it doesn't interfere with other things such as: wallet popover, shields popover, rewards, etc.
  - It also should be tested against both bottom bar & top bar
  - Repeat on iPad

## Screenshots:

| iOS 15 | iOS 16 |
| --- | --- |
| ![iOS 15](https://user-images.githubusercontent.com/529104/231815779-94d5de9e-ae2f-4c3a-adbf-18c9ab9388c4.png) | ![iOS 16](https://user-images.githubusercontent.com/529104/231815808-820c30c2-a04f-4f16-afcb-16b944042e6f.png) |

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
