### PR TITLE
Fix #7256: Revert 2.5x Playlist Speed

### DIFF
--- a/Sources/Brave/Frontend/Browser/Playlist/Controllers/PlaylistViewController.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/Controllers/PlaylistViewController.swift
@@ -362,10 +362,8 @@ class PlaylistViewController: UIViewController {
         button.setTitle("1x", for: .normal)
       } else if playbackRate == 1.5 {
         button.setTitle("1.5x", for: .normal)
-      } else if playbackRate == 2.0 {
-        button.setTitle("2.0x", for: .normal)
       } else {
-        button.setTitle("2.5x", for: .normal)
+        button.setTitle("2.0x", for: .normal)
       }
 
       if !PlaylistCarplayManager.shared.isCarPlayAvailable {

--- a/Sources/Brave/Frontend/Browser/Playlist/VideoPlayer/UI/VideoPlayer.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/VideoPlayer/UI/VideoPlayer.swift
@@ -429,9 +429,6 @@ class VideoView: UIView, VideoTrackerBarDelegate {
     } else if playbackRate == 1.5 {
       playbackRate = 2.0
       button.setTitle("2x", for: .normal)
-    } else if playbackRate == 2.0 {
-        playbackRate = 2.5
-        button.setTitle("2.5x", for: .normal)
     } else {
       playbackRate = 1.0
       button.setTitle("1x", for: .normal)


### PR DESCRIPTION
## Summary of Changes
- AVPlayer on iPad doesn't support speeds higher than 2.0x (same for AVPlayerController) when using HLS streams.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7256

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
