### PR TITLE
Ref #7285: Private text is not fully shown in tab tray

### DIFF
--- a/Sources/Brave/Frontend/Browser/Tabs/TabTray/Views/TabTrayPrivateModeInfoView.swift
+++ b/Sources/Brave/Frontend/Browser/Tabs/TabTray/Views/TabTrayPrivateModeInfoView.swift
@@ -37,6 +37,8 @@ extension TabTrayController {
       $0.font = UX.titleFont
       $0.textAlignment = .center
       $0.text = Strings.privateBrowsing
+      $0.adjustsFontSizeToFitWidth = true
+      $0.minimumScaleFactor = 0.75
     }
 
     let descriptionLabel = UILabel().then {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
Adjusting private mode info title for long titles

This pull request references #7285

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
