### PR TITLE
Fix #7373: Remove Block Phishing Control from Shields Popover

### DIFF
--- a/Sources/Brave/Frontend/Shields/AdvancedShieldsView.swift
+++ b/Sources/Brave/Frontend/Shields/AdvancedShieldsView.swift
@@ -10,7 +10,6 @@ import BraveUI
 class AdvancedShieldsView: UIStackView {
   let siteTitle = HeaderTitleView()
   let adsTrackersControl = ToggleView(title: Strings.blockAdsAndTracking)
-  let blockMalwareControl = ToggleView(title: Strings.blockPhishing)
   let blockScriptsControl = ToggleView(title: Strings.blockScripts)
   let fingerprintingControl = ToggleView(title: Strings.fingerprintingProtection)
   let globalControlsTitleView = HeaderTitleView().then {
@@ -26,7 +25,6 @@ class AdvancedShieldsView: UIStackView {
     let rows: [UIView] = [
       siteTitle,
       adsTrackersControl,
-      blockMalwareControl,
       blockScriptsControl,
       fingerprintingControl,
       globalControlsTitleView,

--- a/Sources/BraveStrings/BraveStrings.swift
+++ b/Sources/BraveStrings/BraveStrings.swift
@@ -1088,7 +1088,6 @@ extension Strings {
   public static let individualControls = NSLocalizedString("IndividualControls", tableName: "BraveShared", bundle: .module, value: "Individual Controls", comment: "title for per-site shield toggles")
   public static let blockingMonitor = NSLocalizedString("BlockingMonitor", tableName: "BraveShared", bundle: .module, value: "Blocking Monitor", comment: "title for section showing page blocking statistics")
   public static let siteShieldSettings = NSLocalizedString("SiteShieldSettings", tableName: "BraveShared", bundle: .module, value: "Shields", comment: "Brave panel topmost title")
-  public static let blockPhishing = NSLocalizedString("BlockPhishing", tableName: "BraveShared", bundle: .module, value: "Block Phishing", comment: "Brave panel individual toggle title")
   public static let adsAndTrackers = NSLocalizedString("AdsAndTrackers", tableName: "BraveShared", bundle: .module, value: "Ads and Trackers", comment: "individual blocking statistic title")
   public static let HTTPSUpgrades = NSLocalizedString("HTTPSUpgrades", tableName: "BraveShared", bundle: .module, value: "HTTPS Upgrades", comment: "individual blocking statistic title")
   public static let scriptsBlocked = NSLocalizedString("ScriptsBlocked", tableName: "BraveShared", bundle: .module, value: "Scripts Blocked", comment: "individual blocking statistic title")


### PR DESCRIPTION
## Summary of Changes
- Remove Phishing control from shields popover.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7373

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
- Test Google Safe Browsing with: https://testsafebrowsing.appspot.com/

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
