### PR TITLE
Fix #7296: Display network chain name on DApp Requests

### DIFF
--- a/Sources/BraveWallet/Panels/RequestContainerView.swift
+++ b/Sources/BraveWallet/Panels/RequestContainerView.swift
@@ -58,6 +58,7 @@ struct RequestContainerView<DismissContent: ToolbarContent>: View {
               requests: requests,
               keyringStore: keyringStore,
               cryptoStore: cryptoStore,
+              networkStore: cryptoStore.networkStore,
               onDismiss: onDismiss
             )
           case let .getEncryptionPublicKey(request):

--- a/Sources/BraveWallet/Panels/Signature Request/SignatureRequestView.swift
+++ b/Sources/BraveWallet/Panels/Signature Request/SignatureRequestView.swift
@@ -12,6 +12,7 @@ struct SignatureRequestView: View {
   var requests: [BraveWallet.SignMessageRequest]
   @ObservedObject var keyringStore: KeyringStore
   var cryptoStore: CryptoStore
+  @ObservedObject var networkStore: NetworkStore
   
   var onDismiss: () -> Void
 
@@ -34,6 +35,10 @@ struct SignatureRequestView: View {
   
   private var account: BraveWallet.AccountInfo {
     keyringStore.allAccounts.first(where: { $0.address == currentRequest.address }) ?? keyringStore.selectedAccount
+  }
+  
+  private var network: BraveWallet.NetworkInfo? {
+    networkStore.allChains.first(where: { $0.chainId == currentRequest.chainId })
   }
   
   /// Request display text, used as fallback.
@@ -130,21 +135,28 @@ struct SignatureRequestView: View {
     requests: [BraveWallet.SignMessageRequest],
     keyringStore: KeyringStore,
     cryptoStore: CryptoStore,
+    networkStore: NetworkStore,
     onDismiss: @escaping () -> Void
   ) {
     assert(!requests.isEmpty)
     self.requests = requests
     self.keyringStore = keyringStore
     self.cryptoStore = cryptoStore
+    self.networkStore = networkStore
     self.onDismiss = onDismiss
   }
   
   var body: some View {
     ScrollView(.vertical) {
       VStack {
-        if requests.count > 1 {
-          HStack {
-            Spacer()
+        HStack {
+          if let network {
+            Text(network.chainName)
+              .font(.callout)
+              .foregroundColor(Color(.braveLabel))
+          }
+          Spacer()
+          if requests.count > 1 {
             Text(String.localizedStringWithFormat(Strings.Wallet.transactionCount, requestIndex + 1, requests.count))
               .fontWeight(.semibold)
             Button(action: next) {
@@ -388,6 +400,7 @@ struct SignatureRequestView_Previews: PreviewProvider {
       requests: [.previewRequest],
       keyringStore: .previewStoreWithWalletCreated,
       cryptoStore: .previewStore,
+      networkStore: .previewStore,
       onDismiss: { }
     )
   }


### PR DESCRIPTION
## Summary of Changes
- `SignatureRequestView` (sign message) previously did not show a network name. Now that we have the `chain_id` of the network, we display the network in the top-left similar to other requests
- `SignTransactionView` previously displayed the selected network for each coin type in the top-left (because we previously only could fetch the requests for the selected network). Now that we have the `chain_id`, we can display

This pull request fixes #7296

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Visit https://pwgoom.csb.app and connect your wallet.
2. Select Solana Devnet in the network picker on the wallet panel.
3. Select one of the `Sign Transaction` buttons (`Sign All Transactions` should work too!). `v0` will require Solana Versioned Transactions PR to merge.
4. Verify network name is displayed top-left. Swipe to close the request without tapping cancel / confirm.
5. Select Solana Mainnet on the wallet panel, then tap the bell icon on the panel to open the pending Sign Transaction.
6. Verify that Solana Devnet is still shown top-left, and not Solana Mainnet.
7. Cancel/approve the request to remove from pending.
8. Select Solana Devnet in the network picker on the wallet panel.
9. Tap `Sign Message`.
10. Verify network name is displayed top-left. Swipe to close the request without tapping cancel / confirm.
11. Select Solana Mainnet on the wallet panel, then tap the bell icon on the panel to open the pending Sign Message request.
12. Verify that Solana Devnet is still shown top-left, and not Solana Mainnet.

Signature Request can also be verified on Ethereum network
1. Visit https://metamask.github.io/test-dapp/ and connect your wallet.
2. Select Goerli testnet in the network picker on the wallet panel.
3. Tap `Sign` under `Sign Typed Data v4`
4. Verify Goerli Testnet is shown top-left. Swipe to close the request without tapping cancel / confirm.
5. Select Ethereum Mainnet (or any EVM network) on the wallet panel, then tap the bell icon on the panel to open the pending Sign Message request.
6. Verify Goerli Testnet is still shown in the top-left, and not Ethereum Mainnet (or whichever EVM selected in step 5).

## Screenshots:

https://user-images.githubusercontent.com/5314553/236025700-f7d59a26-b544-401f-864b-7f48e91bc081.mov


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
