### PR TITLE
Fix #7263: Favicons not showing

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -278,7 +278,8 @@ var package = Package(
         "SDWebImage",
       ],
       resources: [
-        .copy("Assets/top_sites.json")
+        .copy("Assets/top_sites.json"),
+        .copy("Assets/TopSites")
       ],
       plugins: ["LoggerPlugin"]
     ),


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Fix favicons not added to the Packages.swift

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7263

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
