### PR TITLE
Ref #7302: Move Leo SF Symbols pull out of npm for now

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -29,6 +29,15 @@ else
   npm install
 fi
 
+echo "${COLOR_ORANGE}Fetching Leo SF Symbol assets…${COLOR_NONE}"
+if [[ -d "node_modules/leo-sf-symbols" ]]; then
+  rm -rf "node_modules/leo-sf-symbols"
+fi
+git clone https://github.com/brave/leo-sf-symbols node_modules/leo-sf-symbols
+pushd node_modules/leo-sf-symbols > /dev/null
+git reset --hard 71bd5ca
+popd > /dev/null
+
 # Delete Chromium Assets from BraveCore.framework since they aren't used.
 # TODO: Get this removed in the brave-core builds if possible
 echo "${COLOR_ORANGE}Cleaning up BraveCore framework assets…${COLOR_NONE}"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@mozilla/readability": "^0.4.2",
         "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.51.87/brave-core-ios-1.51.87.tgz",
-        "leo-sf-symbols": "github:brave/leo-sf-symbols#71bd5ca",
         "page-metadata-parser": "^1.1.3",
         "webpack-cli": "^4.8.0"
       },
@@ -781,11 +780,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/leo-sf-symbols": {
-      "version": "1.0.1",
-      "resolved": "git+ssh://git@github.com/brave/leo-sf-symbols.git#71bd5ca82c75c1e9ca617a8c1f4d6b4d18f69e18",
-      "license": "MPL-2.0"
     },
     "node_modules/loader-runner": {
       "version": "4.2.0",
@@ -2052,10 +2046,6 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
-    },
-    "leo-sf-symbols": {
-      "version": "git+ssh://git@github.com/brave/leo-sf-symbols.git#71bd5ca82c75c1e9ca617a8c1f4d6b4d18f69e18",
-      "from": "leo-sf-symbols@github:brave/leo-sf-symbols#71bd5ca"
     },
     "loader-runner": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "dependencies": {
     "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.51.87/brave-core-ios-1.51.87.tgz",
     "page-metadata-parser": "^1.1.3",
-    "leo-sf-symbols": "github:brave/leo-sf-symbols#71bd5ca",
     "@mozilla/readability": "^0.4.2",
     "webpack-cli": "^4.8.0"
   },


### PR DESCRIPTION
This avoids the requirement to have `canvas` dependencies when bootstrap runs `npm install`/`npm ci`

When the issue of pulling this via npm is resolved we can move it back into package.json

## Summary of Changes

This pull request refs #7302

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
