### PR TITLE
Fix #7370: NFT Discovery 

### DIFF
--- a/Sources/BraveWallet/AdjustableHeightAttributedTextView.swift
+++ b/Sources/BraveWallet/AdjustableHeightAttributedTextView.swift
@@ -40,6 +40,7 @@ struct AttributedTextView: UIViewRepresentable {
   
   func makeUIView(context: Context) -> UITextView {
     let textView = UITextView().then {
+      $0.backgroundColor = .clear
       $0.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
       $0.isEditable = false
       $0.isSelectable = true

--- a/Sources/BraveWallet/AdjustableHeightAttributedTextView.swift
+++ b/Sources/BraveWallet/AdjustableHeightAttributedTextView.swift
@@ -1,0 +1,76 @@
+// Copyright 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import SwiftUI
+
+/// A `AttributedTextView` with adjustable height to fit the given text. No .frame modifier needed
+struct AdjustableHeightAttributedTextView: View {
+  var attributedString: NSAttributedString
+  var openLink: ((URL?) -> Void)?
+  
+  @State private var height: CGFloat = .zero
+  
+  var body: some View {
+    AttributedTextView(
+      attributedString: attributedString,
+      dynamicHeight: $height,
+      openLink: openLink
+    )
+    .frame(height: height)
+  }
+}
+
+/// A `UIViewPresentable` of `UITextView`,
+struct AttributedTextView: UIViewRepresentable {
+  private var attributedString: NSAttributedString
+  @Binding var dynamicHeight: CGFloat
+  private var openLink: ((URL?) -> Void)?
+  
+  init (
+    attributedString: NSAttributedString,
+    dynamicHeight: Binding<CGFloat>,
+    openLink: ((URL?) -> Void)?
+  ) {
+    self.attributedString = attributedString
+    self.openLink = openLink
+    _dynamicHeight = dynamicHeight
+  }
+  
+  func makeUIView(context: Context) -> UITextView {
+    let textView = UITextView().then {
+      $0.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+      $0.isEditable = false
+      $0.isSelectable = true
+      $0.delegate = context.coordinator
+      $0.isScrollEnabled = false
+      $0.textAlignment = .center
+    }
+    return textView
+  }
+  
+  func updateUIView(_ uiView: UITextView, context: Context) {
+    uiView.attributedText = attributedString
+    DispatchQueue.main.async {
+      dynamicHeight = uiView.sizeThatFits(CGSize(width: uiView.bounds.width, height: CGFloat.greatestFiniteMagnitude)).height
+    }
+  }
+  
+  func makeCoordinator() -> Coordinator {
+    Coordinator(parent: self)
+  }
+  
+  class Coordinator: NSObject, UITextViewDelegate {
+    var parent: AttributedTextView
+    
+    init(parent: AttributedTextView) {
+      self.parent = parent
+    }
+    
+    func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
+      parent.openLink?(URL)
+      return false
+    }
+  }
+}

--- a/Sources/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
+++ b/Sources/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
@@ -235,14 +235,16 @@ struct AssetDetailView: View {
     .background(
       WalletPromptView(
         isPresented: $isShowingAuroraBridgeAlert,
-        buttonTitle: Strings.Wallet.auroraBridgeButtonTitle,
-        action: { proceed, _ in
-          isShowingAuroraBridgeAlert = false
-          if proceed, let link = WalletConstants.auroraBridgeLink {
-            openWalletURL(link)
+        primaryButton: .init(
+          title: Strings.Wallet.auroraBridgeButtonTitle,
+          action: { _ in
+            isShowingAuroraBridgeAlert = false
+            if let link = WalletConstants.auroraBridgeLink {
+              openWalletURL(link)
+            }
           }
-          return true
-        },
+        ),
+        showCloseButton: false,
         content: {
           VStack(spacing: 10) {
             Text(Strings.Wallet.auroraBridgeAlertTitle)

--- a/Sources/BraveWallet/Crypto/NFT/NFTView.swift
+++ b/Sources/BraveWallet/Crypto/NFT/NFTView.swift
@@ -272,7 +272,7 @@ struct NFTView: View {
     }
     .onAppear {
       Task {
-        let isNFTDiscoveryEnabled = await nftStore.checkNFTDiscovery()
+        let isNFTDiscoveryEnabled = await nftStore.isNFTDiscoveryEnabled()
         if !isNFTDiscoveryEnabled && Preferences.Wallet.shouldShowNFTDiscoveryPermissionCallout.value {
           self.isShowingNFTDiscoveryAlert = true
         }

--- a/Sources/BraveWallet/Crypto/NFT/NFTView.swift
+++ b/Sources/BraveWallet/Crypto/NFT/NFTView.swift
@@ -4,6 +4,8 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import SwiftUI
+import DesignSystem
+import Preferences
 
 struct NFTView: View {
   var cryptoStore: CryptoStore
@@ -14,9 +16,12 @@ struct NFTView: View {
   @State private var isPresentingNetworkFilter: Bool = false
   @State private var isPresentingEditUserAssets: Bool = false
   @State private var selectedNFTViewModel: NFTAssetViewModel?
+  @State private var isShowingNFTDiscoveryAlert: Bool = false
+  @State private var isShowingAddCustomNFT: Bool = false
   
   @Environment(\.buySendSwapDestination)
   private var buySendSwapDestination: Binding<BuySendSwapDestination?>
+  @Environment(\.openURL) private var openWalletURL
   
   private var emptyView: some View {
     VStack(alignment: .center, spacing: 10) {
@@ -26,6 +31,11 @@ struct NFTView: View {
       Text(Strings.Wallet.nftPageEmptyDescription)
         .font(.subheadline.weight(.semibold))
         .foregroundColor(Color(.secondaryLabel))
+      Button(Strings.Wallet.nftEmptyImportNFT) {
+        isShowingAddCustomNFT = true
+      }
+      .buttonStyle(BraveFilledButtonStyle(size: .normal))
+      .padding(.top, 8)
     }
     .multilineTextAlignment(.center)
     .frame(maxWidth: .infinity)
@@ -115,14 +125,34 @@ struct NFTView: View {
   private var nftHeaderView: some View {
     HStack {
       Text(Strings.Wallet.assetsTitle)
-        .font(.caption)
+        .font(.footnote)
         .foregroundColor(Color(.secondaryBraveLabel))
+      if nftStore.isLoadingDiscoverAssets {
+        ProgressView()
+          .padding(.leading, 5)
+      }
       Spacer()
       networkFilterButton
     }
     .textCase(nil)
     .padding(.horizontal, 10)
     .frame(maxWidth: .infinity, alignment: .leading)
+  }
+  
+  private var nftDiscoveryDescriptionText: NSAttributedString? {
+    let attributedString = NSMutableAttributedString(
+      string: Strings.Wallet.nftDiscoveryCalloutDescription,
+      attributes: [.foregroundColor: UIColor.braveLabel, .font: UIFont.preferredFont(for: .subheadline, weight: .regular)]
+    )
+    
+    attributedString.addAttributes([.underlineStyle: NSUnderlineStyle.single.rawValue], range: (attributedString.string as NSString).range(of: "SimpleHash")) // `SimpleHash` won't get translated
+    attributedString.addAttribute(
+      .link,
+      value: WalletConstants.nftDiscoveryURL.absoluteString,
+      range: (attributedString.string as NSString).range(of: Strings.Wallet.nftDiscoveryCalloutDescriptionLearnMore)
+    )
+    
+    return attributedString
   }
   
   var body: some View {
@@ -155,15 +185,16 @@ struct NFTView: View {
               }
             }
           }
+          VStack(spacing: 16) {
+            Divider()
+            editUserAssetsButton
+          }
+          .padding(.top, 20)
         }
-        VStack(spacing: 16) {
-          Divider()
-          editUserAssetsButton
-        }
-        .padding(.top, 20)
       }
       .padding(24)
     }
+    .background(Color(UIColor.braveGroupedBackground))
     .background(
       NavigationLink(
         isActive: Binding(
@@ -187,7 +218,66 @@ struct NFTView: View {
           EmptyView()
         })
     )
-    .background(Color(UIColor.braveGroupedBackground))
+    .background(
+      WalletPromptView(
+        isPresented: $isShowingNFTDiscoveryAlert,
+        primaryButton: .init(
+          title: Strings.Wallet.nftDiscoveryCalloutEnable,
+          action: { _ in
+            nftStore.enableNFTDiscovery()
+            Preferences.Wallet.shouldShowNFTDiscoveryPermissionCallout.value = false
+            isShowingNFTDiscoveryAlert = false
+          }
+        ),
+        secondaryButton: .init(
+          title: Strings.Wallet.nftDiscoveryCalloutDisable,
+          action: { _ in
+            Preferences.Wallet.shouldShowNFTDiscoveryPermissionCallout.value = false
+            // don't need to setDiscovery(false) since the default value is false
+            // and when nftDiscoveryEnabled() is true, this WalletPromptView won't
+            // get prompt
+            isShowingNFTDiscoveryAlert = false
+          }
+        ),
+        showCloseButton: false,
+        content: {
+          VStack(spacing: 10) {
+            Text(Strings.Wallet.nftDiscoveryCalloutTitle)
+              .font(.headline.weight(.bold))
+              .multilineTextAlignment(.center)
+            if let attrString = nftDiscoveryDescriptionText {
+              AdjustableHeightAttributedTextView(
+                attributedString: attrString,
+                openLink: { url in
+                  if let url {
+                    openWalletURL(url)
+                  }
+                }
+              )
+            }
+          }
+        }
+      )
+    )
+    .sheet(isPresented: $isShowingAddCustomNFT) {
+      AddCustomAssetView(
+        networkStore: networkStore,
+        networkSelectionStore: networkStore.openNetworkSelectionStore(mode: .formSelection),
+        keyringStore: keyringStore,
+        userAssetStore: nftStore.userAssetsStore,
+        supportedTokenTypes: [.nft]
+      ) {
+        cryptoStore.updateAssets()
+      }
+    }
+    .onAppear {
+      Task {
+        let isNFTDiscoveryEnabled = await nftStore.checkNFTDiscovery()
+        if !isNFTDiscoveryEnabled && Preferences.Wallet.shouldShowNFTDiscoveryPermissionCallout.value {
+          self.isShowingNFTDiscoveryAlert = true
+        }
+      }
+    }
   }
 }
 

--- a/Sources/BraveWallet/Crypto/NFT/NFTView.swift
+++ b/Sources/BraveWallet/Crypto/NFT/NFTView.swift
@@ -18,6 +18,7 @@ struct NFTView: View {
   @State private var selectedNFTViewModel: NFTAssetViewModel?
   @State private var isShowingNFTDiscoveryAlert: Bool = false
   @State private var isShowingAddCustomNFT: Bool = false
+  @State private var isNFTDiscoveryEnabled: Bool = false
   
   @Environment(\.buySendSwapDestination)
   private var buySendSwapDestination: Binding<BuySendSwapDestination?>
@@ -127,7 +128,7 @@ struct NFTView: View {
       Text(Strings.Wallet.assetsTitle)
         .font(.footnote)
         .foregroundColor(Color(.secondaryBraveLabel))
-      if nftStore.isLoadingDiscoverAssets {
+      if nftStore.isLoadingDiscoverAssets && isNFTDiscoveryEnabled {
         ProgressView()
           .padding(.leading, 5)
       }
@@ -224,6 +225,7 @@ struct NFTView: View {
         primaryButton: .init(
           title: Strings.Wallet.nftDiscoveryCalloutEnable,
           action: { _ in
+            isNFTDiscoveryEnabled = true
             nftStore.enableNFTDiscovery()
             Preferences.Wallet.shouldShowNFTDiscoveryPermissionCallout.value = false
             isShowingNFTDiscoveryAlert = false
@@ -232,6 +234,7 @@ struct NFTView: View {
         secondaryButton: .init(
           title: Strings.Wallet.nftDiscoveryCalloutDisable,
           action: { _ in
+            isNFTDiscoveryEnabled = false
             Preferences.Wallet.shouldShowNFTDiscoveryPermissionCallout.value = false
             // don't need to setDiscovery(false) since the default value is false
             // and when nftDiscoveryEnabled() is true, this WalletPromptView won't
@@ -272,8 +275,8 @@ struct NFTView: View {
     }
     .onAppear {
       Task {
-        let isNFTDiscoveryEnabled = await nftStore.isNFTDiscoveryEnabled()
-        if !isNFTDiscoveryEnabled && Preferences.Wallet.shouldShowNFTDiscoveryPermissionCallout.value {
+        isNFTDiscoveryEnabled = await nftStore.isNFTDiscoveryEnabled()
+        if /*!isNFTDiscoveryEnabled && Preferences.Wallet.shouldShowNFTDiscoveryPermissionCallout.value*/ true {
           self.isShowingNFTDiscoveryAlert = true
         }
       }

--- a/Sources/BraveWallet/Crypto/NFT/NFTView.swift
+++ b/Sources/BraveWallet/Crypto/NFT/NFTView.swift
@@ -276,7 +276,7 @@ struct NFTView: View {
     .onAppear {
       Task {
         isNFTDiscoveryEnabled = await nftStore.isNFTDiscoveryEnabled()
-        if /*!isNFTDiscoveryEnabled && Preferences.Wallet.shouldShowNFTDiscoveryPermissionCallout.value*/ true {
+        if !isNFTDiscoveryEnabled && Preferences.Wallet.shouldShowNFTDiscoveryPermissionCallout.value {
           self.isShowingNFTDiscoveryAlert = true
         }
       }

--- a/Sources/BraveWallet/Crypto/Portfolio/EditUserAssetsView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/EditUserAssetsView.swift
@@ -195,7 +195,8 @@ struct EditUserAssetsView: View {
         networkSelectionStore: networkStore.openNetworkSelectionStore(mode: .formSelection),
         keyringStore: keyringStore,
         userAssetStore: userAssetsStore,
-        tokenNeedsTokenId: tokenNeedsTokenId
+        tokenNeedsTokenId: tokenNeedsTokenId,
+        supportedTokenTypes: [.nft]
       )
       .onDisappear {
         networkStore.closeNetworkSelectionStore()

--- a/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -339,7 +339,7 @@ public class CryptoStore: ObservableObject {
   func prepare(isInitialOpen: Bool = false) {
     Task { @MainActor in
       if isInitialOpen {
-        portfolioStore.discoverAssetsOnAllSupportedChains()
+        walletService.discoverAssetsOnAllSupportedChains()
       }
       
       let pendingTransactions = await fetchPendingTransactions()

--- a/Sources/BraveWallet/Crypto/Stores/NFTStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/NFTStore.swift
@@ -30,6 +30,7 @@ public class NFTStore: ObservableObject {
       update()
     }
   }
+  @Published var isLoadingDiscoverAssets: Bool = false
   
   public private(set) lazy var userAssetsStore: UserAssetsStore = .init(
     walletService: self.walletService,
@@ -69,6 +70,7 @@ public class NFTStore: ObservableObject {
     
     self.rpcService.add(self)
     self.keyringService.add(self)
+    self.walletService.add(self)
     
     keyringService.isLocked { [self] isLocked in
       if !isLocked {
@@ -141,6 +143,14 @@ public class NFTStore: ObservableObject {
       userVisibleNFTs[index] = NFTAssetViewModel(token: viewModel.token, network: viewModel.network, balance: viewModel.balance, nftMetadata: metadata)
     }
   }
+  
+  @MainActor func checkNFTDiscovery() async -> Bool {
+    await walletService.nftDiscoveryEnabled()
+  }
+  
+  func enableNFTDiscovery() {
+    walletService.setNftDiscoveryEnabled(true)
+  }
 }
 
 extension NFTStore: BraveWalletJsonRpcServiceObserver {
@@ -184,5 +194,39 @@ extension NFTStore: BraveWalletKeyringServiceObserver {
   }
   
   public func accountsAdded(_ coin: BraveWallet.CoinType, addresses: [String]) {
+  }
+}
+
+extension NFTStore: BraveWalletBraveWalletServiceObserver {
+  public func onActiveOriginChanged(_ originInfo: BraveWallet.OriginInfo) {
+  }
+  
+  public func onDefaultEthereumWalletChanged(_ wallet: BraveWallet.DefaultWallet) {
+  }
+  
+  public func onDefaultSolanaWalletChanged(_ wallet: BraveWallet.DefaultWallet) {
+  }
+  
+  public func onDefaultBaseCurrencyChanged(_ currency: String) {
+  }
+  
+  public func onDefaultBaseCryptocurrencyChanged(_ cryptocurrency: String) {
+  }
+  
+  public func onNetworkListChanged() {
+  }
+  
+  public func onDiscoverAssetsStarted() {
+    isLoadingDiscoverAssets = true
+  }
+  
+  public func onDiscoverAssetsCompleted(_ discoveredAssets: [BraveWallet.BlockchainToken]) {
+    isLoadingDiscoverAssets = false
+    if !discoveredAssets.isEmpty {
+      update()
+    }
+  }
+  
+  public func onResetWallet() {
   }
 }

--- a/Sources/BraveWallet/Crypto/Stores/NFTStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/NFTStore.swift
@@ -144,7 +144,7 @@ public class NFTStore: ObservableObject {
     }
   }
   
-  @MainActor func checkNFTDiscovery() async -> Bool {
+  @MainActor func isNFTDiscoveryEnabled() async -> Bool {
     await walletService.nftDiscoveryEnabled()
   }
   

--- a/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
@@ -150,10 +150,6 @@ public class PortfolioStore: ObservableObject {
     }
   }
   
-  func discoverAssetsOnAllSupportedChains() {
-    walletService.discoverAssetsOnAllSupportedChains()
-  }
-  
   func update() {
     self.updateTask?.cancel()
     self.updateTask = Task { @MainActor in

--- a/Sources/BraveWallet/Crypto/Stores/SettingsStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SettingsStore.swift
@@ -67,10 +67,10 @@ public class SettingsStore: ObservableObject {
   }
   
   /// The current preference for enabling NFT discovery (Enabled / Disabled)
-  @Published var nftDiscovery: Bool = false {
+  @Published var isNFTDiscoveryEnabled: Bool = false {
     didSet {
-      guard oldValue != nftDiscovery else { return }
-      walletService.setNftDiscoveryEnabled(nftDiscovery)
+      guard oldValue != isNFTDiscoveryEnabled else { return }
+      walletService.setNftDiscoveryEnabled(isNFTDiscoveryEnabled)
     }
   }
 
@@ -113,7 +113,7 @@ public class SettingsStore: ObservableObject {
       self.ensOffchainResolveMethod = await rpcService.ensOffchainLookupResolveMethod()
       self.udResolveMethod = await rpcService.unstoppableDomainsResolveMethod()
       
-      self.nftDiscovery = await walletService.nftDiscoveryEnabled()
+      self.isNFTDiscoveryEnabled = await walletService.nftDiscoveryEnabled()
     }
   }
 

--- a/Sources/BraveWallet/Crypto/Stores/SettingsStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SettingsStore.swift
@@ -65,6 +65,14 @@ public class SettingsStore: ObservableObject {
       rpcService.setUnstoppableDomainsResolveMethod(udResolveMethod)
     }
   }
+  
+  /// The current preference for enabling NFT discovery (Enabled / Disabled)
+  @Published var nftDiscovery: Bool = false {
+    didSet {
+      guard oldValue != nftDiscovery else { return }
+      walletService.setNftDiscoveryEnabled(nftDiscovery)
+    }
+  }
 
   private let keyringService: BraveWalletKeyringService
   private let walletService: BraveWalletBraveWalletService
@@ -104,6 +112,8 @@ public class SettingsStore: ObservableObject {
       self.ensResolveMethod = await rpcService.ensResolveMethod()
       self.ensOffchainResolveMethod = await rpcService.ensOffchainLookupResolveMethod()
       self.udResolveMethod = await rpcService.unstoppableDomainsResolveMethod()
+      
+      self.nftDiscovery = await walletService.nftDiscoveryEnabled()
     }
   }
 

--- a/Sources/BraveWallet/Settings/Web3SettingsView.swift
+++ b/Sources/BraveWallet/Settings/Web3SettingsView.swift
@@ -229,6 +229,16 @@ private struct WalletSettingsView: View {
       }
     }
     Section(
+      footer: Text(LocalizedStringKey(String.localizedStringWithFormat(Strings.Wallet.web3SettingsEnableNFTDiscoveryFooter, WalletConstants.nftDiscoveryURL.absoluteDisplayString)))
+        .foregroundColor(Color(.secondaryBraveLabel))
+        .tint(Color(.braveBlurpleTint))
+    ) {
+      Toggle(Strings.Wallet.web3SettingsEnableNFTDiscovery, isOn: $settingsStore.nftDiscovery)
+        .foregroundColor(Color(.braveLabel))
+        .toggleStyle(SwitchToggleStyle(tint: Color(.braveBlurpleTint)))
+        .listRowBackground(Color(.secondaryBraveGroupedBackground))
+    }
+    Section(
       footer: Text(Strings.Wallet.networkFooter)
         .foregroundColor(Color(.secondaryBraveLabel))
     ) {

--- a/Sources/BraveWallet/Settings/Web3SettingsView.swift
+++ b/Sources/BraveWallet/Settings/Web3SettingsView.swift
@@ -233,7 +233,7 @@ private struct WalletSettingsView: View {
         .foregroundColor(Color(.secondaryBraveLabel))
         .tint(Color(.braveBlurpleTint))
     ) {
-      Toggle(Strings.Wallet.web3SettingsEnableNFTDiscovery, isOn: $settingsStore.nftDiscovery)
+      Toggle(Strings.Wallet.web3SettingsEnableNFTDiscovery, isOn: $settingsStore.isNFTDiscoveryEnabled)
         .foregroundColor(Color(.braveLabel))
         .toggleStyle(SwitchToggleStyle(tint: Color(.braveBlurpleTint)))
         .listRowBackground(Color(.secondaryBraveGroupedBackground))

--- a/Sources/BraveWallet/WalletConstants.swift
+++ b/Sources/BraveWallet/WalletConstants.swift
@@ -49,6 +49,9 @@ public struct WalletConstants {
   
   /// The url to the privacy policy for Jupiter swaps
   static let jupiterPrivacyPolicy = URL(string: "https://docs.jup.ag/legal/privacy-policy")!
+  
+  /// The url to learn more about NFT Discovery
+  public static let nftDiscoveryURL = URL(string: "https://github.com/brave/brave-browser/wiki/NFT-Discovery")!
 
   /// The currently supported test networks.
   static let supportedTestNetworkChainIds = [

--- a/Sources/BraveWallet/WalletPreferences.swift
+++ b/Sources/BraveWallet/WalletPreferences.swift
@@ -86,6 +86,9 @@ extension Preferences {
     }
     
     public static let resolveIPFSResources = Option<Int>(key: "web3.resolve-ipfs-resources", default: Web3IPFSOption.ask.rawValue)
+    
+    /// Used to track whether to prompt user to enable NFT discovery
+    public static let shouldShowNFTDiscoveryPermissionCallout = Option<Bool>(key: "wallet.show-nft-discovery-permission-callout", default: true)
   }
 }
 

--- a/Sources/BraveWallet/WalletPromptView.swift
+++ b/Sources/BraveWallet/WalletPromptView.swift
@@ -10,18 +10,27 @@ import Shared
 
 struct WalletPromptContentView<Content, Footer>: View where Content: View, Footer: View {
   let content: () -> Content
-  let buttonTitle: String
-  let action: (_ proceed: Bool) -> Void
+  var primaryButton: WalletPromptButton
+  var secondaryButton: WalletPromptButton?
+  var buttonsAxis: Axis
+  let showCloseButton: Bool
+  let dismissAction: (() -> Void)?
   let footer: () -> Footer
   
   init(
-    buttonTitle: String,
-    action: @escaping (_ proceed: Bool) -> Void,
+    primaryButton: WalletPromptButton,
+    secondaryButton: WalletPromptButton?,
+    buttonsAxis: Axis,
+    showCloseButton: Bool,
+    dismissAction: (() -> Void)?,
     @ViewBuilder content: @escaping () -> Content,
     @ViewBuilder footer: @escaping () -> Footer
   ) {
-    self.buttonTitle = buttonTitle
-    self.action = action
+    self.primaryButton = primaryButton
+    self.secondaryButton = secondaryButton
+    self.buttonsAxis = buttonsAxis
+    self.showCloseButton = showCloseButton
+    self.dismissAction = dismissAction
     self.content = content
     self.footer = footer
   }
@@ -29,34 +38,80 @@ struct WalletPromptContentView<Content, Footer>: View where Content: View, Foote
   var body: some View {
     VStack {
       content()
-        .padding(.bottom)
-      Button(action: { action(true) }) {
-        Text(buttonTitle)
+      if let secondaryButton = self.secondaryButton {
+        if buttonsAxis == .vertical {
+          VStack(spacing: 12) {
+            Button(primaryButton.title, action: { primaryButton.action(nil) })
+              .buttonStyle(BraveFilledButtonStyle(size: .large))
+            Button(secondaryButton.title, action: { secondaryButton.action(nil) })
+              .buttonStyle(BraveOutlineButtonStyle(size: .large))
+          }
+        } else {
+          HStack {
+            Button(secondaryButton.title, action: { secondaryButton.action(nil) })
+              .buttonStyle(BraveOutlineButtonStyle(size: .large))
+            Button(primaryButton.title, action: { primaryButton.action(nil) })
+              .buttonStyle(BraveFilledButtonStyle(size: .large))
+          }
+        }
+      } else {
+        Button(primaryButton.title, action: { primaryButton.action(nil) })
+          .buttonStyle(BraveFilledButtonStyle(size: .large))
       }
-      .buttonStyle(BraveFilledButtonStyle(size: .large))
       footer()
     }
     .frame(maxWidth: .infinity)
     .padding(20)
     .overlay(
-      Button(action: { action(false) }) {
+      showCloseButton ?
+      Button(action: { dismissAction?() }) {
         Image(systemName: "xmark")
           .padding(16)
       }
         .font(.headline)
-        .foregroundColor(.gray),
+        .foregroundColor(.gray)
+      : nil
+      ,
       alignment: .topTrailing
     )
     .accessibilityEmbedInScrollView()
   }
 }
 
+struct WalletPromptButton {
+  let title: String
+  let action: (UINavigationController?) -> Void
+}
+
 struct WalletPromptView<Content, Footer>: UIViewControllerRepresentable where Content: View, Footer: View {
   @Binding var isPresented: Bool
-  var buttonTitle: String
-  var action: (Bool, UINavigationController?) -> Bool
+  var primaryButton: WalletPromptButton
+  var secondaryButton: WalletPromptButton?
+  var buttonsAxis: Axis
+  var showCloseButton: Bool
+  var dismissAction: ((UINavigationController?) -> Void)?
   var content: () -> Content
   var footer: () -> Footer
+  
+  init(
+    isPresented: Binding<Bool>,
+    primaryButton: WalletPromptButton,
+    secondaryButton: WalletPromptButton? = nil,
+    buttonsAxis: Axis = .vertical,
+    showCloseButton: Bool = true,
+    dismissAction: ((UINavigationController?) -> Void)? = nil,
+    @ViewBuilder content: @escaping () -> Content,
+    @ViewBuilder footer: @escaping () -> Footer
+  ) {
+    _isPresented = isPresented
+    self.primaryButton = primaryButton
+    self.secondaryButton = secondaryButton
+    self.buttonsAxis = buttonsAxis
+    self.showCloseButton = showCloseButton
+    self.dismissAction = dismissAction
+    self.content = content
+    self.footer = footer
+  }
   
   func makeUIViewController(context: Context) -> UIViewController {
     .init()
@@ -67,15 +122,23 @@ struct WalletPromptView<Content, Footer>: UIViewControllerRepresentable where Co
       if uiViewController.presentedViewController != nil {
         return
       }
+      let newPrimaryButton = WalletPromptButton(title: primaryButton.title, action: { _ in
+        primaryButton.action(uiViewController.navigationController)
+      })
+      var newSecodaryButton: WalletPromptButton?
+      if let button = secondaryButton {
+        newSecodaryButton = WalletPromptButton(title: button.title, action: { _ in
+          button.action(uiViewController.navigationController)
+        })
+      }
       let controller = PopupViewController(
         rootView: WalletPromptContentView(
-          buttonTitle: buttonTitle,
-          action: { proceed in
-            if action(proceed, uiViewController.navigationController) {
-              uiViewController.dismiss(animated: true) {
-                isPresented = false
-              }
-            }
+          primaryButton: newPrimaryButton,
+          secondaryButton: newSecodaryButton,
+          buttonsAxis: buttonsAxis,
+          showCloseButton: showCloseButton,
+          dismissAction: {
+            dismissAction?(uiViewController.navigationController)
           },
           content: content,
           footer: footer
@@ -103,13 +166,19 @@ struct WalletPromptView<Content, Footer>: UIViewControllerRepresentable where Co
 extension WalletPromptView where Content: View, Footer == EmptyView {
   init(
     isPresented: Binding<Bool>,
-    buttonTitle: String,
-    action: @escaping (Bool, UINavigationController?) -> Bool,
+    primaryButton: WalletPromptButton,
+    secondaryButton: WalletPromptButton? = nil,
+    buttonsAxis: Axis = .vertical,
+    showCloseButton: Bool = true,
+    dismissAction: ((UINavigationController?) -> Void)? = nil,
     @ViewBuilder content: @escaping () -> Content
   ) {
     _isPresented = isPresented
-    self.buttonTitle = buttonTitle
-    self.action = action
+    self.primaryButton = primaryButton
+    self.secondaryButton = secondaryButton
+    self.buttonsAxis = buttonsAxis
+    self.showCloseButton = showCloseButton
+    self.dismissAction = dismissAction
     self.content = content
     self.footer = { EmptyView() }
   }

--- a/Sources/BraveWallet/WalletPromptView.swift
+++ b/Sources/BraveWallet/WalletPromptView.swift
@@ -44,7 +44,7 @@ struct WalletPromptContentView<Content, Footer>: View where Content: View, Foote
             Button(primaryButton.title, action: { primaryButton.action(nil) })
               .buttonStyle(BraveFilledButtonStyle(size: .large))
             Button(secondaryButton.title, action: { secondaryButton.action(nil) })
-              .buttonStyle(BraveOutlineButtonStyle(size: .large))
+              .foregroundColor(Color(.braveLabel))
           }
         } else {
           HStack {

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -1489,7 +1489,7 @@ extension Strings {
       "wallet.customTokenTitle",
       tableName: "BraveWallet",
       bundle: .module,
-      value: "Custom",
+      value: "Add Custom Asset",
       comment: "The title displayed on the add custom token screen"
     )
     public static let tokenName = NSLocalizedString(
@@ -4015,6 +4015,62 @@ extension Strings {
       bundle: .module,
       value: "No market information available yet",
       comment: "The message will be displayed when there is no coin market loaded or having an error."
+    )
+    public static let web3SettingsEnableNFTDiscovery = NSLocalizedString(
+      "wallet.web3SettingsEnableNFTDiscovery",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Enable NFT Discovery",
+      comment: "The title of the toggle for user to enable/disable NFT discovery inside Web3 settings."
+    )
+    public static let web3SettingsEnableNFTDiscoveryFooter = NSLocalizedString(
+      "wallet.web3SettingsEnableNFTDiscoveryFooter",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Automatically add NFTs you own to the Wallet using third party APIs. [Learn more](%@)",
+      comment: "The footer of the toggle for user to enable/disable NFT discovery inside Web3 settings."
+    )
+    public static let nftDiscoveryCalloutTitle = NSLocalizedString(
+      "wallet.nftDiscoveryCalloutTitle",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Want your NFTs displayed automatically?",
+      comment: "The title of the alert that asks users either to enable NFT discovery or import manually."
+    )
+    public static let nftDiscoveryCalloutDescription = NSLocalizedString(
+      "wallet.nftDiscoveryCalloutDescription",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Brave Wallet can use a third-party service to automatically display your NFTs. Brave will share your wallet addresses with SimpleHash to provide this service. Learn more.",
+      comment: "The title of the alert that asks users either to enable NFT discovery or import manually. `SimpleHash` is the third-party service name, so it does not need to be translated."
+    )
+    public static let nftDiscoveryCalloutDescriptionLearnMore = NSLocalizedString(
+      "wallet.nftDiscoveryCalloutDescriptionLearnMore",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Learn more",
+      comment: "This is the same `Learn more` at the end of `nftDiscoveryCalloutDescription`, but we need a separat translation to detect the range of it in order to build some attributed strings."
+    )
+    public static let nftDiscoveryCalloutDisable = NSLocalizedString(
+      "wallet.nftDiscoveryCalloutDisable",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "No thanks, I'll do it manually",
+      comment: "The title of the button that user clicks to disable NFT discovery."
+    )
+    public static let nftDiscoveryCalloutEnable = NSLocalizedString(
+      "wallet.nftDiscoveryCalloutEnable",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Yes, proceed",
+      comment: "The title of the button that user clicks to enable NFT discovery."
+    )
+    public static let nftEmptyImportNFT = NSLocalizedString(
+      "wallet.nftEmptyImportNFT",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Import NFT",
+      comment: "The title of the button that user clicks to add his/her first NFT"
     )
   }
 }

--- a/Tests/BraveWalletTests/SettingsStoreTests.swift
+++ b/Tests/BraveWalletTests/SettingsStoreTests.swift
@@ -41,6 +41,7 @@ class SettingsStoreTests: XCTestCase {
     walletService._addObserver = { _ in }
     walletService._setDefaultBaseCurrency = { _ in }
     walletService._defaultBaseCurrency = { $0(CurrencyCode.usd.code) } // default is USD
+    walletService._nftDiscoveryEnabled = { _ in }
     
     let rpcService = BraveWallet.TestJsonRpcService()
     rpcService._ensResolveMethod = { $0(.ask) }
@@ -64,7 +65,7 @@ class SettingsStoreTests: XCTestCase {
     let (keyringService, walletService, rpcService, txService, ipfsApi) = setupServices()
     keyringService._autoLockMinutes = { $0(1) }
     walletService._defaultBaseCurrency = { $0(CurrencyCode.cad.code) }
-    walletService._nftDiscoveryEnabled = { _ in }
+    walletService._nftDiscoveryEnabled = { $0(false) }
     rpcService._ensResolveMethod = { $0(.disabled) }
     rpcService._ensOffchainLookupResolveMethod = { $0(.disabled) }
     rpcService._snsResolveMethod = { $0(.disabled) }
@@ -94,6 +95,14 @@ class SettingsStoreTests: XCTestCase {
       .sink { currencyCode in
         defer { currencyCodeExpectation.fulfill() }
         XCTAssertEqual(currencyCode, CurrencyCode.cad)
+      }
+      .store(in: &cancellables)
+    let nftDiscoveryExpectation = expectation(description: "setup-nftDiscovery")
+    sut.$isNFTDiscoveryEnabled
+      .dropFirst()
+      .sink { isNFTDiscoveryEnabled in
+        defer { nftDiscoveryExpectation.fulfill() }
+        XCTAssertFalse(isNFTDiscoveryEnabled)
       }
       .store(in: &cancellables)
     

--- a/Tests/BraveWalletTests/SettingsStoreTests.swift
+++ b/Tests/BraveWalletTests/SettingsStoreTests.swift
@@ -64,6 +64,7 @@ class SettingsStoreTests: XCTestCase {
     let (keyringService, walletService, rpcService, txService, ipfsApi) = setupServices()
     keyringService._autoLockMinutes = { $0(1) }
     walletService._defaultBaseCurrency = { $0(CurrencyCode.cad.code) }
+    walletService._nftDiscoveryEnabled = { _ in }
     rpcService._ensResolveMethod = { $0(.disabled) }
     rpcService._ensOffchainLookupResolveMethod = { $0(.disabled) }
     rpcService._snsResolveMethod = { $0(.disabled) }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
NFT discovery can be enabled via the Auto discovery dialog or via the Enable NFT Discovery in settings under Web3.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7370

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Case 1: Check if `Enable NFT Discovery` is available for user to configure under Web3 settings
1. open Brave. Make a wallet account if you dont have one
2. go to the web3 settings screen from wallet or from the browser settings
3. Check if `Enable NFT Discovery` is available for user to config. If you have never configure this preference. The default value should be false (toggle off)

Case 2: The NFT discovery dialog
1. open Brave. Make a wallet account if you dont have one
2. go to the web3 settings screen from wallet or from the browser settings
3. Turn on `Enable NFT Discovery`
4. Go to NFT tab
5. There should be not NFT discovery dialog being prompt 
6. Go back to web3 settings and turn off `Enable NFT Discovery`
7. Go back to NFT tab
8. You should see a NFT discovery dialog appears

Case 3: The NFT discovery dialog should show open [Learn more](https://github.com/brave/brave-browser/wiki/NFT-Discovery) link.
1. From Case 2 step 8, check if `Learn more` will bring you to the correct website.

Case 4: The NFT discovery dialog should never be shown after selecting either option.
1. from case 3 step 1, go back to Wallet and NFT tab
2. the NFT discovery dialog should appear again since no decision has been made
3. Click either yes or no button
4. The dialog will be dismissed 
5. if you click yes, stay inside Wallet or exit wallet. but need 1 or 2 min gap to kill the browser app and relaunch again
6. Unlock into the wallet and go to NFT Tab
7. all the NFTs that you wallet account owns will appear in the tab
8. Once you have made decision on either enable or disable NFT discovery 
9. Check `Enable NFT Discovery` under web3 display the correct preference
10. And there won't be NFT discovery dialog showing up if you go to NFT tab. 

Case 5: Should able to import new NFT if user has no visible NFT.
1. open Brave, Make a wallet account if you dont have one
2. make sure you dont own any NFT or you choose not to auto-discover NFT
3. there will be an import button in NFT tab
4. Click import button
5. A form will show up for you to input NFT information so it can be added as a custom asset
6. Input required info and click Add to add the NFT
7. Newly added NFT should appear in the NFT tab.


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


https://user-images.githubusercontent.com/1187676/236557019-d5a79797-f30e-4878-bb89-4e98f4a5343a.mov

https://user-images.githubusercontent.com/1187676/236557048-a83abdfb-fe70-4152-9a5a-5b5383d73177.mov


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).

