### PR TITLE
Fix #7410: Open Tabs Session Time hour format display error 

### DIFF
--- a/Sources/Brave/Frontend/Browser/Tabs/TabTray/TabTrayController+TableViewDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/Tabs/TabTray/TabTrayController+TableViewDelegate.swift
@@ -210,17 +210,17 @@ extension Date {
   var formattedSyncSessionPeriodDate: String {
     let hourFormatter = DateFormatter().then {
       $0.locale = .current
-      $0.dateFormat = "HH:mm a"
+      $0.dateFormat = "h:mm a"
     }
     
     let hourDayFormatter = DateFormatter().then {
       $0.locale = .current
-      $0.dateFormat = "EEEE HH:mm a"
+      $0.dateFormat = "EEEE h:mm a"
     }
     
     let fullDateFormatter = DateFormatter().then {
       $0.locale = .current
-      $0.dateFormat = "HH:mm a MM-dd-yyyy"
+      $0.dateFormat = "h:mm a MM-dd-yyyy"
     }
         
     if compare(getCurrentDateWith(dayOffset: TimePeriodOffset.today.period)) ==

--- a/Tests/ClientTests/SyncHelperTests.swift
+++ b/Tests/ClientTests/SyncHelperTests.swift
@@ -22,7 +22,7 @@ class SyncHelperTests: XCTestCase {
     let someRandomDateTime = userCalendar.date(from: dateComponents)!
     
     
-    XCTAssertEqual(someRandomDateTime.formattedSyncSessionPeriodDate, "08:34 AM 07-11-1980")
+    XCTAssertEqual(someRandomDateTime.formattedSyncSessionPeriodDate, "8:34 AM 07-11-1980")
     XCTAssertEqual(today.formattedActivePeriodDate, "Active Today")
     XCTAssertEqual(yesterday.formattedActivePeriodDate, "Active Yesterday")
     XCTAssertEqual(randomDateInLastWeek.formattedActivePeriodDate, "Active Last Week")


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

Fixing time formatter for using 24h format

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7410

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Sync Open Tabs
Check hour display on session

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

![Screenshot 2023-05-08 at 2 29 02 PM](https://user-images.githubusercontent.com/6643505/236902587-ea4165f0-0334-490f-a7f4-a99a883d5649.png)


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
