### PR TITLE
Fix #7435: Fix typo in localization key (HistortMenuItem -> HistoryMe…

### DIFF
--- a/App/BraveWidgets/WidgetStrings.swift
+++ b/App/BraveWidgets/WidgetStrings.swift
@@ -76,7 +76,7 @@ extension Strings {
                                                               value: "Brave Wallet",
                                                               comment: "Description for the Brave Wallet option on the 'shortcuts' widget.")
     public static let bookmarksMenuItem = NSLocalizedString("widgets.BookmarksMenuItem", bundle: widgetBundle, value: "Bookmarks", comment: "Title for bookmarks menu item")
-    public static let historyMenuItem = NSLocalizedString("widgets.HistortMenuItem", bundle: widgetBundle, value: "History", comment: "Title for history menu item")
+    public static let historyMenuItem = NSLocalizedString("widgets.HistoryMenuItem", bundle: widgetBundle, value: "History", comment: "Title for history menu item")
     public static let downloadsMenuItem = NSLocalizedString("widgets.DownloadsMenuItem", bundle: widgetBundle, value: "Downloads", comment: "Title for downloads menu item")
     public static let QRCode = NSLocalizedString("widgets.QRCode", bundle: widgetBundle, value: "QR Code", comment: "QR Code section title")
     public static let newsClusteringWidgetTitle = NSLocalizedString(

--- a/App/BraveWidgets/de.lproj/Localizable.strings
+++ b/App/BraveWidgets/de.lproj/Localizable.strings
@@ -14,7 +14,7 @@
 "widgets.favoritesWidgetTitle" = "Favoriten";
 
 /* Title for history menu item */
-"widgets.HistortMenuItem" = "Verlauf";
+"widgets.HistoryMenuItem" = "Verlauf";
 
 /* Displayed on a news widget that has failed to load */
 "widgets.newsClusteringErrorLabel" = "Später erneut versuchen";

--- a/App/BraveWidgets/es.lproj/Localizable.strings
+++ b/App/BraveWidgets/es.lproj/Localizable.strings
@@ -14,7 +14,7 @@
 "widgets.favoritesWidgetTitle" = "Favoritos";
 
 /* Title for history menu item */
-"widgets.HistortMenuItem" = "Historial";
+"widgets.HistoryMenuItem" = "Historial";
 
 /* Displayed on a news widget that has failed to load */
 "widgets.newsClusteringErrorLabel" = "Inténtalo de nuevo más tarde";

--- a/App/BraveWidgets/fr.lproj/Localizable.strings
+++ b/App/BraveWidgets/fr.lproj/Localizable.strings
@@ -14,7 +14,7 @@
 "widgets.favoritesWidgetTitle" = "Favoris";
 
 /* Title for history menu item */
-"widgets.HistortMenuItem" = "Historique";
+"widgets.HistoryMenuItem" = "Historique";
 
 /* Displayed on a news widget that has failed to load */
 "widgets.newsClusteringErrorLabel" = "Réessayez plus tard";

--- a/App/BraveWidgets/id-ID.lproj/Localizable.strings
+++ b/App/BraveWidgets/id-ID.lproj/Localizable.strings
@@ -14,7 +14,7 @@
 "widgets.favoritesWidgetTitle" = "Favorit";
 
 /* Title for history menu item */
-"widgets.HistortMenuItem" = "Riwayat";
+"widgets.HistoryMenuItem" = "Riwayat";
 
 /* Displayed on a news widget that has failed to load */
 "widgets.newsClusteringErrorLabel" = "Coba lagi nanti";

--- a/App/BraveWidgets/it.lproj/Localizable.strings
+++ b/App/BraveWidgets/it.lproj/Localizable.strings
@@ -14,7 +14,7 @@
 "widgets.favoritesWidgetTitle" = "Preferiti";
 
 /* Title for history menu item */
-"widgets.HistortMenuItem" = "Cronologia";
+"widgets.HistoryMenuItem" = "Cronologia";
 
 /* Displayed on a news widget that has failed to load */
 "widgets.newsClusteringErrorLabel" = "Riprova più tardi";

--- a/App/BraveWidgets/ja.lproj/Localizable.strings
+++ b/App/BraveWidgets/ja.lproj/Localizable.strings
@@ -14,7 +14,7 @@
 "widgets.favoritesWidgetTitle" = "お気に入り";
 
 /* Title for history menu item */
-"widgets.HistortMenuItem" = "履歴";
+"widgets.HistoryMenuItem" = "履歴";
 
 /* Displayed on a news widget that has failed to load */
 "widgets.newsClusteringErrorLabel" = "後でもう一度お試しください";

--- a/App/BraveWidgets/ko-KR.lproj/Localizable.strings
+++ b/App/BraveWidgets/ko-KR.lproj/Localizable.strings
@@ -14,7 +14,7 @@
 "widgets.favoritesWidgetTitle" = "즐겨찾기";
 
 /* Title for history menu item */
-"widgets.HistortMenuItem" = "기록";
+"widgets.HistoryMenuItem" = "기록";
 
 /* Displayed on a news widget that has failed to load */
 "widgets.newsClusteringErrorLabel" = "나중에 다시 시도";

--- a/App/BraveWidgets/ms.lproj/Localizable.strings
+++ b/App/BraveWidgets/ms.lproj/Localizable.strings
@@ -14,7 +14,7 @@
 "widgets.favoritesWidgetTitle" = "Kegemaran";
 
 /* Title for history menu item */
-"widgets.HistortMenuItem" = "Sejarah";
+"widgets.HistoryMenuItem" = "Sejarah";
 
 /* Displayed on a news widget that has failed to load */
 "widgets.newsClusteringErrorLabel" = "Cuba lagi kemudian";

--- a/App/BraveWidgets/nb.lproj/Localizable.strings
+++ b/App/BraveWidgets/nb.lproj/Localizable.strings
@@ -14,7 +14,7 @@
 "widgets.favoritesWidgetTitle" = "Favoritter";
 
 /* Title for history menu item */
-"widgets.HistortMenuItem" = "Logg";
+"widgets.HistoryMenuItem" = "Logg";
 
 /* Displayed on a news widget that has failed to load */
 "widgets.newsClusteringErrorLabel" = "Prøv på nytt senere";

--- a/App/BraveWidgets/pl.lproj/Localizable.strings
+++ b/App/BraveWidgets/pl.lproj/Localizable.strings
@@ -14,7 +14,7 @@
 "widgets.favoritesWidgetTitle" = "Ulubione";
 
 /* Title for history menu item */
-"widgets.HistortMenuItem" = "Historia";
+"widgets.HistoryMenuItem" = "Historia";
 
 /* Displayed on a news widget that has failed to load */
 "widgets.newsClusteringErrorLabel" = "Spróbuj ponownie później";

--- a/App/BraveWidgets/pt-BR.lproj/Localizable.strings
+++ b/App/BraveWidgets/pt-BR.lproj/Localizable.strings
@@ -14,7 +14,7 @@
 "widgets.favoritesWidgetTitle" = "Favoritos";
 
 /* Title for history menu item */
-"widgets.HistortMenuItem" = "Histórico";
+"widgets.HistoryMenuItem" = "Histórico";
 
 /* Displayed on a news widget that has failed to load */
 "widgets.newsClusteringErrorLabel" = "Tente novamente mais tarde";

--- a/App/BraveWidgets/ru.lproj/Localizable.strings
+++ b/App/BraveWidgets/ru.lproj/Localizable.strings
@@ -14,7 +14,7 @@
 "widgets.favoritesWidgetTitle" = "Избранное";
 
 /* Title for history menu item */
-"widgets.HistortMenuItem" = "История";
+"widgets.HistoryMenuItem" = "История";
 
 /* Displayed on a news widget that has failed to load */
 "widgets.newsClusteringErrorLabel" = "Повторите попытку позже";

--- a/App/BraveWidgets/sv.lproj/Localizable.strings
+++ b/App/BraveWidgets/sv.lproj/Localizable.strings
@@ -14,7 +14,7 @@
 "widgets.favoritesWidgetTitle" = "Favoriter";
 
 /* Title for history menu item */
-"widgets.HistortMenuItem" = "Historik";
+"widgets.HistoryMenuItem" = "Historik";
 
 /* Displayed on a news widget that has failed to load */
 "widgets.newsClusteringErrorLabel" = "Försök igen senare";

--- a/App/BraveWidgets/tr.lproj/Localizable.strings
+++ b/App/BraveWidgets/tr.lproj/Localizable.strings
@@ -14,7 +14,7 @@
 "widgets.favoritesWidgetTitle" = "Favoriler";
 
 /* Title for history menu item */
-"widgets.HistortMenuItem" = "Geçmiş";
+"widgets.HistoryMenuItem" = "Geçmiş";
 
 /* Displayed on a news widget that has failed to load */
 "widgets.newsClusteringErrorLabel" = "Daha sonra tekrar deneyin";

--- a/App/BraveWidgets/uk.lproj/Localizable.strings
+++ b/App/BraveWidgets/uk.lproj/Localizable.strings
@@ -14,7 +14,7 @@
 "widgets.favoritesWidgetTitle" = "Вибране";
 
 /* Title for history menu item */
-"widgets.HistortMenuItem" = "Історія";
+"widgets.HistoryMenuItem" = "Історія";
 
 /* Displayed on a news widget that has failed to load */
 "widgets.newsClusteringErrorLabel" = "Повторіть спробу пізніше";

--- a/App/BraveWidgets/zh-TW.lproj/Localizable.strings
+++ b/App/BraveWidgets/zh-TW.lproj/Localizable.strings
@@ -14,7 +14,7 @@
 "widgets.favoritesWidgetTitle" = "我的最愛";
 
 /* Title for history menu item */
-"widgets.HistortMenuItem" = "歷史記錄";
+"widgets.HistoryMenuItem" = "歷史記錄";
 
 /* Displayed on a news widget that has failed to load */
 "widgets.newsClusteringErrorLabel" = "請稍後再試";

--- a/App/BraveWidgets/zh.lproj/Localizable.strings
+++ b/App/BraveWidgets/zh.lproj/Localizable.strings
@@ -14,7 +14,7 @@
 "widgets.favoritesWidgetTitle" = "收藏夹";
 
 /* Title for history menu item */
-"widgets.HistortMenuItem" = "历史记录";
+"widgets.HistoryMenuItem" = "历史记录";
 
 /* Displayed on a news widget that has failed to load */
 "widgets.newsClusteringErrorLabel" = "稍后重试";

--- a/Sources/BraveStrings/BraveStrings.swift
+++ b/Sources/BraveStrings/BraveStrings.swift
@@ -1112,7 +1112,7 @@ extension Strings {
   public static let editFolderTitle = NSLocalizedString("EditFolderTitle", tableName: "BraveShared", bundle: .module, value: "Edit folder", comment: "Title for editing a folder")
   public static let historyScreenTitle = NSLocalizedString("HistoryScreenTitle", tableName: "BraveShared", bundle: .module, value: "History", comment: "Title for history screen")
   public static let bookmarksMenuItem = NSLocalizedString("BookmarksMenuItem", tableName: "BraveShared", bundle: .module, value: "Bookmarks", comment: "Title for bookmarks menu item")
-  public static let historyMenuItem = NSLocalizedString("HistortMenuItem", tableName: "BraveShared", bundle: .module, value: "History", comment: "Title for history menu item")
+  public static let historyMenuItem = NSLocalizedString("HistoryMenuItem", tableName: "BraveShared", bundle: .module, value: "History", comment: "Title for history menu item")
   public static let settingsMenuItem = NSLocalizedString("SettingsMenuItem", tableName: "BraveShared", bundle: .module, value: "Settings", comment: "Title for settings menu item")
   public static let passwordsMenuItem = NSLocalizedString("PasswordsMenuItem", tableName: "BraveShared", bundle: .module, value: "Passwords", comment: "Title for passwords menu item")
   public static let addToMenuItem = NSLocalizedString("AddToMenuItem", tableName: "BraveShared", bundle: .module, value: "Add Bookmark", comment: "Title for the button to add a new website bookmark.")

--- a/Sources/BraveStrings/Resources/de.lproj/BraveShared.strings
+++ b/Sources/BraveStrings/Resources/de.lproj/BraveShared.strings
@@ -914,7 +914,7 @@
 "HideRewardsIconSubtitle" = "Versteckt das Brave Rewards-Symbol, wenn Brave Rewards nicht aktiviert ist.";
 
 /* Title for history menu item */
-"HistortMenuItem" = "Verlauf";
+"HistoryMenuItem" = "Verlauf";
 
 /* Title for History Clear All Action */
 "history.historyClearActionTitle" = "Verlauf löschen";

--- a/Sources/BraveStrings/Resources/es.lproj/BraveShared.strings
+++ b/Sources/BraveStrings/Resources/es.lproj/BraveShared.strings
@@ -917,7 +917,7 @@
 "HideRewardsIconSubtitle" = "Oculta el icono de Brave Rewards cuando esta función no está activada";
 
 /* Title for history menu item */
-"HistortMenuItem" = "Historial";
+"HistoryMenuItem" = "Historial";
 
 /* Title for History Clear All Action */
 "history.historyClearActionTitle" = "Borrar historial";

--- a/Sources/BraveStrings/Resources/fr.lproj/BraveShared.strings
+++ b/Sources/BraveStrings/Resources/fr.lproj/BraveShared.strings
@@ -917,7 +917,7 @@
 "HideRewardsIconSubtitle" = "Masque l'icône Brave Rewards lorsque l'option Brave Rewards n'est pas activée.";
 
 /* Title for history menu item */
-"HistortMenuItem" = "Historique";
+"HistoryMenuItem" = "Historique";
 
 /* Title for History Clear All Action */
 "history.historyClearActionTitle" = "Effacer l'historique";

--- a/Sources/BraveStrings/Resources/id-ID.lproj/BraveShared.strings
+++ b/Sources/BraveStrings/Resources/id-ID.lproj/BraveShared.strings
@@ -917,7 +917,7 @@
 "HideRewardsIconSubtitle" = "Menyembunyikan ikon Brave Rewards saat Brave Rewards tidak diaktifkan";
 
 /* Title for history menu item */
-"HistortMenuItem" = "Riwayat";
+"HistoryMenuItem" = "Riwayat";
 
 /* Title for History Clear All Action */
 "history.historyClearActionTitle" = "Hapus Riwayat";

--- a/Sources/BraveStrings/Resources/it.lproj/BraveShared.strings
+++ b/Sources/BraveStrings/Resources/it.lproj/BraveShared.strings
@@ -917,7 +917,7 @@
 "HideRewardsIconSubtitle" = "Nasconde l’icona Brave Rewards quando Brave Rewards non è abilitato";
 
 /* Title for history menu item */
-"HistortMenuItem" = "Cronologia";
+"HistoryMenuItem" = "Cronologia";
 
 /* Title for History Clear All Action */
 "history.historyClearActionTitle" = "Cancella la cronologia";

--- a/Sources/BraveStrings/Resources/ja.lproj/BraveShared.strings
+++ b/Sources/BraveStrings/Resources/ja.lproj/BraveShared.strings
@@ -917,7 +917,7 @@
 "HideRewardsIconSubtitle" = "Brave Rewardsに参加していないページではBrave Rewardsのアイコンを非表示にする";
 
 /* Title for history menu item */
-"HistortMenuItem" = "履歴";
+"HistoryMenuItem" = "履歴";
 
 /* Title for History Clear All Action */
 "history.historyClearActionTitle" = "履歴を消去する";

--- a/Sources/BraveStrings/Resources/ko-KR.lproj/BraveShared.strings
+++ b/Sources/BraveStrings/Resources/ko-KR.lproj/BraveShared.strings
@@ -905,7 +905,7 @@
 "HideRewardsIconSubtitle" = "Brave Rewards가 활성화되지 않았을 때 Brave Rewards 아이콘 숨김";
 
 /* Title for history menu item */
-"HistortMenuItem" = "기록";
+"HistoryMenuItem" = "기록";
 
 /* Title for History Clear All Action */
 "history.historyClearActionTitle" = "기록 지우기";

--- a/Sources/BraveStrings/Resources/ms.lproj/BraveShared.strings
+++ b/Sources/BraveStrings/Resources/ms.lproj/BraveShared.strings
@@ -917,7 +917,7 @@
 "HideRewardsIconSubtitle" = "Sembunyikan ikon Brave Rewards apabila Brave Rewards tidak didayakan";
 
 /* Title for history menu item */
-"HistortMenuItem" = "Sejarah";
+"HistoryMenuItem" = "Sejarah";
 
 /* Title for History Clear All Action */
 "history.historyClearActionTitle" = "Kosongkan Sejarah";

--- a/Sources/BraveStrings/Resources/nb.lproj/BraveShared.strings
+++ b/Sources/BraveStrings/Resources/nb.lproj/BraveShared.strings
@@ -917,7 +917,7 @@
 "HideRewardsIconSubtitle" = "Skjuler ikonet for Brave Rewards når Brave Rewards ikke er tilgjengelig";
 
 /* Title for history menu item */
-"HistortMenuItem" = "Logg";
+"HistoryMenuItem" = "Logg";
 
 /* Title for History Clear All Action */
 "history.historyClearActionTitle" = "Slett logg";

--- a/Sources/BraveStrings/Resources/pl.lproj/BraveShared.strings
+++ b/Sources/BraveStrings/Resources/pl.lproj/BraveShared.strings
@@ -917,7 +917,7 @@
 "HideRewardsIconSubtitle" = "Ukrywa ikonę Brave Rewards, gdy Brave Rewards nie jest włączone.";
 
 /* Title for history menu item */
-"HistortMenuItem" = "Historia";
+"HistoryMenuItem" = "Historia";
 
 /* Title for History Clear All Action */
 "history.historyClearActionTitle" = "Wyczyść historię";

--- a/Sources/BraveStrings/Resources/pt-BR.lproj/BraveShared.strings
+++ b/Sources/BraveStrings/Resources/pt-BR.lproj/BraveShared.strings
@@ -917,7 +917,7 @@
 "HideRewardsIconSubtitle" = "Oculta o ícone do Brave Rewards quando o Brave Rewards não está ativado";
 
 /* Title for history menu item */
-"HistortMenuItem" = "Histórico";
+"HistoryMenuItem" = "Histórico";
 
 /* Title for History Clear All Action */
 "history.historyClearActionTitle" = "Limpar histórico";

--- a/Sources/BraveStrings/Resources/ru.lproj/BraveShared.strings
+++ b/Sources/BraveStrings/Resources/ru.lproj/BraveShared.strings
@@ -914,7 +914,7 @@
 "HideRewardsIconSubtitle" = "Скрывает значок Brave Rewards, если сервис Brave Rewards не включен";
 
 /* Title for history menu item */
-"HistortMenuItem" = "История";
+"HistoryMenuItem" = "История";
 
 /* Title for History Clear All Action */
 "history.historyClearActionTitle" = "Очистить историю";

--- a/Sources/BraveStrings/Resources/sv.lproj/BraveShared.strings
+++ b/Sources/BraveStrings/Resources/sv.lproj/BraveShared.strings
@@ -917,7 +917,7 @@
 "HideRewardsIconSubtitle" = "Döljer Brave Rewards-ikonen när Brave Rewards inte är aktiverat";
 
 /* Title for history menu item */
-"HistortMenuItem" = "Historik";
+"HistoryMenuItem" = "Historik";
 
 /* Title for History Clear All Action */
 "history.historyClearActionTitle" = "Rensa historik";

--- a/Sources/BraveStrings/Resources/tr.lproj/BraveShared.strings
+++ b/Sources/BraveStrings/Resources/tr.lproj/BraveShared.strings
@@ -917,7 +917,7 @@
 "HideRewardsIconSubtitle" = "Brave Ödülleri etkinleştirilmediğinde Brave Ödülleri simgesini gizler";
 
 /* Title for history menu item */
-"HistortMenuItem" = "Geçmiş";
+"HistoryMenuItem" = "Geçmiş";
 
 /* Title for History Clear All Action */
 "history.historyClearActionTitle" = "Geçmişi Temizle";

--- a/Sources/BraveStrings/Resources/uk.lproj/BraveShared.strings
+++ b/Sources/BraveStrings/Resources/uk.lproj/BraveShared.strings
@@ -917,7 +917,7 @@
 "HideRewardsIconSubtitle" = "Позначка Brave Rewards не відображатиметься, коли Brave Rewards не ввімкнено";
 
 /* Title for history menu item */
-"HistortMenuItem" = "Історія";
+"HistoryMenuItem" = "Історія";
 
 /* Title for History Clear All Action */
 "history.historyClearActionTitle" = "Очистити журнал";

--- a/Sources/BraveStrings/Resources/zh-TW.lproj/BraveShared.strings
+++ b/Sources/BraveStrings/Resources/zh-TW.lproj/BraveShared.strings
@@ -917,7 +917,7 @@
 "HideRewardsIconSubtitle" = "未啟用 Brave Rewards 時隱藏 Brave Rewards 圖示";
 
 /* Title for history menu item */
-"HistortMenuItem" = "歷史記錄";
+"HistoryMenuItem" = "歷史記錄";
 
 /* Title for History Clear All Action */
 "history.historyClearActionTitle" = "清除歷史記錄";

--- a/Sources/BraveStrings/Resources/zh.lproj/BraveShared.strings
+++ b/Sources/BraveStrings/Resources/zh.lproj/BraveShared.strings
@@ -917,7 +917,7 @@
 "HideRewardsIconSubtitle" = "未启用“Brave Rewards”时隐藏“Brave Rewards”图标";
 
 /* Title for history menu item */
-"HistortMenuItem" = "历史记录";
+"HistoryMenuItem" = "历史记录";
 
 /* Title for History Clear All Action */
 "history.historyClearActionTitle" = "清除历史记录";


### PR DESCRIPTION
…nuItem)

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
There's a typo in the localization key "HistortMenuItem". Commit fixes.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7435

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
