### PR TITLE
Fix #7405: Fix switching between beta and release crash

### DIFF
--- a/Sources/Data/models/Model.xcdatamodeld/Model20.xcdatamodel/contents
+++ b/Sources/Data/models/Model.xcdatamodeld/Model20.xcdatamodel/contents
@@ -176,22 +176,22 @@
         <attribute name="title" attributeType="String"/>
         <attribute name="url" attributeType="URI"/>
         <relationship name="sessionTabGroup" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SessionTabGroup" inverseName="sessionTabs" inverseEntity="SessionTabGroup"/>
-        <relationship name="sessionWindow" maxCount="1" deletionRule="Nullify" destinationEntity="SessionWindow" inverseName="sessionTabs" inverseEntity="SessionWindow"/>
+        <relationship name="sessionWindow" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SessionWindow" inverseName="sessionTabs" inverseEntity="SessionWindow"/>
     </entity>
     <entity name="SessionTabGroup" representedClassName="Data.SessionTabGroup" syncable="YES">
         <attribute name="groupId" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="index" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="title" attributeType="String"/>
-        <relationship name="sessionTabs" toMany="YES" deletionRule="Nullify" destinationEntity="SessionTab" inverseName="sessionTabGroup" inverseEntity="SessionTab"/>
-        <relationship name="sessionWindow" maxCount="1" deletionRule="Nullify" destinationEntity="SessionWindow" inverseName="sessionTabGroups" inverseEntity="SessionWindow"/>
+        <relationship name="sessionTabs" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="SessionTab" inverseName="sessionTabGroup" inverseEntity="SessionTab"/>
+        <relationship name="sessionWindow" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SessionWindow" inverseName="sessionTabGroups" inverseEntity="SessionWindow"/>
     </entity>
     <entity name="SessionWindow" representedClassName="Data.SessionWindow" syncable="YES">
         <attribute name="index" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="isPrivate" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="isSelected" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="windowId" attributeType="UUID" usesScalarValueType="NO"/>
-        <relationship name="sessionTabGroups" toMany="YES" deletionRule="Cascade" destinationEntity="SessionTabGroup" inverseName="sessionWindow" inverseEntity="SessionTabGroup"/>
-        <relationship name="sessionTabs" toMany="YES" deletionRule="Cascade" destinationEntity="SessionTab" inverseName="sessionWindow" inverseEntity="SessionTab"/>
+        <relationship name="sessionTabGroups" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="SessionTabGroup" inverseName="sessionWindow" inverseEntity="SessionTabGroup"/>
+        <relationship name="sessionTabs" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="SessionTab" inverseName="sessionWindow" inverseEntity="SessionTab"/>
     </entity>
     <entity name="TabMO" representedClassName="Data.TabMO" syncable="YES">
         <attribute name="color" optional="YES" attributeType="String"/>

--- a/Sources/Data/models/SessionTab.swift
+++ b/Sources/Data/models/SessionTab.swift
@@ -20,7 +20,7 @@ public final class SessionTab: NSManagedObject, CRUD {
   @NSManaged private(set) public var tabId: UUID
   
   @NSManaged private(set) public var sessionTabGroup: SessionTabGroup?
-  @NSManaged private(set) public var sessionWindow: SessionWindow
+  @NSManaged private(set) public var sessionWindow: SessionWindow?
   
   @available(*, unavailable)
   public init() {
@@ -53,7 +53,7 @@ public final class SessionTab: NSManagedObject, CRUD {
       fatalError("No such Entity: SessionTab")
     }
     
-    if let sessionTabGroup = sessionTabGroup, sessionTabGroup.sessionWindow.windowId != sessionWindow.windowId {
+    if let sessionTabGroup = sessionTabGroup, sessionTabGroup.sessionWindow?.windowId != sessionWindow.windowId {
       fatalError("Cannot add a tab to a different window and group. The group must belong to the same window as the tab")
     }
     
@@ -204,7 +204,7 @@ extension SessionTab {
         _ = SessionTab(context: context,
                        sessionWindow: window,
                        sessionTabGroup: nil,
-                       index: Int32(window.sessionTabs.count),
+                       index: Int32(window.sessionTabs?.count ?? 0),
                        interactionState: Data(),
                        isPrivate: false,
                        isSelected: false,

--- a/Sources/Data/models/SessionTabGroup.swift
+++ b/Sources/Data/models/SessionTabGroup.swift
@@ -13,8 +13,8 @@ public final class SessionTabGroup: NSManagedObject, CRUD {
   @NSManaged public var index: Int32
   @NSManaged private(set) public var groupId: UUID
   
-  @NSManaged private(set) public var sessionWindow: SessionWindow
-  @NSManaged private(set) public var sessionTabs: Set<SessionTab>
+  @NSManaged private(set) public var sessionWindow: SessionWindow?
+  @NSManaged private(set) public var sessionTabs: Set<SessionTab>?
   
   @available(*, unavailable)
   public init() {

--- a/Sources/Data/models/SessionWindow.swift
+++ b/Sources/Data/models/SessionWindow.swift
@@ -13,8 +13,9 @@ public final class SessionWindow: NSManagedObject, CRUD {
   @NSManaged private(set) public var isPrivate: Bool
   @NSManaged public var isSelected: Bool
   @NSManaged private(set) public var windowId: UUID
-  @NSManaged private(set) public var sessionTabs: Set<SessionTab>
-  @NSManaged private(set) public var sessionTabGroups: Set<SessionTabGroup>
+  
+  @NSManaged private(set) public var sessionTabs: Set<SessionTab>?
+  @NSManaged private(set) public var sessionTabGroups: Set<SessionTabGroup>?
   
   @available(*, unavailable)
   public init() {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Fix a crash when switching between beta and release. For some reason the database says:
```
CoreData: error: Unhandled opt lock error from executeBatchDeleteRequest Constraint trigger violation: Batch delete failed due to mandatory OTO nullify inverse on SessionTab/sessionWindow and userInfo {
    NSExceptionOmitCallstacks = 1;
    NSLocalizedFailureReason = "Constraint trigger violation: Batch delete failed due to mandatory OTO nullify inverse on SessionTab/sessionWindow";
    "_NSCoreDataOptimisticLockingFailureConflictsKey" =     (
    );
}
```

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7405

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
