### PR TITLE
Fix #7198: Wallet Activity Tab

### DIFF
--- a/Sources/BraveWallet/Crypto/CryptoPagesView.swift
+++ b/Sources/BraveWallet/Crypto/CryptoPagesView.swift
@@ -188,6 +188,14 @@ private class CryptoPagesViewController: TabbedPageViewController {
         $0.title = Strings.Wallet.portfolioPageTitle
       },
       UIHostingController(
+        rootView: TransactionsActivityView(
+          store: cryptoStore.transactionsActivityStore,
+          networkStore: cryptoStore.networkStore
+        )
+      ).then {
+        $0.title = Strings.Wallet.activityPageTitle
+      },
+      UIHostingController(
         rootView: AccountsView(
           cryptoStore: cryptoStore,
           keyringStore: keyringStore

--- a/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -48,6 +48,7 @@ enum WebpageRequestResponse: Equatable {
 public class CryptoStore: ObservableObject {
   public let networkStore: NetworkStore
   public let portfolioStore: PortfolioStore
+  let transactionsActivityStore: TransactionsActivityStore
   
   @Published var buySendSwapDestination: BuySendSwapDestination? {
     didSet {
@@ -128,6 +129,15 @@ public class CryptoStore: ObservableObject {
       assetRatioService: assetRatioService,
       blockchainRegistry: blockchainRegistry,
       ipfsApi: ipfsApi
+    )
+    self.transactionsActivityStore = .init(
+      keyringService: keyringService,
+      rpcService: rpcService,
+      walletService: walletService,
+      assetRatioService: assetRatioService,
+      blockchainRegistry: blockchainRegistry,
+      txService: txService,
+      solTxManagerProxy: solTxManagerProxy
     )
     
     self.keyringService.add(self)

--- a/Sources/BraveWallet/Crypto/Stores/TabbedPageViewController.swift
+++ b/Sources/BraveWallet/Crypto/Stores/TabbedPageViewController.swift
@@ -346,9 +346,7 @@ private class TabsBarView: UIView, UICollectionViewDelegate {
       flowLayout.minimumInteritemSpacing = 0
       flowLayout.minimumLineSpacing = 0
       flowLayout.sectionInset = .init(top: 0, left: 16, bottom: 0, right: 16)
-      // When we add back more items to the pages list, switch this back to estimated and remove
-      // item size setting within `layoutSubviews`
-      flowLayout.itemSize = CGSize(width: 44, height: tabBarHeight)
+      flowLayout.estimatedItemSize = CGSize(width: 44, height: tabBarHeight)
       return flowLayout
     }()
   )
@@ -362,14 +360,6 @@ private class TabsBarView: UIView, UICollectionViewDelegate {
         boundsWidthChanged?()
       }
     }
-  }
-
-  override func layoutSubviews() {
-    super.layoutSubviews()
-
-    guard bounds.width != 0 && collectionView.numberOfItems(inSection: 0) != 0 else { return }
-    (collectionView.collectionViewLayout as? UICollectionViewFlowLayout)?
-      .itemSize = CGSize(width: (bounds.width - 32) / CGFloat(collectionView.numberOfItems(inSection: 0)), height: tabBarHeight)
   }
 
   override init(frame: CGRect) {

--- a/Sources/BraveWallet/Crypto/Stores/TransactionsActivityStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/TransactionsActivityStore.swift
@@ -1,0 +1,188 @@
+/* Copyright 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import BraveCore
+import SwiftUI
+
+class TransactionsActivityStore: ObservableObject {
+  @Published var transactionSummaries: [TransactionSummary] = []
+  
+  @Published private(set) var currencyCode: String = CurrencyCode.usd.code {
+    didSet {
+      currencyFormatter.currencyCode = currencyCode
+      guard oldValue != currencyCode else { return }
+      update()
+    }
+  }
+  
+  let currencyFormatter: NumberFormatter = .usdCurrencyFormatter
+  
+  private let keyringService: BraveWalletKeyringService
+  private let rpcService: BraveWalletJsonRpcService
+  private let walletService: BraveWalletBraveWalletService
+  private let assetRatioService: BraveWalletAssetRatioService
+  private let blockchainRegistry: BraveWalletBlockchainRegistry
+  private let txService: BraveWalletTxService
+  private let solTxManagerProxy: BraveWalletSolanaTxManagerProxy
+  
+  init(
+    keyringService: BraveWalletKeyringService,
+    rpcService: BraveWalletJsonRpcService,
+    walletService: BraveWalletBraveWalletService,
+    assetRatioService: BraveWalletAssetRatioService,
+    blockchainRegistry: BraveWalletBlockchainRegistry,
+    txService: BraveWalletTxService,
+    solTxManagerProxy: BraveWalletSolanaTxManagerProxy
+  ) {
+    self.keyringService = keyringService
+    self.rpcService = rpcService
+    self.walletService = walletService
+    self.assetRatioService = assetRatioService
+    self.blockchainRegistry = blockchainRegistry
+    self.txService = txService
+    self.solTxManagerProxy = solTxManagerProxy
+    
+    keyringService.add(self)
+    txService.add(self)
+
+    Task { @MainActor in
+      self.currencyCode = await walletService.defaultBaseCurrency()
+    }
+  }
+  
+  private var updateTask: Task<Void, Never>?
+  func update() {
+    updateTask?.cancel()
+    updateTask = Task { @MainActor in
+      let allKeyrings = await keyringService.keyrings(
+        for: WalletConstants.supportedCoinTypes
+      )
+      let allAccountInfos = allKeyrings.flatMap(\.accountInfos)
+      // Only transactions for the selected network
+      // for each coin type are returned
+      var selectedNetworkForCoin: [BraveWallet.CoinType: BraveWallet.NetworkInfo] = [:]
+      for coin in WalletConstants.supportedCoinTypes {
+        selectedNetworkForCoin[coin] = await rpcService.network(coin)
+      }
+      let allTransactions = await txService.allTransactions(
+        for: allKeyrings
+      )
+      let userVisibleTokens = await walletService.allVisibleUserAssets(
+        in: Array(selectedNetworkForCoin.values)
+      ).flatMap(\.tokens)
+      let allTokens = await blockchainRegistry.allTokens(
+        in: Array(selectedNetworkForCoin.values)
+      ).flatMap(\.tokens)
+      guard !Task.isCancelled else { return }
+      
+      var solEstimatedTxFees: [String: UInt64] = [:]
+      if allTransactions.contains(where: { $0.coin == .sol }) {
+        let solTransactionIds = allTransactions.filter { $0.coin == .sol }.map(\.id)
+        solEstimatedTxFees = await solTxManagerProxy.estimatedTxFees(for: solTransactionIds)
+      }
+      
+      // fetch price for every visible token
+      let allVisibleTokenAssetRatioIds = userVisibleTokens.map(\.assetRatioId)
+      let prices = await assetRatioService.fetchPrices(
+        for: allVisibleTokenAssetRatioIds,
+        toAssets: [currencyFormatter.currencyCode],
+        timeframe: .oneDay
+      ).compactMapValues { Double($0) }
+      self.transactionSummaries = self.transactionSummaries(
+        transactions: allTransactions,
+        selectedNetworkForCoin: selectedNetworkForCoin,
+        accountInfos: allAccountInfos,
+        userVisibleTokens: userVisibleTokens,
+        allTokens: allTokens,
+        assetRatios: prices,
+        solEstimatedTxFees: solEstimatedTxFees
+      )
+    }
+  }
+  
+  private func transactionSummaries(
+    transactions: [BraveWallet.TransactionInfo],
+    selectedNetworkForCoin: [BraveWallet.CoinType: BraveWallet.NetworkInfo],
+    accountInfos: [BraveWallet.AccountInfo],
+    userVisibleTokens: [BraveWallet.BlockchainToken],
+    allTokens: [BraveWallet.BlockchainToken],
+    assetRatios: [String: Double],
+    solEstimatedTxFees: [String: UInt64]
+  ) -> [TransactionSummary] {
+    transactions.compactMap { transaction in
+      guard let network = selectedNetworkForCoin[transaction.coin] else {
+        return nil
+      }
+      return TransactionParser.transactionSummary(
+        from: transaction,
+        network: network,
+        accountInfos: accountInfos,
+        visibleTokens: userVisibleTokens,
+        allTokens: allTokens,
+        assetRatios: assetRatios,
+        solEstimatedTxFee: solEstimatedTxFees[transaction.id],
+        currencyFormatter: currencyFormatter
+      )
+    }.sorted(by: { $0.createdTime > $1.createdTime })
+  }
+  
+  func transactionDetailsStore(
+    for transaction: BraveWallet.TransactionInfo
+  ) -> TransactionDetailsStore {
+    TransactionDetailsStore(
+      transaction: transaction,
+      keyringService: keyringService,
+      walletService: walletService,
+      rpcService: rpcService,
+      assetRatioService: assetRatioService,
+      blockchainRegistry: blockchainRegistry,
+      solanaTxManagerProxy: solTxManagerProxy
+    )
+  }
+}
+
+extension TransactionsActivityStore: BraveWalletKeyringServiceObserver {
+  func keyringCreated(_ keyringId: String) { }
+  
+  func keyringRestored(_ keyringId: String) { }
+  
+  func keyringReset() { }
+  
+  func locked() { }
+  
+  func unlocked() { }
+  
+  func backedUp() { }
+  
+  func accountsChanged() {
+    update()
+  }
+  
+  func accountsAdded(_ coin: BraveWallet.CoinType, addresses: [String]) {
+    update()
+  }
+  
+  func autoLockMinutesChanged() { }
+  
+  func selectedAccountChanged(_ coin: BraveWallet.CoinType) { }
+}
+
+extension TransactionsActivityStore: BraveWalletTxServiceObserver {
+  func onNewUnapprovedTx(_ txInfo: BraveWallet.TransactionInfo) {
+    update()
+  }
+  
+  func onUnapprovedTxUpdated(_ txInfo: BraveWallet.TransactionInfo) {
+    update()
+  }
+  
+  func onTransactionStatusChanged(_ txInfo: BraveWallet.TransactionInfo) {
+    update()
+  }
+  
+  func onTxServiceReset() {
+    update()
+  }
+}

--- a/Sources/BraveWallet/Crypto/Stores/TransactionsActivityStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/TransactionsActivityStore.swift
@@ -71,7 +71,7 @@ class TransactionsActivityStore: ObservableObject {
       }
       let allTransactions = await txService.allTransactions(
         for: allKeyrings
-      )
+      ).filter { $0.txStatus != .rejected }
       let userVisibleTokens = await walletService.allVisibleUserAssets(
         in: Array(selectedNetworkForCoin.values)
       ).flatMap(\.tokens)

--- a/Sources/BraveWallet/Crypto/TransactionsActivityView.swift
+++ b/Sources/BraveWallet/Crypto/TransactionsActivityView.swift
@@ -1,0 +1,77 @@
+/* Copyright 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import BraveCore
+import SwiftUI
+
+struct TransactionsActivityView: View {
+  
+  @ObservedObject var store: TransactionsActivityStore
+  @ObservedObject var networkStore: NetworkStore
+  
+  @State private var isPresentingNetworkFilter = false
+  @State private var transactionDetails: TransactionDetailsStore?
+  
+  var body: some View {
+    List {
+      Section {
+        if store.transactionSummaries.isEmpty {
+          emptyState
+            .listRowBackground(Color.clear)
+        } else {
+          ForEach(store.transactionSummaries) { txSummary in
+            Button(action: {
+              self.transactionDetails = store.transactionDetailsStore(for: txSummary.txInfo)
+            }) {
+              TransactionSummaryView(summary: txSummary)
+            }
+          }
+        }
+      }
+    }
+    .onAppear {
+      store.update()
+    }
+    .sheet(
+      isPresented: Binding(
+        get: { self.transactionDetails != nil },
+        set: { if !$0 { self.transactionDetails = nil } }
+      )
+    ) {
+      if let transactionDetailsStore = self.transactionDetails {
+        TransactionDetailsView(
+          transactionDetailsStore: transactionDetailsStore,
+          networkStore: networkStore
+        )
+      }
+    }
+  }
+  
+  private var emptyState: some View {
+    VStack(alignment: .center, spacing: 10) {
+      Text(Strings.Wallet.activityPageEmptyTitle)
+        .font(.headline.weight(.semibold))
+        .foregroundColor(Color(.braveLabel))
+      Text(Strings.Wallet.activityPageEmptyDescription)
+        .font(.subheadline.weight(.semibold))
+        .foregroundColor(Color(.secondaryLabel))
+    }
+    .multilineTextAlignment(.center)
+    .frame(maxWidth: .infinity)
+    .padding(.vertical, 60)
+    .padding(.horizontal, 32)
+  }
+}
+
+#if DEBUG
+struct TransactionsActivityViewView_Previews: PreviewProvider {
+  static var previews: some View {
+    TransactionsActivityView(
+      store: .preview,
+      networkStore: .previewStore
+    )
+  }
+}
+#endif

--- a/Sources/BraveWallet/Preview Content/MockContent.swift
+++ b/Sources/BraveWallet/Preview Content/MockContent.swift
@@ -166,9 +166,9 @@ extension BraveWallet.TransactionInfo {
       txType: .ethSend,
       txParams: [],
       txArgs: [],
-      createdTime: Date(timeIntervalSince1970: 1636399671),
-      submittedTime: Date(timeIntervalSince1970: 1636399673),
-      confirmedTime: Date(timeIntervalSince1970: 1636402508),
+      createdTime: Date(timeIntervalSince1970: 1636399671), // Monday, November 8, 2021 7:27:51 PM
+      submittedTime: Date(timeIntervalSince1970: 1636399673), // Monday, November 8, 2021 7:27:53 PM
+      confirmedTime: Date(timeIntervalSince1970: 1636402508), // Monday, November 8, 2021 8:15:08 PM
       originInfo: .init(),
       groupId: nil,
       chainId: ""
@@ -204,9 +204,9 @@ extension BraveWallet.TransactionInfo {
       txType: .other,
       txParams: [],
       txArgs: [],
-      createdTime: Date(timeIntervalSince1970: 1636399671),
-      submittedTime: Date(timeIntervalSince1970: 1636399673),
-      confirmedTime: Date(timeIntervalSince1970: 1636402508),
+      createdTime: Date(timeIntervalSince1970: 1636399671), // Monday, November 8, 2021 7:27:51 PM
+      submittedTime: Date(timeIntervalSince1970: 1636399673), // Monday, November 8, 2021 7:27:53 PM
+      confirmedTime: Date(timeIntervalSince1970: 1636402508), // Monday, November 8, 2021 8:15:08 PM
       originInfo: .init(),
       groupId: nil,
       chainId: ""
@@ -253,7 +253,7 @@ extension BraveWallet.TransactionInfo {
     BraveWallet.TransactionInfo(
       id: "3d3c7715-f5f2-4f70-ab97-7fb8d3b2a3cd",
       fromAddress: "6WRQXT2wMAkSjTjGQSqfEnuqgnqskTp5FnT28tScDsAd",
-      txHash: "",
+      txHash: "2rbyfcSQ9xCem4wtpjMYD4u6PdKE9YcBurCHDgkMcAaBMh8CirQvuLYtj8AyaYu62ekwWKM1UDZ2VLRB4uN96Fcu",
       txDataUnion: .init(
         solanaTxData: .init(
           recentBlockhash: "",
@@ -273,9 +273,9 @@ extension BraveWallet.TransactionInfo {
       txType: .solanaSystemTransfer,
       txParams: [],
       txArgs: [],
-      createdTime: Date(timeIntervalSince1970: 1636399671),
-      submittedTime: Date(timeIntervalSince1970: 1636399673),
-      confirmedTime: Date(timeIntervalSince1970: 1636402508),
+      createdTime: Date(timeIntervalSince1970: 1667854800), // Monday, November 7, 2022 9:00:00 PM GMT
+      submittedTime: Date(timeIntervalSince1970: 1667854810), // Monday, November 7, 2022 9:00:10 PM GMT
+      confirmedTime: Date(timeIntervalSince1970: 1667854820), // Monday, November 7, 2022 9:00:20 PM GMT
       originInfo: .init(),
       groupId: nil,
       chainId: ""

--- a/Sources/BraveWallet/Preview Content/MockStores.swift
+++ b/Sources/BraveWallet/Preview Content/MockStores.swift
@@ -216,6 +216,18 @@ extension TabDappStore {
   }
 }
 
+extension TransactionsActivityStore {
+  static let preview: TransactionsActivityStore = .init(
+    keyringService: MockKeyringService(),
+    rpcService: MockJsonRpcService(),
+    walletService: MockBraveWalletService(),
+    assetRatioService: MockAssetRatioService(),
+    blockchainRegistry: MockBlockchainRegistry(),
+    txService: MockTxService(),
+    solTxManagerProxy: BraveWallet.TestSolanaTxManagerProxy.previewProxy
+  )
+}
+
 extension BraveWallet.TestSolanaTxManagerProxy {
   static var previewProxy: BraveWallet.TestSolanaTxManagerProxy {
     let solTxManagerProxy = BraveWallet.TestSolanaTxManagerProxy()

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -3918,5 +3918,26 @@ extension Strings {
       value: "Brave will be using Infura to resolve .crypto (and also %@) domain names that are on Unstoppable Domains. Brave hides your IP address. If you enable this, Infura will see that someone is trying to visit these domains but nothing else. See Infura's <a href=%@>%@</a> and <a href=%@>%@</a>.",
       comment: "Description displayed when users chose Brave to ask them if they want the Unstoppable Domains to be resolved every time they enter one. The first '%@' will be replaced with a list of supported TLDs like '.x' or '.bitcoin'. The second '%@' be replaced with a link to Infura's terms of use page. The third '%@' will be replaced with the value of 'Web3DomainInterstitialPageTAndU'. The fourth '%@' will be replaced with a link to Infura's privacy policy page. The last '%@' will be replaced with the value of 'Web3DomainInterstitialPagePrivacyPolicy'."
     )
+    public static let activityPageTitle = NSLocalizedString(
+      "wallet.activityPageTitle",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Activity",
+      comment: "The title of the tab that will display user's transaction activity for all accounts."
+    )
+    public static let activityPageEmptyTitle = NSLocalizedString(
+      "wallet.activityPageEmptyTitle",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "No transactions yet",
+      comment: "The title when showing no transactions inside Activity tab."
+    )
+    public static let activityPageEmptyDescription = NSLocalizedString(
+      "wallet.activityPageEmptyDescription",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "After your first transaction you will be able to view it here.",
+      comment: "The description when showing no transactions inside Activity tab."
+    )
   }
 }

--- a/Tests/BraveWalletTests/TransactionsActivityStoreTests.swift
+++ b/Tests/BraveWalletTests/TransactionsActivityStoreTests.swift
@@ -1,0 +1,122 @@
+// Copyright 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Combine
+import XCTest
+import BraveCore
+@testable import BraveWallet
+
+class TransactionsActivityStoreTests: XCTestCase {
+  
+  private var cancellables: Set<AnyCancellable> = .init()
+  
+  let networks: [BraveWallet.CoinType: [BraveWallet.NetworkInfo]] = [
+    .eth: [.mockMainnet],
+    .sol: [.mockSolana]
+  ]
+  let visibleAssetsForCoins: [BraveWallet.CoinType: [BraveWallet.BlockchainToken]] = [
+    .eth: [
+      BraveWallet.NetworkInfo.mockMainnet.nativeToken.then { $0.visible = true },
+      .mockERC721NFTToken.then { $0.visible = true },
+      .mockUSDCToken.then { $0.visible = true }],
+    .sol: [
+      BraveWallet.NetworkInfo.mockSolana.nativeToken.then { $0.visible = true },
+      .mockSolanaNFTToken.then { $0.visible = true },
+      .mockSpdToken.then { $0.visible = true }]
+  ]
+  let tokenRegistry: [BraveWallet.CoinType: [BraveWallet.BlockchainToken]] = [:]
+  let mockAssetPrices: [BraveWallet.AssetPrice] = [
+    .init(fromAsset: "eth", toAsset: "usd", price: "3059.99", assetTimeframeChange: "-57.23"),
+    .init(fromAsset: "usdc", toAsset: "usd", price: "1.00", assetTimeframeChange: "-57.23"),
+    .init(fromAsset: "sol", toAsset: "usd", price: "2.00", assetTimeframeChange: "-57.23"),
+    .init(fromAsset: "spd", toAsset: "usd", price: "0.50", assetTimeframeChange: "-57.23")
+  ]
+  let transactions: [BraveWallet.CoinType: [BraveWallet.TransactionInfo]] = [
+    .eth: [.previewConfirmedSend, .previewConfirmedSwap],
+    .sol: [.previewConfirmedSolSystemTransfer]
+  ]
+  
+  func testUpdate() {
+    let keyringService = BraveWallet.TestKeyringService()
+    keyringService._addObserver = { _ in }
+    keyringService._keyringInfo = { keyringId, completion in
+      if keyringId == BraveWallet.DefaultKeyringId {
+        completion(.mockDefaultKeyringInfo)
+      } else {
+        completion(.mockSolanaKeyringInfo)
+      }
+    }
+    
+    let rpcService = BraveWallet.TestJsonRpcService()
+    rpcService._network = { coin, completion in
+      if coin == .sol {
+        completion(.mockSolana)
+      } else {
+        completion(.mockMainnet)
+      }
+    }
+    
+    let walletService = BraveWallet.TestBraveWalletService()
+    walletService._defaultBaseCurrency = { $0(CurrencyCode.usd.code) }
+    walletService._userAssets = { chainId, coin, completion in
+      completion(self.visibleAssetsForCoins[coin] ?? [])
+    }
+    
+    let assetRatioService = BraveWallet.TestAssetRatioService()
+    assetRatioService._price = { _, _, _, completion in
+      completion(true, self.mockAssetPrices)
+    }
+    
+    let blockchainRegistry = BraveWallet.TestBlockchainRegistry()
+    blockchainRegistry._allTokens = { chainId, coin, completion in
+      completion(self.tokenRegistry[coin] ?? [])
+    }
+    
+    let txService = BraveWallet.TestTxService()
+    txService._addObserver = { _ in }
+    txService._allTransactionInfo = { coin, accountAddress, completion in
+      completion(self.transactions[coin] ?? [])
+    }
+    
+    let solTxManagerProxy = BraveWallet.TestSolanaTxManagerProxy()
+    solTxManagerProxy._estimatedTxFee = { $1(UInt64(1), .success, "") }
+    
+    let store = TransactionsActivityStore(
+      keyringService: keyringService,
+      rpcService: rpcService,
+      walletService: walletService,
+      assetRatioService: assetRatioService,
+      blockchainRegistry: blockchainRegistry,
+      txService: txService,
+      solTxManagerProxy: solTxManagerProxy
+    )
+    
+    
+    let transactionsExpectation = expectation(description: "transactionsExpectation")
+    store.$transactionSummaries
+      .dropFirst()
+      .sink { transactionSummaries in
+        defer { transactionsExpectation.fulfill() }
+        let expectedTransactions = self.transactions.values.flatMap { $0 }
+        // verify all transactions from supported coin types are shown
+        XCTAssertEqual(transactionSummaries.count, expectedTransactions.count)
+        // verify sorted by `createdTime`
+        let expectedSortedOrder = expectedTransactions.sorted(by: { $0.createdTime > $1.createdTime })
+        XCTAssertEqual(transactionSummaries.map(\.txInfo.txHash), expectedSortedOrder.map(\.txHash))
+        // summaries are tested in `TransactionParserTests`, just verify they are populated with correct tx
+        XCTAssertEqual(transactionSummaries.count, 3)
+        XCTAssertEqual(transactionSummaries[safe: 0]?.txInfo, self.transactions[.sol]?[safe: 0] ?? .init())
+        XCTAssertEqual(transactionSummaries[safe: 1]?.txInfo, self.transactions[.eth]?[safe: 0] ?? .init())
+        XCTAssertEqual(transactionSummaries[safe: 2]?.txInfo, self.transactions[.eth]?[safe: 1] ?? .init())
+      }
+      .store(in: &cancellables)
+    
+    store.update()
+    
+    waitForExpectations(timeout: 1) { error in
+      XCTAssertNil(error)
+    }
+  }
+}


### PR DESCRIPTION
## Summary of Changes
- Implement the Activity tab for showing transactions across all accounts in Wallet
- Caching the asset prices every 2 minutes so they aren't fetched every time tab is opened

This pull request fixes #7198

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Open wallet and verify Activity tab is shown & visible
2. Tap Activity tab and verify 
    - transactions from all selected networks are shown
    - rejected transactions are filtered out (they are still shown in account detail / account activity)
    - transaction detail opens as expected on tap


## Screenshots:

![Activity tab](https://user-images.githubusercontent.com/5314553/232068433-2ca29ea4-eff7-44e4-9652-2106427fa14c.png) | ![Activity tab - iPad](https://user-images.githubusercontent.com/5314553/232070187-e71b3787-21a9-474b-a947-35ee7f112cc1.png)
--|--


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
