### PR TITLE
Fix #7233: Wallet Tx Activity Supports multiple networks 

### DIFF
--- a/Sources/BraveWallet/Crypto/Stores/AssetDetailStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/AssetDetailStore.swift
@@ -303,10 +303,7 @@ class AssetDetailStore: ObservableObject {
     }
     var solEstimatedTxFees: [String: UInt64] = [:]
     if token.coin == .sol {
-      solEstimatedTxFees = await solTxManagerProxy.estimatedTxFees(
-        chainId: network.chainId,
-        for: allTransactions.map(\.id)
-      )
+      solEstimatedTxFees = await solTxManagerProxy.estimatedTxFees(for: allTransactions)
     }
     return allTransactions
       .filter { tx in

--- a/Sources/BraveWallet/Crypto/TransactionsActivityView.swift
+++ b/Sources/BraveWallet/Crypto/TransactionsActivityView.swift
@@ -14,6 +14,30 @@ struct TransactionsActivityView: View {
   @State private var isPresentingNetworkFilter = false
   @State private var transactionDetails: TransactionDetailsStore?
   
+  private var networkFilterButton: some View {
+    Button(action: {
+      self.isPresentingNetworkFilter = true
+    }) {
+      HStack {
+        Text(store.networkFilter.title)
+        Image(braveSystemName: "leo.list")
+      }
+      .font(.footnote.weight(.medium))
+      .foregroundColor(Color(.braveBlurpleTint))
+    }
+    .sheet(isPresented: $isPresentingNetworkFilter) {
+      NavigationView {
+        NetworkFilterView(
+          networkFilter: $store.networkFilter,
+          networkStore: networkStore
+        )
+      }
+      .onDisappear {
+        networkStore.closeNetworkSelectionStore()
+      }
+    }
+  }
+  
   var body: some View {
     List {
       Section {
@@ -32,6 +56,15 @@ struct TransactionsActivityView: View {
           }
           .listRowBackground(Color(.secondaryBraveGroupedBackground))
         }
+      } header: {
+        HStack {
+          Text(Strings.Wallet.assetsTitle)
+          Spacer()
+          networkFilterButton
+        }
+        .textCase(nil)
+        .padding(.horizontal, -8)
+        .frame(maxWidth: .infinity, alignment: .leading)
       }
     }
     .listBackgroundColor(Color(UIColor.braveGroupedBackground))

--- a/Sources/BraveWallet/Extensions/SolanaTxManagerProxyExtensions.swift
+++ b/Sources/BraveWallet/Extensions/SolanaTxManagerProxyExtensions.swift
@@ -7,38 +7,6 @@ import BraveCore
 
 extension BraveWalletSolanaTxManagerProxy {
   
-  /// Fetches the estimatedTxFee for an array of transaction meta ids.
-  func estimatedTxFees(
-    chainId: String,
-    for transactionMetaIds: [String],
-    completion: @escaping ([String: UInt64]) -> Void
-  ) {
-    var estimatedTxFees: [String: UInt64] = [:]
-    let dispatchGroup = DispatchGroup()
-    transactionMetaIds.forEach { txMetaId in
-      dispatchGroup.enter()
-      estimatedTxFee(chainId, txMetaId: txMetaId) { fee, _, _ in
-        defer { dispatchGroup.leave() }
-        estimatedTxFees[txMetaId] = fee
-      }
-    }
-    dispatchGroup.notify(queue: .main) {
-      completion(estimatedTxFees)
-    }
-  }
-  
-  /// Fetches the estimatedTxFee for an array of transaction meta ids.
-  @MainActor func estimatedTxFees(
-    chainId: String,
-    for transactionMetaIds: [String]
-  ) async -> [String: UInt64] {
-    await withCheckedContinuation { continuation in
-      estimatedTxFees(chainId: chainId, for: transactionMetaIds) { fees in
-        continuation.resume(returning: fees)
-      }
-    }
-  }
-  
   /// Fetches the estimatedTxFee for an array of transactions
   @MainActor func estimatedTxFees(for transactions: [BraveWallet.TransactionInfo]
   ) async -> [String: UInt64] {

--- a/Sources/BraveWallet/Extensions/SolanaTxManagerProxyExtensions.swift
+++ b/Sources/BraveWallet/Extensions/SolanaTxManagerProxyExtensions.swift
@@ -38,4 +38,25 @@ extension BraveWalletSolanaTxManagerProxy {
       }
     }
   }
+  
+  /// Fetches the estimatedTxFee for an array of transactions
+  @MainActor func estimatedTxFees(for transactions: [BraveWallet.TransactionInfo]
+  ) async -> [String: UInt64] {
+    return await withTaskGroup(
+      of: [String: UInt64].self,
+      body: { @MainActor group in
+        for tx in transactions {
+          group.addTask { @MainActor in
+            let (fee, _, _) = await self.estimatedTxFee(tx.chainId, txMetaId: tx.id)
+            return [tx.id: fee]
+          }
+        }
+        var estimatedFees: [String: UInt64] = [:]
+        for await fee in group {
+          estimatedFees.merge(with: fee)
+        }
+        return estimatedFees
+      }
+    )
+  }
 }

--- a/Sources/BraveWallet/Preview Content/MockContent.swift
+++ b/Sources/BraveWallet/Preview Content/MockContent.swift
@@ -157,7 +157,7 @@ extension BraveWallet.TransactionInfo {
             signOnly: false,
             signedTransaction: nil
           ),
-          chainId: "0x3",
+          chainId: BraveWallet.MainnetChainId,
           maxPriorityFeePerGas: "0x2540be400",
           maxFeePerGas: "0x25b7f3d400",
           gasEstimation: nil
@@ -195,7 +195,7 @@ extension BraveWallet.TransactionInfo {
             signOnly: false,
             signedTransaction: nil
           ),
-          chainId: BraveWallet.GoerliChainId,
+          chainId: BraveWallet.MainnetChainId,
           maxPriorityFeePerGas: "0x77359400",
           maxFeePerGas: "0x39bdf3b000",
           gasEstimation: nil
@@ -231,7 +231,7 @@ extension BraveWallet.TransactionInfo {
             signOnly: false,
             signedTransaction: nil
           ),
-          chainId: "0x3",
+          chainId: BraveWallet.MainnetChainId,
           maxPriorityFeePerGas: "0x77359400",
           maxFeePerGas: "0x39bdf3b000",
           gasEstimation: nil

--- a/Sources/BraveWallet/Preview Content/MockContent.swift
+++ b/Sources/BraveWallet/Preview Content/MockContent.swift
@@ -107,7 +107,7 @@ extension BraveWallet.BlockchainToken {
     visible: true,
     tokenId: "30934",
     coingeckoId: "",
-    chainId: "0x1",
+    chainId: BraveWallet.MainnetChainId,
     coin: .eth
   )
   
@@ -124,7 +124,7 @@ extension BraveWallet.BlockchainToken {
     visible: true,
     tokenId: "",
     coingeckoId: "",
-    chainId: "0x65",
+    chainId: BraveWallet.SolanaMainnet,
     coin: .sol
   )
 }

