### PR TITLE
Fix #7396: Keep favicons monogram background color between launches.

### DIFF
--- a/Sources/Favicon/UIImage+FaviconRenderer.swift
+++ b/Sources/Favicon/UIImage+FaviconRenderer.swift
@@ -155,7 +155,7 @@ extension UIImage {
     let imageSize = CGSize(width: 64.0, height: 64.0)
 
     let createBackgroundColor = { (url: URL) -> UIColor in
-      guard let hash = url.baseDomain?.hashValue else {
+      guard let hash = url.baseDomain?.fnv1a else {
         return .gray
       }
       let index = abs(hash) % (UIConstants.defaultColorStrings.count - 1)

--- a/Sources/Shared/Extensions/HashExtensions.swift
+++ b/Sources/Shared/Extensions/HashExtensions.swift
@@ -20,3 +20,20 @@ extension Data {
     return Data(bytes: UnsafePointer<UInt8>(digest), count: len)
   }
 }
+
+public extension String {
+  var fnv1a: Int {
+    let basis: UInt64 = 14695981039346656037
+    let prime: UInt64 = 1099511628211
+    
+    var hash: UInt64 = basis
+    
+    for c in self.utf8 {
+      hash ^= UInt64(c)
+      hash &*= prime
+    }
+    
+    // Prevent overflow crash
+    return Int(hash & UInt64(Int.max))
+  }
+}


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7396 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
