### PR TITLE
No Bug: Show proper error label for feed errors in news debug UI

### DIFF
--- a/Sources/BraveNews/Composer/FeedDataSource.swift
+++ b/Sources/BraveNews/Composer/FeedDataSource.swift
@@ -395,7 +395,7 @@ public class FeedDataSource: ObservableObject {
     return sources.compactMap(\.wrappedValue)
   }
 
-  private func loadFeed(for localeIdentifier: String) async throws -> [FeedItem.Content] {
+  private func loadFeed(for localeIdentifier: String) async -> [FeedItem.Content] {
     do {
       let items = try await loadResource(.feed, localeIdentifier: localeIdentifier, decodedTo: [FailableDecodable<FeedItem.Content>].self)
       if items.isEmpty {
@@ -408,7 +408,7 @@ public class FeedDataSource: ObservableObject {
     }
   }
   
-  private func loadSourceSuggestions(for localeIdentifier: String) async throws -> [String: [FeedItem.SourceSimilarity]] {
+  private func loadSourceSuggestions(for localeIdentifier: String) async -> [String: [FeedItem.SourceSimilarity]] {
     do {
       let items = try await loadResource(.sourceSuggestions, localeIdentifier: localeIdentifier, decodedTo: [String: [FailableDecodable<FeedItem.SourceSimilarity>]].self)
       if items.isEmpty {
@@ -603,7 +603,7 @@ public class FeedDataSource: ObservableObject {
         for locale in followedLocales {
           async let suggestions = loadSourceSuggestions(for: locale)
           async let items = loadFeed(for: locale)
-          let (localeSpecificItems, localeSpecificSuggestions) = try await (items, suggestions)
+          let (localeSpecificItems, localeSpecificSuggestions) = await (items, suggestions)
           self.items.append(contentsOf: localeSpecificItems)
           self.sourceSuggestions.merge(with: localeSpecificSuggestions)
         }

--- a/Sources/BraveNews/Settings/BraveNewsDebugSettingsView.swift
+++ b/Sources/BraveNews/Settings/BraveNewsDebugSettingsView.swift
@@ -107,6 +107,11 @@ public struct BraveNewsDebugSettingsView: View {
             Text("\(cards.count)")
               .foregroundColor(.secondary)
           }
+        case .failure(let error as FeedDataSource.BraveNewsError):
+          // Needed to get actual localized description defined in BraveNewsError
+          // otherwise will show the generic error string
+          Text(error.localizedDescription)
+            .foregroundColor(.secondary)
         case .failure(let error):
           Text(error.localizedDescription)
             .foregroundColor(.secondary)


### PR DESCRIPTION
## Summary of Changes

To try and help understand why some people in the UK are seeing errors loading the feed

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Screenshots:

![image](https://user-images.githubusercontent.com/529104/232101151-8db0d1a0-2c2f-4c88-9d69-58418f58f5cf.png)

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
