### PR TITLE
Fix #7295: Show pending transactions from all networks

### DIFF
--- a/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -375,7 +375,12 @@ public class CryptoStore: ObservableObject {
   @MainActor
   func fetchPendingTransactions() async -> [BraveWallet.TransactionInfo] {
     let allKeyrings = await keyringService.keyrings(for: WalletConstants.supportedCoinTypes)
-    return await txService.pendingTransactions(for: allKeyrings)
+    var allChainIdsForCoin: [BraveWallet.CoinType: [String]] = [:]
+    for coin in WalletConstants.supportedCoinTypes {
+      let allNetworks = await rpcService.allNetworks(coin)
+      allChainIdsForCoin[coin] = allNetworks.map(\.chainId)
+    }
+    return await txService.pendingTransactions(chainIdsForCoin: allChainIdsForCoin, for: allKeyrings)
   }
 
   @MainActor

--- a/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -375,12 +375,7 @@ public class CryptoStore: ObservableObject {
   @MainActor
   func fetchPendingTransactions() async -> [BraveWallet.TransactionInfo] {
     let allKeyrings = await keyringService.keyrings(for: WalletConstants.supportedCoinTypes)
-    var selectedChainIdForCoinTypes: [BraveWallet.CoinType: [String]] = [:]
-    for coin in WalletConstants.supportedCoinTypes {
-      let selectedNetwork = await rpcService.network(coin, origin: nil)
-      selectedChainIdForCoinTypes[coin] = [selectedNetwork.chainId]
-    }
-    return await txService.pendingTransactions(chainIdsForCoin: selectedChainIdForCoinTypes, for: allKeyrings)
+    return await txService.pendingTransactions(for: allKeyrings)
   }
 
   @MainActor

--- a/Sources/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
@@ -550,7 +550,12 @@ public class TransactionConfirmationStore: ObservableObject {
   
   @MainActor private func fetchAllTransactions() async -> [BraveWallet.TransactionInfo] {
     let allKeyrings = await keyringService.keyrings(for: WalletConstants.supportedCoinTypes)
-    return await txService.pendingTransactions(for: allKeyrings)
+    var allChainIdsForCoin: [BraveWallet.CoinType: [String]] = [:]
+    for coin in WalletConstants.supportedCoinTypes {
+      let allNetworks = await rpcService.allNetworks(coin)
+      allChainIdsForCoin[coin] = allNetworks.map(\.chainId)
+    }
+    return await txService.pendingTransactions(chainIdsForCoin: allChainIdsForCoin, for: allKeyrings)
       .sorted(by: { $0.createdTime < $1.createdTime })
   }
 

--- a/Sources/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
@@ -121,6 +121,8 @@ public class TransactionConfirmationStore: ObservableObject {
       }
     }
   }
+  /// A cache of networks for the supported coin types.
+  private var allNetworks: [BraveWallet.NetworkInfo] = []
   
   private let assetRatioService: BraveWalletAssetRatioService
   private let rpcService: BraveWalletJsonRpcService
@@ -189,14 +191,15 @@ public class TransactionConfirmationStore: ObservableObject {
   }
   
   @MainActor func prepare() async {
+    allNetworks = await rpcService.allNetworksForSupportedCoins()
     allTxs = await fetchAllTransactions()
     if !unapprovedTxs.contains(where: { $0.id == activeTransactionId }) {
       self.activeTransactionId = unapprovedTxs.first?.id ?? ""
     }
-    let coinsForTransactions: Set<BraveWallet.CoinType> = .init(unapprovedTxs.map(\.coin))
-    for coin in coinsForTransactions {
-      let network = await rpcService.network(coin, origin: nil)
-      let userVisibleTokens = await walletService.userAssets(network.chainId, coin: coin)
+    let transactionNetworks: [BraveWallet.NetworkInfo] = Set(allTxs.map(\.chainId))
+      .compactMap { chainId in allNetworks.first(where: { $0.chainId == chainId }) }
+    for network in transactionNetworks {
+      let userVisibleTokens = await walletService.userAssets(network.chainId, coin: network.coin)
       await fetchAssetRatios(for: userVisibleTokens)
     }
     await fetchUnknownTokens(for: unapprovedTxs)
@@ -213,7 +216,15 @@ public class TransactionConfirmationStore: ObservableObject {
       
       let coin = transaction.coin
       let keyring = await keyringService.keyringInfo(coin.keyringId)
-      let network = await rpcService.network(coin, origin: nil)
+      if !allNetworks.contains(where: { $0.chainId == transaction.chainId }) {
+        allNetworks = await rpcService.allNetworksForSupportedCoins()
+      }
+      guard let network = allNetworks.first(where: { $0.chainId == transaction.chainId }) else {
+        // Transactions should be removed if their network is removed
+        // https://github.com/brave/brave-browser/issues/30234
+        assertionFailure("The NetworkInfo for the transaction's chainId (\(transaction.chainId)) is unavailable")
+        return
+      }
       let allTokens = await blockchainRegistry.allTokens(network.chainId, coin: coin) + tokenInfoCache.map(\.value)
       let userVisibleTokens = await walletService.userAssets(network.chainId, coin: coin)
       let solEstimatedTxFee: UInt64? = solEstimatedTxFeeCache[transaction.id]
@@ -326,11 +337,17 @@ public class TransactionConfirmationStore: ObservableObject {
   @MainActor private func fetchUnknownTokens(
     for transactions: [BraveWallet.TransactionInfo]
   ) async {
-    let coin = await walletService.selectedCoin()
-    let network = await rpcService.network(coin, origin: nil)
+    // `AssetRatioService` can only fetch tokens from Ethereum Mainnet
+    let mainnetTransactions = transactions.filter { $0.chainId == BraveWallet.MainnetChainId }
+    guard !mainnetTransactions.isEmpty else { return }
+    let coin: BraveWallet.CoinType = .eth
+    let allNetworks = await rpcService.allNetworks(coin)
+    guard let network = allNetworks.first(where: { $0.chainId == BraveWallet.MainnetChainId }) else {
+      return
+    }
     let userVisibleTokens = await walletService.userAssets(network.chainId, coin: network.coin)
     let allTokens = await blockchainRegistry.allTokens(network.chainId, coin: network.coin)
-    let unknownTokenContractAddresses = transactions.flatMap(\.tokenContractAddresses)
+    let unknownTokenContractAddresses = mainnetTransactions.flatMap(\.tokenContractAddresses)
       .filter { contractAddress in
         !userVisibleTokens.contains(where: { $0.contractAddress(in: network).caseInsensitiveCompare(contractAddress) == .orderedSame })
         && !allTokens.contains(where: { $0.contractAddress(in: network).caseInsensitiveCompare(contractAddress) == .orderedSame })
@@ -533,12 +550,7 @@ public class TransactionConfirmationStore: ObservableObject {
   
   @MainActor private func fetchAllTransactions() async -> [BraveWallet.TransactionInfo] {
     let allKeyrings = await keyringService.keyrings(for: WalletConstants.supportedCoinTypes)
-    var selectedChainIdForCoinTypes: [BraveWallet.CoinType: [String]] = [:]
-    for coin in WalletConstants.supportedCoinTypes {
-      let selectedNetwork = await rpcService.network(coin, origin: nil)
-      selectedChainIdForCoinTypes[coin] = [selectedNetwork.chainId]
-    }
-    return await txService.pendingTransactions(chainIdsForCoin: selectedChainIdForCoinTypes, for: allKeyrings)
+    return await txService.pendingTransactions(for: allKeyrings)
   }
 
   func confirm(transaction: BraveWallet.TransactionInfo, completion: @escaping (_ error: String?) -> Void) {

--- a/Sources/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
@@ -551,6 +551,7 @@ public class TransactionConfirmationStore: ObservableObject {
   @MainActor private func fetchAllTransactions() async -> [BraveWallet.TransactionInfo] {
     let allKeyrings = await keyringService.keyrings(for: WalletConstants.supportedCoinTypes)
     return await txService.pendingTransactions(for: allKeyrings)
+      .sorted(by: { $0.createdTime < $1.createdTime })
   }
 
   func confirm(transaction: BraveWallet.TransactionInfo, completion: @escaping (_ error: String?) -> Void) {

--- a/Sources/BraveWallet/Extensions/WalletTxServiceExtensions.swift
+++ b/Sources/BraveWallet/Extensions/WalletTxServiceExtensions.swift
@@ -8,36 +8,6 @@ import BraveCore
 
 extension BraveWalletTxService {
   
-  // Fetches all pending transactions for all given keyrings. This will return transactions from all networks.
-  func pendingTransactions(
-    for keyrings: [BraveWallet.KeyringInfo]
-  ) async -> [BraveWallet.TransactionInfo] {
-    await allTransactions(for: keyrings).filter { $0.txStatus == .unapproved }
-  }
-
-  // Fetches all transactions for all given keyrings. This will return transactions from all networks.
-  func allTransactions(
-    for keyrings: [BraveWallet.KeyringInfo]
-  ) async -> [BraveWallet.TransactionInfo] {
-    return await withTaskGroup(
-      of: [BraveWallet.TransactionInfo].self,
-      body: { @MainActor group in
-        for keyring in keyrings {
-          for info in keyring.accountInfos {
-            group.addTask { @MainActor in
-              await self.allTransactionInfo(info.coin, chainId: nil, from: info.address)
-            }
-          }
-        }
-        var allTx: [BraveWallet.TransactionInfo] = []
-        for await transactions in group {
-          allTx.append(contentsOf: transactions)
-        }
-        return allTx
-      }
-    )
-  }
-  
   // Fetches all pending transactions for all given keyrings
   func pendingTransactions(
     chainIdsForCoin: [BraveWallet.CoinType: [String]],

--- a/Sources/BraveWallet/Preview Content/MockContent.swift
+++ b/Sources/BraveWallet/Preview Content/MockContent.swift
@@ -241,9 +241,9 @@ extension BraveWallet.TransactionInfo {
       txType: .erc20Approve,
       txParams: ["address", "uint256"],
       txArgs: ["0xe592427a0aece92de3edee1f18e0157c05861564Z", "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"],
-      createdTime: Date(timeIntervalSince1970: 1636399671),
-      submittedTime: Date(timeIntervalSince1970: 1636399673),
-      confirmedTime: Date(timeIntervalSince1970: 1636402508),
+      createdTime: Date(timeIntervalSince1970: 1636399671), // Monday, November 8, 2021 7:27:51 PM
+      submittedTime: Date(timeIntervalSince1970: 1636399673), // Monday, November 8, 2021 7:27:53 PM
+      confirmedTime: Date(timeIntervalSince1970: 1636402508), // Monday, November 8, 2021 8:15:08 PM
       originInfo: .init(),
       groupId: nil,
       chainId: BraveWallet.MainnetChainId
@@ -283,13 +283,13 @@ extension BraveWallet.TransactionInfo {
       confirmedTime: Date(timeIntervalSince1970: 1667854820), // Monday, November 7, 2022 9:00:20 PM GMT
       originInfo: .init(),
       groupId: nil,
-      chainId: BraveWallet.MainnetChainId
+      chainId: BraveWallet.SolanaMainnet
     )
   }
   /// Solana Token Transfer
   static var previewConfirmedSolTokenTransfer: BraveWallet.TransactionInfo {
     BraveWallet.TransactionInfo(
-      id: "3d3c7715-f5f2-4f70-ab97-7fb8d3b2a3cd",
+      id: "12345675-f5f2-4f70-ab97-7fb8d3b2a3cd",
       fromAddress: "6WRQXT2wMAkSjTjGQSqfEnuqgnqskTp5FnT28tScDsAd",
       txHash: "",
       txDataUnion: .init(
@@ -315,12 +315,12 @@ extension BraveWallet.TransactionInfo {
       txType: .solanaSplTokenTransfer,
       txParams: [],
       txArgs: [],
-      createdTime: Date(timeIntervalSince1970: 1636399671),
-      submittedTime: Date(timeIntervalSince1970: 1636399673),
-      confirmedTime: Date(timeIntervalSince1970: 1636402508),
+      createdTime: Date(timeIntervalSince1970: 1636399671), // Monday, November 8, 2021 7:27:51 PM
+      submittedTime: Date(timeIntervalSince1970: 1636399673), // Monday, November 8, 2021 7:27:53 PM
+      confirmedTime: Date(timeIntervalSince1970: 1636402508), // Monday, November 8, 2021 8:15:08 PM
       originInfo: .init(),
       groupId: nil,
-      chainId: BraveWallet.MainnetChainId
+      chainId: BraveWallet.SolanaMainnet
     )
   }
   static private func _transactionBase64ToData(_ base64String: String) -> [NSNumber] {

--- a/Tests/BraveWalletTests/TransactionConfirmationStoreTests.swift
+++ b/Tests/BraveWalletTests/TransactionConfirmationStoreTests.swift
@@ -17,6 +17,10 @@ import BraveCore
       .eth : BraveWallet.NetworkInfo.mockMainnet,
       .sol : BraveWallet.NetworkInfo.mockSolana
     ],
+    allNetworksForCoinType: [BraveWallet.CoinType: [BraveWallet.NetworkInfo]] = [
+      .eth: [.mockMainnet, .mockGoerli],
+      .sol: [.mockSolana, .mockSolanaTestnet]
+    ],
     accountInfos: [BraveWallet.AccountInfo] = [.mockEthAccount, .mockSolAccount],
     allTokens: [BraveWallet.BlockchainToken] = [],
     transactions: [BraveWallet.TransactionInfo] = [],
@@ -40,6 +44,9 @@ import BraveCore
     rpcService._network = { coin, origin, completion in
       completion(selectedNetworkForCoinType[coin] ?? .mockMainnet)
     }
+    rpcService._allNetworks = { coin, completion in
+      completion(allNetworksForCoinType[coin] ?? [])
+    }
     rpcService._balance = { _, _, _, completion in
       completion(mockBalanceWei, .success, "")
     }
@@ -48,8 +55,9 @@ import BraveCore
     }
     let txService = BraveWallet.TestTxService()
     txService._addObserver = { _ in }
-    txService._allTransactionInfo = { _, _, _, completion in
-      completion(transactions)
+    txService._allTransactionInfo = { coin, chainId, address, completion in
+      let transactionsForCoin = transactions.filter { $0.coin == coin }
+      completion(transactionsForCoin)
     }
     let blockchainRegistry = BraveWallet.TestBlockchainRegistry()
     blockchainRegistry._allTokens = { _, _, completion in
@@ -79,7 +87,12 @@ import BraveCore
         isKeyringCreated: true,
         isLocked: false,
         isBackedUp: true,
-        accountInfos: accountInfos)
+        accountInfos: [])
+      if id == BraveWallet.DefaultKeyringId {
+        keyring.accountInfos = accountInfos.filter { $0.coin == .eth }
+      } else {
+        keyring.accountInfos = accountInfos.filter { $0.coin == .sol }
+      }
       completion(keyring)
     }
     
@@ -275,6 +288,66 @@ import BraveCore
       .store(in: &cancellables)
     
     await fulfillment(of: [prepareExpectation], timeout: 1)
+  }
+  
+  /// Test `network` property is updated for the `activeTransaction`, regardess of the current selected network for that coin type.
+  func testPrepareTransactionNotOnSelectedNetwork() async {
+    let firstTransactionDate = Date(timeIntervalSince1970: 1636399671) // Monday, November 8, 2021 7:27:51 PM
+    let sendCopy = BraveWallet.TransactionInfo.previewConfirmedSend.copy() as! BraveWallet.TransactionInfo
+    sendCopy.chainId = BraveWallet.GoerliChainId
+    sendCopy.txStatus = .unapproved
+    let swapCopy = BraveWallet.TransactionInfo.previewConfirmedSwap.copy() as! BraveWallet.TransactionInfo
+    swapCopy.chainId = BraveWallet.MainnetChainId
+    swapCopy.txStatus = .unapproved
+    let solanaSendCopy = BraveWallet.TransactionInfo.previewConfirmedSolSystemTransfer.copy() as! BraveWallet.TransactionInfo
+    solanaSendCopy.chainId = BraveWallet.SolanaMainnet
+    let solanaSPLSendCopy = BraveWallet.TransactionInfo.previewConfirmedSolTokenTransfer.copy() as! BraveWallet.TransactionInfo
+    solanaSPLSendCopy.chainId = BraveWallet.SolanaTestnet
+    let pendingTransactions: [BraveWallet.TransactionInfo] = [
+      sendCopy, swapCopy, solanaSendCopy, solanaSPLSendCopy
+    ].enumerated().map { (index, tx) in
+      tx.txStatus = .unapproved
+      // transactions sorted by created time, make sure they are in-order
+      tx.createdTime = firstTransactionDate.addingTimeInterval(TimeInterval(index))
+      return tx
+    }
+    let allTokens: [BraveWallet.BlockchainToken] = [.previewToken, .daiToken]
+    let store = setupStore(
+      allTokens: allTokens,
+      transactions: pendingTransactions
+    )
+    let networkExpectation = expectation(description: "network-expectation")
+    store.$network
+      .dropFirst(6) // `network` is assigned multiple times during setup
+      .collect(4) // collect all transactions
+      .sink { networks in
+        defer { networkExpectation.fulfill() }
+        XCTAssertEqual(networks.count, 4)
+        XCTAssertEqual(networks[safe: 0], BraveWallet.NetworkInfo.mockGoerli)
+        XCTAssertEqual(networks[safe: 1], BraveWallet.NetworkInfo.mockMainnet)
+        XCTAssertEqual(networks[safe: 2], BraveWallet.NetworkInfo.mockSolana)
+        XCTAssertEqual(networks[safe: 3], BraveWallet.NetworkInfo.mockSolanaTestnet)
+      }
+      .store(in: &cancellables)
+    let activeTransactionIdExpectation = expectation(description: "activeTransactionId-expectation")
+    store.$activeTransactionId
+      .dropFirst()
+      .collect(4) // collect all transactions
+      .sink { activeTransactionIds in
+        defer { activeTransactionIdExpectation.fulfill() }
+        XCTAssertEqual(activeTransactionIds.count, 4)
+        XCTAssertEqual(activeTransactionIds[safe: 0], pendingTransactions[safe: 0]?.id)
+        XCTAssertEqual(activeTransactionIds[safe: 1], pendingTransactions[safe: 1]?.id)
+        XCTAssertEqual(activeTransactionIds[safe: 2], pendingTransactions[safe: 2]?.id)
+        XCTAssertEqual(activeTransactionIds[safe: 3], pendingTransactions[safe: 3]?.id)
+      }
+      .store(in: &cancellables)
+    
+    await store.prepare() // `sendCopy` on Goerli Testnet
+    store.nextTransaction() // `swapCopy` on Ethereum Mainnet
+    store.nextTransaction() // `solanaSendCopy` on Solana Mainnet
+    store.nextTransaction() // `solanaSPLSendCopy` on Solana Testnet
+    await fulfillment(of: [networkExpectation, activeTransactionIdExpectation], timeout: 1)
   }
   
   /// Test `editAllowance(txMetaId:spenderAddress:amount:completion)` will return false if we fail to make ERC20 approve data with `BraveWalletEthTxManagerProxy`

--- a/Tests/BraveWalletTests/TransactionConfirmationStoreTests.swift
+++ b/Tests/BraveWalletTests/TransactionConfirmationStoreTests.swift
@@ -56,8 +56,14 @@ import BraveCore
     let txService = BraveWallet.TestTxService()
     txService._addObserver = { _ in }
     txService._allTransactionInfo = { coin, chainId, address, completion in
-      let transactionsForCoin = transactions.filter { $0.coin == coin }
-      completion(transactionsForCoin)
+      let filteredTransactions = transactions.filter {
+        if let chainId = chainId {
+          return $0.coin == coin && $0.chainId == chainId
+        } else {
+          return $0.coin == coin
+        }
+      }
+      completion(filteredTransactions)
     }
     let blockchainRegistry = BraveWallet.TestBlockchainRegistry()
     blockchainRegistry._allTokens = { _, _, completion in


### PR DESCRIPTION
## Summary of Changes
- Add support for transactions from all networks for pending transactions, transaction confirmation
- Previously only selected network for each coin type (Eth or Sol) was displayed

This pull request fixes #7295

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Open wallet with an account with balance on at least 2 Ethereum networks, and at least 2 Solana networks.
2. Create any transaction on each of the 4+ networks
3. Verify pending transactions button is available regardless of the currently selected network
    - Selected network is only visible in buy/send/swap, or on wallet panel (DApp)
4. Verify pending transactions display the correct network in Transaction Confirmation
5. Confirm a transaction and wait for it to show `Transaction Completed` status.
6. Tap `View Receipt` and verify correct network is displayed
7. Verify confirm / reject and other transaction actions are working as expected


## Screenshots:

https://github.com/brave/brave-ios/assets/5314553/f56692bd-67a6-4bb9-8cba-840c134e442b


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
