### PR TITLE
Ref #7302: Update Leo SF Symbols version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@mozilla/readability": "^0.4.2",
         "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.51.87/brave-core-ios-1.51.87.tgz",
-        "leo-sf-symbols": "github:brave/leo-sf-symbols#71bd5ca",
+        "leo-sf-symbols": "github:brave/leo-sf-symbols#07337c2dc9a52d0e065b3d0986885e3b59a7fc5e",
         "page-metadata-parser": "^1.1.3",
         "webpack-cli": "^4.8.0"
       },
@@ -784,7 +784,8 @@
     },
     "node_modules/leo-sf-symbols": {
       "version": "1.0.1",
-      "resolved": "git+ssh://git@github.com/brave/leo-sf-symbols.git#71bd5ca82c75c1e9ca617a8c1f4d6b4d18f69e18",
+      "resolved": "git+ssh://git@github.com/brave/leo-sf-symbols.git#07337c2dc9a52d0e065b3d0986885e3b59a7fc5e",
+      "integrity": "sha512-fKFuds4gfUvJbIvFmeoOYobddECtpCGyHtdLQn6iKALMW49V7ulw473NxxrGnurdtv1ysOhOYZZglg1GAri45w==",
       "license": "MPL-2.0"
     },
     "node_modules/loader-runner": {
@@ -2054,8 +2055,9 @@
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
     },
     "leo-sf-symbols": {
-      "version": "git+ssh://git@github.com/brave/leo-sf-symbols.git#71bd5ca82c75c1e9ca617a8c1f4d6b4d18f69e18",
-      "from": "leo-sf-symbols@github:brave/leo-sf-symbols#71bd5ca"
+      "version": "git+ssh://git@github.com/brave/leo-sf-symbols.git#07337c2dc9a52d0e065b3d0986885e3b59a7fc5e",
+      "integrity": "sha512-fKFuds4gfUvJbIvFmeoOYobddECtpCGyHtdLQn6iKALMW49V7ulw473NxxrGnurdtv1ysOhOYZZglg1GAri45w==",
+      "from": "leo-sf-symbols@github:brave/leo-sf-symbols#07337c2dc9a52d0e065b3d0986885e3b59a7fc5e"
     },
     "loader-runner": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.51.87/brave-core-ios-1.51.87.tgz",
     "page-metadata-parser": "^1.1.3",
-    "leo-sf-symbols": "github:brave/leo-sf-symbols#71bd5ca",
+    "leo-sf-symbols": "github:brave/leo-sf-symbols#07337c2dc9a52d0e065b3d0986885e3b59a7fc5e",
     "@mozilla/readability": "^0.4.2",
     "webpack-cli": "^4.8.0"
   },


### PR DESCRIPTION
This bumps the version to include a fix that would require a number of `canvas` dependencies to install the leo-sf-symbols package

## Summary of Changes

This pull request refs #7302

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
