### PR TITLE
Fix #7293: Sync shared playlist folders automatically by default

### DIFF
--- a/Sources/Brave/Frontend/ClientPreferences.swift
+++ b/Sources/Brave/Frontend/ClientPreferences.swift
@@ -225,7 +225,7 @@ extension Preferences {
       Option<Date?>(key: "playlist.lastPlaylistFoldersSyncTime", default: nil)
     /// Sync shared folders automatically preference
     static let syncSharedFoldersAutomatically =
-      Option<Bool>(key: "playlist.syncSharedFoldersAutomatically", default: false)
+      Option<Bool>(key: "playlist.syncSharedFoldersAutomatically", default: true)
   }
     
   final public class PrivacyReports {

--- a/Sources/BraveStrings/BraveStrings.swift
+++ b/Sources/BraveStrings/BraveStrings.swift
@@ -2027,7 +2027,7 @@ extension Strings {
     
     public static let sharedFolderSyncAutomaticallyTitle =
     NSLocalizedString("playList.sharedFolderSyncAutomaticallyTitle", tableName: "BraveShared", bundle: .module,
-                      value: "Sync playlist folders automatically",
+                      value: "Sync Playlist Folders Automatically",
                       comment: "Title of the settings option to sync folders with the server automatically, every 4 hours.")
     
     public static let sharedFolderSyncAutomaticallyDescription =


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7293 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Verify that the preference is now enabled by default. No need to test the shared folders functionality.

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
