### PR TITLE
Fix #7305: Fix wallet activity tab, add account backgrounds

### DIFF
--- a/Sources/BraveWallet/Crypto/Accounts/Add/AddAccountView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/Add/AddAccountView.swift
@@ -152,6 +152,7 @@ struct AddAccountView: View {
               }
               .padding(.vertical, 10)
             }
+            .listRowBackground(Color(.secondaryBraveGroupedBackground))
         }
       }
     }

--- a/Sources/BraveWallet/Crypto/TransactionsActivityView.swift
+++ b/Sources/BraveWallet/Crypto/TransactionsActivityView.swift
@@ -21,16 +21,20 @@ struct TransactionsActivityView: View {
           emptyState
             .listRowBackground(Color.clear)
         } else {
-          ForEach(store.transactionSummaries) { txSummary in
-            Button(action: {
-              self.transactionDetails = store.transactionDetailsStore(for: txSummary.txInfo)
-            }) {
-              TransactionSummaryView(summary: txSummary)
+          Group {
+            ForEach(store.transactionSummaries) { txSummary in
+              Button(action: {
+                self.transactionDetails = store.transactionDetailsStore(for: txSummary.txInfo)
+              }) {
+                TransactionSummaryView(summary: txSummary)
+              }
             }
           }
+          .listRowBackground(Color(.secondaryBraveGroupedBackground))
         }
       }
     }
+    .listBackgroundColor(Color(UIColor.braveGroupedBackground))
     .onAppear {
       store.update()
     }


### PR DESCRIPTION
## Summary of Changes
- Set correct list background colour and list row background color on Activity tab
- Set correct list row background color on Add Account coin selection view

This pull request fixes #7305 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Open activity tab in dark mode. Verify list background color and row background color (requires at least 1 transaction not in rejected state)
2. Open Accounts tab, tap add account button in dark mode. Verify list background color and row background color are correct.


## Screenshots:
![activity](https://user-images.githubusercontent.com/5314553/233498455-b53429db-bbff-41df-87e5-865d9fceb31c.png) | ![add account](https://user-images.githubusercontent.com/5314553/233498456-ecec7277-9a2f-46f8-b045-595a3f78d2f6.png)
--|--


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
