### PR TITLE
No Bug: Fix potential crash when Tab is deallocated off main

### DIFF
--- a/Sources/Brave/Frontend/Browser/Tab.swift
+++ b/Sources/Brave/Frontend/Browser/Tab.swift
@@ -410,6 +410,21 @@ class Tab: NSObject {
     deleteWebView()
     deleteNewTabPageController()
     contentScriptManager.helpers.removeAll()
+    
+    // A number of mojo-powered core objects have to be deconstructed on the same
+    // thread they were constructed
+    var mojoObjects: [Any?] = [
+      faviconDriver,
+      walletEthProvider,
+      walletSolProvider,
+      walletKeyringService
+    ]
+    
+    DispatchQueue.main.async {
+      // Reference inside to retain it, supress warnings by reading/writing
+      _ = mojoObjects
+      mojoObjects = []
+    }
   }
 
   var loading: Bool {


### PR DESCRIPTION
## Summary of Changes

There was a crash report around Mojo due to Tab.deinit being called off main, this should fix that

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
