### PR TITLE
Fix #7382: Auto-focus password field in unlock wallet view

### DIFF
--- a/Sources/BraveWallet/Crypto/NFT/NFTView.swift
+++ b/Sources/BraveWallet/Crypto/NFT/NFTView.swift
@@ -38,7 +38,7 @@ struct NFTView: View {
       Text(Strings.Wallet.editVisibleAssetsButtonTitle)
         .multilineTextAlignment(.center)
         .font(.footnote.weight(.semibold))
-        .foregroundColor(Color(.braveBlurple))
+        .foregroundColor(Color(.braveBlurpleTint))
         .frame(maxWidth: .infinity)
     }
     .sheet(isPresented: $isPresentingEditUserAssets) {

--- a/Sources/BraveWallet/Crypto/UnlockWalletView.swift
+++ b/Sources/BraveWallet/Crypto/UnlockWalletView.swift
@@ -138,10 +138,9 @@ struct UnlockWalletView: View {
         if !keyringStore.lockedManually && !attemptedBiometricsUnlock && keyringStore.defaultKeyring.isLocked && UIApplication.shared.isProtectedDataAvailable {
           attemptedBiometricsUnlock = true
           fillPasswordFromKeychain()
-        } else {
-          // only focus field if not auto-filling via biometrics, and user did not manually lock
-          isPasswordFieldFocused = !keyringStore.lockedManually
         }
+        // only focus field if user did not manually lock
+        isPasswordFieldFocused = !keyringStore.lockedManually
       }
     }
   }


### PR DESCRIPTION
## Summary of Changes
- Regressed in https://github.com/brave/brave-ios/pull/7269 with changes to reveal password.
- Field was not being focused because we attempted biometrics unlock. Previously field was always auto-focused.

This pull request fixes #7382

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
  1. Setup a Wallet if not setup
  2. Lock Wallet if not locked
  3. Tap `...` button and select Wallet row
  4. Verify password field is auto-focused


## Screenshots:

https://user-images.githubusercontent.com/5314553/236003267-c49ea2ed-93e1-471e-ac9c-46bc940db267.mp4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
