### PR TITLE
No Bug: Log Brave blocking

### DIFF
--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Paged/RequestBlockingScript.js
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Paged/RequestBlockingScript.js
@@ -16,6 +16,9 @@ window.__firefox__.execute(function($) {
         sourceURL: window.location.href,
         resourceType: 'xmlhttprequest'
       }
+    }).then(blocked => {
+      console.info(`Brave prevented frame displaying ${window.location.href} from loading a resource from ${resourceURL.href}`)
+      return blocked
     });
   });
   

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Paged/RequestBlockingScript.js
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Paged/RequestBlockingScript.js
@@ -17,7 +17,10 @@ window.__firefox__.execute(function($) {
         resourceType: 'xmlhttprequest'
       }
     }).then(blocked => {
-      console.info(`Brave prevented frame displaying ${window.location.href} from loading a resource from ${resourceURL.href}`)
+      if (blocked) {
+        console.info(`Brave prevented frame displaying ${window.location.href} from loading a resource from ${resourceURL.href}`)
+      }
+      
       return blocked
     });
   });


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
Add brave blocking info in console similar to the format Content Blockers use. the purpose is to facilitate the debugging of webcompat issues

The following screenshot shows the output of our logs along side the built in (apple) content blocker logs:
<img width="1096" alt="Screenshot 2023-04-19 at 11 37 26 AM" src="https://user-images.githubusercontent.com/909331/233034514-f60e7cae-25a5-4ca0-a4a2-1fa061bd8891.png">


<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request has no fix

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
