### PR TITLE
No Bug: Don't call ads reporting methods unless its initialized

### DIFF
--- a/Sources/Brave/Frontend/Rewards/BraveRewards.swift
+++ b/Sources/Brave/Frontend/Rewards/BraveRewards.swift
@@ -183,7 +183,9 @@ public class BraveRewards: NSObject {
       ledger?.selectedTabId = UInt32(tabId)
       tabRetrieved(tabId, url: url, html: nil)
     }
-    ads.reportTabUpdated(tabId, url: url, redirectedFrom: tab.redirectURLs, isSelected: isSelected, isPrivate: isPrivate)
+    if isAdsInitialized {
+      ads.reportTabUpdated(tabId, url: url, redirectedFrom: tab.redirectURLs, isSelected: isSelected, isPrivate: isPrivate)
+    }
   }
 
   /// Report that a page has loaded in the current browser tab, and the HTML is available for analysis
@@ -198,7 +200,7 @@ public class BraveRewards: NSObject {
     adsInnerText: String?
   ) {
     tabRetrieved(tabId, url: url, html: html)
-    if let innerText = adsInnerText {
+    if let innerText = adsInnerText, isAdsInitialized {
       ads.reportLoadedPage(
         with: url,
         redirectedFrom: redirectionURLs ?? [],
@@ -222,11 +224,13 @@ public class BraveRewards: NSObject {
 
   /// Report that media has started on a tab with a given id
   func reportMediaStarted(tabId: Int) {
+    if !isAdsInitialized { return }
     ads.reportMediaStarted(tabId: tabId)
   }
 
   /// Report that media has stopped on a tab with a given id
   func reportMediaStopped(tabId: Int) {
+    if !isAdsInitialized { return }
     ads.reportMediaStopped(tabId: tabId)
   }
 
@@ -237,7 +241,9 @@ public class BraveRewards: NSObject {
 
   /// Report that a tab with a given id was closed by the user
   func reportTabClosed(tabId: Int) {
-    ads.reportTabClosed(tabId: tabId)
+    if isAdsInitialized {
+      ads.reportTabClosed(tabId: tabId)
+    }
     ledger?.reportTabNavigationOrClosed(tabId: UInt32(tabId))
   }
 


### PR DESCRIPTION
## Summary of Changes

These used to be no-ops on the core side when not initialized but as of https://github.com/brave/brave-ios/pull/7318 this is no longer the case since the ads service is created earlier

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
