### PR TITLE
Fix #7321: soften check on consecutive newline character to 3 and more

### DIFF
--- a/Sources/BraveWallet/Panels/Signature Request/SignatureRequestView.swift
+++ b/Sources/BraveWallet/Panels/Signature Request/SignatureRequestView.swift
@@ -110,8 +110,8 @@ struct SignatureRequestView: View {
       var result = currentRequest.message
       if needPilcrowFormatted[requestIndex] == true {
         var copy = currentRequest.message
-        while copy.range(of: "\\n{2,}", options: .regularExpression) != nil {
-          if let range = copy.range(of: "\\n{2,}", options: .regularExpression) {
+        while copy.range(of: "\\n{3,}", options: .regularExpression) != nil {
+          if let range = copy.range(of: "\\n{3,}", options: .regularExpression) {
             let newlines = String(copy[range])
             result.replaceSubrange(range, with: "\n\(uuid.uuidString) <\(newlines.count)>\n")
             copy.replaceSubrange(range, with: "\n\(uuid.uuidString) <\(newlines.count)>\n")
@@ -360,7 +360,7 @@ extension String {
   
   var hasConsecutiveNewLines: Bool {
     // return true if string has two or more consecutive newline chars
-    return range(of: "\\n{2,}", options: .regularExpression) != nil
+    return range(of: "\\n{3,}", options: .regularExpression) != nil
   }
   
   var printableWithUnknownUnicode: String {

--- a/Tests/BraveWalletTests/WalletStringExtensionTests.swift
+++ b/Tests/BraveWalletTests/WalletStringExtensionTests.swift
@@ -24,6 +24,12 @@ class WalletStringExtensionTests: XCTestCase {
     let stringsHasNewlineButNoConsecutiveNewlines = "Here is one sentence.\nAnd here is another."
     XCTAssertFalse(stringsHasNewlineButNoConsecutiveNewlines.hasConsecutiveNewLines)
     
+    let stringsHasNewlineBut2ConsecutiveNewlines = "Here is one sentence.\n\nAnd here is another."
+    XCTAssertFalse(stringsHasNewlineBut2ConsecutiveNewlines.hasConsecutiveNewLines)
+    
+    let stringsHasNewlineBut3ConsecutiveNewlines = "Here is one sentence.\n\n\nAnd here is another."
+    XCTAssertTrue(stringsHasNewlineBut3ConsecutiveNewlines.hasConsecutiveNewLines)
+    
     let stringHasConsecutiveNewlines = "Main Message\n\n\n\n\nEvil payload is below"
     XCTAssertTrue(stringHasConsecutiveNewlines.hasConsecutiveNewLines)
   }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
soften check on consecutive newline character to 3 and more

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7321

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
To test this you would need a test Brave premium account. (If you want to get a test brave premium account. please talk to me or @srirambv)
1. Open brave ios browser to navigate to https://talk.brave.software/
2. click host a web3 call
3. wallet notification will show up asking for wallet connection permission 
4. give permission 
5. click start a web3 call again
6. another wallet notification will show up
7. click the notification to see a signature request panel which will contain SIWE message.
8. Observe there is no consecutive newline character warning showing up

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

https://user-images.githubusercontent.com/1187676/234326520-e6d19303-f287-42d2-98d6-8ada97a483db.mp4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
