### PR TITLE
Fix #7375: Lazy Load Tabs when opening batch URLs

### DIFF
--- a/Sources/Brave/Frontend/Browser/FaviconHandler.swift
+++ b/Sources/Brave/Frontend/Browser/FaviconHandler.swift
@@ -23,7 +23,7 @@ class FaviconHandler {
     unregister(tabObservers)
   }
 
-  @MainActor func loadFaviconURL(
+  func loadFaviconURL(
     _ url: URL,
     forTab tab: Tab
   ) async throws -> Favicon {
@@ -42,7 +42,7 @@ extension FaviconHandler: TabEventHandler {
         tab.favicon = Favicon.default
       }
       
-      Task { @MainActor in
+      Task {
         let favicon = try await loadFaviconURL(currentURL, forTab: tab)
         TabEvent.post(.didLoadFavicon(favicon), for: tab)
       }

--- a/Sources/Brave/Frontend/Browser/Tab.swift
+++ b/Sources/Brave/Frontend/Browser/Tab.swift
@@ -576,6 +576,9 @@ class Tab: NSObject {
       }
 
       return webView.load(request)
+    } else {
+      lastRequest = request
+      sslPinningError = nil
     }
     return nil
   }

--- a/Sources/Brave/Frontend/Browser/Tab.swift
+++ b/Sources/Brave/Frontend/Browser/Tab.swift
@@ -395,6 +395,20 @@ class Tab: NSObject {
       Logger.module.warning("creating webview with no lastRequest and no session data: \(self.url?.absoluteString ?? "nil")")
     }
   }
