### PR TITLE
Fix #7278: Disable incompatible filter lists

### DIFF
--- a/Sources/Brave/WebFilters/FilterList.swift
+++ b/Sources/Brave/WebFilters/FilterList.swift
@@ -19,6 +19,12 @@ struct FilterList: Identifiable {
   public static let maintainedRegionalComponentIDs = [
     "llgjaaddopeckcifdceaaadmemagkepi" // Japanese filter lists
   ]
+  /// This is a list of disabled filter lists. These lists are disabled because they are incompatible with iOS (for the time being)
+  public static let disabledComponentIDs = [
+    // The Anti-porn list has 500251 rules and is strictly all content blocking driven content
+    // The limit for the rule store is 150000 rules. We have no way to handle this at the current moment
+    "lbnibkdpkdjnookgfeogjdanfenekmpe"
+  ]
   
   /// All the component ids that should be set to on by default.
   public static var defaultOnComponentIds: Set<String> {
@@ -36,11 +42,13 @@ struct FilterList: Identifiable {
   }
   
   var id: String { return entry.uuid }
+  let order: Int
   let entry: AdblockFilterListCatalogEntry
   var isEnabled: Bool = false
   
-  init(from entry: AdblockFilterListCatalogEntry, isEnabled: Bool) {
+  init(from entry: AdblockFilterListCatalogEntry, order: Int, isEnabled: Bool) {
     self.entry = entry
+    self.order = order
     self.isEnabled = isEnabled
   }
 }

--- a/Sources/Brave/WebFilters/FilterListResourceDownloader.swift
+++ b/Sources/Brave/WebFilters/FilterListResourceDownloader.swift
@@ -194,7 +194,6 @@ public class FilterListResourceDownloader {
   @MainActor private func register(filterList: FilterList) {
     guard adBlockServiceTasks[filterList.uuid] == nil else { return }
     guard let adBlockService = adBlockService else { return }
-    guard let index = FilterListStorage.shared.filterLists.firstIndex(where: { $0.id == filterList.id }) else { return }
     startFetchingGenericContentBlockingBehaviors(for: filterList)
 
     adBlockServiceTasks[filterList.uuid] = Task { @MainActor in
@@ -203,7 +202,7 @@ public class FilterListResourceDownloader {
         guard FilterListStorage.shared.isEnabled(for: filterList.entry.componentId) else { return }
         
         await self.addEngineResources(
-          forFilterListUUID: filterList.uuid, downloadedFolderURL: folderURL, relativeOrder: index
+          forFilterListUUID: filterList.uuid, downloadedFolderURL: folderURL, relativeOrder: filterList.order
         )
         
         // Save the downloaded folder for later (caching) purposes


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7278 

This PR disables the anti-porn list as it is broken with no clear idea of how to fix it in the short run.

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
STR in the ticket

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
