### PR TITLE
Fix #7249: Resolve Wallet warnings

### DIFF
--- a/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
@@ -266,7 +266,7 @@ public class SendTokenStore: ObservableObject {
         await validateEthereumSendAddress(fromAddress: sendFromAddress)
       case .sol:
         await validateSolanaSendAddress(fromAddress: sendFromAddress)
-      case .fil:
+      case .fil, .btc:
         break
       @unknown default:
         break

--- a/Sources/BraveWallet/Crypto/Transactions/TransactionParser.swift
+++ b/Sources/BraveWallet/Crypto/Transactions/TransactionParser.swift
@@ -50,7 +50,7 @@ enum TransactionParser {
           gasFee = .init(fee: value, fiat: "$0.00")
         }
       }
-    case .fil:
+    case .fil, .btc:
       break
     @unknown default:
       break

--- a/Sources/BraveWallet/Extensions/BraveWalletExtensions.swift
+++ b/Sources/BraveWallet/Extensions/BraveWalletExtensions.swift
@@ -101,6 +101,8 @@ extension BraveWallet.CoinType {
       return BraveWallet.SolanaKeyringId
     case .fil:
       return BraveWallet.FilecoinKeyringId
+    case .btc:
+      return BraveWallet.BitcoinKeyringId
     @unknown default:
       return BraveWallet.DefaultKeyringId
     }
@@ -114,6 +116,8 @@ extension BraveWallet.CoinType {
       return Strings.Wallet.coinTypeSolana
     case .fil:
       return Strings.Wallet.coinTypeFilecoin
+    case .btc:
+      fallthrough
     @unknown default:
       return Strings.Wallet.coinTypeUnknown
     }
@@ -127,6 +131,8 @@ extension BraveWallet.CoinType {
       return Strings.Wallet.coinTypeSolanaDescription
     case .fil:
       return Strings.Wallet.coinTypeFilecoinDescription
+    case .btc:
+      fallthrough
     @unknown default:
       return Strings.Wallet.coinTypeUnknown
     }
@@ -140,6 +146,8 @@ extension BraveWallet.CoinType {
       return "sol-asset-icon"
     case .fil:
       return "filecoin-asset-icon"
+    case .btc:
+      fallthrough
     @unknown default:
       return ""
     }
@@ -153,6 +161,8 @@ extension BraveWallet.CoinType {
       return Strings.Wallet.defaultSolAccountName
     case .fil:
       return Strings.Wallet.defaultFilAccountName
+    case .btc:
+      fallthrough
     @unknown default:
       return ""
     }
@@ -166,6 +176,8 @@ extension BraveWallet.CoinType {
       return Strings.Wallet.defaultSecondarySolAccountName
     case .fil:
       return Strings.Wallet.defaultSecondaryFilAccountName
+    case .btc:
+      fallthrough
     @unknown default:
       return ""
     }
@@ -180,6 +192,8 @@ extension BraveWallet.CoinType {
       return 2
     case .fil:
       return 3
+    case .btc:
+      fallthrough
     @unknown default:
       return 10
     }

--- a/Sources/BraveWallet/Extensions/RpcServiceExtensions.swift
+++ b/Sources/BraveWallet/Extensions/RpcServiceExtensions.swift
@@ -83,7 +83,7 @@ extension BraveWalletJsonRpcService {
           }
         }
       }
-    case .fil:
+    case .fil, .btc:
       completion(nil)
     @unknown default:
       completion(nil)
@@ -181,7 +181,7 @@ extension BraveWalletJsonRpcService {
           }
         }
       }
-    case .fil:
+    case .fil, .btc:
       completion(nil)
     @unknown default:
       completion(nil)

--- a/Sources/BraveWallet/Panels/WalletPanelView.swift
+++ b/Sources/BraveWallet/Panels/WalletPanelView.swift
@@ -240,7 +240,7 @@ struct WalletPanelView: View {
       } else {
         return solConnectedAddresses.contains(selectedAccount.address) ? .connected : .disconnected
       }
-    case .fil:
+    case .fil, .btc:
       return .blocked
     @unknown default:
       return .blocked

--- a/Sources/BraveWallet/WalletPreferences.swift
+++ b/Sources/BraveWallet/WalletPreferences.swift
@@ -56,7 +56,7 @@ extension Preferences {
       case .sol:
         Preferences.Wallet.defaultSolWallet.reset()
         Preferences.Wallet.allowSolProviderAccess.reset()
-      case .fil:
+      case .fil, .btc:
         // not supported
         fallthrough
       @unknown default:

--- a/Tests/BraveWalletTests/PortfolioStoreTests.swift
+++ b/Tests/BraveWalletTests/PortfolioStoreTests.swift
@@ -91,6 +91,8 @@ class PortfolioStoreTests: XCTestCase {
         completion([solNetwork])
       case .fil:
         XCTFail("Should not fetch filecoin network")
+      case .btc:
+        XCTFail("Should not fetch bitcoin network")
       @unknown default:
         XCTFail("Should not fetch unknown network")
       }
@@ -136,6 +138,8 @@ class PortfolioStoreTests: XCTestCase {
         completion(mockSolUserAssets)
       case .fil:
         XCTFail("Should not fetch filecoin assets")
+      case .btc:
+        XCTFail("Should not fetch bitcoin network")
       @unknown default:
         XCTFail("Should not fetch unknown assets")
       }

--- a/Tests/BraveWalletTests/TransactionConfirmationStoreTests.swift
+++ b/Tests/BraveWalletTests/TransactionConfirmationStoreTests.swift
@@ -148,7 +148,7 @@ import BraveCore
       }
       .store(in: &cancellables)
 
