### PR TITLE
Revert "Fix #7242: Bump Brave Core to 1.51.97"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@mozilla/readability": "^0.4.2",
-        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.51.97/brave-core-ios-1.51.97.tgz",
+        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.51.87/brave-core-ios-1.51.87.tgz",
         "page-metadata-parser": "^1.1.3",
         "webpack-cli": "^4.8.0"
       },
@@ -355,9 +355,9 @@
       }
     },
     "node_modules/brave-core-ios": {
-      "version": "1.51.97",
-      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.51.97/brave-core-ios-1.51.97.tgz",
-      "integrity": "sha512-uGrxbUPfrJaD4pxjQ5L7vJ2iBJ+EcqYatLMt1+kF7Fqk4A8PMbM2Y/xorR8kPU7D3y8mGh693UT9qJi2gDbMwg==",
+      "version": "1.51.87",
+      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.51.87/brave-core-ios-1.51.87.tgz",
+      "integrity": "sha512-M/GFJoqfjcv+JEYF/hgW4ktNqBW3rDMfMi2TUZZhTnbg7uk1HQiP1ECqqPal3oi5T6YHyV4UNhNSiuY+IQfxsQ==",
       "license": "ISC"
     },
     "node_modules/browserslist": {
@@ -1731,8 +1731,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-browser/releases/download/v1.51.97/brave-core-ios-1.51.97.tgz",
-      "integrity": "sha512-uGrxbUPfrJaD4pxjQ5L7vJ2iBJ+EcqYatLMt1+kF7Fqk4A8PMbM2Y/xorR8kPU7D3y8mGh693UT9qJi2gDbMwg=="
+      "version": "https://github.com/brave/brave-browser/releases/download/v1.51.87/brave-core-ios-1.51.87.tgz",
+      "integrity": "sha512-M/GFJoqfjcv+JEYF/hgW4ktNqBW3rDMfMi2TUZZhTnbg7uk1HQiP1ECqqPal3oi5T6YHyV4UNhNSiuY+IQfxsQ=="
     },
     "browserslist": {
       "version": "4.17.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.51.97/brave-core-ios-1.51.97.tgz",
+    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.51.87/brave-core-ios-1.51.87.tgz",
     "page-metadata-parser": "^1.1.3",
     "@mozilla/readability": "^0.4.2",
     "webpack-cli": "^4.8.0"


### PR DESCRIPTION
Reverts brave/brave-ios#7297 due to a crash on device.

ref: https://bravesoftware.slack.com/archives/C7VLGSR55/p1682013501977969