### PR TITLE
Fix #7347: Remove unnecessary PIP code on iOS 15+ (prevents potential crash).

### DIFF
--- a/Sources/Brave/Frontend/Browser/Playlist/Controllers/PlaylistViewController+AVDelegates.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/Controllers/PlaylistViewController+AVDelegates.swift
@@ -30,10 +30,6 @@ extension PlaylistViewController: AVPictureInPictureControllerDelegate {
   }
 
   func pictureInPictureControllerDidStopPictureInPicture(_ pictureInPictureController: AVPictureInPictureController) {
-    if UIDevice.isIpad {
-      attachPlayerView()
-    }
-
     PlaylistCarplayManager.shared.playlistController = nil
   }
 
@@ -51,17 +47,8 @@ extension PlaylistViewController: AVPictureInPictureControllerDelegate {
     if let restorationController = PlaylistCarplayManager.shared.playlistController {
       restorationController.modalPresentationStyle = .fullScreen
       guard let browserViewController = view.window == nil ? PlaylistCarplayManager.shared.browserController : self.currentScene?.browserViewController else {
-
-        if UIDevice.isIpad {
-          attachPlayerView()
-        }
-
         completionHandler(true)
         return
-      }
-
-      if UIDevice.isIpad {
-        attachPlayerView()
       }
 
       // There is a case when the user can manually present the PlaylistController through 3-dot menu

--- a/Sources/Brave/Frontend/Browser/Playlist/Controllers/PlaylistViewController.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/Controllers/PlaylistViewController.swift
@@ -21,7 +21,6 @@ import os.log
 // MARK: PlaylistViewControllerDelegate
 protocol PlaylistViewControllerDelegate: AnyObject {
   func attachPlayerView()
-  func detachPlayerView()
   func onSidePanelStateChanged()
   func onFullscreen()
   func onExitFullscreen()
@@ -118,14 +117,6 @@ class PlaylistViewController: UIViewController {
     listController.stopLoadingSharedPlaylist()
     assetLoadingStateObservers.removeAll()
     assetStateObservers.removeAll()
-
-    // If this controller is retained in app-delegate for Picture-In-Picture support
-    // then we need to re-attach the player layer
-    // and deallocate it.
-    if UIDevice.isIpad {
-      playerView.attachLayer(player: player)
-    }
-
     PlaylistCarplayManager.shared.playlistController = nil
   }
 
@@ -534,11 +525,6 @@ extension PlaylistViewController: PlaylistViewControllerDelegate {
     playerView.attachLayer(player: player)
   }
 
-  func detachPlayerView() {
-    playerView.delegate = nil
-    playerView.detachLayer()
-  }
-
   func onSidePanelStateChanged() {
     detailController.onSidePanelStateChanged()
   }
@@ -730,10 +716,6 @@ extension PlaylistViewController: VideoViewDelegate {
         player.pictureInPictureController?.delegate = nil
         player.pictureInPictureController?.stopPictureInPicture()
         player.stop()
-
-        if UIDevice.isIpad {
-          playerView.attachLayer(player: player)
-        }
         PlaylistCarplayManager.shared.playlistController = nil
         return
       }

--- a/Sources/Brave/Frontend/Browser/Playlist/VideoPlayer/MediaPlayer.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/VideoPlayer/MediaPlayer.swift
@@ -343,10 +343,6 @@ class MediaPlayer: NSObject {
     playerLayer.player = player
     return playerLayer
   }
-
-  func detachLayer() {
-    playerLayer.player = nil
-  }
   
   func addTimeObserver(interval: Int, onTick: @escaping (CMTime) -> Void) -> Any {
     let interval = CMTimeMake(value: Int64(interval), timescale: 1000)
@@ -459,36 +455,6 @@ extension MediaPlayer {
 extension MediaPlayer {
   /// Registers basic notifications
   private func registerNotifications() {
-    Publishers.Zip(
-      NotificationCenter.default.publisher(for: UIScene.didEnterBackgroundNotification),
-      NotificationCenter.default.publisher(for: UIApplication.didEnterBackgroundNotification)
-    )
-    .sink { [weak self] _ in
-      guard let self = self else { return }
-
-      if let pictureInPictureController = self.pictureInPictureController,
-        pictureInPictureController.isPictureInPictureActive {
-        return
-      }
-
-      self.detachLayer()
-    }.store(in: &notificationObservers)
-
-    Publishers.Zip(
-      NotificationCenter.default.publisher(for: UIScene.didActivateNotification),
-      NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)
-    )
-    .sink { [weak self] _ in
-      guard let self = self else { return }
-
-      if let pictureInPictureController = self.pictureInPictureController,
-        pictureInPictureController.isPictureInPictureActive {
-        return
-      }
-
-      self.attachLayer()
-    }.store(in: &notificationObservers)
-
     NotificationCenter.default.publisher(for: AVAudioSession.interruptionNotification, object: AVAudioSession.sharedInstance())
       .sink { [weak self] notification in
 

--- a/Sources/Brave/Frontend/Browser/Playlist/VideoPlayer/UI/VideoPlayer.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/VideoPlayer/UI/VideoPlayer.swift
@@ -189,10 +189,6 @@ class VideoView: UIView, VideoTrackerBarDelegate {
     fatalError("init(coder:) has not been implemented")
   }
 
-  deinit {
-    detachLayer()
-  }
-
   override func layoutSubviews() {
     super.layoutSubviews()
 
@@ -664,14 +660,6 @@ class VideoView: UIView, VideoTrackerBarDelegate {
         )
       }
     }
-  }
-
-  func detachLayer() {
-    playerStatusObserver = nil
-
-    staticImageView.layer.removeFromSuperlayer()
-    playerLayer?.removeFromSuperlayer()
-    playerLayer?.player = nil
   }
 
   func play() {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Remove observers for backgrounding from Playlist PIP.
- Stop detaching the AVPlayerLayer from the view hierarchy when entering PIP (on iOS 14, this was required or PIP won't work!!!).

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7347

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
- See the ticket for details
- Test that picture in picture in Playlist works on iPad and iPhone (on iOS 15 and 16).


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
