### PR TITLE
No Bug: Replace macOS app with a script for making leo asset catalogs

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -328,7 +328,7 @@ var package = Package(
     .testTarget(name: "GrowthTests", dependencies: ["Growth", "Shared", "BraveShared", "BraveVPN"]),
     .plugin(name: "IntentBuilderPlugin", capability: .buildTool()),
     .plugin(name: "LoggerPlugin", capability: .buildTool()),
-    .plugin(name: "LeoAssetsPlugin", capability: .buildTool(), dependencies: ["LeoAssetCatalogGenerator"]),
+    .plugin(name: "LeoAssetsPlugin", capability: .buildTool()/*, dependencies: ["LeoAssetCatalogGenerator"]*/),
     .executableTarget(name: "LeoAssetCatalogGenerator")
   ],
   cxxLanguageStandard: .cxx17

--- a/Plugins/LeoAssetsPlugin/make_asset_catalog.sh
+++ b/Plugins/LeoAssetsPlugin/make_asset_catalog.sh
@@ -1,0 +1,72 @@
+#!/bin/zsh
+
+# Creates an asset catalog in the provided output directory
+#
+# Usage: ./make_asset_catalog.sh icon[,icon1,icon2] -o outputDirectory
+
+output_directory=""
+leo_sf_symbols_directory=""
+icons=()
+
+function usage() {
+  echo "Usage: ./ios_make_asset_catalog.sh -l leo_sf_symbols_directory -i icon[,icon1,icon2] -o output_directory"
+  exit 1
+}
+
+while getopts ":l:o:i:" arg
+do
+  case "$arg" in
+    o) output_directory="$OPTARG/LeoAssets.xcassets" ;;
+    l) leo_sf_symbols_directory=$OPTARG ;;
+    i) icons=($(echo "$OPTARG" | awk -F',' '{for(i=1; i<=NF; i++) print $i}')) ;;
+  esac
+done
+
+if [ $output_directory = "" ] || [ $leo_sf_symbols_directory = "" ] || [ ${#icons[@]} -eq 0 ]; then
+  usage
+fi
+
+echo "Output Directory: $output_directory"
+
+if [ -d "$output_directory" ]; then
+  rm -r "$output_directory"
+fi
+
+mkdir -p "$output_directory"
+if [ ! -f "$output_directory/Contents.json" ]; then
+cat > "$output_directory/Contents.json" << EOF 
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}
+EOF
+fi
+
+for icon in $icons
+do
+  declare svg_name="$icon.svg"
+  if [ ! -f "$leo_sf_symbols_directory/symbols/$svg_name" ]; then 
+    echo "Could not find Leo SF symbol named $svg_name"
+    exit 1
+  fi
+  mkdir -p "$output_directory/$icon.symbolset"
+  cp "$leo_sf_symbols_directory/symbols/$svg_name" "$output_directory/$icon.symbolset/$svg_name"
+  if [ ! -f "$output_directory/$icon.symbolset/Contents.json" ]; then
+    cat > "$output_directory/$icon.symbolset/Contents.json" << EOF
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "symbols" : [
+    {
+      "filename" : "$svg_name",
+      "idiom" : "universal"
+    }
+  ]
+}
+EOF
+  fi
+done


### PR DESCRIPTION
Running a macOS tool while archiving a iOS build is unfortunately broken in Xcode 14. It attempts to run the macOS tool from the wrong directory and fails to find it. One way around this is to use a precompiled version of this tool instead, but it will mean building and uploading them somewhere so for now the tool will be replaced by a bash script.

I've left the asset catalog generator code for future Xcode testing

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
