### PR TITLE
Fix 7380: VPN easy access Region switcher

### DIFF
--- a/App/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/GuardianFirewall/GuardianConnect",
       "state" : {
-        "revision" : "5e7d412e4c005f6b9668722cceadbc5e0d9150b8",
-        "version" : "1.8.3"
+        "revision" : "5a00da66f1368e5c325489676fe9281ec98c3a8f",
+        "version" : "1.8.4-dev-2"
       }
     },
     {

--- a/App/iOS/Delegates/AppDelegate.swift
+++ b/App/iOS/Delegates/AppDelegate.swift
@@ -171,7 +171,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // This is a light operation, can be called at every launch without troubles.
     BraveVPN.migrateV1Credentials()
 
-    //
+    // Fetching details of GRDRegion for Automatic Region selection
     BraveVPN.fetchLastUsedRegionDetail()
     
     // Start the keyboard helper to monitor and cache keyboard state.

--- a/App/iOS/Delegates/AppDelegate.swift
+++ b/App/iOS/Delegates/AppDelegate.swift
@@ -166,10 +166,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     // Set the Safari UA for browsing.
     setUserAgent()
+    
     // Moving Brave VPN v1 users to v2 type of credentials.
     // This is a light operation, can be called at every launch without troubles.
     BraveVPN.migrateV1Credentials()
 
+    //
+    BraveVPN.fetchLastUsedRegionDetail()
+    
     // Start the keyboard helper to monitor and cache keyboard state.
     KeyboardHelper.defaultHelper.startObserving()
     DynamicFontHelper.defaultHelper.startObserving()

--- a/Package.swift
+++ b/Package.swift
@@ -60,7 +60,7 @@ var package = Package(
     .package(url: "https://github.com/apple/swift-algorithms", from: "1.0.0"),
     .package(url: "https://github.com/devxoul/Then", from: "2.7.0"),
     .package(url: "https://github.com/mkrd/Swift-BigInt", from: "2.0.0"),
-    .package(url: "https://github.com/GuardianFirewall/GuardianConnect", exact: "1.8.3"),
+    .package(url: "https://github.com/GuardianFirewall/GuardianConnect", exact: "1.8.4-dev-2"),
     .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "0.6.0"),
     .package(name: "Static", path: "ThirdParty/Static"),
   ],

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
@@ -68,9 +68,10 @@ extension BrowserViewController {
       )
       
       RegionMenuButton(vpnRegionInfo: BraveVPN.activatedRegion, regionSelectAction: {
-        
-        }
-      )
+        let vc = BraveVPNRegionPickerViewController()
+        (self.presentedViewController as? MenuViewController)?
+          .pushInnerMenu(vc)
+      })
       
       Divider()
 

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
@@ -16,7 +16,7 @@ import BraveVPN
 
 extension BrowserViewController {
   func featuresMenuSection(_ menuController: MenuViewController) -> some View {
-    VStack(spacing: 0) {
+    VStack(alignment: .leading, spacing: 5) {
       VPNMenuButton(
         vpnProductInfo: self.vpnProductInfo,
         displayVPNDestination: { [unowned self] vc in
@@ -34,6 +34,12 @@ extension BrowserViewController {
           self?.openURLInNewTab(url, isPrivate: PrivateBrowsingManager.shared.isPrivateBrowsing,
                                isPrivileged: false)
         })
+      
+      RegionMenuButton(vpnRegionInfo: BraveVPN.activatedRegion, settingTitleEnabled: false, regionSelectAction: {
+        let vc = BraveVPNRegionPickerViewController()
+        (self.presentedViewController as? MenuViewController)?
+          .pushInnerMenu(vc)
+      })
     }
   }
 

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
@@ -65,6 +65,8 @@ extension BrowserViewController {
                                isPrivileged: false)
         }
       )
+      
+      Divider()
 
       MenuItemFactory.button(for: .playlist(subtitle: Strings.OptionsMenu.bravePlaylistItemDescription)) { [weak self] in
         guard let self = self else { return }

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
@@ -12,6 +12,7 @@ import Data
 import BraveWallet
 import BraveCore
 import os.log
+import BraveVPN
 
 extension BrowserViewController {
   func featuresMenuSection(_ menuController: MenuViewController) -> some View {
@@ -63,6 +64,11 @@ extension BrowserViewController {
           self.openURLInNewTab(url,
                                isPrivate: PrivateBrowsingManager.shared.isPrivateBrowsing,
                                isPrivileged: false)
+        }
+      )
+      
+      RegionMenuButton(vpnRegionInfo: BraveVPN.activatedRegion, regionSelectAction: {
+        
         }
       )
       

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
@@ -35,6 +35,7 @@ extension BrowserViewController {
                                isPrivileged: false)
         })
       
+      // Region Button is populated without current selected detail title for features menu
       RegionMenuButton(vpnRegionInfo: BraveVPN.activatedRegion, settingTitleEnabled: false, regionSelectAction: {
         let vc = BraveVPNRegionPickerViewController()
         (self.presentedViewController as? MenuViewController)?
@@ -73,6 +74,7 @@ extension BrowserViewController {
         }
       )
       
+      // Region Button is populated including the details for privacy feature menu
       RegionMenuButton(vpnRegionInfo: BraveVPN.activatedRegion, regionSelectAction: {
         let vc = BraveVPNRegionPickerViewController()
         (self.presentedViewController as? MenuViewController)?

--- a/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/RegionMenuButton.swift
+++ b/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/RegionMenuButton.swift
@@ -25,8 +25,9 @@ struct RegionMenuButton: View {
       return nil
     }
     
-    
-    return vpnRegionInfo?.settingTitle ?? "Current Setting: Automatic"
+    return vpnRegionInfo?.settingTitle ?? String(
+      format: Strings.VPN.vpnRegionSelectorButtonSubTitle,
+      Strings.VPN.regionPickerAutomaticModeCellText)
   }
   
   @State private var isVPNEnabled = BraveVPN.isConnected
@@ -37,7 +38,7 @@ struct RegionMenuButton: View {
         HStack {
           MenuItemHeaderView(
             icon: vpnRegionInfo?.regionFlag ?? Image(braveSystemName: "leo.globe"),
-            title: "VPN Region",
+            title: Strings.VPN.vpnRegionSelectorButtonTitle,
             subtitle: subTitle)
           Spacer()
           Image(braveSystemName: "leo.arrow.small-right")
@@ -51,11 +52,11 @@ struct RegionMenuButton: View {
           }) {
             Color.clear
           }
-            .buttonStyle(TableCellButtonStyle())
+          .buttonStyle(TableCellButtonStyle())
         )
         .accessibilityElement()
         .accessibility(addTraits: .isButton)
-        .accessibility(label: Text("VPN Region"))
+        .accessibility(label: Text(Strings.VPN.vpnRegionSelectorButtonTitle))
       }
     }
     .onReceive(NotificationCenter.default.publisher(for: .NEVPNStatusDidChange)) { _ in

--- a/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/RegionMenuButton.swift
+++ b/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/RegionMenuButton.swift
@@ -18,45 +18,38 @@ struct RegionMenuButton: View {
   /// A closure executed when the region select is clicked
   var regionSelectAction: () -> Void
   
-  @State private var isVPNStatusChanging: Bool = BraveVPN.reconnectPending
   @State private var isVPNEnabled = BraveVPN.isConnected
-  @State private var isErrorShowing: Bool = false
   
   var body: some View {
-    HStack {
-      MenuItemHeaderView(
-        icon: vpnRegionInfo?.regionFlag ?? Image(braveSystemName: "leo.globe"),
-        title: "VPN Region",
-        subtitle: vpnRegionInfo?.settingTitle ?? "Current Setting: Automatic")
-      Spacer()
-      if isVPNStatusChanging {
-        hidden()
+      HStack {
+        if isVPNEnabled {
+          HStack {
+            MenuItemHeaderView(
+              icon: vpnRegionInfo?.regionFlag ?? Image(braveSystemName: "leo.globe"),
+              title: "VPN Region",
+              subtitle: vpnRegionInfo?.settingTitle ?? "Current Setting: Automatic")
+            Spacer()
+            Image(braveSystemName: "leo.arrow.small-right")
+              .foregroundColor(Color(.secondaryBraveLabel))
+          }
+          .padding(.horizontal, 14)
+          .frame(maxWidth: .infinity, minHeight: 48.0, alignment: .leading)
+          .background(
+            Button(action: {
+              regionSelectAction()
+            }) {
+              Color.clear
+            }
+              .buttonStyle(TableCellButtonStyle())
+          )
+          .accessibilityElement()
+          .accessibility(addTraits: .isButton)
+          .accessibility(label: Text("VPN Region"))
+        }
       }
-    }
-    .padding(.horizontal, 14)
-    .frame(maxWidth: .infinity, minHeight: 48.0, alignment: .leading)
-    .background(
-      Button(action: {
-        regionSelectAction()
-      }) {
-        Color.clear
+      .onReceive(NotificationCenter.default.publisher(for: .NEVPNStatusDidChange)) { _ in
+        isVPNEnabled = BraveVPN.isConnected
       }
-      .buttonStyle(TableCellButtonStyle())
-    )
-    .accessibilityElement()
-    .accessibility(addTraits: .isButton)
-    .accessibility(label: Text("VPN Region"))
-    .alert(isPresented: $isErrorShowing) {
-      Alert(
-        title: Text(verbatim: Strings.VPN.errorCantGetPricesTitle),
-        message: Text(verbatim: Strings.VPN.errorCantGetPricesBody),
-        dismissButton: .default(Text(verbatim: Strings.OKString))
-      )
-    }
-    .onReceive(NotificationCenter.default.publisher(for: .NEVPNStatusDidChange)) { _ in
-      isVPNEnabled = BraveVPN.isConnected
-      isVPNStatusChanging = BraveVPN.reconnectPending
-    }
   }
   
 }

--- a/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/RegionMenuButton.swift
+++ b/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/RegionMenuButton.swift
@@ -15,15 +15,16 @@ import GuardianConnect
 struct RegionMenuButton: View {
   /// The region information
   var vpnRegionInfo: GRDRegion?
-  ///
+  /// Boolean determining if current setting subtitle is going to be shown
   var settingTitleEnabled = true
   /// A closure executed when the region select is clicked
   var regionSelectAction: () -> Void
-  
+  /// Subtitle generation according to menu selection
   var subTitle: String? {
     guard settingTitleEnabled else {
       return nil
     }
+    
     
     return vpnRegionInfo?.settingTitle ?? "Current Setting: Automatic"
   }

--- a/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/RegionMenuButton.swift
+++ b/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/RegionMenuButton.swift
@@ -1,0 +1,64 @@
+// Copyright 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import Shared
+import BraveShared
+import SwiftUI
+import BraveUI
+import BraveVPN
+
+/// A menu button that provides a shortcut to changing Brave VPN region
+struct RegionMenuButton: View {
+  /// The region information
+  var vpnRegionInfo: VPNProductInfo
+  /// The current setting which shows which server is selected
+  var currentSettingsTitle: String
+  /// A closure executed when the region select is clicked
+  var regionSelectAction: () -> Void
+  
+  @State private var isVPNStatusChanging: Bool = BraveVPN.reconnectPending
+  @State private var isVPNEnabled = BraveVPN.isConnected
+  @State private var isErrorShowing: Bool = false
+  
+  var body: some View {
+    HStack {
+      MenuItemHeaderView(
+        icon: Image(braveSystemName: "leo.product.vpn"),
+        title: "VPN Region",
+        subtitle: currentSettingsTitle)
+      Spacer()
+      if isVPNStatusChanging {
+        ActivityIndicatorView(isAnimating: true)
+      }
+      NavigationLink<<#Label: View#>, <#Destination: View#>>.empty
+    }
+    .padding(.horizontal, 14)
+    .frame(maxWidth: .infinity, minHeight: 48.0, alignment: .leading)
+    .background(
+      Button(action: {
+        regionSelectAction()
+      }) {
+        Color.clear
+      }
+      .buttonStyle(TableCellButtonStyle())
+    )
+    .accessibilityElement()
+    .accessibility(addTraits: .isButton)
+    .accessibility(label: Text("VPN Region"))
+    .alert(isPresented: $isErrorShowing) {
+      Alert(
+        title: Text(verbatim: Strings.VPN.errorCantGetPricesTitle),
+        message: Text(verbatim: Strings.VPN.errorCantGetPricesBody),
+        dismissButton: .default(Text(verbatim: Strings.OKString))
+      )
+    }
+    .onReceive(NotificationCenter.default.publisher(for: .NEVPNStatusDidChange)) { _ in
+      isVPNEnabled = BraveVPN.isConnected
+      isVPNStatusChanging = BraveVPN.reconnectPending
+    }
+  }
+  
+}

--- a/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/RegionMenuButton.swift
+++ b/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/RegionMenuButton.swift
@@ -15,41 +15,50 @@ import GuardianConnect
 struct RegionMenuButton: View {
   /// The region information
   var vpnRegionInfo: GRDRegion?
+  ///
+  var settingTitleEnabled = true
   /// A closure executed when the region select is clicked
   var regionSelectAction: () -> Void
+  
+  var subTitle: String? {
+    guard settingTitleEnabled else {
+      return nil
+    }
+    
+    return vpnRegionInfo?.settingTitle ?? "Current Setting: Automatic"
+  }
   
   @State private var isVPNEnabled = BraveVPN.isConnected
   
   var body: some View {
-      HStack {
-        if isVPNEnabled {
-          HStack {
-            MenuItemHeaderView(
-              icon: vpnRegionInfo?.regionFlag ?? Image(braveSystemName: "leo.globe"),
-              title: "VPN Region",
-              subtitle: vpnRegionInfo?.settingTitle ?? "Current Setting: Automatic")
-            Spacer()
-            Image(braveSystemName: "leo.arrow.small-right")
-              .foregroundColor(Color(.secondaryBraveLabel))
-          }
-          .padding(.horizontal, 14)
-          .frame(maxWidth: .infinity, minHeight: 48.0, alignment: .leading)
-          .background(
-            Button(action: {
-              regionSelectAction()
-            }) {
-              Color.clear
-            }
-              .buttonStyle(TableCellButtonStyle())
-          )
-          .accessibilityElement()
-          .accessibility(addTraits: .isButton)
-          .accessibility(label: Text("VPN Region"))
+    HStack {
+      if isVPNEnabled {
+        HStack {
+          MenuItemHeaderView(
+            icon: vpnRegionInfo?.regionFlag ?? Image(braveSystemName: "leo.globe"),
+            title: "VPN Region",
+            subtitle: subTitle)
+          Spacer()
+          Image(braveSystemName: "leo.arrow.small-right")
+            .foregroundColor(Color(.secondaryBraveLabel))
         }
+        .padding(.horizontal, 14)
+        .frame(maxWidth: .infinity, minHeight: 48.0, alignment: .leading)
+        .background(
+          Button(action: {
+            regionSelectAction()
+          }) {
+            Color.clear
+          }
+            .buttonStyle(TableCellButtonStyle())
+        )
+        .accessibilityElement()
+        .accessibility(addTraits: .isButton)
+        .accessibility(label: Text("VPN Region"))
       }
-      .onReceive(NotificationCenter.default.publisher(for: .NEVPNStatusDidChange)) { _ in
-        isVPNEnabled = BraveVPN.isConnected
-      }
+    }
+    .onReceive(NotificationCenter.default.publisher(for: .NEVPNStatusDidChange)) { _ in
+      isVPNEnabled = BraveVPN.isConnected
+    }
   }
-  
 }

--- a/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/RegionMenuButton.swift
+++ b/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/RegionMenuButton.swift
@@ -30,7 +30,7 @@ struct RegionMenuButton: View {
         subtitle: vpnRegionInfo?.settingTitle ?? "Current Setting: Automatic")
       Spacer()
       if isVPNStatusChanging {
-        ActivityIndicatorView(isAnimating: true)
+        hidden()
       }
     }
     .padding(.horizontal, 14)

--- a/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/RegionMenuButton.swift
+++ b/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/RegionMenuButton.swift
@@ -9,13 +9,12 @@ import BraveShared
 import SwiftUI
 import BraveUI
 import BraveVPN
+import GuardianConnect
 
 /// A menu button that provides a shortcut to changing Brave VPN region
 struct RegionMenuButton: View {
   /// The region information
-  var vpnRegionInfo: VPNProductInfo
-  /// The current setting which shows which server is selected
-  var currentSettingsTitle: String
+  var vpnRegionInfo: GRDRegion?
   /// A closure executed when the region select is clicked
   var regionSelectAction: () -> Void
   
@@ -26,14 +25,13 @@ struct RegionMenuButton: View {
   var body: some View {
     HStack {
       MenuItemHeaderView(
-        icon: Image(braveSystemName: "leo.product.vpn"),
+        icon: vpnRegionInfo?.regionFlag ?? Image(braveSystemName: "leo.globe"),
         title: "VPN Region",
-        subtitle: currentSettingsTitle)
+        subtitle: vpnRegionInfo?.settingTitle ?? "Current Setting: Automatic")
       Spacer()
       if isVPNStatusChanging {
         ActivityIndicatorView(isAnimating: true)
       }
-      NavigationLink<<#Label: View#>, <#Destination: View#>>.empty
     }
     .padding(.horizontal, 14)
     .frame(maxWidth: .infinity, minHeight: 48.0, alignment: .leading)

--- a/Sources/BraveShared/Extensions/StringExtensions.swift
+++ b/Sources/BraveShared/Extensions/StringExtensions.swift
@@ -43,9 +43,9 @@ extension String {
 
 extension String {
   
-  /// <#Description#>
-  /// - Parameter fontSize: <#fontSize description#>
-  /// - Returns: <#description#>
+  /// Image generation from String with changing font size
+  /// - Parameter fontSize: Desired Font Size
+  /// - Returns: Image generated from the String
   public func image(fontSize: CGFloat = 28.0) -> UIImage {
     let font = UIFont.systemFont(ofSize: fontSize)
     let size = self.size(withAttributes: [.font: font])

--- a/Sources/BraveShared/Extensions/StringExtensions.swift
+++ b/Sources/BraveShared/Extensions/StringExtensions.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import Foundation
+import UIKit
 
 extension String {
   /// The first URL found within this String, or nil if no URL is found
@@ -38,4 +39,24 @@ extension String {
   public var preferredSearchSuggestionText: String {
     return self.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
   }
+}
+
+extension String {
+  
+  /// <#Description#>
+  /// - Parameter fontSize: <#fontSize description#>
+  /// - Returns: <#description#>
+  public func image(fontSize: CGFloat = 32.0) -> UIImage {
+    let font = UIFont.systemFont(ofSize: fontSize)
+    let size = self.size(withAttributes: [.font: font])
+    
+    return UIGraphicsImageRenderer(size: size).image { context in
+      context.cgContext.setFillColor(UIColor.white.cgColor)
+      context.cgContext.setStrokeColor(UIColor.white.cgColor)
+      context.fill(CGRect(origin: .zero, size: size))
+      
+      (self as AnyObject).draw(in: CGRect(origin: .zero, size: size), withAttributes: [.font: font])
+    }
+  }
+  
 }

--- a/Sources/BraveShared/Extensions/StringExtensions.swift
+++ b/Sources/BraveShared/Extensions/StringExtensions.swift
@@ -46,13 +46,13 @@ extension String {
   /// <#Description#>
   /// - Parameter fontSize: <#fontSize description#>
   /// - Returns: <#description#>
-  public func image(fontSize: CGFloat = 32.0) -> UIImage {
+  public func image(fontSize: CGFloat = 28.0) -> UIImage {
     let font = UIFont.systemFont(ofSize: fontSize)
     let size = self.size(withAttributes: [.font: font])
     
     return UIGraphicsImageRenderer(size: size).image { context in
-      context.cgContext.setFillColor(UIColor.white.cgColor)
-      context.cgContext.setStrokeColor(UIColor.white.cgColor)
+      context.cgContext.setFillColor(UIColor.clear.cgColor)
+      context.cgContext.setStrokeColor(UIColor.clear.cgColor)
       context.fill(CGRect(origin: .zero, size: size))
       
       (self as AnyObject).draw(in: CGRect(origin: .zero, size: size), withAttributes: [.font: font])

--- a/Sources/BraveStrings/BraveStrings.swift
+++ b/Sources/BraveStrings/BraveStrings.swift
@@ -2928,6 +2928,17 @@ extension Strings {
       NSLocalizedString("vpn.sessionExpiredDismissButton", tableName: "BraveShared", bundle: .module,
         value: "Dismiss",
         comment: "Dismiss button to close the alert showing that the vpn session has expired")
+    
+    public static let vpnRegionSelectorButtonTitle =
+      NSLocalizedString("vpn.vpnRegionSelectorButtonTitle", tableName: "BraveShared", bundle: .module,
+        value: "VPN Region",
+        comment: "Button title for VPN region selection in menu")
+    
+    public static let vpnRegionSelectorButtonSubTitle =
+      NSLocalizedString("vpn.vpnRegionSelectorButtonSubTitle", tableName: "BraveShared", bundle: .module,
+        value: "Current Setting: %@",
+        comment: "Button subtitle for VPN region selection in menu. %@ will be replaced with country name or automatic ex: Current Setting: Automatic")
+    
   }
 }
 

--- a/Sources/BraveVPN/BraveVPN.swift
+++ b/Sources/BraveVPN/BraveVPN.swift
@@ -296,9 +296,15 @@ public class BraveVPN {
         } else {
           helper.ikev2VPNManager.removeFromPreferences()
         }
-        
-        reconnectPending = false
-        completion?(success)
+         
+        // First time user will connect automatic region - detail is pulled
+        fetchLastUsedRegionDetail() { _, _ in
+          reconnectPending = false
+          DispatchQueue.main.async {  
+            completion?(success)
+          }
+        }
+      
       }
     }
   }

--- a/Sources/BraveVPN/BraveVPN.swift
+++ b/Sources/BraveVPN/BraveVPN.swift
@@ -25,7 +25,7 @@ public class BraveVPN {
   static var regions: [GRDRegion] = []
   
   /// Record last used region
-  /// It is used to hold details of the region when automatic slection is used
+  /// It is used to hold details of the region when automatic selection is used
   static var lastKnownRegion: GRDRegion?
   
   // Non translatable
@@ -515,7 +515,7 @@ public class BraveVPN {
   /// The function that fetched the last used region details from timezones
   /// It used to get details of Region when Automatic Region is used
   /// Otherwise the region detail items will be empty
-  /// - Parameter completion: comnpletion block that returns region with details or error
+  /// - Parameter completion: completion block that returns region with details or error
   public static func fetchLastUsedRegionDetail(_ completion: ((GRDRegion?, Bool) -> Void)? = nil) {
     switch vpnState {
     case .expired, .notPurchased:

--- a/Sources/BraveVPN/BraveVPNPickerViewController.swift
+++ b/Sources/BraveVPN/BraveVPNPickerViewController.swift
@@ -10,7 +10,7 @@ import Lottie
 import NetworkExtension
 import GuardianConnect
 
-class BraveVPNPickerViewController: UIViewController {
+public class BraveVPNPickerViewController: UIViewController {
 
   private var overlayView: UIView?
   let tableView: UITableView = .init(frame: .zero, style: .insetGrouped)
@@ -49,14 +49,14 @@ class BraveVPNPickerViewController: UIViewController {
     }
   }
 
-  init() {
+  public init() {
     super.init(nibName: nil, bundle: nil)
   }
 
   @available(*, unavailable)
   required init?(coder: NSCoder) { fatalError() }
 
-  override func viewDidLoad() {
+  public override func viewDidLoad() {
     tableView.register(VPNRegionCell.self)
     
     NotificationCenter.default.addObserver(self, selector: #selector(vpnConfigChanged(notification:)),
@@ -68,7 +68,7 @@ class BraveVPNPickerViewController: UIViewController {
     }
   }
 
-  override func viewWillAppear(_ animated: Bool) {
+  public override func viewWillAppear(_ animated: Bool) {
     super.viewWillAppear(animated)
     tableView.reloadData()
   }

--- a/Sources/BraveVPN/BraveVPNRegionPickerViewController.swift
+++ b/Sources/BraveVPN/BraveVPNRegionPickerViewController.swift
@@ -143,6 +143,7 @@ extension BraveVPNRegionPickerViewController: UITableViewDelegate, UITableViewDa
 
           self.dismiss(animated: true) {
             self.showSuccessAlert(text: Strings.VPN.regionSwitchSuccessPopupText)
+            BraveVPN.fetchLastUsedRegionDetail()
           }
         } else {
           self.showErrorAlert(title: Strings.VPN.regionPickerErrorTitle,

--- a/Sources/BraveVPN/BraveVPNRegionPickerViewController.swift
+++ b/Sources/BraveVPN/BraveVPNRegionPickerViewController.swift
@@ -10,7 +10,7 @@ import Lottie
 import NetworkExtension
 import GuardianConnect
 
-class BraveVPNRegionPickerViewController: BraveVPNPickerViewController {
+public class BraveVPNRegionPickerViewController: BraveVPNPickerViewController {
   private let regionList: [GRDRegion]
 
   private enum Section: Int, CaseIterable {
@@ -22,7 +22,7 @@ class BraveVPNRegionPickerViewController: BraveVPNPickerViewController {
   private var dispatchGroup: DispatchGroup?
   private var vpnRegionChangeSuccess = false
 
-  override init() {
+  public override init() {
     self.regionList = BraveVPN.regions
       .sorted { $0.displayName < $1.displayName }
 
@@ -32,7 +32,7 @@ class BraveVPNRegionPickerViewController: BraveVPNPickerViewController {
   @available(*, unavailable)
   required init?(coder: NSCoder) { fatalError() }
 
-  override func viewDidLoad() {
+  public override func viewDidLoad() {
     title = Strings.VPN.regionPickerTitle
 
     tableView.delegate = self
@@ -56,15 +56,15 @@ class BraveVPNRegionPickerViewController: BraveVPNPickerViewController {
 
 extension BraveVPNRegionPickerViewController: UITableViewDelegate, UITableViewDataSource {
   
-  func numberOfSections(in tableView: UITableView) -> Int {
+  public func numberOfSections(in tableView: UITableView) -> Int {
     Section.allCases.count
   }
 
-  func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+  public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
     section == Section.automatic.rawValue ? 1 : regionList.count
   }
 
-  func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
+  public func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
     if section == Section.automatic.rawValue {
       return Strings.VPN.regionPickerAutomaticDescription
     }
@@ -72,7 +72,7 @@ extension BraveVPNRegionPickerViewController: UITableViewDelegate, UITableViewDa
     return nil
   }
 
-  func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+  public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
     let cell = tableView.dequeueReusableCell(for: indexPath) as VPNRegionCell
     cell.accessoryType = .none
 
@@ -96,7 +96,7 @@ extension BraveVPNRegionPickerViewController: UITableViewDelegate, UITableViewDa
     return cell
   }
 
-  func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+  public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
     tableView.deselectRow(at: indexPath, animated: true)
     guard let region = regionList[safe: indexPath.row] else { return }
 

--- a/Sources/BraveVPN/VPNRegion.swift
+++ b/Sources/BraveVPN/VPNRegion.swift
@@ -7,20 +7,19 @@ import Foundation
 import GuardianConnect
 import BraveUI
 import SwiftUI
+import Shared
 
 extension GRDRegion {
   
   /// The title used in menu while chaging region
   public var settingTitle: String {
-    var title = "Current Setting: "
+    var settingSelection = displayName
     
     if BraveVPN.isAutomaticRegion {
-      title.append("Automatic")
-    } else {
-      title.append(displayName)
+      settingSelection = Strings.VPN.regionPickerAutomaticModeCellText
     }
     
-    return title
+    return  String(format: Strings.VPN.vpnRegionSelectorButtonSubTitle, settingSelection)
   }
   
   /// Flag of the region as an image

--- a/Sources/BraveVPN/VPNRegion.swift
+++ b/Sources/BraveVPN/VPNRegion.swift
@@ -10,6 +10,7 @@ import SwiftUI
 
 extension GRDRegion {
   
+  /// The title used in menu while chaging region
   public var settingTitle: String {
     var title = "Current Setting: "
     
@@ -22,12 +23,16 @@ extension GRDRegion {
     return title
   }
   
+  /// Flag of the region as an image
   public var regionFlag: Image? {
+    // Root Unicode flags index
     let rootIndex: UInt32 = 127397
     var unicodeScalarView = ""
     
     for scalar in countryISOCode.unicodeScalars {
+      // Shift the letter index to the flags index
       if let appendedScalar = UnicodeScalar(rootIndex + scalar.value) {
+        // Append symbol to the Unicode string
         unicodeScalarView.unicodeScalars.append(appendedScalar)
       }
     }

--- a/Sources/BraveVPN/VPNRegion.swift
+++ b/Sources/BraveVPN/VPNRegion.swift
@@ -4,15 +4,34 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import Foundation
+import GuardianConnect
+import BraveUI
+import SwiftUI
 
-struct VPNRegion: Codable {
-  let continent: String
-  let name: String
-  let namePretty: String
-
-  private enum CodingKeys: String, CodingKey {
-    case continent
-    case name
-    case namePretty = "name-pretty"
+extension GRDRegion {
+  
+  public var settingTitle: String {
+    var title = "Current Setting: "
+    
+    if BraveVPN.isAutomaticRegion {
+      title.append("Automatic")
+    } else {
+      title.append(displayName)
+    }
+    
+    return title
+  }
+  
+  public var regionFlag: Image? {
+    let rootIndex: UInt32 = 127397
+    var unicodeScalarView = ""
+    
+    for scalar in countryISOCode.unicodeScalars {
+      if let appendedScalar = UnicodeScalar(rootIndex + scalar.value) {
+        unicodeScalarView.unicodeScalars.append(appendedScalar)
+      }
+    }
+    
+    return Image(uiImage: unicodeScalarView.image())
   }
 }

--- a/Sources/DesignSystem/Icons/Symbols.xcassets/leo.arrow.small-right.symbolset/Contents.json
+++ b/Sources/DesignSystem/Icons/Symbols.xcassets/leo.arrow.small-right.symbolset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "symbols" : [
+    {
+      "idiom" : "universal"
+    }
+  ]
+}

--- a/Sources/DesignSystem/Icons/Symbols.xcassets/leo.globe.symbolset/Contents.json
+++ b/Sources/DesignSystem/Icons/Symbols.xcassets/leo.globe.symbolset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "symbols" : [
+    {
+      "idiom" : "universal"
+    }
+  ]
+}


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This PR is adding easy access for region switcher in  menu.

The region switcher will fallow the rules of menu layout and it will be hidden when the VPN is off. When Automatic mode is selected the Title will represent current setting as automatic but the country flag will show the active region.

Other selection will follow the logic of showing country name and country flag.

Same with menu logic the region selector visual will follow same logic as when a website is loaded the region selection will not show subtitle but when an epoty tab is loaded the region selector will show the current title.


<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7380

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

- Turn on / off VPN and check the region selector is being shown
- Change country or automatic region to see the selection is effected


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


![1 2 9 0 1 1](https://user-images.githubusercontent.com/6643505/236286364-affa3c33-254a-46c4-a343-8ff2d277a05c.png)



https://user-images.githubusercontent.com/6643505/236286596-f419fe93-02c0-4229-9de4-2083efc8ac87.MP4



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
