### PR TITLE
Fix #7324: Fix bug where Tab Title can be Empty when lazily restored.

### DIFF
--- a/Sources/Brave/Frontend/Browser/FrequencyQuery.swift
+++ b/Sources/Brave/Frontend/Browser/FrequencyQuery.swift
@@ -79,10 +79,8 @@ class FrequencyQuery {
     var tabList = [Site]()
         
     for tab in tabs {
-        
       if PrivateBrowsingManager.shared.isPrivateBrowsing {
         if let url = tab.url, url.isWebPage(), !(InternalURL(url)?.isAboutHomeURL ?? false) {
-          
           if let selectedTabID = tabManager.selectedTab?.id, selectedTabID == tab.id {
             continue
           }
@@ -90,20 +88,13 @@ class FrequencyQuery {
           tabList.append(Site(url: url.absoluteString, title: tab.displayTitle, siteType: .tab, tabID: tab.id.uuidString))
         }
       } else {
-        var tabURL: URL?
-        
-        if let url = tab.url {
-          tabURL = url
-        } else if let fetchedTab = SessionTab.from(tabId: tab.id){
-          tabURL = fetchedTab.url
-        }
-        
+        let tabURL = tab.url ?? SessionTab.from(tabId: tab.id)?.url
         if let url = tabURL, url.isWebPage(), !(InternalURL(url)?.isAboutHomeURL ?? false) {
           if let selectedTabID = tabManager.selectedTab?.id, selectedTabID == tab.id {
             continue
           }
           
-          tabList.append(Site(url: url.absoluteString, title: tab.title, siteType: .tab, tabID: tab.id.uuidString))
+          tabList.append(Site(url: url.absoluteString, title: tab.displayTitle, siteType: .tab, tabID: tab.id.uuidString))
         }
       }
     }

--- a/Sources/Brave/Frontend/Browser/Tab.swift
+++ b/Sources/Brave/Frontend/Browser/Tab.swift
@@ -464,6 +464,9 @@ class Tab: NSObject {
         syncTab?.setTitle(title)
         return title
       } else if let tab = SessionTab.from(tabId: id) {
+        if tab.title.isEmpty {
+          return Strings.Hotkey.newTabTitle
+        }
         syncTab?.setTitle(tab.title)
         return tab.title
       }


### PR DESCRIPTION
## Summary of Changes
- When Tabs are lazily restored, their webView can be null/nil. This means, calling `tab.title` will return empty. We should have been using `tab.displayTitle` which checks the session restore status and title.
- Also, restored NTP tabs have no title, so we can return "New Tab" for those.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7324

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
