### PR TITLE
Fix #7285: Private text is not fully shown in tab tray

### DIFF
--- a/Sources/Brave/Frontend/Browser/Tabs/TabTray/TabTrayController.swift
+++ b/Sources/Brave/Frontend/Browser/Tabs/TabTray/TabTrayController.swift
@@ -153,10 +153,13 @@ class TabTrayController: LoadingViewController {
   }
 
   let privateModeButton = SelectedInsetButton().then {
+    $0.setTitle(Strings.private, for: .normal)
     $0.titleLabel?.font = .preferredFont(forTextStyle: .body)
     $0.titleLabel?.adjustsFontForContentSizeCategory = true
     $0.contentHorizontalAlignment = .left
-    $0.setTitle(Strings.private, for: .normal)
+    $0.titleLabel?.adjustsFontSizeToFitWidth = true
+    $0.accessibilityLabel = Strings.done
+    $0.accessibilityIdentifier = "TabTrayController.privateButton"
     $0.tintColor = .braveLabel
 
     if Preferences.Privacy.privateBrowsingOnly.value {


### PR DESCRIPTION
AdjustsFontSizeToFitWidth is added to handle size changes when accessibility fonts are used.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This very rare case happens when TabTray was open and accessibility font size is updated. AdjustsFontSizeToFitWidth handles the problem.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7285

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
- Open TabTray - Enable private mode
-Leave screen open put the phone in background and enable larger font accessibility size

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


![Simulator Screenshot - iPhone 7 (iOS 15 5) - 2023-05-05 at 16 09 48](https://user-images.githubusercontent.com/6643505/236564420-d56e6ca4-8111-4b8e-a7eb-4a727c8ba3b4.png)


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
