### PR TITLE
Fix #7158: Implement Playback where last left off spec

### DIFF
--- a/Sources/Brave/Frontend/Browser/Playlist/Controllers/PlaylistCarplayController.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/Controllers/PlaylistCarplayController.swift
@@ -1012,14 +1012,12 @@ extension PlaylistCarplayController {
   }
 
   func updateLastPlayedItem(item: PlaylistInfo) {
-    Preferences.Playlist.lastPlayedItemUrl.value = item.pageSrc
-
-    if let playTime = player.currentItem?.currentTime(),
-      Preferences.Playlist.playbackLeftOff.value {
-      Preferences.Playlist.lastPlayedItemTime.value = playTime.seconds
-    } else {
-      Preferences.Playlist.lastPlayedItemTime.value = 0.0
+    guard let playTime = player.currentItem?.currentTime() else {
+      return
     }
+    
+    let lastPlayedTime = Preferences.Playlist.playbackLeftOff.value ? playTime.seconds : 0.0
+    PlaylistItem.updateLastPlayed(itemId: item.tagId, pageSrc: item.pageSrc, lastPlayedOffset: lastPlayedTime)
   }
 
   func displayExpiredResourceError(item: PlaylistInfo?) {

--- a/Sources/Brave/Frontend/Browser/Playlist/Controllers/PlaylistCarplayController.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/Controllers/PlaylistCarplayController.swift
@@ -207,8 +207,14 @@ class PlaylistCarplayController: NSObject {
     }.store(in: &playerStateObservers)
 
     player.publisher(for: .finishedPlaying).sink { [weak self] event in
+      guard let self = self else { return }
+      
       event.mediaPlayer.pause()
       event.mediaPlayer.seek(to: .zero)
+      
+      if let item = PlaylistCarplayManager.shared.currentPlaylistItem {
+        self.updateLastPlayedItem(item: item)
+      }
 
       var nowPlayingInfo = MPNowPlayingInfoCenter.default().nowPlayingInfo
       nowPlayingInfo?[MPNowPlayingInfoPropertyPlaybackProgress] = 0.0
@@ -216,7 +222,7 @@ class PlaylistCarplayController: NSObject {
       nowPlayingInfo?[MPNowPlayingInfoPropertyPlaybackRate] = 0.0
       MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlayingInfo
 
-      self?.onNextTrack(isUserInitiated: false)
+      self.onNextTrack(isUserInitiated: false)
     }.store(in: &playerStateObservers)
   }
 

--- a/Sources/Brave/Frontend/Browser/Playlist/Controllers/PlaylistListViewController+TableViewDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/Controllers/PlaylistListViewController+TableViewDelegate.swift
@@ -382,7 +382,11 @@ extension PlaylistListViewController: UITableViewDelegate {
           PlaylistCarplayManager.shared.currentlyPlayingItemIndex = indexPath.row
           PlaylistCarplayManager.shared.currentPlaylistItem = item
           self.commitPlayerItemTransaction(at: indexPath, isExpired: false)
-          self.delegate?.updateLastPlayedItem(item: item)
+          
+          self.seekLastPlayedItem(
+            at: indexPath,
+            lastPlayedItemId: item.tagId,
+            lastPlayedTime: item.lastPlayedOffset)
         case .cancelled:
           self.commitPlayerItemTransaction(at: indexPath, isExpired: false)
           Logger.module.debug("User cancelled Playlist Playback")

--- a/Sources/Brave/Frontend/Browser/Playlist/Controllers/PlaylistMoveFolderView.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/Controllers/PlaylistMoveFolderView.swift
@@ -111,13 +111,10 @@ struct PlaylistMoveFolderView: View {
 
   private var itemDescription: String {
     if selectedItems.count == 1 {
-      return selectedItems[0].name ?? Strings.PlaylistFolders.playlistFolderMoveItemWithMultipleNoNameTitle
+      return selectedItems[0].name
     }
 
-    guard let title = selectedItems[0].name else {
-      return Strings.PlaylistFolders.playlistFolderMoveItemWithMultipleNoNameTitle
-    }
-
+    let title = selectedItems[0].name
     if selectedItems.count == 2 {
       return String.localizedStringWithFormat(Strings.PlaylistFolders.playlistFolderMoveItemDescription, title)
     }

--- a/Sources/Brave/Frontend/Browser/Playlist/Controllers/PlaylistNewFolderView.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/Controllers/PlaylistNewFolderView.swift
@@ -19,8 +19,7 @@ class PlaylistFolderImageLoader: ObservableObject {
   private var faviconTask: Task<Void, Error>?
 
   func load(thumbnail: PlaylistItem) {
-    guard let mediaSrc = thumbnail.mediaSrc,
-      let assetUrl = URL(string: mediaSrc)
+    guard let assetUrl = URL(string: thumbnail.mediaSrc)
     else {
       image = nil
       return
@@ -30,8 +29,7 @@ class PlaylistFolderImageLoader: ObservableObject {
   }
 
   func load(favIcon: PlaylistItem) {
-    guard let pageSrc = favIcon.pageSrc,
-      let favIconUrl = URL(string: pageSrc)
+    guard let favIconUrl = URL(string: favIcon.pageSrc)
     else {
       image = nil
       return
@@ -98,12 +96,10 @@ private struct PlaylistFolderImage: View {
 
           Spacer()
 
-          if let title = item.name {
-            Text(title)
-              .font(.footnote.weight(.semibold))
-              .lineLimit(2)
-              .foregroundColor(.white)
-          }
+          Text(item.name)
+            .font(.footnote.weight(.semibold))
+            .lineLimit(2)
+            .foregroundColor(.white)
         }.padding(8.0), alignment: .topLeading
       )
       .clipShape(RoundedRectangle(cornerRadius: PlaylistFolderImage.cornerRadius, style: .continuous))

--- a/Sources/Brave/Frontend/Browser/Playlist/Controllers/PlaylistViewController.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/Controllers/PlaylistViewController.swift
@@ -431,6 +431,10 @@ class PlaylistViewController: UIViewController {
 
         self.playerView.controlsView.trackBar.setTimeRange(currentTime: currentItem.currentTime(), endTime: endTime)
         event.mediaPlayer.seek(to: .zero)
+        
+        if let item = PlaylistCarplayManager.shared.currentPlaylistItem {
+          self.updateLastPlayedItem(item: item)
+        }
 
         self.playerView.controlsView.playPauseButton.isEnabled = true
         self.playerView.controlsView.playPauseButton.setImage(UIImage(named: "playlist_play", in: .module, compatibleWith: nil)!, for: .normal)

--- a/Sources/Brave/Frontend/Browser/Playlist/Controllers/PlaylistViewController.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/Controllers/PlaylistViewController.swift
@@ -56,6 +56,7 @@ class PlaylistViewController: UIViewController {
   private lazy var listController = PlaylistListViewController(playerView: playerView)
   private let detailController = PlaylistDetailViewController()
 
+  private var lastPlayedTimeObserver: Any?
   private var folderObserver: AnyCancellable?
   private var playerStateObservers = Set<AnyCancellable>()
   private var assetStateObservers = Set<AnyCancellable>()
@@ -93,11 +94,8 @@ class PlaylistViewController: UIViewController {
 
   deinit {
     // Store the last played item's time-offset
-    if let playTime = player.currentItem?.currentTime(),
-      Preferences.Playlist.playbackLeftOff.value {
-      Preferences.Playlist.lastPlayedItemTime.value = playTime.seconds
-    } else {
-      Preferences.Playlist.lastPlayedItemTime.value = 0.0
+    if let item = PlaylistCarplayManager.shared.currentPlaylistItem {
+      updateLastPlayedItem(item: item)
     }
 
     // Stop picture in picture
@@ -460,6 +458,12 @@ class PlaylistViewController: UIViewController {
       self.playerView.infoView.pictureInPictureButton.isEnabled =
         event.mediaPlayer.pictureInPictureController?.isPictureInPicturePossible == true
     }.store(in: &playerStateObservers)
+    
+    lastPlayedTimeObserver = self.player.addTimeObserver(interval: 5000, onTick: { [weak self] _ in
+      if let currentItem = PlaylistCarplayManager.shared.currentPlaylistItem {
+        self?.updateLastPlayedItem(item: currentItem)
+      }
+    })
   }
 
   private func observeFolderStates() {
@@ -595,13 +599,13 @@ extension PlaylistViewController: PlaylistViewControllerDelegate {
 
   func updateLastPlayedItem(item: PlaylistInfo) {
     Preferences.Playlist.lastPlayedItemUrl.value = item.pageSrc
-
-    if let playTime = player.currentItem?.currentTime(),
-      Preferences.Playlist.playbackLeftOff.value {
-      Preferences.Playlist.lastPlayedItemTime.value = playTime.seconds
-    } else {
-      Preferences.Playlist.lastPlayedItemTime.value = 0.0
+    
+    guard let playTime = player.currentItem?.currentTime() else {
+      return
     }
+    
+    let lastPlayedTime = Preferences.Playlist.playbackLeftOff.value ? playTime.seconds : 0.0
+    PlaylistItem.updateLastPlayed(itemId: item.tagId, pageSrc: item.pageSrc, lastPlayedOffset: lastPlayedTime)
   }
 
   func displayLoadingResourceError() {

--- a/Sources/Brave/Frontend/Browser/Playlist/Managers & Cache/PlaylistDownloadManager.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/Managers & Cache/PlaylistDownloadManager.swift
@@ -450,8 +450,7 @@ private class PlaylistFileDownloadManager: NSObject, URLSessionDownloadDelegate 
         ensureMainThread {
           if task.state != .completed,
             let item = PlaylistItem.getItem(uuid: itemId),
-            let mediaSrc = item.mediaSrc,
-            let assetUrl = URL(string: mediaSrc) {
+            let assetUrl = URL(string: item.mediaSrc) {
             let info = PlaylistInfo(item: item)
             let asset = MediaDownloadTask(id: info.tagId, name: info.name, asset: AVURLAsset(url: assetUrl, options: AVAsset.defaultOptions))
             self.activeDownloadTasks[task] = asset

--- a/Sources/Brave/Frontend/Browser/Playlist/Managers & Cache/PlaylistManager.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/Managers & Cache/PlaylistManager.swift
@@ -440,10 +440,9 @@ public class PlaylistManager: NSObject {
               includingPropertiesForKeys: nil,
               options: [.skipsHiddenFiles])
             assets.forEach({
-              if let item = PlaylistItem.cachedItem(cacheURL: $0),
-                 let itemId = item.uuid {
-                self.cancelDownload(itemId: itemId)
-                PlaylistItem.updateCache(uuid: itemId, cachedData: nil)
+              if let item = PlaylistItem.cachedItem(cacheURL: $0) {
+                self.cancelDownload(itemId: item.uuid)
+                PlaylistItem.updateCache(uuid: item.uuid, cachedData: nil)
               }
             })
           } catch {
@@ -708,6 +707,7 @@ extension PlaylistManager {
               pageTitle: item.pageTitle,
               mimeType: item.mimeType,
               duration: duration.seconds,
+              lastPlayedOffset: 0.0,
               detected: item.detected,
               dateAdded: item.dateAdded,
               tagId: item.tagId,

--- a/Sources/Brave/Frontend/Browser/Playlist/Managers & Cache/PlaylistManager.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/Managers & Cache/PlaylistManager.swift
@@ -440,9 +440,9 @@ public class PlaylistManager: NSObject {
               includingPropertiesForKeys: nil,
               options: [.skipsHiddenFiles])
             assets.forEach({
-              if let item = PlaylistItem.cachedItem(cacheURL: $0) {
-                self.cancelDownload(itemId: item.uuid)
-                PlaylistItem.updateCache(uuid: item.uuid, cachedData: nil)
+              if let item = PlaylistItem.cachedItem(cacheURL: $0), let itemId = item.uuid {
+                self.cancelDownload(itemId: itemId)
+                PlaylistItem.updateCache(uuid: itemId, cachedData: nil)
               }
             })
           } catch {

--- a/Sources/Brave/Frontend/Browser/Playlist/PlaylistSharedFolder.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/PlaylistSharedFolder.swift
@@ -31,7 +31,17 @@ struct PlaylistSharedFolderModel: Decodable {
     _creatorLink = try container.decode(URLString.self, forKey: .creatorLink)
     updateAt = try container.decode(String.self, forKey: .updateAt)
     mediaItems = try container.decode([MediaItem].self, forKey: .mediaItems).map { item in
-      PlaylistInfo(name: item.title, src: item.url.absoluteString, pageSrc: item.url.absoluteString, pageTitle: item.title, mimeType: "video", duration: 0.0, detected: true, dateAdded: Date(), tagId: item.mediaItemId, order: Int32(item.order) ?? -1)
+      PlaylistInfo(name: item.title,
+                   src: item.url.absoluteString,
+                   pageSrc: item.url.absoluteString,
+                   pageTitle: item.title,
+                   mimeType: "video",
+                   duration: 0.0,
+                   lastPlayedOffset: 0.0,
+                   detected: true,
+                   dateAdded: Date(),
+                   tagId: item.mediaItemId,
+                   order: Int32(item.order) ?? -1)
     }.sorted(by: { $0.order < $1.order })
   }
   
@@ -159,6 +169,7 @@ struct PlaylistSharedFolderNetwork {
                                        pageTitle: item.pageTitle,
                                        mimeType: newItem.mimeType,
                                        duration: duration ?? newItem.duration,
+                                       lastPlayedOffset: 0.0,
                                        detected: newItem.detected,
                                        dateAdded: newItem.dateAdded,
                                        tagId: item.tagId,

--- a/Sources/Brave/Frontend/Browser/Playlist/Utilities/PlaylistMediaStreamer.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/Utilities/PlaylistMediaStreamer.swift
@@ -137,6 +137,7 @@ class PlaylistMediaStreamer {
                                              pageTitle: newItem.pageTitle,
                                              mimeType: newItem.mimeType,
                                              duration: newItem.duration,
+                                             lastPlayedOffset: 0.0,
                                              detected: newItem.detected,
                                              dateAdded: item.dateAdded, // Keep the same dateAdded
                                              tagId: item.tagId,  // Keep the same tagId

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/PlaylistScriptHandler.swift
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/PlaylistScriptHandler.swift
@@ -136,6 +136,7 @@ class PlaylistScriptHandler: NSObject, TabContentScript {
                         pageTitle: handler.tab?.webView?.title ?? item.pageTitle,
                         mimeType: item.mimeType,
                         duration: item.duration,
+                        lastPlayedOffset: 0.0,
                         detected: item.detected,
                         dateAdded: item.dateAdded,
                         tagId: item.tagId,

--- a/Sources/BraveShared/BraveStrings.swift
+++ b/Sources/BraveShared/BraveStrings.swift
@@ -1691,12 +1691,12 @@ extension Strings {
 
     public static let playlistStartPlaybackSettingsOptionTitle =
       NSLocalizedString("playlist.playlistStartPlaybackSettingsOptionTitle", tableName: "BraveShared", bundle: .module,
-        value: "Start Playback where I last left off",
+        value: "Remember file playback position",
         comment: "Title for the Playlist Settings Option for Enable/Disable ability to start playing from the point where user last left-off")
 
     public static let playlistStartPlaybackSettingsFooterText =
       NSLocalizedString("playlist.playlistStartPlaybackSettingsFooterText", tableName: "BraveShared", bundle: .module,
-        value: "This option will enable/disable the ability to start playback of media (video/audio) from the time where you last left off.",
+        value: "For individual files, resume playing from the point of last pause.",
         comment: "Footer Text for the Playlist Settings Option for Enable/Disable ability to start playing from the point where user last left-off")
 
     public static let playlistAutoSaveOptionOn =

--- a/Sources/Data/models/Model.xcdatamodeld/Model19.xcdatamodel/contents
+++ b/Sources/Data/models/Model.xcdatamodeld/Model19.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21754" systemVersion="22E252" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21754" systemVersion="22E261" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="BlockedResource" representedClassName="Data.BlockedResource" syncable="YES">
         <attribute name="domain" optional="YES" attributeType="String"/>
         <attribute name="faviconUrl" optional="YES" attributeType="String"/>

--- a/Sources/Data/models/Model.xcdatamodeld/Model19.xcdatamodel/contents
+++ b/Sources/Data/models/Model.xcdatamodeld/Model19.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21513" systemVersion="22A380" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21754" systemVersion="22E252" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="BlockedResource" representedClassName="Data.BlockedResource" syncable="YES">
         <attribute name="domain" optional="YES" attributeType="String"/>
         <attribute name="faviconUrl" optional="YES" attributeType="String"/>
@@ -141,6 +141,7 @@
         <attribute name="cachedData" optional="YES" attributeType="Binary"/>
         <attribute name="dateAdded" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="duration" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="lastPlayedOffset" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
         <attribute name="mediaSrc" attributeType="String"/>
         <attribute name="mimeType" attributeType="String"/>
         <attribute name="name" attributeType="String"/>

--- a/Sources/Data/models/PlaylistInfo.swift
+++ b/Sources/Data/models/PlaylistInfo.swift
@@ -15,6 +15,7 @@ public struct PlaylistInfo: Codable, Identifiable, Hashable, Equatable {
   public let pageTitle: String
   public let mimeType: String
   public let duration: TimeInterval
+  public let lastPlayedOffset: TimeInterval
   public let detected: Bool
   public let dateAdded: Date
   public let tagId: String
@@ -31,6 +32,7 @@ public struct PlaylistInfo: Codable, Identifiable, Hashable, Equatable {
     self.pageTitle = ""
     self.mimeType = ""
     self.duration = 0.0
+    self.lastPlayedOffset = 0.0
     self.dateAdded = Date()
     self.detected = false
     self.tagId = UUID().uuidString
@@ -38,25 +40,27 @@ public struct PlaylistInfo: Codable, Identifiable, Hashable, Equatable {
   }
 
   public init(item: PlaylistItem) {
-    self.name = item.name ?? ""
-    self.src = item.mediaSrc ?? ""
-    self.pageSrc = item.pageSrc ?? ""
+    self.name = item.name
+    self.src = item.mediaSrc
+    self.pageSrc = item.pageSrc
     self.pageTitle = item.pageTitle ?? ""
-    self.mimeType = item.mimeType ?? ""
+    self.mimeType = item.mimeType
     self.duration = item.duration
-    self.dateAdded = item.dateAdded ?? Date()
+    self.lastPlayedOffset = item.lastPlayedOffset
+    self.dateAdded = item.dateAdded
     self.detected = false
     self.tagId = item.uuid ?? UUID().uuidString
     self.order = item.order
   }
 
-  public init(name: String, src: String, pageSrc: String, pageTitle: String, mimeType: String, duration: TimeInterval, detected: Bool, dateAdded: Date, tagId: String, order: Int32) {
+  public init(name: String, src: String, pageSrc: String, pageTitle: String, mimeType: String, duration: TimeInterval, lastPlayedOffset: TimeInterval, detected: Bool, dateAdded: Date, tagId: String, order: Int32) {
     self.name = name
     self.src = src
     self.pageSrc = pageSrc
     self.pageTitle = pageTitle
     self.mimeType = mimeType
     self.duration = duration
+    self.lastPlayedOffset = lastPlayedOffset
     self.detected = detected
     self.dateAdded = dateAdded
     self.tagId = tagId.isEmpty ? UUID().uuidString : tagId
@@ -71,6 +75,7 @@ public struct PlaylistInfo: Codable, Identifiable, Hashable, Equatable {
     self.pageTitle = try container.decode(String.self, forKey: .pageTitle)
     self.mimeType = try container.decodeIfPresent(String.self, forKey: .mimeType) ?? ""
     self.duration = try container.decodeIfPresent(TimeInterval.self, forKey: .duration) ?? 0.0
+    self.lastPlayedOffset = try container.decodeIfPresent(TimeInterval.self, forKey: .lastPlayedOffset) ?? 0.0
     self.detected = try container.decodeIfPresent(Bool.self, forKey: .detected) ?? false
     self.tagId = try container.decodeIfPresent(String.self, forKey: .tagId) ?? UUID().uuidString
     self.dateAdded = Date()
@@ -121,6 +126,7 @@ public struct PlaylistInfo: Codable, Identifiable, Hashable, Equatable {
     case pageTitle
     case mimeType
     case duration
+    case lastPlayedOffset
     case detected
     case tagId
     case dateAdded

--- a/Sources/Data/models/PlaylistItem.swift
+++ b/Sources/Data/models/PlaylistItem.swift
@@ -11,16 +11,48 @@ import os.log
 @objc(PlaylistItem)
 final public class PlaylistItem: NSManagedObject, CRUD, Identifiable {
   @NSManaged public var cachedData: Data?
-  @NSManaged public var dateAdded: Date?
+  @NSManaged public var dateAdded: Date
   @NSManaged public var duration: TimeInterval
-  @NSManaged public var mediaSrc: String?
-  @NSManaged public var mimeType: String?
-  @NSManaged public var name: String?
+  @NSManaged public var lastPlayedOffset: TimeInterval
+  @NSManaged public var mediaSrc: String
+  @NSManaged public var mimeType: String
+  @NSManaged public var name: String
   @NSManaged public var order: Int32
-  @NSManaged public var pageSrc: String?
+  @NSManaged public var pageSrc: String
   @NSManaged public var pageTitle: String?
-  @NSManaged public var uuid: String?
+  @NSManaged public var uuid: String
   @NSManaged public var playlistFolder: PlaylistFolder?
+  
+  @available(*, unavailable)
+  public init() {
+    fatalError("No Such Initializer: init()")
+  }
+
+  @available(*, unavailable)
+  public init(context: NSManagedObjectContext) {
+    fatalError("No Such Initializer: init(context:)")
+  }
+
+  @objc
+  private override init(entity: NSEntityDescription, insertInto context: NSManagedObjectContext?) {
+    super.init(entity: entity, insertInto: context)
+  }
+  
+  public init(context: NSManagedObjectContext, name: String, pageTitle: String?, pageSrc: String, cachedData: Data, duration: TimeInterval, mimeType: String, mediaSrc: String) {
+    let entity = Self.entity(context)
+    super.init(entity: entity, insertInto: context)
+    self.name = name
+    self.pageTitle = pageTitle
+    self.pageSrc = pageSrc
+    self.dateAdded = Date()
+    self.cachedData = cachedData
+    self.duration = duration
+    self.lastPlayedOffset = 0.0
+    self.mimeType = mimeType
+    self.mediaSrc = mediaSrc
+    self.order = .min
+    self.uuid = UUID().uuidString
+  }
 
   public var id: String {
     objectID.uriRepresentation().absoluteString
@@ -79,15 +111,14 @@ final public class PlaylistItem: NSManagedObject, CRUD, Identifiable {
 
   public static func addItem(_ item: PlaylistInfo, cachedData: Data?, completion: (() -> Void)? = nil) {
     DataController.perform(context: .new(inMemory: false), save: false) { context in
-      let playlistItem = PlaylistItem(context: context)
-      playlistItem.name = item.name
-      playlistItem.pageTitle = item.pageTitle
-      playlistItem.pageSrc = item.pageSrc
-      playlistItem.dateAdded = Date()
-      playlistItem.cachedData = cachedData ?? Data()
-      playlistItem.duration = item.duration
-      playlistItem.mimeType = item.mimeType
-      playlistItem.mediaSrc = item.src
+      let playlistItem = PlaylistItem(context: context,
+                                      name: item.name,
+                                      pageTitle: item.pageTitle,
+                                      pageSrc: item.pageSrc,
+                                      cachedData: cachedData ?? Data(),
+                                      duration: item.duration,
+                                      mimeType: item.mimeType,
+                                      mediaSrc: item.src)
       playlistItem.order = item.order
       playlistItem.uuid = item.tagId
       playlistItem.playlistFolder = PlaylistFolder.getFolder(uuid: PlaylistFolder.savedFolderUUID, context: context)
@@ -107,15 +138,14 @@ final public class PlaylistItem: NSManagedObject, CRUD, Identifiable {
         let folder = PlaylistFolder.getFolder(uuid: folderUUID, context: context)
         
         items.forEach({ item in
-          let playlistItem = PlaylistItem(context: context)
-          playlistItem.name = item.name
-          playlistItem.pageTitle = item.pageTitle
-          playlistItem.pageSrc = item.pageSrc
-          playlistItem.dateAdded = Date()
-          playlistItem.cachedData = Data()
-          playlistItem.duration = item.duration
-          playlistItem.mimeType = item.mimeType
-          playlistItem.mediaSrc = item.src
+          let playlistItem = PlaylistItem(context: context,
+                                          name: item.name,
+                                          pageTitle: item.pageTitle,
+                                          pageSrc: item.pageSrc,
+                                          cachedData: Data(),
+                                          duration: item.duration,
+                                          mimeType: item.mimeType,
+                                          mediaSrc: item.src)
           playlistItem.order = item.order
           playlistItem.uuid = item.tagId
           playlistItem.playlistFolder = folder
@@ -136,16 +166,15 @@ final public class PlaylistItem: NSManagedObject, CRUD, Identifiable {
       let folder = PlaylistFolder.getFolder(uuid: folderUUID, context: context)
       
       items.forEach({ item in
-        let playlistItem = PlaylistItem(context: context)
-        playlistItem.cachedData = item.cachedData
-        playlistItem.dateAdded = item.dateAdded
-        playlistItem.duration = item.duration
-        playlistItem.mediaSrc = item.mediaSrc
-        playlistItem.mimeType = item.mimeType
-        playlistItem.name = item.name
+        let playlistItem = PlaylistItem(context: context,
+                                        name: item.name,
+                                        pageTitle: item.pageTitle,
+                                        pageSrc: item.pageSrc,
+                                        cachedData: item.cachedData ?? Data(),
+                                        duration: item.duration,
+                                        mimeType: item.mimeType,
+                                        mediaSrc: item.mediaSrc)
         playlistItem.order = item.order
-        playlistItem.pageSrc = item.pageSrc
-        playlistItem.pageTitle = item.pageTitle
         playlistItem.uuid = item.uuid
         playlistItem.playlistFolder = folder
       })
@@ -220,6 +249,18 @@ final public class PlaylistItem: NSManagedObject, CRUD, Identifiable {
       return false
     })
   }
+  
+  public static func updateLastPlayed(itemId: String, pageSrc: String, lastPlayedOffset: TimeInterval) {
+    if itemExists(pageSrc: pageSrc) || itemExists(uuid: itemId) {
+      DataController.perform(context: .new(inMemory: false), save: false) { context in
+        if let existingItem = PlaylistItem.first(where: NSPredicate(format: "pageSrc == %@ OR uuid == %@", pageSrc, itemId), context: context) {
+          existingItem.lastPlayedOffset = lastPlayedOffset
+        }
+
+        PlaylistItem.saveContext(context)
+      }
+    }
+  }
 
   public static func updateItem(_ item: PlaylistInfo, completion: (() -> Void)? = nil) {
     if itemExists(pageSrc: item.pageSrc) || itemExists(uuid: item.tagId) {
@@ -229,6 +270,7 @@ final public class PlaylistItem: NSManagedObject, CRUD, Identifiable {
           existingItem.pageTitle = item.pageTitle
           existingItem.pageSrc = item.pageSrc
           existingItem.duration = item.duration
+          existingItem.lastPlayedOffset = item.lastPlayedOffset
           existingItem.mimeType = item.mimeType
           existingItem.mediaSrc = item.src
           existingItem.uuid = item.tagId
@@ -265,18 +307,17 @@ final public class PlaylistItem: NSManagedObject, CRUD, Identifiable {
         }
       }
       
-      newItems.forEach {
-        let playlistItem = PlaylistItem(context: context)
-        playlistItem.name = $0.name
-        playlistItem.pageTitle = $0.pageTitle
-        playlistItem.pageSrc = $0.pageSrc
-        playlistItem.dateAdded = Date()
-        playlistItem.cachedData = Data()
-        playlistItem.duration = $0.duration
-        playlistItem.mimeType = $0.mimeType
-        playlistItem.mediaSrc = $0.src
-        playlistItem.order = $0.order
-        playlistItem.uuid = $0.tagId
+      newItems.forEach { item in
+        let playlistItem = PlaylistItem(context: context,
+                                        name: item.name,
+                                        pageTitle: item.pageTitle,
+                                        pageSrc: item.pageSrc,
+                                        cachedData: Data(),
+                                        duration: item.duration,
+                                        mimeType: item.mimeType,
+                                        mediaSrc: item.src)
+        playlistItem.order = item.order
+        playlistItem.uuid = item.tagId
         playlistItem.playlistFolder = PlaylistFolder.getFolder(uuid: folderUUID ?? PlaylistFolder.savedFolderUUID, context: context)
       }
       

--- a/Sources/Data/models/PlaylistItem.swift
+++ b/Sources/Data/models/PlaylistItem.swift
@@ -20,7 +20,7 @@ final public class PlaylistItem: NSManagedObject, CRUD, Identifiable {
   @NSManaged public var order: Int32
   @NSManaged public var pageSrc: String
   @NSManaged public var pageTitle: String?
-  @NSManaged public var uuid: String
+  @NSManaged public var uuid: String?
   @NSManaged public var playlistFolder: PlaylistFolder?
   
   @available(*, unavailable)


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Implement playback where last left off.
- Changed preference title and description as per spec.
- Added playback where last left off for EACH ITEM (every item plays back where last left off).

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7158

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
- Test that playing where last left off works for each item, when the preference is turned on.
- Test that playing where last left off does NOT work at all, when the preference is turned off.


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
