### PR TITLE
Fix #7259: Add In-App event behavior for the VPN promotion.

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController.swift
@@ -1183,7 +1183,7 @@ public class BrowserViewController: UIViewController {
       self.presentDefaultBrowserScreenCallout()
       self.presentBraveRewardsScreenCallout()
       self.presentCookieNotificationBlockingCalloutIfNeeded()
-      self.presentLinkReceiptCallout()
+      self.presentLinkReceiptCallout(skipSafeGuards: false)
     }
 
     screenshotHelper.viewIsVisible = true

--- a/Sources/Brave/Frontend/Browser/NavigationRouter.swift
+++ b/Sources/Brave/Frontend/Browser/NavigationRouter.swift
@@ -10,11 +10,8 @@ import BraveWidgetsModels
 
 // Used by the App to navigate to different views.
 // To open a URL use /open-url or to open a blank tab use /open-url with no params
-public enum DeepLink: Equatable {
-  public init?(urlString: String) {
-    // Currently unused for now
-    return nil
-  }
+public enum DeepLink: String {
+  case vpnCrossPlatformPromo = "vpn_promo"
 }
 
 // The root navigation for the Router. Look at the tests to see a complete URL
@@ -46,7 +43,7 @@ public enum NavigationPath: Equatable {
       return nil
     }
 
-    if urlString.starts(with: "\(scheme)://deep-link"), let deepURL = components.valueForQuery("url"), let link = DeepLink(urlString: deepURL) {
+    if urlString.starts(with: "\(scheme)://deep-link"), let deepURL = components.valueForQuery("path"), let link = DeepLink(rawValue: deepURL) {
       self = .deepLink(link)
     } else if urlString.starts(with: "\(scheme)://open-url") {
       let urlText = components.valueForQuery("url")
@@ -80,7 +77,10 @@ public enum NavigationPath: Equatable {
   }
 
   private static func handleDeepLink(_ link: DeepLink, with bvc: BrowserViewController) {
-    // Handle any deep links we add
+    switch link {
+    case .vpnCrossPlatformPromo:
+      bvc.presentVPNInAppEventCallout()
+    }
   }
 
   private static func handleURL(url: URL?, isPrivate: Bool, with bvc: BrowserViewController) {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7259 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Use production channel.
Add following url to your notes.app, copy this link to Safari browser to force opening it in Brave
`brave://deep-link?path=vpn_promo`

**Purchased VPN scenario**:
1. Install the app, buy the VPN using iOS in app purchase
2. open the deep link from Safari
3. Verify that the deep link opens "Link your receipt" popup

**No VPN scenario**:
1. Install the app.
2. open the deep link from Safari
3. Verify that the deep link opens Buy-VPN screen


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
