### PR TITLE
Fix #7260: Don't auto submit URL from a QR code

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController.swift
@@ -2412,7 +2412,11 @@ public class BrowserViewController: UIViewController {
 extension BrowserViewController {
   func didScanQRCodeWithURL(_ url: URL) {
     popToBVC()
-    finishEditingAndSubmit(url, visitType: .typed)
+    let overlayText = URLFormatter.formatURL(url.absoluteString, formatTypes: [], unescapeOptions: [])
+
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.9) {
+      self.topToolbar.enterOverlayMode(overlayText, pasted: false, search: false)
+    }
 
     if !url.isBookmarklet && !PrivateBrowsingManager.shared.isPrivateBrowsing {
       RecentSearch.addItem(type: .qrCode, text: nil, websiteUrl: url.absoluteString)

--- a/Sources/Brave/Frontend/Browser/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController.swift
@@ -1968,11 +1968,11 @@ public class BrowserViewController: UIViewController {
     present(settingsNavigationController, animated: true)
   }
 
-  func popToBVC() {
+  func popToBVC(completion: (() -> Void)? = nil) {
     guard let currentViewController = navigationController?.topViewController else {
       return
     }
-    currentViewController.dismiss(animated: true, completion: nil)
+    currentViewController.dismiss(animated: true, completion: completion)
 
     if currentViewController != self {
       _ = self.navigationController?.popViewController(animated: true)
@@ -2411,10 +2411,9 @@ public class BrowserViewController: UIViewController {
 
 extension BrowserViewController {
   func didScanQRCodeWithURL(_ url: URL) {
-    popToBVC()
     let overlayText = URLFormatter.formatURL(url.absoluteString, formatTypes: [], unescapeOptions: [])
 
-    DispatchQueue.main.asyncAfter(deadline: .now() + 0.9) {
+    popToBVC() {
       self.topToolbar.enterOverlayMode(overlayText, pasted: false, search: false)
     }
 


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
This change prevents Brave to auto navigate to a URL scanned from a QR code. URL bar will be updated with the scanned URL and the user would need to press enter to navigate to it.
<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes brave/brave-ios#7260

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
1. Tap QR code button in omnibox
2. Scan QR code (`https://brave.com`)
<img width="318" alt="image" src="https://user-images.githubusercontent.com/10810135/234002990-84a5097a-e773-4c69-a474-7e0b3b773d87.png">
3. Confirm Brave didn't navigate to the scanned URL and URL bar was updated with the scanned URL

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