--- a/Sources/BraveWallet/Preview Content/MockContent.swift
+++ b/Sources/BraveWallet/Preview Content/MockContent.swift
@@ -195,7 +195,7 @@ extension BraveWallet.TransactionInfo {
             signOnly: false,
             signedTransaction: nil
           ),
-          chainId: "0x3",
+          chainId: BraveWallet.GoerliChainId,
           maxPriorityFeePerGas: "0x77359400",
           maxFeePerGas: "0x39bdf3b000",
           gasEstimation: nil

--- a/Sources/BraveWallet/Preview Content/MockJsonRpcService.swift
+++ b/Sources/BraveWallet/Preview Content/MockJsonRpcService.swift
@@ -327,7 +327,7 @@ extension BraveWallet.NetworkInfo {
     rpcEndpoints: [URL(string: "https://rpc.mockchain.com")!],
     symbol: "SOL",
     symbolName: "Solana",
-    decimals: 18,
+    decimals: 9,
     coin: .sol,
     isEip1559: false
   )

--- a/Tests/BraveWalletTests/AccountActivityStoreTests.swift
+++ b/Tests/BraveWalletTests/AccountActivityStoreTests.swift
@@ -39,17 +39,14 @@ class AccountActivityStoreTests: XCTestCase {
     .init(fromAsset: BraveWallet.BlockchainToken.mockSpdToken.assetRatioId.lowercased(),
           toAsset: "usd", price: "0.50", assetTimeframeChange: "-57.23")
   ]
