### PR TITLE
Fix #7242: Bump Brave Core to 1.51.97

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@mozilla/readability": "^0.4.2",
-        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.51.87/brave-core-ios-1.51.87.tgz",
+        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.51.97/brave-core-ios-1.51.97.tgz",
         "page-metadata-parser": "^1.1.3",
         "webpack-cli": "^4.8.0"
       },
@@ -355,9 +355,9 @@
       }
     },
     "node_modules/brave-core-ios": {
-      "version": "1.51.87",
-      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.51.87/brave-core-ios-1.51.87.tgz",
-      "integrity": "sha512-M/GFJoqfjcv+JEYF/hgW4ktNqBW3rDMfMi2TUZZhTnbg7uk1HQiP1ECqqPal3oi5T6YHyV4UNhNSiuY+IQfxsQ==",
+      "version": "1.51.97",
+      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.51.97/brave-core-ios-1.51.97.tgz",
+      "integrity": "sha512-uGrxbUPfrJaD4pxjQ5L7vJ2iBJ+EcqYatLMt1+kF7Fqk4A8PMbM2Y/xorR8kPU7D3y8mGh693UT9qJi2gDbMwg==",
       "license": "ISC"
     },
     "node_modules/browserslist": {
@@ -1731,8 +1731,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-browser/releases/download/v1.51.87/brave-core-ios-1.51.87.tgz",
-      "integrity": "sha512-M/GFJoqfjcv+JEYF/hgW4ktNqBW3rDMfMi2TUZZhTnbg7uk1HQiP1ECqqPal3oi5T6YHyV4UNhNSiuY+IQfxsQ=="
+      "version": "https://github.com/brave/brave-browser/releases/download/v1.51.97/brave-core-ios-1.51.97.tgz",
+      "integrity": "sha512-uGrxbUPfrJaD4pxjQ5L7vJ2iBJ+EcqYatLMt1+kF7Fqk4A8PMbM2Y/xorR8kPU7D3y8mGh693UT9qJi2gDbMwg=="
     },
     "browserslist": {
       "version": "4.17.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.51.87/brave-core-ios-1.51.87.tgz",
+    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.51.97/brave-core-ios-1.51.97.tgz",
     "page-metadata-parser": "^1.1.3",
     "@mozilla/readability": "^0.4.2",
     "webpack-cli": "^4.8.0"


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #7242

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
