### PR TITLE
Fix #6824: Recent searches 'show more' text is cut in some languages

### DIFF
--- a/Sources/Brave/Frontend/Browser/Search/Recent Search/RecentSearchHeaderView.swift
+++ b/Sources/Brave/Frontend/Browser/Search/Recent Search/RecentSearchHeaderView.swift
@@ -19,8 +19,10 @@ class RecentSearchHeaderView: UICollectionReusableView {
 
   private let titleLabel = UILabel().then {
     $0.text = Strings.recentSearchSectionTitle
-    $0.font = .systemFont(ofSize: 17.0, weight: .semibold)
+    $0.font = .systemFont(ofSize: 15.0, weight: .semibold)
     $0.textColor = .braveLabel
+    $0.setContentHuggingPriority(.required, for: .horizontal)
+    $0.setContentCompressionResistancePriority(.required, for: .horizontal)
   }
 
   private let subtitleLabel = UILabel().then {
@@ -83,21 +85,33 @@ class RecentSearchHeaderView: UICollectionReusableView {
 
     let spacer = UIView().then {
       $0.setContentHuggingPriority(.defaultLow, for: .horizontal)
-      $0.setContentCompressionResistancePriority(.required, for: .horizontal)
+      $0.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
     }
 
     if showRecentSearches {
       vStackView.addArrangedSubview(hStackView)
 
       [titleLabel, spacer, showButton, hideClearButton].forEach(hStackView.addArrangedSubview(_:))
+      hStackView.setCustomSpacing(0, after: spacer)
+      hStackView.setCustomSpacing(15, after: showButton)
+
+      showButton.do {
+        $0.setContentHuggingPriority(.required, for: .horizontal)
+        $0.setContentCompressionResistancePriority(.required, for: .horizontal)
+        $0.contentHorizontalAlignment = .leading
+      }
+
+      hideClearButton.do {
+        $0.setContentHuggingPriority(.required, for: .horizontal)
+        $0.setContentCompressionResistancePriority(.required, for: .horizontal)
+        $0.contentHorizontalAlignment = .trailing
+      }
 
       showButton.snp.makeConstraints {
-        $0.width.equalTo(hideClearButton)
         $0.height.lessThanOrEqualTo(DesignUX.buttonHeight)
       }
 
       hideClearButton.snp.makeConstraints {
-        $0.width.equalTo(showButton)
         $0.height.lessThanOrEqualTo(DesignUX.buttonHeight)
       }
     } else {
@@ -105,6 +119,7 @@ class RecentSearchHeaderView: UICollectionReusableView {
         self.vStackView.addArrangedSubview($0)
       })
 
+      vStackView.setCustomSpacing(12.0, after: titleLabel)
       vStackView.setCustomSpacing(22.0, after: subtitleLabel)
 
       [showButton, hideClearButton, spacer].forEach({


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

Recent Search button display is  altered to have better visuals

- Preventing the button action titles to cut-off in normal mode
- The aligning of right action titles with trailing arrow of suggestion button 

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6824

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [ ] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

- The aligning of right action titles with trailing arrow of suggestion button 

![1 1 1](https://user-images.githubusercontent.com/6643505/232613264-29ead96a-5d2a-44d8-a6da-f98087940b34.png)

- Preventing the button action titles to cut-off in normal mode

![1 1 2 1 3 1 1](https://user-images.githubusercontent.com/6643505/232613776-d6dd0cd2-cf73-4dd6-87d1-703ca2e8b38f.png)


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
