### PR TITLE
Fix #7337: Update reset wallet button copy

### DIFF
--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -726,7 +726,7 @@ extension Strings {
       "wallet.settingsResetButtonTitle",
       tableName: "BraveWallet",
       bundle: .module,
-      value: "Reset Brave Wallet",
+      value: "Reset and Clear Wallet Data",
       comment: "The title of a button that will reset the wallet. As in to erase the users wallet from the device"
     )
     public static let settingsResetWalletAlertTitle = NSLocalizedString(


### PR DESCRIPTION
## Summary of Changes
- https://bravesoftware.slack.com/archives/C023VS4HJ6Q/p1682324758670509

This pull request fixes #7337

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
Open Web3 settings with a wallet setup and verify copy is `Reset and Clear Wallet Data`


## Screenshots:

![reset wallet](https://user-images.githubusercontent.com/5314553/234594591-8659f235-8188-4c86-bb64-b3f3a3adbabe.png)


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
