### PR TITLE
Fix #7392: Error formatting for Ethereum DApp responses

### DIFF
--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Paged/WalletEthereumProviderScript.js
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Paged/WalletEthereumProviderScript.js
@@ -18,8 +18,11 @@ if (window.isSecureContext) {
         "args": JSON.stringify(payload)
       })
       .then(resolve, (errorJSON) => {
+        /* remove `Error: ` prefix. errorJSON=`Error: {code: 1, errorMessage: "Internal error"}` */
+        const errorJSONString = new String(errorJSON);
+        const errorJSONStringSliced = errorJSONString.slice(errorJSONString.indexOf('{'));
         try {
-          reject(JSON.parse(errorJSON))
+          reject(JSON.parse(errorJSONStringSliced))
         } catch(e) {
           reject(errorJSON)
         }


### PR DESCRIPTION
## Summary of Changes
- Similar to [Solana](
https://github.com/brave/brave-ios/blob/development/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Paged/WalletSolanaProviderScript.js#L50-L58), we need to strip the `Error: ` prefix that Webkit applies when responding to a request or we lose the json formatting.

This pull request fixes #7392

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Visit [Brave Talk](https://talk.brave.software/) with a Premium account 
2. Connect your wallet to Brave Talk
3. Tap `Host a Web3 Call`
4. Tap cancel on the signature request
5. Verify error is displayed as `Sign request cancelled` instead of messy formatting (see issue).

If you have Brave Talk Premium, please verify the fix is working there.
This can also be verified using Ethereum Test DApp.
1. Visit https://metamask.github.io/test-dapp/
2. Connect your wallet to the test DApp
3. Tap `Sign` under `Personal Sign`.
4. Tap cancel on the signature request
5. Verify `Sign` button now displays `ERROR: THE USER REJECTED THE REQUEST`
    - Previously: `ERROR: ("CODE": 4001, 'MESSAGE": "THE USER REJECTED THE REQUEST.)`


## Screenshots:

https://user-images.githubusercontent.com/5314553/236294181-ba90f34a-246e-4830-9177-debdda010c51.mp4


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