-  let transactions: [BraveWallet.CoinType: [BraveWallet.TransactionInfo]] = [
-    .eth: [.previewConfirmedSend, .previewConfirmedSwap],
-    .sol: [.previewConfirmedSolSystemTransfer]
-  ]
 
   private func setupServices(
     mockEthBalanceWei: String = "",
     mockERC20BalanceWei: String = "",
     mockERC721BalanceWei: String = "",
     mockLamportBalance: UInt64 = 0,
-    mockSplTokenBalances: [String: String] = [:] // [tokenMintAddress: balance]
+    mockSplTokenBalances: [String: String] = [:], // [tokenMintAddress: balance]
+    transactions: [BraveWallet.TransactionInfo]
   ) -> (BraveWallet.TestKeyringService, BraveWallet.TestJsonRpcService, BraveWallet.TestBraveWalletService, BraveWallet.TestBlockchainRegistry, BraveWallet.TestAssetRatioService, BraveWallet.TestTxService, BraveWallet.TestSolanaTxManagerProxy, IpfsAPI) {
     let keyringService = BraveWallet.TestKeyringService()
     keyringService._addObserver = { _ in }
@@ -120,8 +117,7 @@ class AccountActivityStoreTests: XCTestCase {
     let txService = BraveWallet.TestTxService()
     txService._addObserver = { _ in }
     txService._allTransactionInfo = { coin, chainId, _, completion in
-      let txs = self.transactions[coin] ?? []
-      completion(txs.filter({ $0.chainId == chainId }))
+      completion(transactions.filter({ $0.chainId == chainId }))
     }
     
     let solTxManagerProxy = BraveWallet.TestSolanaTxManagerProxy()
@@ -145,10 +141,15 @@ class AccountActivityStoreTests: XCTestCase {
     
     let mockERC721Metadata: NFTMetadata = .init(imageURLString: "mock.image.url", name: "mock nft name", description: "mock nft description")
     
+    let ethSendTxCopy = BraveWallet.TransactionInfo.previewConfirmedSend.copy() as! BraveWallet.TransactionInfo // default in mainnet
+    let goerliSwapTxCopy = BraveWallet.TransactionInfo.previewConfirmedSwap.copy() as! BraveWallet.TransactionInfo
+    goerliSwapTxCopy.chainId = BraveWallet.GoerliChainId
+    
     let (keyringService, rpcService, walletService, blockchainRegistry, assetRatioService, txService, solTxManagerProxy, ipfsApi) = setupServices(
       mockEthBalanceWei: mockEthBalanceWei,
       mockERC20BalanceWei: mockERC20BalanceWei,
-      mockERC721BalanceWei: mockERC721BalanceWei
+      mockERC721BalanceWei: mockERC721BalanceWei,
+      transactions: [ethSendTxCopy, goerliSwapTxCopy]
     )
     
     let accountActivityStore = AccountActivityStore(
@@ -217,8 +218,10 @@ class AccountActivityStoreTests: XCTestCase {
         defer { transactionSummariesExpectation.fulfill() }
         // summaries are tested in `TransactionParserTests`, just verify they are populated with correct tx
         XCTAssertEqual(transactionSummaries.count, 2)
-        XCTAssertEqual(transactionSummaries[safe: 0]?.txInfo, self.transactions[.eth]?[safe: 0] ?? .init())
-        XCTAssertEqual(transactionSummaries[safe: 1]?.txInfo, self.transactions[.eth]?[safe: 1] ?? .init())
+        XCTAssertEqual(transactionSummaries[safe: 0]?.txInfo, ethSendTxCopy)
+        XCTAssertEqual(transactionSummaries[safe: 0]?.txInfo.chainId, ethSendTxCopy.chainId)
+        XCTAssertEqual(transactionSummaries[safe: 1]?.txInfo, goerliSwapTxCopy)
+        XCTAssertEqual(transactionSummaries[safe: 1]?.txInfo.chainId, goerliSwapTxCopy.chainId)
       }.store(in: &cancellables)
     
     accountActivityStore.update()
@@ -243,9 +246,14 @@ class AccountActivityStoreTests: XCTestCase {
     
     let mockSolMetadata: NFTMetadata = .init(imageURLString: "sol.mock.image.url", name: "sol mock nft name", description: "sol mock nft description")
     
+    let solSendTxCopy = BraveWallet.TransactionInfo.previewConfirmedSolSystemTransfer.copy() as! BraveWallet.TransactionInfo // default in mainnet
+    let solTestnetSendTxCopy = BraveWallet.TransactionInfo.previewConfirmedSolTokenTransfer.copy() as! BraveWallet.TransactionInfo
+    solTestnetSendTxCopy.chainId = BraveWallet.SolanaTestnet
+    
     let (keyringService, rpcService, walletService, blockchainRegistry, assetRatioService, txService, solTxManagerProxy, ipfsApi) = setupServices(
       mockLamportBalance: mockLamportBalance,
-      mockSplTokenBalances: mockSplTokenBalances
+      mockSplTokenBalances: mockSplTokenBalances,
+      transactions: [solSendTxCopy, solTestnetSendTxCopy]
     )
     
     let accountActivityStore = AccountActivityStore(
@@ -313,8 +321,11 @@ class AccountActivityStoreTests: XCTestCase {
       .sink { transactionSummaries in
         defer { transactionSummariesExpectation.fulfill() }
         // summaries are tested in `TransactionParserTests`, just verify they are populated with correct tx
-        XCTAssertEqual(transactionSummaries.count, 1)
-        XCTAssertEqual(transactionSummaries[safe: 0]?.txInfo, self.transactions[.sol]?[safe: 0] ?? .init())
+        XCTAssertEqual(transactionSummaries.count, 2)
+        XCTAssertEqual(transactionSummaries[safe: 0]?.txInfo, solSendTxCopy)
+        XCTAssertEqual(transactionSummaries[safe: 0]?.txInfo.chainId, solSendTxCopy.chainId)
+        XCTAssertEqual(transactionSummaries[safe: 1]?.txInfo, solTestnetSendTxCopy)
+        XCTAssertEqual(transactionSummaries[safe: 1]?.txInfo.chainId, solTestnetSendTxCopy.chainId)
       }.store(in: &cancellables)
     
     accountActivityStore.update()

--- a/Tests/BraveWalletTests/TransactionsActivityStoreTests.swift
+++ b/Tests/BraveWalletTests/TransactionsActivityStoreTests.swift
@@ -50,11 +50,11 @@ class TransactionsActivityStoreTests: XCTestCase {
     }
     
     let rpcService = BraveWallet.TestJsonRpcService()
-    rpcService._network = { coin, _, completion in
+    rpcService._allNetworks = { coin, completion in
       if coin == .sol {
-        completion(.mockSolana)
+        completion([.mockSolana, .mockSolanaTestnet])
       } else {
-        completion(.mockMainnet)
+        completion([.mockMainnet, .mockGoerli])
       }
     }
     
@@ -76,8 +76,9 @@ class TransactionsActivityStoreTests: XCTestCase {
     
     let txService = BraveWallet.TestTxService()
     txService._addObserver = { _ in }
-    txService._allTransactionInfo = { coin, accountAddress, _, completion in
-      completion(self.transactions[coin] ?? [])
+    txService._allTransactionInfo = { coin, chainId, address, completion in
+      let txs = self.transactions[coin] ?? []
+      completion(txs.filter({ $0.chainId == chainId }))
     }
     
     let solTxManagerProxy = BraveWallet.TestSolanaTxManagerProxy()

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -40,6 +40,7 @@ platform :ios do
       device: "iPhone 8",
       code_coverage: true,
       skip_testing: [
+	"CertificateUtilitiesTests/CertificatePinningTest/testSelfSignedRootAllowed",
         "CertificateUtilitiesTests/CertificatePinningTest/testSelfSignedRootAllowed2",
         "ClientTests/TabManagerTests/testQueryAddedTabs",
         "ClientTests/TabManagerTests/testQueryAddedPrivateTabs",


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
Currently, all the screens that display transaction information is restricted by the default network from the current user selected account's coin type. Core now removes this restriction, so front-end is now able to fetch tx for all networks.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7233 #7385

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
1. Open Brave browser and login to Brave Wallet
2. make some transaction using the same coin type but in different networks. (For example: Using a solana account to make some tx on Solana Mainnet and Solana Devnet. Using a eth account to make some tx on Eth mainnet and Goerli)
3. Confirm or reject those tx
4. Go to Activity tab
5. Observe that all non-rejected for all accounts in all networks will be displayed 
6. Go to each account screen 
7. Observe that all tx made by this account in all networks will be displayed 
8. Go to activity history from the wallet panel 
9. Observe that all tx made by this account in all networks will be displayed 
10. Click the global BSS button and choose a different network.
11. Repeat from step 4
12. Step 5, 7 and 9 should also be expected. 


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->
https://github.com/brave/brave-ios/assets/1187676/7c750d9c-f8fa-44b4-a835-14ebbb13aff4

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
