### PR TITLE
Fix #7401: Previously opened tabs are closed on Brave relaunching

### DIFF
--- a/Sources/Brave/Migration/Migration.swift
+++ b/Sources/Brave/Migration/Migration.swift
@@ -73,13 +73,15 @@ public class Migration {
   
   // Migrate from TabMO to SessionTab and SessionWindow
   public static func migrateTabStateToWebkitState(diskImageStore: DiskImageStore?) {
+    let isPrivate = PrivateBrowsingManager.shared.isPrivateBrowsing
+
     if Preferences.Migration.tabMigrationToInteractionStateCompleted.value {
+      SessionWindow.createIfNeeded(index: 0, isPrivate: isPrivate, isSelected: true)
       return
     }
     
     // Get all the old Tabs from TabMO
     let oldTabIDs = TabMO.getAll().map({ $0.objectID })
-    let isPrivate = PrivateBrowsingManager.shared.isPrivateBrowsing
 
     // Nothing to migrate
     if oldTabIDs.isEmpty {

--- a/Sources/Data/models/SessionWindow.swift
+++ b/Sources/Data/models/SessionWindow.swift
@@ -63,6 +63,22 @@ extension SessionWindow {
     return Self.from(windowId: windowId, in: DataController.viewContext)
   }
   
+  public static func createIfNeeded(index: Int32, isPrivate: Bool, isSelected: Bool) {
+    DataController.performOnMainContext { context in
+      if SessionWindow.getActiveWindow(context: context) != nil {
+        return
+      }
+      
+      _ = SessionWindow(context: context, index: index, isPrivate: isPrivate, isSelected: isSelected)
+      
+      do {
+        try context.save()
+      } catch {
+        Logger.module.error("performTask save error: \(error.localizedDescription, privacy: .public)")
+      }
+    }
+  }
+  
   /// Marks the specified window as selected
   /// Since only one window can be active at a time, all other windows are marked as deselected
   public static func setSelected(windowId: UUID) {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

Create Session Window If needed when migrate webs state is called

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7401

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->

- Launch Brave
- Open a few tabs
- Close and relaunch Brave > Observe

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
