### PR TITLE
Add ad-block level to advanced shield settings

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController.swift
@@ -509,6 +509,7 @@ public class BrowserViewController: UIViewController {
     Preferences.Playlist.enablePlaylistMenuBadge.observe(from: self)
     Preferences.Playlist.enablePlaylistURLBarButton.observe(from: self)
     Preferences.Playlist.syncSharedFoldersAutomatically.observe(from: self)
+    ShieldPreferences.blockAdsAndTrackingLevelRaw.observe(from: self)
     
     pageZoomListener = NotificationCenter.default.addObserver(forName: PageZoomView.notificationName, object: nil, queue: .main) { [weak self] _ in
       self?.tabManager.allTabs.forEach({
@@ -2990,7 +2991,7 @@ extension BrowserViewController: PreferencesObserver {
       tabManager.reloadSelectedTab()
     case Preferences.General.enablePullToRefresh.key:
       tabManager.selectedTab?.updatePullToRefreshVisibility()
-    case Preferences.Shields.blockAdsAndTracking.key,
+    case ShieldPreferences.blockAdsAndTrackingLevelRaw.key,
       Preferences.Shields.blockScripts.key,
       Preferences.Shields.blockImages.key,
       Preferences.Shields.fingerprintingProtection.key,

--- a/Sources/Brave/Frontend/Settings/Shields/DefaultShieldsSectionView.swift
+++ b/Sources/Brave/Frontend/Settings/Shields/DefaultShieldsSectionView.swift
@@ -9,7 +9,7 @@ import Data
 import DesignSystem
 import BraveUI
 import Preferences
-import Strings
+import BraveShields
 
 struct DefaultShieldsViewView: View {
   enum CookieAlertType: String, Identifiable {
@@ -24,11 +24,20 @@ struct DefaultShieldsViewView: View {
   
   var body: some View {
     Section {
-      OptionToggleView(
-        title: Strings.blockAdsAndTracking,
-        subtitle: Strings.blockAdsAndTrackingDescription,
-        option: Preferences.Shields.blockAdsAndTracking
-      )
+      Picker(selection: $settings.adBlockAndTrackingPreventionLevel) {
+        ForEach(ShieldLevel.allCases) { level in
+          Text(level.localizedTitle)
+            .foregroundColor(Color(.secondaryBraveLabel))
+            .tag(level)
+        }
+      } label: {
+        ShieldLabelView(
+          title: Strings.Shields.trackersAndAdsBlocking,
+          subtitle: Strings.Shields.trackersAndAdsBlockingDescription
+        )
+      }
+      .listRowBackground(Color(.secondaryBraveGroupedBackground))
+      
       OptionToggleView(
         title: Strings.HTTPSEverywhere,
         subtitle: Strings.HTTPSEverywhereDescription,
@@ -131,6 +140,20 @@ struct DefaultShieldsViewView: View {
       }
       
       cookieAlertType = .failed
+    }
+  }
+}
+
+extension ShieldLevel: Identifiable {
+  public var id: String {
+    return rawValue
+  }
+  
+  public var localizedTitle: String {
+    switch self {
+    case .aggressive: return Strings.Shields.trackersAndAdsBlockingAggressive
+    case .disabled: return Strings.Shields.trackersAndAdsBlockingDisabled
+    case .standard: return Strings.Shields.trackersAndAdsBlockingStandard
     }
   }
 }

--- a/Sources/Brave/Frontend/Shields/AdvancedShieldsView.swift
+++ b/Sources/Brave/Frontend/Shields/AdvancedShieldsView.swift
@@ -6,10 +6,11 @@ import UIKit
 import Shared
 import BraveShared
 import BraveUI
+import BraveShields
 
 class AdvancedShieldsView: UIStackView {
   let siteTitle = HeaderTitleView()
-  let adsTrackersControl = ToggleView(title: Strings.blockAdsAndTracking)
+  let adsTrackersControl = ToggleView(title: Strings.Shields.trackersAndAdsBlocking)
   let blockScriptsControl = ToggleView(title: Strings.blockScripts)
   let fingerprintingControl = ToggleView(title: Strings.fingerprintingProtection)
   let globalControlsTitleView = HeaderTitleView().then {

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/SiteStateListenerScriptHandler.swift
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/SiteStateListenerScriptHandler.swift
@@ -6,6 +6,7 @@
 import Foundation
 import WebKit
 import Shared
+import BraveShields
 import os.log
 
 class SiteStateListenerScriptHandler: TabContentScript {
@@ -67,7 +68,7 @@ class SiteStateListenerScriptHandler: TabContentScript {
           if domain.areAllShieldsOff { return }
           
           let models = await AdBlockStats.shared.cosmeticFilterModels(forFrameURL: frameURL, domain: domain)
-          let args = try self.makeArgs(from: models, frameURL: frameURL)
+          let args = try self.makeArgs(from: models, frameURL: frameURL, isAggressive: ShieldPreferences.blockAdsAndTrackingLevel.isAggressive)
           let source = try ScriptFactory.shared.makeScriptSource(of: .selectorsPoller).replacingOccurrences(of: "$<args>", with: args)
           
           let secureSource = CosmeticFiltersScriptHandler.secureScript(
@@ -97,7 +98,7 @@ class SiteStateListenerScriptHandler: TabContentScript {
     }
   }
   
-  @MainActor private func makeArgs(from modelTuples: [CachedAdBlockEngine.CosmeticFilterModelTuple], frameURL: URL) throws -> String {
+  @MainActor private func makeArgs(from modelTuples: [CachedAdBlockEngine.CosmeticFilterModelTuple], frameURL: URL, isAggressive: Bool) throws -> String {
     var standardSelectors: Set<String> = []
     var agressiveSelectors: Set<String> = []
     var styleSelectors: [String: Set<String>] = [:]
@@ -126,7 +127,7 @@ class SiteStateListenerScriptHandler: TabContentScript {
     // (i.e. we don't hide first party content on standard mode)
     let setup = UserScriptType.SelectorsPollerSetup(
       frameURL: frameURL,
-      hideFirstPartyContent: false,
+      hideFirstPartyContent: isAggressive,
       genericHide: modelTuples.contains { $0.model.genericHide },
       firstSelectorsPollingDelayMs: nil,
       switchToSelectorsPollingThreshold: 1000,

--- a/Sources/BraveShields/BraveShield.swift
+++ b/Sources/BraveShields/BraveShield.swift
@@ -17,7 +17,7 @@ public enum BraveShield {
     case .AllOff:
       return false
     case .AdblockAndTp:
-      return Preferences.Shields.blockAdsAndTracking.value
+      return ShieldPreferences.blockAdsAndTrackingLevel.isEnabled
     case .FpProtection:
       return Preferences.Shields.fingerprintingProtection.value
     case .NoScript:

--- a/Sources/BraveShields/ShieldLevel.swift
+++ b/Sources/BraveShields/ShieldLevel.swift
@@ -1,0 +1,32 @@
+// Copyright 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+
+/// A 3 part option for shield levels varying in strength of blocking content
+public enum ShieldLevel: String, CaseIterable, Hashable {
+  /// Mode blocks all content
+  case aggressive
+  /// Mode indicating that 1st party content is not blocked for default and regional lists
+  case standard
+  /// Mode indicating this setting is disabled
+  case disabled
+  
+  /// Wether this setting indicates that the shields are enabled or not
+  public var isEnabled: Bool {
+    switch self {
+    case .aggressive, .standard: return true
+    case .disabled: return false
+    }
+  }
+  
+  /// Wether this setting indicates that the shields are aggressive or not
+  public var isAggressive: Bool {
+    switch self {
+    case .aggressive: return true
+    case .disabled, .standard: return false
+    }
+  }
+}

--- a/Sources/BraveShields/ShieldPreferences.swift
+++ b/Sources/BraveShields/ShieldPreferences.swift
@@ -1,0 +1,24 @@
+// Copyright 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import Preferences
+
+public class ShieldPreferences {
+  private static let defaultBlockAdsAndTrackingLevel: ShieldLevel = .standard
+  
+  /// Get the level of the adblock and tracking protection as a stored preference
+  /// - Warning: You should not access this directly but  through ``blockAdsAndTrackingLevel``
+  public static var blockAdsAndTrackingLevelRaw = Preferences.Option<String>(
+    key: "shields.block-ads-and-tracking-level",
+    default: defaultBlockAdsAndTrackingLevel.rawValue
+  )
+  
+  /// Get the level of the adblock and tracking protection
+  public static var blockAdsAndTrackingLevel: ShieldLevel {
+    get { ShieldLevel(rawValue: blockAdsAndTrackingLevelRaw.value) ?? defaultBlockAdsAndTrackingLevel }
+    set { blockAdsAndTrackingLevelRaw.value = newValue.rawValue }
+  }
+}

--- a/Sources/BraveShields/ShieldStrings.swift
+++ b/Sources/BraveShields/ShieldStrings.swift
@@ -19,3 +19,38 @@ extension Strings {
     public static let shieldsTimeStatsDays = NSLocalizedString("ShieldsTimeStatsDays", bundle: .module, value: "d", comment: "Time Saved Days")
   }
 }
+
+// MARK: - Trackers and Ad-Blocking
+
+public extension Strings.Shields {
+  /// A label for a shield option that allows you to switch between different blocking levels for tracker and ads blocking. Options include disabled, standard and aggressive.
+  static let trackersAndAdsBlocking = NSLocalizedString(
+    "TrackersAndAdsBlocking", tableName: "BraveShared", bundle: .module,
+    value: "Trackers & Ads Blocking",
+    comment: "A label for a shield option that allows you to switch between different blocking levels for tracker and ads blocking. Options include disabled, standard and aggressive."
+  )
+  /// A description for a shield options that allows you to switch between different blocking levels for trackers and ads blocking. Options include disabled, standard and aggressive.
+  static let trackersAndAdsBlockingDescription = NSLocalizedString(
+    "BlockAdsAndTrackingDescription", tableName: "BraveShared", bundle: .module,
+    value: "Prevents ads, popups, and trackers from loading.",
+    comment: "A description for a shield options that allows you to switch between different blocking levels for trackers and ads blocking. Options include disabled, standard and aggressive."
+  )
+  /// The option the user can select to disable ad and tracker blocking
+  static let trackersAndAdsBlockingDisabled = NSLocalizedString(
+    "BlockAdsAndTrackingDisabled", tableName: "BraveShared", bundle: .module,
+    value: "Disabled",
+    comment: "The option the user can select to disable ad and tracker blocking"
+  )
+  /// The option the user can select to do aggressive ad and tracker blocking
+  static let trackersAndAdsBlockingAggressive = NSLocalizedString(
+    "BlockAdsAndTrackingAggressive", tableName: "BraveShared", bundle: .module,
+    value: "Aggressive",
+    comment: "The option the user can select to do aggressive ad and tracker blocking"
+  )
+  /// The option the user can select to do standard (non-aggressive) ad and tracker blocking
+  static let trackersAndAdsBlockingStandard = NSLocalizedString(
+    "BlockAdsAndTrackingStandard", tableName: "BraveShared", bundle: .module,
+    value: "Standard",
+    comment: "The option the user can select to do standard (non-aggressive) ad and tracker blocking"
+  )
+}

--- a/Sources/BraveStrings/BraveStrings.swift
+++ b/Sources/BraveStrings/BraveStrings.swift
@@ -1036,8 +1036,6 @@ extension Strings {
   public static let privateBrowsingOnly = NSLocalizedString("PrivateBrowsingOnly", tableName: "BraveShared", bundle: .module, value: "Private Browsing Only", comment: "Setting to keep app in private mode")
   public static let shieldsDefaults = NSLocalizedString("ShieldsDefaults", tableName: "BraveShared", bundle: .module, value: "Brave Shields Global Defaults", comment: "Section title for adbblock, tracking protection, HTTPS-E, and cookies")
   public static let shieldsDefaultsFooter = NSLocalizedString("ShieldsDefaultsFooter", tableName: "BraveShared", bundle: .module, value: "These are the default Shields settings for new sites. Changing these won't affect your existing per-site settings.", comment: "Section footer for global shields defaults")
-  public static let blockAdsAndTracking = NSLocalizedString("BlockAdsAndTracking", tableName: "BraveShared", bundle: .module, value: "Block Cross-Site Trackers", comment: "")
-  public static let blockAdsAndTrackingDescription = NSLocalizedString("BlockAdsAndTrackingDescription", tableName: "BraveShared", bundle: .module, value: "Prevents ads, popups, and trackers from loading.", comment: "")
   public static let HTTPSEverywhere = NSLocalizedString("HTTPSEverywhere", tableName: "BraveShared", bundle: .module, value: "Upgrade Connections to HTTPS", comment: "")
   public static let HTTPSEverywhereDescription = NSLocalizedString("HTTPSEverywhereDescription", tableName: "BraveShared", bundle: .module, value: "Opens sites using secure HTTPS instead of HTTP when possible.", comment: "")
   public static let googleSafeBrowsing = NSLocalizedString("GoogleSafeBrowsing", tableName: "BraveShared", bundle: .module, value: "Block Dangerous Sites", comment: "")

--- a/Sources/Data/models/Domain.swift
+++ b/Sources/Data/models/Domain.swift
@@ -109,7 +109,7 @@ public final class Domain: NSManagedObject, CRUD {
       case .AllOff:
         return self.shield_allOff?.boolValue ?? false
       case .AdblockAndTp:
-        return self.shield_adblockAndTp?.boolValue ?? Preferences.Shields.blockAdsAndTracking.value
+        return self.shield_adblockAndTp?.boolValue ?? ShieldPreferences.blockAdsAndTrackingLevel.isEnabled
       case .FpProtection:
         return self.shield_fpProtection?.boolValue ?? Preferences.Shields.fingerprintingProtection.value
       case .NoScript:
@@ -156,7 +156,7 @@ public final class Domain: NSManagedObject, CRUD {
   }
   
   public class func totalDomainsWithAdblockShieldsLoweredFromGlobal() -> Int {
-    guard Preferences.Shields.blockAdsAndTracking.value,
+    guard ShieldPreferences.blockAdsAndTrackingLevel.isEnabled,
           let domains = Domain.all(where: NSPredicate(format: "shield_adblockAndTp != nil")) else {
       return 0 // Can't be lower than off
     }
@@ -164,7 +164,7 @@ public final class Domain: NSManagedObject, CRUD {
   }
   
   public class func totalDomainsWithAdblockShieldsIncreasedFromGlobal() -> Int {
-    guard !Preferences.Shields.blockAdsAndTracking.value,
+    guard !ShieldPreferences.blockAdsAndTrackingLevel.isEnabled,
           let domains = Domain.all(where: NSPredicate(format: "shield_adblockAndTp != nil")) else {
       return 0 // Can't be higher than on
     }
@@ -402,20 +402,6 @@ extension Domain {
     case .AdblockAndTp: shield_adblockAndTp = setting
     case .FpProtection: shield_fpProtection = setting
     case .NoScript: shield_noScript = setting
-    }
-  }
-
-  /// Get whether or not a shield override is set for a given shield.
-  private func getBraveShield(_ shield: BraveShield) -> Bool? {
-    switch shield {
-    case .AllOff:
-      return self.shield_allOff?.boolValue
-    case .AdblockAndTp:
-      return self.shield_adblockAndTp?.boolValue
-    case .FpProtection:
-      return self.shield_fpProtection?.boolValue
-    case .NoScript:
-      return self.shield_noScript?.boolValue
     }
   }
 

--- a/Sources/Preferences/GlobalPreferences.swift
+++ b/Sources/Preferences/GlobalPreferences.swift
@@ -34,10 +34,7 @@ extension Preferences {
   }
   
   public final class Shields {
-    public static let allShields = [blockAdsAndTracking, httpsEverywhere, googleSafeBrowsing, blockScripts, fingerprintingProtection, blockImages]
-    
-    /// Shields will block ads and tracking if enabled
-    public static let blockAdsAndTracking = Option<Bool>(key: "shields.block-ads-and-tracking", default: true)
+    public static let allShields = [httpsEverywhere, googleSafeBrowsing, blockScripts, fingerprintingProtection, blockImages]
     /// Websites will be upgraded to HTTPS if a loaded page attempts to use HTTP
     public static let httpsEverywhere = Option<Bool>(key: "shields.https-everywhere", default: true)
     /// Enable Google Safe Browsing


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7352

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
1. Go to brave search and search for "trezor". (note it's possible the blocking rules or ads might change or may be regional)
- [ ] The ad on the top of the page should be hidden on aggressive
- [ ] The ad on the top of the page should be shown on standard
<!-- Any useful notes explaining how best to test and verify. -->
2. Go to brave search and search for "3d printer" (you need to VPN to the United States).
- [ ] Should see the shopping carrousel on standard mode
- [ ] Should not see the shopping carrousel on aggressive mode
3. Enable "Block cookie consent notices" and go to reddit. (note rules and ads sometimes change this is a somewhat uncontrolled test)
- [ ] Cookie notices should be blocked on standard and aggressive
4. Enable "Block open in app notices" and go to reddit. (note rules and ads sometimes change this is a somewhat uncontrolled test)
- [ ] Open in app notices should be blocked on standard and aggressive
5. Go to the following page: https://dev-pages.brave.software/filtering/cosmetic-filtering.html
- [ ] On aggressive mode, all images should be hidden after clicking "Run tests"
- [ ] On standard mode, only 3rd party images should be hidden after clicking "Run tests" (there is a slight unhiding delay)
6. Test any other known sites you're familiar with.
7. These changes doesn't touch at all YouTube ad blocking but just in case its worthwhile to test this.
8. Test migration. Install an older version of the app and set the default blocking to false (disabled)
- [ ] Update the app and ensure that the default is set to "Disabled"
9. Test migration. Install an older version of the app and switch between off and on for tracking and ad blocking
- [ ] Update the app and ensure that the default is set to "Standard"
10. Test default. 
- [ ] Install the app from scratch and ensure that the default is set to "Standard".
11. Test site settings.
- [ ] Install from scratch and make sure the site tracking and ad blocking is on
- [ ] Change the default to "Disabled". Ensure the site tracking blocking is off
- [ ] Change the site settings to be different than the default. Change the default. Site settings are not affected.


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

### iPhone 14
| Dark | Light |
|------|------|
| ![Simulator Screenshot - iPhone 14 Pro - 2023-05-12 at 12 41 05](https://github.com/brave/brave-ios/assets/909331/cd826fda-fdbe-42a7-977f-9a8406bac2bc) | ![Simulator Screenshot - iPhone 14 Pro - 2023-05-12 at 12 40 36](https://github.com/brave/brave-ios/assets/909331/17f77a9c-b88e-4198-bfe1-36ac0e65bed6) |
| ![Simulator Screenshot - iPhone 14 Pro - 2023-05-12 at 12 41 00](https://github.com/brave/brave-ios/assets/909331/6da45cac-aa2d-4342-835e-37fea778e703) | ![Simulator Screenshot - iPhone 14 Pro - 2023-05-12 at 12 40 39](https://github.com/brave/brave-ios/assets/909331/233c7feb-4391-4bf2-92bb-7001fdbfe720) |

### Tests
| Aggressive | Standard |
|------------|-----------|
| ![Simulator Screenshot - iPhone 14 Pro - 2023-05-12 at 12 50 43](https://github.com/brave/brave-ios/assets/909331/91b5c8fb-93b9-4612-a42d-0594845df028) | ![Simulator Screenshot - iPhone 14 Pro - 2023-05-12 at 12 50 10](https://github.com/brave/brave-ios/assets/909331/278de4e9-bfc8-4cd9-bd9b-5cdc7c10e557) |

### iPad
| Model 1 | Model 2 |
|------------|-----------|
| ![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2023-05-12 at 12 54 29](https://github.com/brave/brave-ios/assets/909331/056f5c4f-3ce9-499b-bd9a-ae5e09d70940) | ![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2023-05-12 at 12 55 23](https://github.com/brave/brave-ios/assets/909331/85d44a99-e891-4aaf-b859-044ddd6f8942) |
| ![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2023-05-12 at 12 54 10](https://github.com/brave/brave-ios/assets/909331/c1f8d40a-8866-4092-910e-3c01bd285602) | ![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2023-05-12 at 12 55 01](https://github.com/brave/brave-ios/assets/909331/06c8788a-980b-47ec-88a7-f226d8fe71ba) |
| ![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2023-05-12 at 12 54 39](https://github.com/brave/brave-ios/assets/909331/9fed4245-99ac-412c-bfba-c1c013b1a503) | ![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2023-05-12 at 12 54 53](https://github.com/brave/brave-ios/assets/909331/28c7a148-d730-48a6-a833-5a63b780123f) |

### Ads
| Standard | Aggressive |
|------------|-----------|
| ![Simulator Screenshot - iPhone 14 Pro - 2023-05-12 at 19 57 16](https://github.com/brave/brave-ios/assets/909331/7619ef73-0b36-4a2e-b9c7-b685604cba90) | ![Simulator Screenshot - iPhone 14 Pro - 2023-05-12 at 19 59 58](https://github.com/brave/brave-ios/assets/909331/7ad25727-09d8-465e-bb51-93f95388ba32) |
| ![Simulator Screenshot - iPhone 14 Pro - 2023-05-12 at 20 01 52](https://github.com/brave/brave-ios/assets/909331/33d953f8-d062-4a57-979d-c06edb55a818) | ![Simulator Screenshot - iPhone 14 Pro - 2023-05-12 at 20 03 24](https://github.com/brave/brave-ios/assets/909331/bbfdeda0-00c6-4b44-b9fd-61bfd2927094) |

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
