### PR TITLE
Fix #7432: VPN region easy access displays incorrect region on existing profile

### DIFF
--- a/Sources/BraveVPN/BraveVPN.swift
+++ b/Sources/BraveVPN/BraveVPN.swift
@@ -279,8 +279,13 @@ public class BraveVPN {
           logAndStoreError("configureAndConnectVPN: \(error)")
         }
         
-        reconnectPending = false
-        completion?(status == .success)
+        // Re-connected user should update last used region - detail is pulled
+        fetchLastUsedRegionDetail() { _, _ in
+          reconnectPending = false
+          DispatchQueue.main.async {
+            completion?(status == .success)
+          }
+        }
       }
     } else {
       // Setting User preferred Transport Protocol to WireGuard
@@ -379,11 +384,7 @@ public class BraveVPN {
   /// Return the region last activated with the details
   /// It will give region details for automatic
   public static var activatedRegion: GRDRegion? {
-    guard let isoCode = helper.selectedRegion?.countryISOCode, isoCode.isEmpty else {
-      return helper.selectedRegion
-    }
-    
-    return lastKnownRegion
+    helper.selectedRegion ?? lastKnownRegion
   }
   
   /// Switched to use an automatic region, region closest to user location.


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7432

Automatic Region should be the only region where last used region details is fetched using time zones local

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:

- Install 1.50.x app version
- Enabled VPN
- Change region something other than your region (Canada in this case)
- Upgrade to version 1.52.x
- Open menu on NTP, check region selected
- Open VPN settings, check location selected

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
