### PR TITLE
Fix #7389: network picker missing icon in NFT tab

### DIFF
--- a/Sources/BraveWallet/Crypto/NFT/NFTView.swift
+++ b/Sources/BraveWallet/Crypto/NFT/NFTView.swift
@@ -94,7 +94,7 @@ struct NFTView: View {
     }) {
       HStack {
         Text(nftStore.networkFilter.title)
-        Image(braveSystemName: "brave.text.alignleft")
+        Image(braveSystemName: "leo.list")
       }
       .font(.footnote.weight(.medium))
       .foregroundColor(Color(.braveBlurpleTint))


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
use leo image

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7389

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

![simulator_screenshot_BC5560C2-7EAF-4F83-85BF-1725654D99C9](https://user-images.githubusercontent.com/1187676/236256206-0799e9ec-d408-450c-86b3-6151e786a566.png)

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
