### PR TITLE
Fix #7288: Add Client controlled Brave Search fallback mixing toggle.

### DIFF
--- a/Sources/Brave/Frontend/Browser/Search/BraveSearchManager.swift
+++ b/Sources/Brave/Frontend/Browser/Search/BraveSearchManager.swift
@@ -9,6 +9,7 @@ import Shared
 import BraveShared
 import WebKit
 import os.log
+import Preferences
 
 // A helper class to handle Brave Search fallback needs.
 class BraveSearchManager: NSObject {
@@ -74,7 +75,19 @@ class BraveSearchManager: NSObject {
     self.url = url
     self.query = queryItem
     self.domainCookies = cookies.filter { $0.domain == url.host }
-    if domainCookies.first(where: { $0.name == "fallback" })?.value != "1" {
+    
+    // The fallback mixing can be set from two places:
+    // 1. Brave Search website settings
+    // 2. Brave iOS app search settings
+    // If the in-app setting is enabled it will override the website setting.
+    //
+    // States:
+    // App: ON  site: OFF -> ON
+    // App: OFF site: ON  -> ON
+    // App: OFF site: OFF -> OFF
+    // App: ON site: ON -> ON
+    if domainCookies.first(where: { $0.name == "fallback" })?.value != "1"
+        && !Preferences.General.forceBraveSearchFallbackMixing.value {
       return nil
     }
 

--- a/Sources/Brave/Frontend/ClientPreferences.swift
+++ b/Sources/Brave/Frontend/ClientPreferences.swift
@@ -82,6 +82,8 @@ extension Preferences {
     static var defaultPageZoomLevel = Option<Double>(key: "general.default-page-zoom-level", default: 1.0)
     
     static let isUsingBottomBar = Option<Bool>(key: "general.bottom-bar", default: false)
+    
+    static let forceBraveSearchFallbackMixing = Option<Bool>(key: "general.fallback-mixing", default: false)
   }
 
   final public class Search {

--- a/Sources/BraveStrings/BraveStrings.swift
+++ b/Sources/BraveStrings/BraveStrings.swift
@@ -840,6 +840,24 @@ extension Strings {
         bundle: .module,
         value: "After One Month",
         comment: "Settings option to close old tabs after 1 month")
+    public static let braveSearchSection =
+      NSLocalizedString(
+        "settings.braveSearchSection", tableName: "BraveShared",
+        bundle: .module,
+        value: "Brave Search",
+        comment: "A table section where you can update your Brave Search settings")
+    public static let braveSearchFallbackMixingOption =
+      NSLocalizedString(
+        "settings.braveSearchFallbackMixingOption", tableName: "BraveShared",
+        bundle: .module,
+        value: "Google Fallback Mixing",
+        comment: "Setting that allows users to turn Google fallback mixing when making queries with Brave Search")
+    public static let braveSearchFallbackMixingFooter =
+      NSLocalizedString(
+        "settings.braveSearchFallbackMixingFooter", tableName: "BraveShared",
+        bundle: .module,
+        value: "For queries where Brave Search is not yet refined, your browser will anonymously check Google for the same query, mix the results for you and send the query data back to us so we can improve Brave Search for everyone. This setting will take preference over what was set on the Brave Search website",
+        comment: "This footer text explains the Google fallback mixing feature.")
   }
 }
 

--- a/Sources/BraveStrings/BraveStrings.swift
+++ b/Sources/BraveStrings/BraveStrings.swift
@@ -856,7 +856,7 @@ extension Strings {
       NSLocalizedString(
         "settings.braveSearchFallbackMixingFooter", tableName: "BraveShared",
         bundle: .module,
-        value: "For queries where Brave Search is not yet refined, your browser will anonymously check Google for the same query, mix the results for you and send the query data back to us so we can improve Brave Search for everyone. This setting will take preference over what was set on the Brave Search website",
+        value: "For queries where Brave Search is not yet refined, your browser will anonymously check Google for the same query, mix the results for you and send the query data back to us so we can improve Brave Search for everyone. This setting will take precedence over what was set on the Brave Search website",
         comment: "This footer text explains the Google fallback mixing feature.")
   }
 }

--- a/Tests/ClientTests/BraveSearchManagerTests.swift
+++ b/Tests/ClientTests/BraveSearchManagerTests.swift
@@ -1,0 +1,86 @@
+// Copyright 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+
+import XCTest
+import Preferences
+@testable import Brave
+
+class BraveSearchManagerTests: XCTestCase {
+  var profile: Profile!
+  let url = URL(string: "https://search.brave.com?q=test")!
+  let domain = "search.brave.com"
+  var cookies: [HTTPCookie]!
+  
+  override func setUp() {
+    super.setUp()
+    profile = MockProfile()
+    Preferences.General.forceBraveSearchFallbackMixing.reset()
+  }
+  
+  private func createCookie(value: String) -> HTTPCookie {
+    let properties: [HTTPCookiePropertyKey: Any] = [
+      .name: "fallback",
+      .value: value,
+      .domain: domain,
+      .path: "/",
+      .expires: Date().addingTimeInterval(3600)
+    ]
+    
+    return HTTPCookie(properties: properties)!
+  }
+  
+  func testFallbackState1() {
+    // App: ON, site: OFF -> ON
+    Preferences.General.forceBraveSearchFallbackMixing.value = true
+    cookies = [
+      createCookie(value: "0")
+    ]
+    
+    let searchManager = BraveSearchManager(profile: profile, url: url, cookies: cookies)
+    XCTAssertNotNil(searchManager)
+  }
+  
+  func testFallbackState2() {
+    // App: OFF, site: ON -> ON
+    Preferences.General.forceBraveSearchFallbackMixing.value = false
+    cookies = [
+      createCookie(value: "1")
+    ]
+    
+    let searchManager = BraveSearchManager(profile: profile, url: url, cookies: cookies)
+    XCTAssertNotNil(searchManager)
+  }
+  
+  func testFallbackState3() {
+    // App: OFF, site: OFF -> OFF
+    Preferences.General.forceBraveSearchFallbackMixing.value = false
+    cookies = [
+      createCookie(value: "0")
+    ]
+    
+    let searchManager = BraveSearchManager(profile: profile, url: url, cookies: cookies)
+    XCTAssertNil(searchManager)
+  }
+  
+  func testFallbackState4() {
+    // App: ON, site: ON -> ON
+    Preferences.General.forceBraveSearchFallbackMixing.value = true
+    cookies = [
+      createCookie(value: "1")
+    ]
+    
+    let searchManager = BraveSearchManager(profile: profile, url: url, cookies: cookies)
+    XCTAssertNotNil(searchManager)
+  }
+  
+  func testFallbackStateNoCookie() {
+    Preferences.General.forceBraveSearchFallbackMixing.value = true
+    // No cookie -> OFF
+    let searchManager = BraveSearchManager(profile: profile, url: url, cookies: [])
+    XCTAssertNotNil(searchManager)
+  }
+}


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7288 
Security ticket https://github.com/brave/security/issues/1259

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Enable the fallback mixing from either the website or the Brave app.
Verify that you see the fallback results, you can verify that by enabling "callback logging" from the Brave Search debug menu at the bottom of the settings.

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

<img width="516" alt="Zrzut ekranu 2023-04-24 o 20 26 02" src="https://user-images.githubusercontent.com/6950387/234083814-994d63b3-5ff8-4459-ac35-d4e0c7700fd0.png">


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
