### PR TITLE
Fix #7397: Scrolling Tab Bar Long-Press problem

### DIFF
--- a/Sources/Brave/Frontend/Browser/Tabs/TabBar/TabsBarViewController.swift
+++ b/Sources/Brave/Frontend/Browser/Tabs/TabBar/TabsBarViewController.swift
@@ -80,6 +80,7 @@ class TabsBarViewController: UIViewController {
 
     let longPressGesture = UILongPressGestureRecognizer(target: self, action: #selector(handleLongGesture(gesture:)))
     longPressGesture.minimumPressDuration = 0.2
+    longPressGesture.delaysTouchesBegan = true
     collectionView.addGestureRecognizer(longPressGesture)
 
     NotificationCenter.default.addObserver(self, selector: #selector(orientationChanged), name: UIDevice.orientationDidChangeNotification, object: nil)
@@ -253,10 +254,13 @@ class TabsBarViewController: UIViewController {
   @objc func handleLongGesture(gesture: UILongPressGestureRecognizer) {
     switch gesture.state {
     case .began:
-      guard let selectedIndexPath = self.collectionView.indexPathForItem(at: gesture.location(in: self.collectionView)) else {
+      guard let selectedIndexPath = collectionView.indexPathForItem(at: gesture.location(in: self.collectionView)) else {
         break
       }
-      collectionView.beginInteractiveMovementForItem(at: selectedIndexPath)
+      
+      Task.delayed(bySeconds: 0.1) { @MainActor in
+        self.collectionView.beginInteractiveMovementForItem(at: selectedIndexPath)
+      }
     case .changed:
       if let gestureView = gesture.view {
         var location = gesture.location(in: gestureView)


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

The `indexPathForItem` for `gesture.location` is causing rare crashes when moving the tabs in tabsbar. All the crshes are iOS16 and the suggested fix (band-aid) solution is 

Adding delay to beginInteraction and delaysTouchesBegan is enabled for longpress gesture.

Crash log 

![Screenshot 2023-05-05 at 2 56 59 PM](https://user-images.githubusercontent.com/6643505/236545162-1cf1bed2-7e51-4049-a230-dca10bd3da4a.png)


<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7397

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
-Enable Tabs Bar
-Add different amount of tabs and try long press gesture recognization and replacement

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
