### PR TITLE
Fix #7247: Move block popups setting to general settings section.

### DIFF
--- a/Sources/Brave/Frontend/Settings/BraveShieldsAndPrivacySettingsController.swift
+++ b/Sources/Brave/Frontend/Settings/BraveShieldsAndPrivacySettingsController.swift
@@ -332,7 +332,6 @@ class BraveShieldsAndPrivacySettingsController: TableViewController {
             self.pboModeToggled(value: value)
           }
         ),
-        .boolRow(title: Strings.blockPopups, option: Preferences.General.blockPopups),
         blockMobileAnnoyancesRow,
         .boolRow(title: Strings.followUniversalLinks, option: Preferences.General.followUniversalLinks),
       ]

--- a/Sources/Brave/Frontend/Settings/SettingsViewController.swift
+++ b/Sources/Brave/Frontend/Settings/SettingsViewController.swift
@@ -338,6 +338,8 @@ class SettingsViewController: TableViewController {
         title: Strings.mediaAutoBackgrounding,
         option: Preferences.General.mediaAutoBackgrounding,
         image: UIImage(named: "background_play_settings_icon", in: .module, compatibleWith: nil)!.template),
+      .boolRow(title: Strings.blockPopups, option: Preferences.General.blockPopups,
+               image: UIImage(systemName: "macwindow")),
     ])
 
     let websiteRedirectsRow = Row(


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7247 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Verify that the block-popups settings is now in the general settings section

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