-    wait(for: [prepareExpectation], timeout: 1)
+    await fulfillment(of: [prepareExpectation], timeout: 1)
   }
   
   /// Test `prepare()`  update `state` data for symbol, value, isUnlimitedApprovalRequested.
@@ -208,7 +208,7 @@ import BraveCore
       }
       .store(in: &cancellables)
     
-    wait(for: [prepareExpectation], timeout: 1)
+    await fulfillment(of: [prepareExpectation], timeout: 1)
   }
   
   /// Test `prepare()`  update `state` data for symbol, value, isUnlimitedApprovalRequested.
@@ -269,7 +269,7 @@ import BraveCore
       }
       .store(in: &cancellables)
     
-    wait(for: [prepareExpectation], timeout: 1)
+    await fulfillment(of: [prepareExpectation], timeout: 1)
   }
   
   /// Test `editAllowance(txMetaId:spenderAddress:amount:completion)` will return false if we fail to make ERC20 approve data with `BraveWalletEthTxManagerProxy`
@@ -297,9 +297,7 @@ import BraveCore
         XCTAssertEqual(id, mockTransaction.id)
       }
       .store(in: &cancellables)
-    waitForExpectations(timeout: 1) { error in
-      XCTAssertNil(error)
-    }
+    await fulfillment(of: [prepareExpectation], timeout: 1)
     
     let editExpectation = expectation(description: "edit allowance")
     store.editAllowance(
@@ -312,9 +310,7 @@ import BraveCore
         }
       }
     )
-    waitForExpectations(timeout: 1) { error in
-      XCTAssertNil(error)
-    }
+    await fulfillment(of: [editExpectation], timeout: 1)
   }
   
   /// Test `editAllowance(txMetaId:spenderAddress:amount:completion)` will return false if we fail to set new ERC20 Approve data with `BraveWalletEthTxManagerProxy`
@@ -343,9 +339,7 @@ import BraveCore
         XCTAssertEqual(id, mockTransaction.id)
       }
       .store(in: &cancellables)
-    waitForExpectations(timeout: 1) { error in
-      XCTAssertNil(error)
-    }
+    await fulfillment(of: [prepareExpectation], timeout: 1)
     
     let editExpectation = expectation(description: "edit allowance")
     store.editAllowance(
@@ -358,9 +352,7 @@ import BraveCore
         }
       }
     )
-    waitForExpectations(timeout: 1) { error in
-      XCTAssertNil(error)
-    }
+    await fulfillment(of: [editExpectation], timeout: 1)
   }
   
   /// Test `editAllowance(txMetaId:spenderAddress:amount:completion)` will return true if we suceed in creating and setting ERC20 Approve data with `BraveWalletEthTxManagerProxy`
@@ -389,9 +381,7 @@ import BraveCore
         XCTAssertEqual(id, mockTransaction.id)
       }
       .store(in: &cancellables)
-    waitForExpectations(timeout: 1) { error in
-      XCTAssertNil(error)
-    }
+    await fulfillment(of: [prepareExpectation], timeout: 1)
     
     let editExpectation = expectation(description: "edit allowance")
     store.editAllowance(
@@ -404,9 +394,7 @@ import BraveCore
         }
       }
     )
-    waitForExpectations(timeout: 1) { error in
-      XCTAssertNil(error)
-    }
+    await fulfillment(of: [editExpectation], timeout: 1)
   }
 }
 

--- a/Tests/BraveWalletTests/TransactionConfirmationStoreTests.swift
+++ b/Tests/BraveWalletTests/TransactionConfirmationStoreTests.swift
@@ -418,3 +418,20 @@ private extension BraveWallet.BlockchainToken {
     coin: .eth
   )
 }
+
+extension XCTestCase {
+  @MainActor func fulfillment(of expectations: [XCTestExpectation], timeout: TimeInterval) async {
+    #if compiler(>=5.8)
+    await fulfillment(of: expectations, timeout: timeout, enforceOrder: false)
+    #else
+    await withCheckedContinuation { continuation in
+      waitForExpectations(timeout: timeout) { error in
+        // `fulfillment(of:timeout:enforceOrder:) timeout will fail on the function
+        // Verify we did not timeout here
+        XCTAssertNil(error)
+        continuation.resume()
+      }
+    }
+    #endif
+  }
+}


### PR DESCRIPTION
## Summary of Changes
- Update async unit tests to use `fulfillment(of:timeout:enforceOrder:)` expectation API
- Update `BraveWallet.CoinType` switch statements to include `.btc` coin type

This pull request fixes #7249

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
Tests pass; there should be zero functionality changes


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