+  
+  func restore(_ webView: WKWebView, requestRestorationData: (title: String, request: URLRequest)?) {
+    if let sessionInfo = requestRestorationData {
+      restoring = true
+      lastTitle = sessionInfo.title
+      webView.load(sessionInfo.request)
+      restoring = false
+      self.sessionData = nil
+    } else if let request = lastRequest {
+      webView.load(request)
+    } else {
+      Logger.module.warning("creating webview with no lastRequest and no session data: \(self.url?.absoluteString ?? "nil")")
+    }
+  }
 
   func deleteWebView() {
     contentScriptManager.uninstall(from: self)
@@ -576,9 +590,6 @@ class Tab: NSObject {
       }
 
       return webView.load(request)
-    } else {
-      lastRequest = request
-      sslPinningError = nil
     }
     return nil
   }

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/FaviconScriptHandler.swift
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/FaviconScriptHandler.swift
@@ -39,67 +39,76 @@ class FaviconScriptHandler: NSObject, TabContentScript {
     defer { replyHandler(nil, nil) }
     guard let tab = tab else { return }
     
-    // Assign default favicon
-    tab.favicon = Favicon.default
-    
-    guard let webView = message.webView,
-          let url = webView.url else {
-      return
+    Task { @MainActor in
+      // Assign default favicon
+      tab.favicon = Favicon.default
+      
+      guard let webView = message.webView,
+            let url = webView.url else {
+        return
+      }
+      
+      // The WebView has a valid URL
+      // Attempt to fetch the favicon from cache
+      let isPrivate = tab.isPrivate
+      tab.favicon = FaviconFetcher.getIconFromCache(for: url) ?? Favicon.default
+      
+      // If this is an internal page, we don't fetch favicons for such pages from Brave-Core
+      guard !InternalURL.isValid(url: url),
+            !(InternalURL(url)?.isSessionRestore ?? false) else {
+        return
+      }
+      
+      // Update the favicon for this tab, from Brave-Core
+      tab.faviconDriver?.webView(webView, scriptMessage: message) { [weak tab] iconUrl, icon in
+        FaviconScriptHandler.updateFavicon(tab: tab,
+                                           url: url,
+                                           isPrivate: isPrivate,
+                                           icon: icon,
+                                           iconUrl: iconUrl)
+      }
     }
-    
-    // The WebView has a valid URL
-    // Attempt to fetch the favicon from cache
-    let isPrivate = tab.isPrivate
-    tab.favicon = FaviconFetcher.getIconFromCache(for: url) ?? Favicon.default
-    
-    // If this is an internal page, we don't fetch favicons for such pages from Brave-Core
-    guard !InternalURL.isValid(url: url),
-          !(InternalURL(url)?.isSessionRestore ?? false) else {
-      return
-    }
-    
-    // Update the favicon for this tab, from Brave-Core
-    tab.faviconDriver?.webView(webView, scriptMessage: message) { [weak tab] iconUrl, icon in
-      let tab = tab
-      if let icon = icon {
-        if let iconUrl = iconUrl {
-          Logger.module.debug("Fetched Favicon: \(iconUrl.absoluteString), for page: \(url.absoluteString)")
-        } else {
-          Logger.module.debug("Fetched Favicon for page: \(url.absoluteString)")
-        }
-        
-        // If the icon is too small, we don't want to cache it.
-        // It's better to show monogram or bundled icons.
-        if icon.size.width < CGFloat(FaviconLoader.Sizes.desiredMedium.rawValue) ||
-           icon.size.height < CGFloat(FaviconLoader.Sizes.desiredMedium.rawValue) {
-          return
-        }
-        
-        Task { @MainActor in
-          let favicon = await Favicon.renderImage(icon, backgroundColor: .clear, shouldScale: true)
-
-          // We can only cache favicons for non-private tabs
-          FaviconFetcher.updateCache(favicon, for: url, persistent: !isPrivate)
-          
-          guard let tab = tab else { return }
-          tab.favicon = favicon
-          TabEvent.post(.didLoadFavicon(favicon), for: tab)
-        }
+  }
+  
+  private static func updateFavicon(tab: Tab?, url: URL, isPrivate: Bool, icon: UIImage?, iconUrl: URL?) {
+    if let icon = icon {
+      if let iconUrl = iconUrl {
+        Logger.module.debug("Fetched Favicon: \(iconUrl.absoluteString), for page: \(url.absoluteString)")
       } else {
-        if let iconUrl = iconUrl {
-          Logger.module.error("Failed fetching Favicon: \(iconUrl.absoluteString), for page: \(url.absoluteString)")
-        } else {
-          Logger.module.error("Website: \(url.absoluteString), has no Favicon")
-        }
+        Logger.module.debug("Fetched Favicon for page: \(url.absoluteString)")
+      }
+      
+      // If the icon is too small, we don't want to cache it.
+      // It's better to show monogram or bundled icons.
+      if icon.size.width < CGFloat(FaviconLoader.Sizes.desiredMedium.rawValue) ||
+         icon.size.height < CGFloat(FaviconLoader.Sizes.desiredMedium.rawValue) {
+        return
+      }
+      
+      Task {
+        let favicon = await Favicon.renderImage(icon, backgroundColor: .clear, shouldScale: true)
+
+        // We can only cache favicons for non-private tabs
+        FaviconFetcher.updateCache(favicon, for: url, persistent: !isPrivate)
         
-        Task { @MainActor in
-          let favicon = try await FaviconFetcher.monogramIcon(url: url, persistent: !isPrivate)
-          FaviconFetcher.updateCache(favicon, for: url, persistent: true)
-          
-          guard let tab = tab else { return }
-          tab.favicon = favicon
-          TabEvent.post(.didLoadFavicon(nil), for: tab)
-        }
+        guard let tab = tab else { return }
+        tab.favicon = favicon
+        TabEvent.post(.didLoadFavicon(favicon), for: tab)
+      }
+    } else {
+      if let iconUrl = iconUrl {
+        Logger.module.error("Failed fetching Favicon: \(iconUrl.absoluteString), for page: \(url.absoluteString)")
+      } else {
+        Logger.module.error("Website: \(url.absoluteString), has no Favicon")
+      }
+      
+      Task {
+        let favicon = try await FaviconFetcher.monogramIcon(url: url, persistent: !isPrivate)
+        FaviconFetcher.updateCache(favicon, for: url, persistent: true)
+        
+        guard let tab = tab else { return }
+        tab.favicon = favicon
+        TabEvent.post(.didLoadFavicon(nil), for: tab)
       }
     }
   }

--- a/Sources/Data/models/RecentlyClosed.swift
+++ b/Sources/Data/models/RecentlyClosed.swift
@@ -58,14 +58,14 @@ public final class RecentlyClosed: NSManagedObject, CRUD {
   
   public class func insertAll(_ savedList: [SavedRecentlyClosed]) {
     DataController.perform { context in
-      savedList.forEach { saved in
+      savedList.enumerated().forEach { index, saved in
         if let entity = entity(in: context) {
           let source = RecentlyClosed(entity: entity, insertInto: context)
           source.url = saved.url
           source.title = saved.title
           source.dateAdded = saved.dateAdded
           source.interactionState = saved.interactionState
-          source.historyIndex = Int16(saved.index)
+          source.historyIndex = Int16(index)
         }
       }
     }

--- a/Sources/Data/models/SessionTab.swift
+++ b/Sources/Data/models/SessionTab.swift
@@ -86,8 +86,12 @@ extension SessionTab {
   }
   
   public static func exists(tabId: UUID) -> Bool {
+    return Self.exists(tabId: tabId, in: DataController.viewContext)
+  }
+  
+  public static func exists(tabId: UUID, in context: NSManagedObjectContext) -> Bool {
     let predicate = NSPredicate(format: "\(#keyPath(SessionTab.tabId)) == %@", argumentArray: [tabId])
-    return Self.count(predicate: predicate, context: DataController.viewContext) != 0
+    return Self.count(predicate: predicate, context: context) != 0
   }
   
   /// Returns the tab with the specificed tabId
@@ -108,9 +112,15 @@ extension SessionTab {
     let predicate = NSPredicate(format: "\(lastUpdatedKeyPath) = nil OR \(lastUpdatedKeyPath) > %@", date)
     return all(where: predicate, sortDescriptors: sortDescriptors) ?? []
   }
-  
-  public func delete() {
-    delete(context: .new(inMemory: false))
+    
+  public static func delete(tabId: UUID) {
+    DataController.perform { context in
+      guard let sessionTab = SessionTab.from(tabId: tabId, in: context) else {
+        return
+      }
+      
+      sessionTab.delete(context: .existing(context))
+    }
   }
   
   public static func deleteAll() {
@@ -198,27 +208,29 @@ extension SessionTab {
   }
   
   public static func createIfNeeded(tabId: UUID, title: String, tabURL: URL) {
-    if !SessionTab.exists(tabId: tabId) {
-      DataController.performOnMainContext { context in
-        guard let window = SessionWindow.getActiveWindow(context: context) else { return }
-        _ = SessionTab(context: context,
-                       sessionWindow: window,
-                       sessionTabGroup: nil,
-                       index: Int32(window.sessionTabs?.count ?? 0),
-                       interactionState: Data(),
-                       isPrivate: false,
-                       isSelected: false,
-                       lastUpdated: .now,
-                       screenshotData: Data(),
-                       title: title,
-                       url: tabURL,
-                       tabId: tabId)
-        
-        do {
-          try context.save()
-        } catch {
-          Logger.module.error("performTask save error: \(error.localizedDescription, privacy: .public)")
-        }
+    DataController.perform { context in
+      guard !SessionTab.exists(tabId: tabId, in: context) else {
+        return
+      }
+      
+      guard let window = SessionWindow.getActiveWindow(context: context) else { return }
+      _ = SessionTab(context: context,
+                     sessionWindow: window,
+                     sessionTabGroup: nil,
+                     index: Int32(window.sessionTabs.count),
+                     interactionState: Data(),
+                     isPrivate: false,
+                     isSelected: false,
+                     lastUpdated: .now,
+                     screenshotData: Data(),
+                     title: title,
+                     url: tabURL,
+                     tabId: tabId)
+      
+      do {
+        try context.save()
+      } catch {
+        Logger.module.error("performTask save error: \(error.localizedDescription, privacy: .public)")
       }
     }
   }

--- a/Sources/Data/models/SessionTab.swift
+++ b/Sources/Data/models/SessionTab.swift
@@ -209,15 +209,13 @@ extension SessionTab {
   
   public static func createIfNeeded(tabId: UUID, title: String, tabURL: URL) {
     DataController.perform { context in
-      guard !SessionTab.exists(tabId: tabId, in: context) else {
-        return
-      }
+      guard !SessionTab.exists(tabId: tabId, in: context),
+            let window = SessionWindow.getActiveWindow(context: context) else { return }
       
-      guard let window = SessionWindow.getActiveWindow(context: context) else { return }
       _ = SessionTab(context: context,
                      sessionWindow: window,
                      sessionTabGroup: nil,
-                     index: Int32(window.sessionTabs.count),
+                     index: Int32(window.sessionTabs?.count ?? 0),
                      interactionState: Data(),
                      isPrivate: false,
                      isSelected: false,

--- a/Sources/Data/models/SessionWindow.swift
+++ b/Sources/Data/models/SessionWindow.swift
@@ -56,7 +56,7 @@ extension SessionWindow {
   /// Returns the active window
   public static func getActiveWindow(context: NSManagedObjectContext) -> SessionWindow? {
     let predicate = NSPredicate(format: "\(#keyPath(SessionWindow.isSelected)) == true")
-    return first(where: predicate, context: DataController.viewContext)
+    return first(where: predicate, context: context)
   }
   
   /// Returns the tab with the specificed windowId

--- a/Sources/Favicon/FaviconFetcher.swift
+++ b/Sources/Favicon/FaviconFetcher.swift
@@ -44,7 +44,6 @@ public class FaviconFetcher {
   /// 4. Fetch Monogram Icons
   /// Notes: Does NOT make a request to fetch icons from the page.
   ///      Requests are only made in FaviconScriptHandler, when the user visits the page.
-  @MainActor
   public static func loadIcon(url: URL, kind: FaviconFetcher.Kind = .smallIcon, persistent: Bool) async throws -> Favicon {
     try Task.checkCancellation()
     
@@ -81,7 +80,6 @@ public class FaviconFetcher {
   /// Creates a monogram Favicon with the following conditions
   /// 1. If `monogramString` is not null, it is used to render the Favicon image.
   /// 2. If `monogramString` is null, the first character of the URL's domain is used to render the Favicon image.
-  @MainActor
   public static func monogramIcon(url: URL, monogramString: Character? = nil, persistent: Bool) async throws -> Favicon {
     try Task.checkCancellation()
     


### PR DESCRIPTION
## Summary of Changes
- Lazy Load Tabs when opening a lot of them (I chose 5 arbitrarily because my 2015 MBP simulator lags with more than 5)
- Optimize restoring tabs.
- Optimize recently closed tabs.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7375

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
