### PR TITLE
Revert "Ref #7168: Update News widget ordering to be based on recency"

### DIFF
--- a/App/BraveWidgets/News Topics/NewsTopicsModel.swift
+++ b/App/BraveWidgets/News Topics/NewsTopicsModel.swift
@@ -146,7 +146,7 @@ struct NewsTopic: Decodable, Comparable, Identifiable, Hashable {
   }
   
   static func < (lhs: Self, rhs: Self) -> Bool {
-    return lhs.date < rhs.date
+    return lhs.score < rhs.score
   }
   
   var id: String {


### PR DESCRIPTION
This reverts the change that sorted News widget items by recency instead of score

original change: d4a5b39739e31415dd526737e7b1a305d2de12ea

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
