### PR TITLE
Fix #7433: Asset auto discovery may show loading indicator when not loading

### DIFF
--- a/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
@@ -151,7 +151,6 @@ public class PortfolioStore: ObservableObject {
   }
   
   func discoverAssetsOnAllSupportedChains() {
-    isLoadingDiscoverAssets = true
     walletService.discoverAssetsOnAllSupportedChains()
   }
   


### PR DESCRIPTION
## Summary of Changes
- Only update `isLoadingDiscoverAssets` in the Wallet Service observer methods `onDiscoverAssetsStarted` & `onDiscoverAssetsCompleted`, otherwise we might set `isLoadingDiscoverAssets` to true but rate limiting in core prevents asset auto-discovery from running (because we just discovered assets moments prior).

This pull request fixes #7433

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
  1. Unlock your wallet
  2. Wait for loading spinner beside `Assets` header to disappear
  3. Lock your wallet & immediately unlock it again
  4. Verify loading spinner is not displayed, or is displayed and removed as expected


## Screenshots:

https://github.com/brave/brave-ios/assets/5314553/141d4edd-4b5e-44f3-b59d-bf2853ff8a9f


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
