### PR TITLE
Fix #7312: Reset wallet from app settings does not hide wallet sections

### DIFF
--- a/Sources/BraveWallet/Settings/Web3SettingsView.swift
+++ b/Sources/BraveWallet/Settings/Web3SettingsView.swift
@@ -171,13 +171,13 @@ private struct WalletSettingsView: View {
   }
 
   var body: some View {
-    if !keyringStore.isDefaultKeyringCreated {
+    if keyringStore.isDefaultKeyringCreated {
+      sections
+    } else {
       // `KeyringStore` is optional in `Web3SettingsView`, but observed here.
       // When wallet is reset, we need SwiftUI to be notified `isDefaultKeyringCreated`
       // changed so we can hide Wallet specific sections
       EmptyView()
-    } else {
-      sections
     }
   }
   

--- a/Sources/BraveWallet/Settings/Web3SettingsView.swift
+++ b/Sources/BraveWallet/Settings/Web3SettingsView.swift
@@ -36,7 +36,7 @@ public struct Web3SettingsView: View {
   public var body: some View {
     List {
       if let settingsStore = settingsStore {
-        if let networkStore = networkStore, let keyringStore = keyringStore, keyringStore.isDefaultKeyringCreated {
+        if let networkStore = networkStore, let keyringStore = keyringStore {
           WalletSettingsView(
             settingsStore: settingsStore,
             networkStore: networkStore,
@@ -171,6 +171,17 @@ private struct WalletSettingsView: View {
   }
 
   var body: some View {
+    if !keyringStore.isDefaultKeyringCreated {
+      // `KeyringStore` is optional in `Web3SettingsView`, but observed here.
+      // When wallet is reset, we need SwiftUI to be notified `isDefaultKeyringCreated`
+      // changed so we can hide Wallet specific sections
+      EmptyView()
+    } else {
+      sections
+    }
+  }
+  
+  @ViewBuilder private var sections: some View {
     Section(
       footer: Text(Strings.Wallet.autoLockFooter)
         .foregroundColor(Color(.secondaryBraveLabel))


### PR DESCRIPTION
## Summary of Changes
- Small regression in https://github.com/brave/brave-ios/pull/6923/files caused us to no longer observe changes to `isDefaultKeyringCreated` which was being used to determine if we hide or show these Wallet specific settings sections

This pull request fixes #7312

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Setup or restore a wallet if one is not setup
2. Visit main app settings via `...` menu in Browser view.
3. Tap `Web3` section
4. Tap `Reset Brave Wallet` and confirm the reset on the alert
5. Verify Wallet specific sections are removed (everything above & including `Reset Brave Wallet` row)


## Screenshots:


https://user-images.githubusercontent.com/5314553/233716517-c8abc482-e9b2-4495-bc43-6c1359df4040.mp4




## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
