### PR TITLE
Ref #7168: Update News widget ordering to be based on recency

### DIFF
--- a/App/BraveWidgets/News Topics/NewsTopicsModel.swift
+++ b/App/BraveWidgets/News Topics/NewsTopicsModel.swift
@@ -146,7 +146,7 @@ struct NewsTopic: Decodable, Comparable, Identifiable, Hashable {
   }
   
   static func < (lhs: Self, rhs: Self) -> Bool {
-    return lhs.score < rhs.score
+    return lhs.date < rhs.date
   }
   
   var id: String {

--- a/App/BraveWidgets/TopNewsListWidget.swift
+++ b/App/BraveWidgets/TopNewsListWidget.swift
@@ -88,6 +88,7 @@ private struct TopNewsListView: View {
     }
     .padding(.horizontal)
     .padding(.vertical, widgetFamily == .systemLarge ? 12 : 8)
+    .unredacted()
   }
   
   var body: some View {

--- a/App/BraveWidgets/TopNewsWidget.swift
+++ b/App/BraveWidgets/TopNewsWidget.swift
@@ -131,6 +131,7 @@ private struct LockScreenTopNewsView: View {
             .foregroundColor(.orange)
             .font(.system(size: 12))
             .padding(.trailing, -1)
+            .unredacted()
           Divider()
             .frame(height: 11)
           Text("\(topic.publisherName)")


### PR DESCRIPTION
Also small adjustments to the preview state of the widget

## Summary of Changes

This pull request refs #7168 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
