### PR TITLE
Fix #7211: Support for Solana v0 VersionedTransaction's

### DIFF
--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/SolanaProviderScriptHandler.swift
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/SolanaProviderScriptHandler.swift
@@ -24,7 +24,6 @@ class SolanaProviderScriptHandler: TabContentScript {
     case method
     case params
     case code
-    case data
   }
   
   static let scriptName = "WalletSolanaProviderScript"
@@ -301,13 +300,13 @@ class SolanaProviderScriptHandler: TabContentScript {
   /// Helper function to build `SolanaSignTransactionParam` given the serializedMessage and signatures from the `solanaWeb3.Transaction`.
   private func createSignTransactionParam(serializedMessage: MojoBase.Value, signatures: MojoBase.Value) -> BraveWallet.SolanaSignTransactionParam {
     // get the serialized message
-    let serializedMessageValues = serializedMessage.bufferToList?.map { UInt8($0.intValue) } ?? []
+    let serializedMessageValues = serializedMessage.listValue?.map { UInt8($0.intValue) } ?? []
     let encodedSerializedMsg = (Data(serializedMessageValues) as NSData).base58EncodedString()
     // get the signatures array
     let signaturesValues = (signatures.listValue ?? []).compactMap { $0.dictionaryValue }
     let signatures: [BraveWallet.SignaturePubkeyPair] = signaturesValues.map {
       BraveWallet.SignaturePubkeyPair(
-        signature: $0[Keys.signature.rawValue]?.bufferToList?.map { NSNumber(value: $0.intValue) },
+        signature: $0[Keys.signature.rawValue]?.numberArray,
         publicKey: $0[Keys.publicKey.rawValue]?.stringValue ?? ""
       )
     }
@@ -327,12 +326,6 @@ class SolanaProviderScriptHandler: TabContentScript {
 }
 
 private extension MojoBase.Value {
-  /// Returns the array of numbers given a Buffer as MojoBase.Value.
-  /// `Buffer` comes as ["data": [UInt8], "type": "Buffer"].
-  var bufferToList: [MojoBase.Value]? {
-    dictionaryValue?[SolanaProviderScriptHandler.Keys.data.rawValue]?.listValue
-  }
-  
   var numberArray: [NSNumber]? {
     listValue?.map { NSNumber(value: $0.intValue) }
   }

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/SolanaProviderScriptHandler.swift
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/SolanaProviderScriptHandler.swift
@@ -24,6 +24,8 @@ class SolanaProviderScriptHandler: TabContentScript {
     case method
     case params
     case code
+    case serializedTx
+    case version
   }
   
   static let scriptName = "WalletSolanaProviderScript"
@@ -249,16 +251,18 @@ class SolanaProviderScriptHandler: TabContentScript {
       return (nil, buildErrorJson(status: .invalidParams, errorMessage: "Invalid args"))
     }
     let param = createSignTransactionParam(serializedMessage: serializedMessage, signatures: signatures)
-    // TODO: Wallet #7211 - `version` needs returned to DApp.
     let (status, errorMessage, serializedTx, version) = await provider.signTransaction(param)
     guard status == .success else {
       return (nil, buildErrorJson(status: status, errorMessage: errorMessage))
     }
-    let listMojoInt = serializedTx.map { MojoBase.Value(intValue: $0.int32Value) }
-    guard let encodedSerializedTx = MojoBase.Value(listValue: listMojoInt).jsonObject else {
+    let transactionDict = self.buildSerializedTxJson(
+      serializedTx: serializedTx,
+      version: version
+    )
+    guard let transactionDict = transactionDict.jsonObject else {
       return (nil, buildErrorJson(status: .internalError, errorMessage: "Internal error"))
     }
-    return (encodedSerializedTx, nil)
+    return (transactionDict, nil)
   }
   
   /// Given args `[{serializedMessage: Buffer, signatures: {publicKey: String, signature: Buffer}}]`,
@@ -280,21 +284,19 @@ class SolanaProviderScriptHandler: TabContentScript {
     guard !params.isEmpty else {
       return (nil, buildErrorJson(status: .invalidParams, errorMessage: "Invalid args"))
     }
-    // TODO: Wallet #7211 - `versions` needs returned to DApp.
     let (status, errorMessage, serializedTxs, versions) = await provider.signAllTransactions(params)
     guard status == .success else {
       return (nil, buildErrorJson(status: status, errorMessage: errorMessage))
     }
-    let encodedSerializedTxs = serializedTxs.compactMap {
-      let listMojoInt = $0.map { number in
-        MojoBase.Value(intValue: number.int32Value)
-      }
-      return MojoBase.Value(listValue: listMojoInt).jsonObject
+    let serializedTransactionDicts: [MojoBase.Value] = zip(serializedTxs, versions).compactMap { serializedTx, versionInt in
+      guard let version = BraveWallet.SolanaMessageVersion(rawValue: versionInt.intValue) else { return nil }
+      return buildSerializedTxJson(serializedTx: serializedTx, version: version)
     }
-    guard !encodedSerializedTxs.isEmpty else {
+    guard serializedTransactionDicts.count == serializedTxs.count,
+          let encodedSerializedTxDicts = MojoBase.Value(listValue: serializedTransactionDicts).jsonObject else {
       return (nil, buildErrorJson(status: .internalError, errorMessage: "Internal error"))
     }
-    return (encodedSerializedTxs, nil)
+    return (encodedSerializedTxDicts, nil)
   }
   
   /// Helper function to build `SolanaSignTransactionParam` given the serializedMessage and signatures from the `solanaWeb3.Transaction`.
@@ -313,8 +315,30 @@ class SolanaProviderScriptHandler: TabContentScript {
     return .init(encodedSerializedMsg: encodedSerializedMsg, signatures: signatures)
   }
   
-  private func buildErrorJson(status: BraveWallet.SolanaProviderError, errorMessage: String) -> String? {
-    JSONSerialization.jsObject(withNative: [Keys.code.rawValue: status.rawValue, Keys.message.rawValue: errorMessage] as [String: Any])
+  private func buildSerializedTxJson(
+    serializedTx: [NSNumber],
+    version: BraveWallet.SolanaMessageVersion
+  ) -> MojoBase.Value {
+    let encodedSerializedTxMojoInts = serializedTx.map { MojoBase.Value(intValue: $0.int32Value) }
+    let encodedSerializedTx = MojoBase.Value(listValue: encodedSerializedTxMojoInts)
+    let versionMojoInt = MojoBase.Value(intValue: Int32(version.rawValue))
+    let dict = MojoBase.Value(dictionaryValue: [
+      Keys.serializedTx.rawValue: encodedSerializedTx,
+      Keys.version.rawValue: versionMojoInt
+    ])
+    return dict
+  }
+  
+  private func buildErrorJson(
+    status: BraveWallet.SolanaProviderError,
+    errorMessage: String
+  ) -> String? {
+    JSONSerialization.jsObject(
+      withNative: [
+        Keys.code.rawValue: status.rawValue,
+        Keys.message.rawValue: errorMessage
+      ] as [String: Any]
+    )
   }
   
   @MainActor private func emitConnectEvent(publicKey: String) async {

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Paged/WalletSolanaProviderScript.js
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Paged/WalletSolanaProviderScript.js
@@ -66,15 +66,9 @@ window.__firefox__.execute(function($, $Object, $Function, $Array) {
      [UInt8]
      */
     let serializedMessageFromTx = $(function(transaction) {
-      if (transaction.message) { // VersionedTransaction (v0)
-        const serializeMessageBuffer = transaction.message.serialize();
-        const serializedMessage = [...serializeMessageBuffer]; // Buffer to Array
-        return serializedMessage;
-      } else { // Transaction (legacy)
-        const serializeMessageBuffer = transaction.serializeMessage();
-        const serializedMessage = [...serializeMessageBuffer]; // Buffer to Array
-        return serializedMessage;
-      }
+      // VersionedTransaction (v0) : Transaction (legacy)
+      let serializeMessageBuffer = transaction.message ? transaction.message.serialize() : transaction.serializeMessage();
+      return [...serializeMessageBuffer]; // Buffer to Array
     })
     /*
      solanaWeb3.Transaction | solanaWeb3.VersionedTransaction

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Paged/WalletSolanaProviderScript.js
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Paged/WalletSolanaProviderScript.js
@@ -105,7 +105,8 @@ window.__firefox__.execute(function($, $Object, $Function, $Array) {
           }
           return $.extensiveFreeze(obj, freezeExceptions);
         })
-        return transaction.signatures.map(convertSignaturePubkeyTuple);
+        const txSignatures = $Array.of(...transaction.signatures);
+        return txSignatures.map(convertSignaturePubkeyTuple);
       }
     })
     /*
@@ -200,12 +201,12 @@ window.__firefox__.execute(function($, $Object, $Function, $Array) {
         }),
         /* Deprecated */
         signAllTransactions: $(function(transactions) { /* -> Promise<[solanaWeb3.Transaction]> */
-          const objects = transactions.map(convertTransaction);
+          const objects = $Array.of(...transactions).map(convertTransaction);
           $.extensiveFreeze(objects, freezeExceptions);
           
           function completion(serializedTxs, resolve) {
             /* Convert `[[UInt8]]` -> `[solanaWeb3.Transaction]` */
-            const result = serializedTxs.map(createTransaction);
+            const result = $Array.of(...serializedTxs).map(createTransaction);
             resolve($.extensiveFreeze(result, freezeExceptions));
           }
           return post('signAllTransactions', objects, completion)

--- a/Sources/BraveWallet/Crypto/Transactions/TransactionParser.swift
+++ b/Sources/BraveWallet/Crypto/Transactions/TransactionParser.swift
@@ -518,14 +518,7 @@ enum TransactionParser {
     let formatter = WeiFormatter(decimalFormatStyle: decimalFormatStyle ?? .decimals(precision: 9))
     var details: [SolanaTxDetails.ParsedSolanaInstruction.KeyValue] = []
     if instruction.isSystemProgram {
-      let accounts = decodedData.accountParams.enumerated().compactMap { (index, param) -> SolanaTxDetails.ParsedSolanaInstruction.KeyValue? in
-        guard let account = instruction.accountMetas[safe: index] else {
-          // 'Signer' is optional for .createAccountWithSeed
-          // so if unavailable in `accountMetas`, no signer
-          return nil
-        }
-        return SolanaTxDetails.ParsedSolanaInstruction.KeyValue(key: param.localizedName, value: account.pubkey)
-      }
+      let accounts = instruction.accountKeyValues
       details.append(contentsOf: accounts)
       
       if let lamportsParam = decodedData.paramFor(BraveWallet.Lamports),
@@ -542,23 +535,7 @@ enum TransactionParser {
       }
       
     } else if instruction.isTokenProgram {
-      let accounts = decodedData.accountParams.enumerated().compactMap { (index, param) -> SolanaTxDetails.ParsedSolanaInstruction.KeyValue? in
-        if param.name == BraveWallet.Signers { // special case
-          // the signers are the `accountMetas` from this index to the end of the array
-          // its possible to have any number of signers, including 0
-          if instruction.accountMetas[safe: index] != nil {
-            let signers = instruction.accountMetas[index...].map(\.pubkey)
-              .map { pubkey in "\(pubkey)" }
-              .joined(separator: "\n")
-            return SolanaTxDetails.ParsedSolanaInstruction.KeyValue(key: param.localizedName, value: signers)
-          } else {
-            return nil // no signers
-          }
-        } else {
-          guard let account = instruction.accountMetas[safe: index] else { return nil }
-          return SolanaTxDetails.ParsedSolanaInstruction.KeyValue(key: param.localizedName, value: account.pubkey)
-        }
-      }
+      let accounts = instruction.accountKeyValues
       details.append(contentsOf: accounts)
       
       if let amountParam = decodedData.paramFor(BraveWallet.Amount),

--- a/Sources/BraveWallet/Crypto/Transactions/TransactionParser.swift
+++ b/Sources/BraveWallet/Crypto/Transactions/TransactionParser.swift
@@ -479,10 +479,10 @@ enum TransactionParser {
         instructions: parsedInstructions
       )
       let details: ParsedTransaction.Details
-      if transaction.txType == .solanaDappSignTransaction, transaction.txType == .solanaDappSignAndSendTransaction {
-        details = .solDappTransaction(solanaTxDetails)
-      } else {
+      if transaction.txType == .solanaSwap {
         details = .solSwapTransaction(solanaTxDetails)
+      } else { // .solanaDappSignTransaction, .solanaDappSignAndSendTransaction
+        details = .solDappTransaction(solanaTxDetails)
       }
       return .init(
         transaction: transaction,

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -3347,6 +3347,20 @@ extension Strings {
       value: "Data",
       comment: "The label displayed beside the Data for an instruction type we don't support decoding. Ex. \"Data: [1, 20, 3, 5, 50]]\""
     )
+    public static let solanaInstructionAddressLookupAcc = NSLocalizedString(
+      "wallet.solanaInstructionAddressLookupAcc",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Address Lookup Table Account",
+      comment: "The label displayed beside the address for the Address Lookup Table Account. Ex. \"Address Lookup Table Account: B1A2...\""
+    )
+    public static let solanaInstructionAddressLookupIndex = NSLocalizedString(
+      "wallet.solanaInstructionAddressLookupIndex",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Address Lookup Table Index",
+      comment: "The label displayed beside the address for the Address Lookup Table Account. Ex. \"Address Lookup Table Index: 1\""
+    )
     public static let solanaSignTransactionWarning = NSLocalizedString(
       "wallet.solanaSignTransactionWarning",
       tableName: "BraveWallet",


### PR DESCRIPTION
## Summary of Changes
- Javascript updates for Solana `VersionedTransaction`s
    - Desktop / core PR: https://github.com/brave/brave-core/pull/17542 
- UI updates for displaying address lookup table account & index.
- Security review: https://github.com/brave/security/issues/1265

For both `solanaWeb3.Transaction` and `solanaWeb3.VersionedTransaction`, the transaction(s) are converted to a dictionary/JS object to pass into Swift:
```
{  
  serializedMessage: [UInt8], 
  signatures: [{
    pubkey: String, 
    signature: [UInt8]
  }]
}
```
Which is then converted in Swift from dictionary to `SolanaSignTransactionParam` and given to the core `SolanaProvider`.

After the `SolanaProvider` responds (typically after user input unless an error is found, ex. invalid blockhash), we are given the encoded transaction _and it's version_ back, we pass the response back to Javascript as a dictionary:
```
{  
  serializedTx: [UInt8], 
  version: Int
}
```
Where the version is an Int raw value of the [SolanaMessageVersion enum](https://github.com/brave/brave-core/blob/1.52.x/components/brave_wallet/common/brave_wallet.mojom#L1800-L1803). Depending on the version, we will give the `serializedTx` to either the `solanaWeb3.Transaction` (`SolanaMessageVersion.legacy`) or the `solanaWeb3.VersionedTransaction` (for `SolanaMessageVersion.V0`) constructor as appropriate.

This pull request fixes #7211

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. All cases with v0 keyword in https://pwgoom.csb.app/ should work.
    - Verify `Address Lookup Table Account:` and `Address Lookup Table Index:` are shown under the `To Account:` label in the details for all `v0 + lookup table` cases. 
    - For `Sign and Send Transaction (v0 + lookup table) (devnet only)`, the transaction header (in Tx Confirmation and in Tx detail modal) and transaction summary should only display the from account; it should not show the 'to account' as a destination.
2. Three Send Transactions cases in the bottom row in https://solana-labs.github.io/wallet-adapter/example/ should all work.


## Screenshots:

Solana Provider Test DApp:

https://user-images.githubusercontent.com/5314553/235525893-01b1f09a-28c7-4d5d-9117-6743f05afc22.mp4

Solana Labs Example DApp:

https://user-images.githubusercontent.com/5314553/235526448-15eb41cf-4de3-47b5-b59b-ecd411867d48.mp4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).

@Brandon-T @kdenhartog @stoletheminerals I've tagged you in the PR due to the javascript changes in `WalletSolanaProviderScript.js`; the existing protections should all still apply. 