### PR TITLE
Fix #7403: Fix ServerTrust notification to update the URL bar

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -608,6 +608,16 @@ extension BrowserViewController: WKNavigationDelegate {
     // Set the committed url which will also set tab.url
     tab.committedURL = webView.url
     
+    DispatchQueue.main.async {
+      // Server Trust and URL is also updated in didCommit
+      // However, WebKit does NOT trigger the `serverTrust` observer when the URL changes, but the trust has not.
+      // So manually trigger it with the current trust.
+      self.observeValue(forKeyPath: KVOConstants.serverTrust.rawValue,
+                        of: webView,
+                        change: [.newKey: webView.serverTrust, .kindKey: 1],
+                        context: nil)
+    }
+    
     // Need to evaluate Night mode script injection after url is set inside the Tab
     tab.nightMode = Preferences.General.nightModeEnabled.value
     tab.clearSolanaConnectedAccounts()


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Server Trust does not post a notification if the trust itself hasn't changed. Problem is that the trust on NTP is the same as on an HTTP site. So visiting an HTTP site takes the same trust as on NTP, which is wrong. To fix this, we post a notification ourselves to let us know that the URL changed but the trust stayed the same.
This in turn causes the revalidation to happen.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7403

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
