### PR TITLE
Fix #7412: VPN Region Selector related changes

### DIFF
--- a/App/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/GuardianFirewall/GuardianConnect",
       "state" : {
-        "revision" : "5a00da66f1368e5c325489676fe9281ec98c3a8f",
-        "version" : "1.8.4-dev-2"
+        "revision" : "cf99f1babca17a3d94ea20e2fc56cc48dfd65575",
+        "version" : "1.8.4"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -60,7 +60,7 @@ var package = Package(
     .package(url: "https://github.com/apple/swift-algorithms", from: "1.0.0"),
     .package(url: "https://github.com/devxoul/Then", from: "2.7.0"),
     .package(url: "https://github.com/mkrd/Swift-BigInt", from: "2.0.0"),
-    .package(url: "https://github.com/GuardianFirewall/GuardianConnect", exact: "1.8.4-dev-2"),
+    .package(url: "https://github.com/GuardianFirewall/GuardianConnect", exact: "1.8.4"),
     .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "0.6.0"),
     .package(name: "Static", path: "ThirdParty/Static"),
   ],

--- a/Sources/BraveVPN/BraveVPN.swift
+++ b/Sources/BraveVPN/BraveVPN.swift
@@ -379,7 +379,11 @@ public class BraveVPN {
   /// Return the region last activated with the details
   /// It will give region details for automatic
   public static var activatedRegion: GRDRegion? {
-    helper.selectedRegion ?? lastKnownRegion
+    guard let isoCode = helper.selectedRegion?.countryISOCode, isoCode.isEmpty else {
+      return helper.selectedRegion
+    }
+    
+    return lastKnownRegion
   }
   
   /// Switched to use an automatic region, region closest to user location.

--- a/Sources/BraveVPN/BraveVPNPickerViewController.swift
+++ b/Sources/BraveVPN/BraveVPNPickerViewController.swift
@@ -12,40 +12,39 @@ import GuardianConnect
 
 public class BraveVPNPickerViewController: UIViewController {
 
-  private var overlayView: UIView?
   let tableView: UITableView = .init(frame: .zero, style: .insetGrouped)
 
-  deinit {
-    NotificationCenter.default.removeObserver(self)
+  private lazy var overlayView = UIView().then {
+    $0.backgroundColor = UIColor.black.withAlphaComponent(0.5)
+
+    let activityIndicator = UIActivityIndicatorView().then {
+      $0.style = .large
+      $0.color = .white
+      $0.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+      $0.startAnimating()
+    }
+
+    $0.addSubview(activityIndicator)
   }
 
   var isLoading: Bool = false {
     didSet {
-      overlayView?.removeFromSuperview()
 
       navigationItem.hidesBackButton = isLoading
 
       // Prevent dismissing the modal by swipe when the VPN is being configured
       navigationController?.isModalInPresentation = isLoading
 
-      if !isLoading { return }
-
-      let overlay = UIView().then {
-        $0.backgroundColor = UIColor.black.withAlphaComponent(0.5)
-        let activityIndicator = UIActivityIndicatorView().then { indicator in
-          indicator.startAnimating()
-          indicator.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+      if isLoading {
+        view.addSubview(overlayView)
+        overlayView.snp.makeConstraints {
+          $0.edges.equalToSuperview()
         }
-
-        $0.addSubview(activityIndicator)
+      } else {
+        if overlayView.isDescendant(of: view) {
+          overlayView.removeFromSuperview()
+        }
       }
-
-      view.addSubview(overlay)
-      overlay.snp.makeConstraints {
-        $0.edges.equalToSuperview()
-      }
-
-      overlayView = overlay
     }
   }
 
@@ -71,6 +70,10 @@ public class BraveVPNPickerViewController: UIViewController {
   public override func viewWillAppear(_ animated: Bool) {
     super.viewWillAppear(animated)
     tableView.reloadData()
+  }
+  
+  deinit {
+    NotificationCenter.default.removeObserver(self)
   }
   
   @objc func vpnConfigChanged(notification: NSNotification) { }

--- a/Sources/BraveVPN/BraveVPNSettingsViewController.swift
+++ b/Sources/BraveVPN/BraveVPNSettingsViewController.swift
@@ -54,9 +54,11 @@ public class BraveVPNSettingsViewController: TableViewController {
 
       let overlay = UIView().then {
         $0.backgroundColor = UIColor.black.withAlphaComponent(0.5)
-        let activityIndicator = UIActivityIndicatorView().then { indicator in
-          indicator.startAnimating()
-          indicator.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        let activityIndicator = UIActivityIndicatorView().then {
+          $0.style = .large
+          $0.color = .white
+          $0.startAnimating()
+          $0.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         }
 
         $0.addSubview(activityIndicator)

--- a/Sources/BraveVPN/VPNRegion.swift
+++ b/Sources/BraveVPN/VPNRegion.swift
@@ -36,6 +36,10 @@ extension GRDRegion {
       }
     }
     
+    if unicodeScalarView.isEmpty {
+      return nil
+    }
+    
     return Image(uiImage: unicodeScalarView.image())
   }
 }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This PR handles couple of small bugs and changes related with VPN region selector.

Updating SDK Guardian 1.8.4
Properly handle loading indicator so they will cause crash
Empty Flag image handling

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7412
This pull request fixes #7380

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
