### PR TITLE
Fix #7113, #7181: Ability to reveal password during wallet unlock, restore, and create

### DIFF
--- a/Sources/BraveWallet/Crypto/Onboarding/CreateWalletView.swift
+++ b/Sources/BraveWallet/Crypto/Onboarding/CreateWalletView.swift
@@ -47,6 +47,7 @@ private struct CreateWalletView: View {
 
   @State private var password: String = ""
   @State private var repeatedPassword: String = ""
+  @State private var isPasswordRevealed: Bool = false
   @State private var validationError: ValidationError?
   @State private var isShowingBiometricsPrompt: Bool = false
   @State private var isSkippingBiometricsPrompt: Bool = false
@@ -111,12 +112,22 @@ private struct CreateWalletView: View {
             .multilineTextAlignment(.center)
             .fixedSize(horizontal: false, vertical: true)
           VStack {
-            SecureField(Strings.Wallet.passwordPlaceholder, text: $password)
-              .textContentType(.newPassword)
-              .textFieldStyle(BraveValidatedTextFieldStyle(error: validationError, when: .requirementsNotMet))
-            SecureField(Strings.Wallet.repeatedPasswordPlaceholder, text: $repeatedPassword, onCommit: createWallet)
-              .textContentType(.newPassword)
-              .textFieldStyle(BraveValidatedTextFieldStyle(error: validationError, when: .inputsDontMatch))
+            RevealableSecureField(
+              Strings.Wallet.passwordPlaceholder,
+              text: $password,
+              isRevealed: $isPasswordRevealed
+            )
+            .textContentType(.newPassword)
+            .textFieldStyle(BraveValidatedTextFieldStyle(error: validationError, when: .requirementsNotMet))
+            RevealableSecureField(
+              Strings.Wallet.repeatedPasswordPlaceholder,
+              showsRevealButton: false,
+              text: $repeatedPassword,
+              isRevealed: $isPasswordRevealed
+            )
+            .textContentType(.newPassword)
+            .textFieldStyle(BraveValidatedTextFieldStyle(error: validationError, when: .inputsDontMatch))
+            .onSubmit(createWallet)
           }
           .font(.subheadline)
           .padding(.horizontal, 48)

--- a/Sources/BraveWallet/Crypto/Onboarding/CreateWalletView.swift
+++ b/Sources/BraveWallet/Crypto/Onboarding/CreateWalletView.swift
@@ -136,53 +136,53 @@ private struct CreateWalletView: View {
           Text(Strings.Wallet.continueButtonTitle)
         }
         .buttonStyle(BraveFilledButtonStyle(size: .normal))
+        .background(
+          WalletPromptView(
+            isPresented: $isShowingBiometricsPrompt,
+            buttonTitle: Strings.Wallet.biometricsSetupEnableButtonTitle,
+            action: { enabled, navController in
+              // Store password in keychain
+              if enabled, case let status = keyringStore.storePasswordInKeychain(password),
+                 status != errSecSuccess {
+                let isPublic = AppConstants.buildChannel.isPublic
+                let alert = UIAlertController(
+                  title: Strings.Wallet.biometricsSetupErrorTitle,
+                  message: Strings.Wallet.biometricsSetupErrorMessage + (isPublic ? "" : " (\(status))"),
+                  preferredStyle: .alert
+                )
+                alert.addAction(.init(title: Strings.OKString, style: .default, handler: nil))
+                navController?.presentedViewController?.present(alert, animated: true)
+                return false
+              }
+              let controller = UIHostingController(
+                rootView: BackupWalletView(
+                  password: password,
+                  keyringStore: keyringStore
+                )
+              )
+              navController?.pushViewController(controller, animated: true)
+              return true
+            },
+            content: {
+              VStack {
+                Image(sharedName: "pin-migration-graphic")
+                  .resizable()
+                  .aspectRatio(contentMode: .fit)
+                  .frame(maxWidth: 250)
+                  .padding()
+                Text(Strings.Wallet.biometricsSetupTitle)
+                  .font(.headline)
+                  .fixedSize(horizontal: false, vertical: true)
+                  .multilineTextAlignment(.center)
+                  .padding(.bottom)
+              }
+            }
+          )
+        )
       }
       .frame(maxHeight: .infinity, alignment: .top)
       .padding()
       .padding(.vertical)
-      .background(
-        WalletPromptView(
-          isPresented: $isShowingBiometricsPrompt,
-          buttonTitle: Strings.Wallet.biometricsSetupEnableButtonTitle,
-          action: { enabled, navController in
-            // Store password in keychain
-            if enabled, case let status = keyringStore.storePasswordInKeychain(password),
-               status != errSecSuccess {
-              let isPublic = AppConstants.buildChannel.isPublic
-              let alert = UIAlertController(
-                title: Strings.Wallet.biometricsSetupErrorTitle,
-                message: Strings.Wallet.biometricsSetupErrorMessage + (isPublic ? "" : " (\(status))"),
-                preferredStyle: .alert
-              )
-              alert.addAction(.init(title: Strings.OKString, style: .default, handler: nil))
-              navController?.presentedViewController?.present(alert, animated: true)
-              return false
-            }
-            let controller = UIHostingController(
-              rootView: BackupWalletView(
-                password: password,
-                keyringStore: keyringStore
-              )
-            )
-            navController?.pushViewController(controller, animated: true)
-            return true
-          },
-          content: {
-            VStack {
-              Image(sharedName: "pin-migration-graphic")
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .frame(maxWidth: 250)
-                .padding()
-              Text(Strings.Wallet.biometricsSetupTitle)
-                .font(.headline)
-                .fixedSize(horizontal: false, vertical: true)
-                .multilineTextAlignment(.center)
-                .padding(.bottom)
-            }
-          }
-        )
-      )
       .background(
         NavigationLink(
           destination: BackupWalletView(password: password, keyringStore: keyringStore),

--- a/Sources/BraveWallet/Crypto/Onboarding/RestoreWalletView.swift
+++ b/Sources/BraveWallet/Crypto/Onboarding/RestoreWalletView.swift
@@ -50,6 +50,7 @@ private struct RestoreWalletView: View {
 
   @State private var password: String = ""
   @State private var repeatedPassword: String = ""
+  @State private var isPasswordRevealed: Bool = false
   @State private var phrase: String = ""
   @State private var isEditingPhrase: Bool = false
   @State private var showingRecoveryPhase: Bool = false
@@ -192,12 +193,21 @@ private struct RestoreWalletView: View {
       VStack {
         Text(Strings.Wallet.restoreWalletNewPasswordTitle)
           .font(.subheadline.weight(.medium))
-        SecureField(Strings.Wallet.passwordPlaceholder, text: $password)
-          .textContentType(.newPassword)
-          .textFieldStyle(BraveValidatedTextFieldStyle(error: restoreError, when: .requirementsNotMet))
-        SecureField(Strings.Wallet.repeatedPasswordPlaceholder, text: $repeatedPassword)
-          .textContentType(.newPassword)
-          .textFieldStyle(BraveValidatedTextFieldStyle(error: restoreError, when: .inputsDontMatch))
+        RevealableSecureField(
+          Strings.Wallet.passwordPlaceholder,
+          text: $password,
+          isRevealed: $isPasswordRevealed
+        )
+        .textContentType(.newPassword)
+        .textFieldStyle(BraveValidatedTextFieldStyle(error: restoreError, when: .requirementsNotMet))
+        RevealableSecureField(
+          Strings.Wallet.repeatedPasswordPlaceholder,
+          showsRevealButton: false,
+          text: $repeatedPassword,
+          isRevealed: $isPasswordRevealed
+        )
+        .textContentType(.newPassword)
+        .textFieldStyle(BraveValidatedTextFieldStyle(error: restoreError, when: .inputsDontMatch))
       }
       .font(.subheadline)
       .padding(.horizontal, 48)
@@ -210,6 +220,20 @@ private struct RestoreWalletView: View {
     .onChange(of: phrase, perform: handlePhraseChanged)
     .onChange(of: password, perform: handlePasswordChanged)
     .onChange(of: repeatedPassword, perform: handleRepeatedPasswordChanged)
+    .onChange(of: isPasswordRevealed) { isPasswordRevealed in
+      // only reveal password or recovery phrase, not both. Used to prevent
+      // 3rd-party keyboard usage on this view by keeping a SecureField visible
+      if isPasswordRevealed && showingRecoveryPhase {
+        showingRecoveryPhase = false
+      }
+    }
+    .onChange(of: showingRecoveryPhase) { showingRecoveryPhase in
+      // only reveal password or recovery phrase, not both. Used to prevent
+      // 3rd-party keyboard usage on this view by keeping a SecureField visible
+      if showingRecoveryPhase && isPasswordRevealed {
+        isPasswordRevealed = false
+      }
+    }
     .background(
       WalletPromptView(
         isPresented: $keyringStore.isRestoreFromUnlockBiometricsPromptVisible,

--- a/Sources/BraveWallet/Crypto/Onboarding/RestoreWalletView.swift
+++ b/Sources/BraveWallet/Crypto/Onboarding/RestoreWalletView.swift
@@ -145,6 +145,7 @@ private struct RestoreWalletView: View {
           }
         }
         .textFieldStyle(BraveValidatedTextFieldStyle(error: restoreError, when: .invalidPhrase))
+        .textInputAutocapitalization(.never)
         if isShowingLegacyWalletToggle {
           HStack {
             Toggle(Strings.Wallet.restoreWalletImportFromLegacyBraveWallet, isOn: $isBraveLegacyWallet)

--- a/Sources/BraveWallet/Crypto/UnlockWalletView.swift
+++ b/Sources/BraveWallet/Crypto/UnlockWalletView.swift
@@ -12,6 +12,7 @@ struct UnlockWalletView: View {
   @ObservedObject var keyringStore: KeyringStore
 
   @State private var password: String = ""
+  @State private var isPasswordRevealed: Bool = false
   @State private var unlockError: UnlockError?
   @State private var attemptedBiometricsUnlock: Bool = false
 
@@ -45,6 +46,8 @@ struct UnlockWalletView: View {
 
   private func fillPasswordFromKeychain() {
     if let password = keyringStore.retrievePasswordFromKeychain() {
+      // hide password (if revealed) before populating field with stored password
+      isPasswordRevealed = false
       self.password = password
       unlock()
     }
@@ -80,13 +83,14 @@ struct UnlockWalletView: View {
             .multilineTextAlignment(.center)
             .fixedSize(horizontal: false, vertical: true)
           HStack {
-            SecureField(Strings.Wallet.passwordPlaceholder, text: $password, onCommit: unlock)
+            RevealableSecureField(Strings.Wallet.passwordPlaceholder, text: $password, isRevealed: $isPasswordRevealed)
               .textContentType(.password)
               .font(.subheadline)
               .introspectTextField(customize: { tf in
                 tf.becomeFirstResponder()
               })
               .textFieldStyle(BraveValidatedTextFieldStyle(error: unlockError))
+              .onSubmit(unlock)
             if keyringStore.isKeychainPasswordStored, let icon = biometricsIcon {
               Button(action: fillPasswordFromKeychain) {
                 icon

--- a/Sources/BraveWallet/RevealableSecureField.swift
+++ b/Sources/BraveWallet/RevealableSecureField.swift
@@ -1,0 +1,72 @@
+// Copyright 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import SwiftUI
+
+struct RevealableSecureField: View {
+  
+  private enum Focus: Hashable {
+    case secure
+    case visible
+  }
+
+  let placeholder: String
+  let showsRevealButton: Bool
+  @Binding var text: String
+  @Binding var isRevealed: Bool
+  @FocusState private var focus: Focus?
+  
+  init(
+    _ placeholder: String,
+    showsRevealButton: Bool = true,
+    text: Binding<String>,
+    isRevealed: Binding<Bool>
+  ) {
+    self.placeholder = placeholder
+    self.showsRevealButton = showsRevealButton
+    self._text = text
+    self._isRevealed = isRevealed
+  }
+
+  var body: some View {
+    HStack(alignment: .firstTextBaseline) {
+      Group {
+        if isRevealed {
+          TextField(placeholder, text: $text)
+            .focused($focus, equals: .visible)
+        } else {
+          SecureField(placeholder, text: $text)
+            .focused($focus, equals: .secure)
+        }
+      }
+      .keyboardType(.asciiCapable)
+      .autocorrectionDisabled(true)
+      .autocapitalization(.none)
+      .introspectTextField {
+        $0.autocorrectionType = .no
+        $0.autocapitalizationType = .none
+        $0.spellCheckingType = .no
+      }
+      if showsRevealButton {
+        Button(action: {
+          if let focus { // if user has a field focused
+            // focus the new field automatically
+            if focus == .secure {
+              self.focus = .visible
+            } else {
+              self.focus = .secure
+            }
+          }
+          self.isRevealed.toggle()
+        }) {
+          Image(braveSystemName: isRevealed ? "brave.eye.slash" : "brave.eye")
+            .contentShape(Rectangle())
+            .transition(.identity)
+            .animation(nil, value: isRevealed)
+        }
+      }
+    }
+  }
+}

--- a/Sources/BraveWallet/RevealableSecureField.swift
+++ b/Sources/BraveWallet/RevealableSecureField.swift
@@ -61,7 +61,7 @@ struct RevealableSecureField: View {
           }
           self.isRevealed.toggle()
         }) {
-          Image(braveSystemName: isRevealed ? "brave.eye.slash" : "brave.eye")
+          Image(braveSystemName: isRevealed ? "leo.eye.off" : "leo.eye.on")
             .contentShape(Rectangle())
             .transition(.identity)
             .animation(nil, value: isRevealed)

--- a/Sources/BraveWallet/RevealableSecureField.swift
+++ b/Sources/BraveWallet/RevealableSecureField.swift
@@ -31,7 +31,7 @@ struct RevealableSecureField: View {
   }
 
   var body: some View {
-    HStack(alignment: .firstTextBaseline) {
+    HStack(alignment: .firstTextBaseline, spacing: 4) {
       Group {
         if isRevealed {
           TextField(placeholder, text: $text)
@@ -62,6 +62,8 @@ struct RevealableSecureField: View {
           self.isRevealed.toggle()
         }) {
           Image(braveSystemName: isRevealed ? "leo.eye.off" : "leo.eye.on")
+            .padding(.vertical, 6)
+            .padding(.horizontal, 4)
             .contentShape(Rectangle())
             .transition(.identity)
             .animation(nil, value: isRevealed)


### PR DESCRIPTION
## Summary of Changes
- Add a button beside the password field to reveal the entered password, moved biometrics buttons below (having 2 buttons beside the field looked too busy).
- When unlocking a wallet, the password field will be set to secure/hidden before we auto-fill the password via biometrics (when applicable).
- When restoring a wallet, revealing the recovery phrase will hide the password(s) and vice-versa. 
    - This is done to keep a `SecureField` on screen which will blocks 3rd-party keyboards on this view.
    - Unlock wallet & create/setup wallet do not need this. iOS seems to detect that a `SecureField` was present on screen previously and password is being revealed, where having 3 fields on view for restore seems to trip up that logic and allows 3rd-party keyboards when the fields are revealed. 
    - Removing the `.onChange(of: isPasswordRevealed)` & `.onChange(of: showingRecoveryPhase)` logic from `RestoreWalletView` will allow 3rd-party keyboards when the fields are revealed.
- Designs: https://www.figma.com/file/oXIiv45pIhF2RGlpEjOfUg/Wallet-onboarding?node-id=50-11678&t=Lrq127EJo2HLMio1-0

This pull request fixes #7113, fixes #7181

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
Needs tested on device with 3rd-party keyboard installed. I haven't noticed any behaviour differences between iOS 15 and iOS 16.
- Verify you cannot get 3rd-party keyboard to show for fields on Unlock, Restore and Create (setup new wallet) views.
- Verify password is revealed when eye button is tapped; hidden when crossed-eye button is tapped.
- Verify that auto-filling password via biometrics will hide / mask the password before autofilling.


## Screenshots:

iPhone 14 Pro | iPhone 8
--|--
![iPhone 14 Pro](https://user-images.githubusercontent.com/5314553/232587016-7ce97baa-79ba-4ba8-8918-b9d54eff68a1.png) | ![iPhone 8](https://user-images.githubusercontent.com/5314553/232587030-8ee4fcdc-caff-4606-b26f-c5f8cfcc6d0d.png)


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
