### PR TITLE
Fix #7373: Remove duplicate shields settings (Phishing and Malware)

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController.swift
@@ -2991,7 +2991,6 @@ extension BrowserViewController: PreferencesObserver {
       tabManager.selectedTab?.updatePullToRefreshVisibility()
     case Preferences.Shields.blockAdsAndTracking.key,
       Preferences.Shields.blockScripts.key,
-      Preferences.Shields.blockPhishingAndMalware.key,
       Preferences.Shields.blockImages.key,
       Preferences.Shields.fingerprintingProtection.key,
       Preferences.Shields.useRegionAdBlock.key:

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+P3A.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+P3A.swift
@@ -42,7 +42,7 @@ extension BrowserViewController {
       // Q54 On how many domains has the user set the FP setting to be higher (block more) than the default?
       let fingerprintingAboveGlobalCount = Domain.totalDomainsWithFingerprintingProtectionIncreasedFromGlobal()
       UmaHistogramRecordValueToBucket("Brave.Shields.DomainFingerprintSettingsAboveGlobal", buckets: buckets, value: fingerprintingAboveGlobalCount)
-    case .AllOff, .NoScript, .SafeBrowsing:
+    case .AllOff, .NoScript:
       break
     }
   }

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -254,7 +254,7 @@ extension BrowserViewController: WKNavigationDelegate {
       
       let domainForMainFrame = Domain.getOrCreate(forUrl: mainDocumentURL, persistent: !isPrivateBrowsing)
       // Enable safe browsing (frodulent website warnings)
-      webView.configuration.preferences.isFraudulentWebsiteWarningEnabled = domainForMainFrame.isShieldExpected(.SafeBrowsing, considerAllShieldsOption: true)
+      webView.configuration.preferences.isFraudulentWebsiteWarningEnabled = Preferences.Shields.googleSafeBrowsing.value
       
       // Debouncing logic
       // Handle debouncing for main frame only and only if the site (etld+1) changes

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -253,8 +253,6 @@ extension BrowserViewController: WKNavigationDelegate {
       }
       
       let domainForMainFrame = Domain.getOrCreate(forUrl: mainDocumentURL, persistent: !isPrivateBrowsing)
-      // Enable safe browsing (frodulent website warnings)
-      webView.configuration.preferences.isFraudulentWebsiteWarningEnabled = Preferences.Shields.googleSafeBrowsing.value
       
       // Debouncing logic
       // Handle debouncing for main frame only and only if the site (etld+1) changes

--- a/Sources/Brave/Frontend/Browser/Playlist/Managers & Cache/PlaylistCacheLoader.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/Managers & Cache/PlaylistCacheLoader.swift
@@ -563,7 +563,7 @@ extension PlaylistWebLoader: WKNavigationDelegate {
         tab.setCustomUserScript(scripts: scriptTypes)
       }
       
-      webView.configuration.preferences.isFraudulentWebsiteWarningEnabled = domainForMainFrame.isShieldExpected(.SafeBrowsing, considerAllShieldsOption: true)
+      webView.configuration.preferences.isFraudulentWebsiteWarningEnabled = Preferences.Shields.googleSafeBrowsing.value
     }
 
     if ["http", "https", "data", "blob", "file"].contains(url.scheme) {

--- a/Sources/Brave/Frontend/Browser/Playlist/Managers & Cache/PlaylistCacheLoader.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/Managers & Cache/PlaylistCacheLoader.swift
@@ -562,8 +562,6 @@ extension PlaylistWebLoader: WKNavigationDelegate {
         let scriptTypes = await tab.currentPageData?.makeUserScriptTypes(domain: domainForMainFrame) ?? []
         tab.setCustomUserScript(scripts: scriptTypes)
       }
-      
-      webView.configuration.preferences.isFraudulentWebsiteWarningEnabled = Preferences.Shields.googleSafeBrowsing.value
     }
 
     if ["http", "https", "data", "blob", "file"].contains(url.scheme) {

--- a/Sources/Brave/Frontend/Settings/BraveShieldsAndPrivacySettingsController.swift
+++ b/Sources/Brave/Frontend/Settings/BraveShieldsAndPrivacySettingsController.swift
@@ -134,7 +134,6 @@ class BraveShieldsAndPrivacySettingsController: TableViewController {
       rows: [
         .boolRow(title: Strings.blockAdsAndTracking, detailText: Strings.blockAdsAndTrackingDescription, option: Preferences.Shields.blockAdsAndTracking),
         .boolRow(title: Strings.HTTPSEverywhere, detailText: Strings.HTTPSEverywhereDescription, option: Preferences.Shields.httpsEverywhere),
-        .boolRow(title: Strings.blockPhishingAndMalware, option: Preferences.Shields.blockPhishingAndMalware),
         .boolRow(title: Strings.autoRedirectAMPPages, detailText: Strings.autoRedirectAMPPagesDescription, option: Preferences.Shields.autoRedirectAMPPages),
         .boolRow(title: Strings.autoRedirectTrackingURLs, detailText: Strings.autoRedirectTrackingURLsDescription, option: Preferences.Shields.autoRedirectTrackingURLs),
         .boolRow(title: Strings.blockScripts, detailText: Strings.blockScriptsDescription, option: Preferences.Shields.blockScripts),

--- a/Sources/Brave/Frontend/Shields/ShieldsViewController.swift
+++ b/Sources/Brave/Frontend/Shields/ShieldsViewController.swift
@@ -213,7 +213,7 @@ class ShieldsViewController: UIViewController, PopoverContentComponent {
   /// Groups the shield types with their control and global preference
   private lazy var shieldControlMapping: [(BraveShield, AdvancedShieldsView.ToggleView, Preferences.Option<Bool>?)] = [
     (.AdblockAndTp, shieldsView.advancedShieldView.adsTrackersControl, Preferences.Shields.blockAdsAndTracking),
-    (.SafeBrowsing, shieldsView.advancedShieldView.blockMalwareControl, Preferences.Shields.blockPhishingAndMalware),
+    (.SafeBrowsing, shieldsView.advancedShieldView.blockMalwareControl, Preferences.Shields.googleSafeBrowsing),
     (.NoScript, shieldsView.advancedShieldView.blockScriptsControl, Preferences.Shields.blockScripts),
     (.FpProtection, shieldsView.advancedShieldView.fingerprintingControl, Preferences.Shields.fingerprintingProtection),
   ]

--- a/Sources/Brave/Frontend/Shields/ShieldsViewController.swift
+++ b/Sources/Brave/Frontend/Shields/ShieldsViewController.swift
@@ -213,7 +213,6 @@ class ShieldsViewController: UIViewController, PopoverContentComponent {
   /// Groups the shield types with their control and global preference
   private lazy var shieldControlMapping: [(BraveShield, AdvancedShieldsView.ToggleView, Preferences.Option<Bool>?)] = [
     (.AdblockAndTp, shieldsView.advancedShieldView.adsTrackersControl, Preferences.Shields.blockAdsAndTracking),
-    (.SafeBrowsing, shieldsView.advancedShieldView.blockMalwareControl, Preferences.Shields.googleSafeBrowsing),
     (.NoScript, shieldsView.advancedShieldView.blockScriptsControl, Preferences.Shields.blockScripts),
     (.FpProtection, shieldsView.advancedShieldView.fingerprintingControl, Preferences.Shields.fingerprintingProtection),
   ]

--- a/Sources/Brave/Migration/Migration.swift
+++ b/Sources/Brave/Migration/Migration.swift
@@ -284,7 +284,6 @@ fileprivate extension Preferences {
     // Shields
     migrate(key: "braveBlockAdsAndTracking", to: Preferences.Shields.blockAdsAndTracking)
     migrate(key: "braveHttpsEverywhere", to: Preferences.Shields.httpsEverywhere)
-    migrate(key: "braveSafeBrowsing", to: Preferences.Shields.blockPhishingAndMalware)
     migrate(key: "noscript_on", to: Preferences.Shields.blockScripts)
     migrate(key: "fingerprintprotection_on", to: Preferences.Shields.fingerprintingProtection)
     migrate(key: "braveAdblockUseRegional", to: Preferences.Shields.useRegionAdBlock)

--- a/Sources/BraveShields/BraveShield.swift
+++ b/Sources/BraveShields/BraveShield.swift
@@ -20,7 +20,7 @@ public enum BraveShield {
     case .AdblockAndTp:
       return Preferences.Shields.blockAdsAndTracking.value
     case .SafeBrowsing:
-      return Preferences.Shields.blockPhishingAndMalware.value
+      return Preferences.Shields.googleSafeBrowsing.value
     case .FpProtection:
       return Preferences.Shields.fingerprintingProtection.value
     case .NoScript:

--- a/Sources/BraveShields/BraveShield.swift
+++ b/Sources/BraveShields/BraveShield.swift
@@ -9,7 +9,6 @@ import Preferences
 public enum BraveShield {
   case AllOff
   case AdblockAndTp
-  case SafeBrowsing
   case FpProtection
   case NoScript
 
@@ -19,8 +18,6 @@ public enum BraveShield {
       return false
     case .AdblockAndTp:
       return Preferences.Shields.blockAdsAndTracking.value
-    case .SafeBrowsing:
-      return Preferences.Shields.googleSafeBrowsing.value
     case .FpProtection:
       return Preferences.Shields.fingerprintingProtection.value
     case .NoScript:

--- a/Sources/BraveStrings/BraveStrings.swift
+++ b/Sources/BraveStrings/BraveStrings.swift
@@ -1040,7 +1040,6 @@ extension Strings {
   public static let blockAdsAndTrackingDescription = NSLocalizedString("BlockAdsAndTrackingDescription", tableName: "BraveShared", bundle: .module, value: "Prevents ads, popups, and trackers from loading.", comment: "")
   public static let HTTPSEverywhere = NSLocalizedString("HTTPSEverywhere", tableName: "BraveShared", bundle: .module, value: "Upgrade Connections to HTTPS", comment: "")
   public static let HTTPSEverywhereDescription = NSLocalizedString("HTTPSEverywhereDescription", tableName: "BraveShared", bundle: .module, value: "Opens sites using secure HTTPS instead of HTTP when possible.", comment: "")
-  public static let blockPhishingAndMalware = NSLocalizedString("BlockPhishingAndMalware", tableName: "BraveShared", bundle: .module, value: "Block Phishing and Malware", comment: "")
   public static let googleSafeBrowsing = NSLocalizedString("GoogleSafeBrowsing", tableName: "BraveShared", bundle: .module, value: "Block Dangerous Sites", comment: "")
   public static let googleSafeBrowsingUsingWebKitDescription = NSLocalizedString("GoogleSafeBrowsingUsingWebKitDescription", tableName: "BraveShared", bundle: .module, value: "Sends obfuscated URLs of some pages you visit to the Google Safe Browsing service, when your security is at risk.", comment: "")
   public static let blockScripts = NSLocalizedString("BlockScripts", tableName: "BraveShared", bundle: .module, value: "Block Scripts", comment: "")

--- a/Sources/Data/models/Domain.swift
+++ b/Sources/Data/models/Domain.swift
@@ -111,7 +111,7 @@ public final class Domain: NSManagedObject, CRUD {
       case .AdblockAndTp:
         return self.shield_adblockAndTp?.boolValue ?? Preferences.Shields.blockAdsAndTracking.value
       case .SafeBrowsing:
-        return self.shield_safeBrowsing?.boolValue ?? Preferences.Shields.blockPhishingAndMalware.value
+        return self.shield_safeBrowsing?.boolValue ?? Preferences.Shields.googleSafeBrowsing.value
       case .FpProtection:
         return self.shield_fpProtection?.boolValue ?? Preferences.Shields.fingerprintingProtection.value
       case .NoScript:

--- a/Sources/Data/models/Domain.swift
+++ b/Sources/Data/models/Domain.swift
@@ -110,8 +110,6 @@ public final class Domain: NSManagedObject, CRUD {
         return self.shield_allOff?.boolValue ?? false
       case .AdblockAndTp:
         return self.shield_adblockAndTp?.boolValue ?? Preferences.Shields.blockAdsAndTracking.value
-      case .SafeBrowsing:
-        return self.shield_safeBrowsing?.boolValue ?? Preferences.Shields.googleSafeBrowsing.value
       case .FpProtection:
         return self.shield_fpProtection?.boolValue ?? Preferences.Shields.fingerprintingProtection.value
       case .NoScript:
@@ -402,7 +400,6 @@ extension Domain {
     switch shield {
     case .AllOff: shield_allOff = setting
     case .AdblockAndTp: shield_adblockAndTp = setting
-    case .SafeBrowsing: shield_safeBrowsing = setting
     case .FpProtection: shield_fpProtection = setting
     case .NoScript: shield_noScript = setting
     }
@@ -415,8 +412,6 @@ extension Domain {
       return self.shield_allOff?.boolValue
     case .AdblockAndTp:
       return self.shield_adblockAndTp?.boolValue
-    case .SafeBrowsing:
-      return self.shield_safeBrowsing?.boolValue
     case .FpProtection:
       return self.shield_fpProtection?.boolValue
     case .NoScript:

--- a/Sources/Preferences/GlobalPreferences.swift
+++ b/Sources/Preferences/GlobalPreferences.swift
@@ -34,7 +34,7 @@ extension Preferences {
   }
   
   public final class Shields {
-    public static let allShields = [blockAdsAndTracking, httpsEverywhere, blockPhishingAndMalware, googleSafeBrowsing, blockScripts, fingerprintingProtection, blockImages]
+    public static let allShields = [blockAdsAndTracking, httpsEverywhere, googleSafeBrowsing, blockScripts, fingerprintingProtection, blockImages]
     
     /// Shields will block ads and tracking if enabled
     public static let blockAdsAndTracking = Option<Bool>(key: "shields.block-ads-and-tracking", default: true)
@@ -42,8 +42,6 @@ extension Preferences {
     public static let httpsEverywhere = Option<Bool>(key: "shields.https-everywhere", default: true)
     /// Enable Google Safe Browsing
     public static let googleSafeBrowsing = Option<Bool>(key: "shields.google-safe-browsing", default: true)
-    /// Shields will block websites related to potential phishing and malware
-    public static let blockPhishingAndMalware = Option<Bool>(key: "shields.block-phishing-and-malware", default: true)
     /// Disables JavaScript execution in the browser
     public static let blockScripts = Option<Bool>(key: "shields.block-scripts", default: false)
     /// Enforces fingerprinting protection on the users session

--- a/Tests/DataTests/DomainTests.swift
+++ b/Tests/DataTests/DomainTests.swift
@@ -62,7 +62,6 @@ class DomainTests: CoreDataTestCase {
   @MainActor func testDefaultShieldSettings() {
     let domain = Domain.getOrCreate(forUrl: url, persistent: true)
     XCTAssertTrue(domain.isShieldExpected(BraveShield.AdblockAndTp, considerAllShieldsOption: true))
-    XCTAssertTrue(domain.isShieldExpected(BraveShield.SafeBrowsing, considerAllShieldsOption: true))
     XCTAssertFalse(domain.isShieldExpected(BraveShield.AllOff, considerAllShieldsOption: true))
     XCTAssertFalse(domain.isShieldExpected(BraveShield.NoScript, considerAllShieldsOption: true))
     XCTAssertTrue(domain.isShieldExpected(BraveShield.FpProtection, considerAllShieldsOption: true))
@@ -79,7 +78,6 @@ class DomainTests: CoreDataTestCase {
     }
 
     XCTAssertFalse(domain.isShieldExpected(BraveShield.AdblockAndTp, considerAllShieldsOption: true))
-    XCTAssertTrue(domain.isShieldExpected(BraveShield.SafeBrowsing, considerAllShieldsOption: false))
     XCTAssertFalse(domain.isShieldExpected(BraveShield.AllOff, considerAllShieldsOption: true))
     XCTAssertFalse(domain.isShieldExpected(BraveShield.NoScript, considerAllShieldsOption: true))
     XCTAssertFalse(domain.isShieldExpected(BraveShield.FpProtection, considerAllShieldsOption: true))
@@ -89,7 +87,6 @@ class DomainTests: CoreDataTestCase {
     }
 
     XCTAssertTrue(domain.isShieldExpected(BraveShield.AdblockAndTp, considerAllShieldsOption: true))
-    XCTAssertTrue(domain.isShieldExpected(BraveShield.SafeBrowsing, considerAllShieldsOption: true))
     XCTAssertFalse(domain.isShieldExpected(BraveShield.AllOff, considerAllShieldsOption: true))
     XCTAssertFalse(domain.isShieldExpected(BraveShield.NoScript, considerAllShieldsOption: true))
     XCTAssertTrue(domain.isShieldExpected(BraveShield.FpProtection, considerAllShieldsOption: true))
@@ -97,32 +94,19 @@ class DomainTests: CoreDataTestCase {
 
   /// Tests non-HTTPSE shields
   @MainActor func testNormalShieldSettings() {
-
-    backgroundSaveAndWaitForExpectation {
-      Domain.setBraveShield(forUrl: url2HTTPS, shield: .SafeBrowsing, isOn: true, isPrivateBrowsing: false)
-    }
-
     backgroundSaveAndWaitForExpectation {
       Domain.setBraveShield(forUrl: url2HTTPS, shield: .AdblockAndTp, isOn: false, isPrivateBrowsing: false)
     }
+    
     let domain = Domain.getOrCreate(forUrl: url2HTTPS, persistent: true)
-    XCTAssertTrue(domain.isShieldExpected(BraveShield.SafeBrowsing, considerAllShieldsOption: true))
-
     // These should be the same in this situation
     XCTAssertFalse(domain.isShieldExpected(BraveShield.AdblockAndTp, considerAllShieldsOption: true))
-
-    // Setting to "new" values
-    // Setting to same value
-    backgroundSaveAndWaitForExpectation {
-      Domain.setBraveShield(forUrl: url2HTTPS, shield: .SafeBrowsing, isOn: true, isPrivateBrowsing: false)
-    }
 
     backgroundSaveAndWaitForExpectation {
       Domain.setBraveShield(forUrl: url2HTTPS, shield: .AdblockAndTp, isOn: true, isPrivateBrowsing: false)
     }
 
     domain.managedObjectContext?.refreshAllObjects()
-    XCTAssertTrue(domain.isShieldExpected(BraveShield.SafeBrowsing, considerAllShieldsOption: true))
     XCTAssertTrue(domain.isShieldExpected(BraveShield.AdblockAndTp, considerAllShieldsOption: true))
   }
 
@@ -198,30 +182,5 @@ class DomainTests: CoreDataTestCase {
       Domain.clearAllWalletPermissions(for: .sol)
     }
     XCTAssertFalse(raydiumDomain.walletPermissions(for: .sol, account: walletSolAccount))
-  }
-  
-  @MainActor func testSafeBrowsing() {
-    Preferences.Shields.googleSafeBrowsing.reset()
-    DataController.shared = DataController()
-    DataController.shared.initializeOnce()
-    
-    let urls = [
-      URL(string: "http://brave.com")!,
-      URL(string: "https://brave.com")!,
-      URL(string: "https://www.brave.com")!,
-      URL(string: "https://example.com")!
-    ]
-    
-    for url in urls {
-      let domain = Domain.getOrCreate(forUrl: url, persistent: false)
-      XCTAssertTrue(domain.isShieldExpected(.SafeBrowsing, considerAllShieldsOption: true))
-    }
-    
-    Preferences.Shields.googleSafeBrowsing.value = false
-    
-    for url in urls {
-      let domain = Domain.getOrCreate(forUrl: url, persistent: false)
-      XCTAssertFalse(domain.isShieldExpected(.SafeBrowsing, considerAllShieldsOption: true))
-    }
   }
 }

--- a/Tests/DataTests/DomainTests.swift
+++ b/Tests/DataTests/DomainTests.swift
@@ -201,7 +201,7 @@ class DomainTests: CoreDataTestCase {
   }
   
   @MainActor func testSafeBrowsing() {
-    Preferences.Shields.blockPhishingAndMalware.reset()
+    Preferences.Shields.googleSafeBrowsing.reset()
     DataController.shared = DataController()
     DataController.shared.initializeOnce()
     
@@ -217,7 +217,7 @@ class DomainTests: CoreDataTestCase {
       XCTAssertTrue(domain.isShieldExpected(.SafeBrowsing, considerAllShieldsOption: true))
     }
     
-    Preferences.Shields.blockPhishingAndMalware.value = false
+    Preferences.Shields.googleSafeBrowsing.value = false
     
     for url in urls {
       let domain = Domain.getOrCreate(forUrl: url, persistent: false)


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Remove duplicate setting since we already have a GoogleSafeBrowsing preference.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7373

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
