### PR TITLE
Fix #7103: Shields show Session Restore - Reader Mode Internal URL

### DIFF
--- a/Sources/Brave/Frontend/Shields/ShieldsViewController.swift
+++ b/Sources/Brave/Frontend/Shields/ShieldsViewController.swift
@@ -18,14 +18,9 @@ class ShieldsViewController: UIViewController, PopoverContentComponent {
   let tab: Tab
   private lazy var url: URL? = {
     guard let _url = tab.url else { return nil }
-
-    if InternalURL.isValid(url: _url),
-       let internalURL = InternalURL(_url) {
-      if internalURL.isErrorPage {
-        return internalURL.originalURLFromErrorPage
-      } else if internalURL.isWeb3URL {
-        return internalURL.extractedUrlParam?.displayURL
-      }
+    
+    if let tabURL = _url.stippedInternalURL {
+      return tabURL
     }
 
     return _url

--- a/Sources/BraveShared/Extensions/URLExtensions.swift
+++ b/Sources/BraveShared/Extensions/URLExtensions.swift
@@ -35,7 +35,7 @@ extension URL {
       case .errorPage:
         return internalURL.originalURLFromErrorPage
       case .web3Page, .sessionRestorePage, .readerModePage, .aboutHomePage:
-        return internalURL.extractedUrlParam?.displayURL
+        return internalURL.extractedUrlParam
       default:
         return nil
       }

--- a/Sources/BraveShared/Extensions/URLExtensions.swift
+++ b/Sources/BraveShared/Extensions/URLExtensions.swift
@@ -5,6 +5,7 @@
 
 import Foundation
 import BraveCore
+import Shared
 
 extension URL {
   /// Obtains a URLOrigin given the current URL
@@ -21,5 +22,61 @@ extension URL {
   /// |url| (e.g. in case of blob URLs - see OriginTest.ConstructFromGURL).
   public var origin: URLOrigin {
     .init(url: self)
+  }
+  
+  /// Obtains a clean stripped url from the current Internal URL
+  ///
+  /// Returns the original url without  internal parameters
+  public var stippedInternalURL: URL? {
+    if InternalURL.isValid(url: self),
+       let internalURL = InternalURL(self) {
+      
+      switch internalURL.urlType {
+      case .errorPage:
+        return internalURL.originalURLFromErrorPage
+      case .web3Page, .sessionRestorePage, .readerModePage, .aboutHomePage:
+        return internalURL.extractedUrlParam?.displayURL
+      default:
+        return nil
+      }
+    }
+    
+    return nil
+  }
+}
+
+extension InternalURL {
+  
+  enum URLType {
+    case sessionRestorePage
+    case errorPage
+    case readerModePage
+    case aboutHomePage
+    case web3Page
+    case other
+  }
+  
+  var urlType: URLType {
+    if isErrorPage {
+      return .errorPage
+    }
+    
+    if isWeb3URL {
+      return .web3Page
+    }
+    
+    if isReaderModePage {
+      return .readerModePage
+    }
+    
+    if isSessionRestore {
+      return .sessionRestorePage
+    }
+    
+    if isAboutHomeURL {
+      return .aboutHomePage
+    }
+    
+    return .other
   }
 }

--- a/Tests/BraveSharedTests/URLExtensionTests.swift
+++ b/Tests/BraveSharedTests/URLExtensionTests.swift
@@ -25,5 +25,15 @@ class URLExtensionTests: XCTestCase {
     urls.forEach { XCTAssertEqual(URL(string: $0.0)!.origin.serialized, $0.1) }
     badurls.forEach { XCTAssertTrue(URL(string: $0)!.origin.isOpaque) }
   }
+  
+  func testStrippedInternalURL() {
+    let urls = [
+      ("internal://local/web3/ddns?service_id=ethereum&url=http%3A%2F%2Fvitalik%2Eeth%2F", URL(string: "http://vitalik.eth/")),
+      ("internal://local/sessionrestore?url=https://en.m.wikipedia.org/wiki/Main_Page", URL(string: "https://en.m.wikipedia.org/wiki/Main_Page")),
+      ("internal://local/reader-mode?url=https://en.m.wikipedia.org/wiki/Main_Page", URL(string: "https://en.m.wikipedia.org/wiki/Main_Page"))
+    ]
+    
+    urls.forEach { XCTAssertEqual(URL(string: $0.0)!.stippedInternalURL, $0.1) }
+  }
 
 }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
Adding Internal URL display for Shields Screen

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7103

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

Test 1:

Load a page
Quit browser and relaunch
Open shields while the page is loading

Test 2:

Load a page
Activate Reader mode
Open shields

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

![1 1 1 1 2 3 1](https://user-images.githubusercontent.com/6643505/232519747-5507f5ac-d918-4835-abe9-eaa2bcca36b1.png)


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
