### PR TITLE
Fix #7394: Fix ETags Header Parsing all over the app

### DIFF
--- a/Sources/Brave/Frontend/Browser/Helpers/OpenInHelper.swift
+++ b/Sources/Brave/Frontend/Browser/Helpers/OpenInHelper.swift
@@ -54,7 +54,7 @@ class DownloadHelper: NSObject {
       return nil
     }
 
-    let contentDisposition = (response as? HTTPURLResponse)?.allHeaderFields["Content-Disposition"] as? String
+    let contentDisposition = (response as? HTTPURLResponse)?.value(forHTTPHeaderField: "Content-Disposition")
     let mimeType = response.mimeType ?? MIMEType.octetStream
     let isAttachment = contentDisposition?.starts(with: "attachment") ?? (mimeType == MIMEType.octetStream)
 

--- a/Sources/Brave/Frontend/Browser/New Tab Page/Backgrounds/NTPDownloader.swift
+++ b/Sources/Brave/Frontend/Browser/New Tab Page/Backgrounds/NTPDownloader.swift
@@ -460,11 +460,7 @@ public class NTPDownloader {
   // MARK: - Download & Unpacking
 
   private func parseETagResponseInfo(_ response: HTTPURLResponse) -> CacheResponse {
-    if let etag = response.allHeaderFields["Etag"] as? String {
-      return CacheResponse(statusCode: response.statusCode, etag: etag)
-    }
-
-    if let etag = response.allHeaderFields["ETag"] as? String {
+    if let etag = response.value(forHTTPHeaderField: "ETag") {
       return CacheResponse(statusCode: response.statusCode, etag: etag)
     }
 

--- a/Sources/Brave/Frontend/Browser/Playlist/Managers & Cache/PlaylistDownloadManager.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/Managers & Cache/PlaylistDownloadManager.swift
@@ -582,9 +582,9 @@ private class PlaylistFileDownloadManager: NSObject, URLSessionDownloadDelegate 
 
       // Detect based on Content-Type header.
       if detectedFileExtension == nil,
-        let contentType = response.allHeaderFields["Content-Type"] as? String,
-        let detectedExtension = PlaylistMimeTypeDetector(mimeType: contentType).fileExtension {
-        detectedFileExtension = detectedExtension
+         let contentType = response.value(forHTTPHeaderField: "Content-Type"),
+         let detectedExtension = PlaylistMimeTypeDetector(mimeType: contentType).fileExtension {
+          detectedFileExtension = detectedExtension
       }
 
       // Detect based on Data.

--- a/Sources/Brave/Frontend/Browser/Playlist/Managers & Cache/PlaylistManager.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/Managers & Cache/PlaylistManager.swift
@@ -735,7 +735,7 @@ extension PlaylistManager {
   @MainActor
   static func syncSharedFolder(sharedFolderUrl: String) async throws {
     guard let folder = PlaylistFolder.getSharedFolder(sharedFolderUrl: sharedFolderUrl),
-          let folderId = folder.sharedFolderId else {
+          let folderId = folder.uuid else {
       return
     }
     
@@ -749,7 +749,7 @@ extension PlaylistManager {
     
     if !newItems.isEmpty {
       await withCheckedContinuation { continuation in
-        PlaylistItem.updateItems(Array(newItems), folderUUID: folderId) {
+        PlaylistItem.updateItems(Array(newItems), folderUUID: folderId, newETag: model.eTag) {
           continuation.resume()
         }
       }

--- a/Sources/Brave/Frontend/Browser/Playlist/PlaylistSharedFolder.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/PlaylistSharedFolder.swift
@@ -114,7 +114,7 @@ struct PlaylistSharedFolderNetwork {
     let (data, response) = try await executeRequest(method: "GET", headers: [:])
     var model = try JSONDecoder().decode(PlaylistSharedFolderModel.self, from: data)
     model.folderUrl = folderUrl
-    model.eTag = response.allHeaderFields["ETag"] as? String
+    model.eTag = response.value(forHTTPHeaderField: "ETag")
     return model
   }
   

--- a/Sources/Brave/Frontend/Browser/Playlist/Utilities/PlaylistMediaStreamer.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/Utilities/PlaylistMediaStreamer.swift
@@ -265,7 +265,7 @@ class PlaylistMediaStreamer {
         }
 
         if let response = response as? HTTPURLResponse, response.statusCode == 302 || response.statusCode >= 200 && response.statusCode <= 299 {
-          if let contentType = response.allHeaderFields["Content-Type"] as? String {
+          if let contentType = response.value(forHTTPHeaderField: "Content-Type") {
             completion(contentType)
             return
           } else {

--- a/Sources/Brave/Networking/NetworkManager.swift
+++ b/Sources/Brave/Networking/NetworkManager.swift
@@ -162,9 +162,6 @@ extension NetworkManager {
                                       response: URLResponse) throws -> CachedNetworkResource {
     let fileNotModifiedStatusCode = 304
 
-    // Identifier for a specific version of a resource for a HTTP request
-    let etagHeader = "Etag"
-    
     guard let response = response as? HTTPURLResponse else {
       throw URLError(.badServerResponse)
     }
@@ -182,12 +179,12 @@ extension NetworkManager {
       throw NetworkManagerError.fileNotModified
 
     default:
-      let responseEtag = resourceType.isCached() ? response.allHeaderFields[etagHeader] as? String : nil
+      let responseEtag = resourceType.isCached() ? response.value(forHTTPHeaderField: "ETag") : nil
 
       var lastModified: TimeInterval?
 
       if checkLastServerSideModification,
-        let lastModifiedHeaderValue = response.allHeaderFields["Last-Modified"] as? String {
+         let lastModifiedHeaderValue = response.value(forHTTPHeaderField: "Last-Modified") {
         let formatter = DateFormatter().then {
           $0.timeZone = TimeZone(abbreviation: "GMT")
           $0.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"

--- a/Tests/ClientTests/NetworkManagerTests.swift
+++ b/Tests/ClientTests/NetworkManagerTests.swift
@@ -197,7 +197,7 @@ class NetworkManagerTests: XCTestCase {
     }
 
     wait(for: [exp], timeout: 5)
-    XCTAssertNotNil(response.allHeaderFields["Etag"])
+    XCTAssertNotNil(response.value(forHTTPHeaderField: "Etag"))
     XCTAssert(true)
   }
 


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Fix ETag header parsing all over the app.
- Fix Playlist storing ETag.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7394

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes


## Test Plan
- Make sure NTP backgrounds works
- Make sure Adblock lists works
- Make sure Playlist folder sharing works

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
