### PR TITLE
Fix #7436: [hackerone] Sync settings should be behind Face ID / Passcode authentication

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
@@ -38,9 +38,12 @@ extension BrowserViewController: TopToolbarDelegate {
 
     isTabTrayActive = true
 
-    let tabTrayController = TabTrayController(tabManager: tabManager, braveCore: braveCore).then {
-      $0.delegate = self
-      $0.toolbarUrlActionsDelegate = self
+    let tabTrayController = TabTrayController(
+      tabManager: tabManager,
+      braveCore: braveCore,
+      windowProtection: windowProtection).then {
+        $0.delegate = self
+        $0.toolbarUrlActionsDelegate = self
     }
     let container = UINavigationController(rootViewController: tabTrayController)
 

--- a/Sources/Brave/Frontend/Browser/Tabs/TabTray/TabTrayController.swift
+++ b/Sources/Brave/Frontend/Browser/Tabs/TabTray/TabTrayController.swift
@@ -46,6 +46,8 @@ class TabTrayController: LoadingViewController {
 
   let tabManager: TabManager
   let braveCore: BraveCoreMain
+  
+  private let windowProtection: WindowProtection?
   private var openTabsSessionServiceListener: OpenTabsSessionStateListener?
   private var syncServicStateListener: AnyObject?
 
@@ -183,9 +185,11 @@ class TabTrayController: LoadingViewController {
 
   // MARK: Lifecycle
   
-  init(tabManager: TabManager, braveCore: BraveCoreMain) {
+  init(tabManager: TabManager, braveCore: BraveCoreMain, windowProtection: WindowProtection?) {
     self.tabManager = tabManager
     self.braveCore = braveCore
+    self.windowProtection = windowProtection
+    
     super.init(nibName: nil, bundle: nil)
 
     if !UIAccessibility.isReduceMotionEnabled {
@@ -638,7 +642,8 @@ class TabTrayController: LoadingViewController {
           with: SyncWelcomeViewController(
             syncAPI: braveCore.syncAPI,
             syncProfileServices: braveCore.syncProfileService,
-            tabManager: tabManager))
+            tabManager: tabManager,
+            windowProtection: windowProtection))
       case .openTabsDisabled, .noSyncedSessions:
         if !DeviceInfo.hasConnectivity() {
           present(SyncAlerts.noConnection, animated: true)
@@ -649,7 +654,8 @@ class TabTrayController: LoadingViewController {
           SyncSettingsTableViewController(
             syncAPI: braveCore.syncAPI,
             syncProfileService: braveCore.syncProfileService,
-            tabManager: tabManager))
+            tabManager: tabManager,
+            windowProtection: windowProtection))
       default:
         return
     }

--- a/Sources/Brave/Frontend/Settings/SettingsViewController.swift
+++ b/Sources/Brave/Frontend/Settings/SettingsViewController.swift
@@ -321,11 +321,24 @@ class SettingsViewController: TableViewController {
                 self.present(SyncAlerts.noConnection, animated: true)
                 return
               }
+              
+              let syncSettingsViewController = SyncSettingsTableViewController(
+                syncAPI: syncAPI,
+                syncProfileService:
+                  syncProfileServices,
+                tabManager: tabManager,
+                windowProtection: windowProtection)
 
               self.navigationController?
-                .pushViewController(SyncSettingsTableViewController(syncAPI: syncAPI, syncProfileService: syncProfileServices, tabManager: tabManager), animated: true)
+                .pushViewController(syncSettingsViewController, animated: true)
             } else {
-              self.navigationController?.pushViewController(SyncWelcomeViewController(syncAPI: syncAPI, syncProfileServices: syncProfileServices, tabManager: tabManager), animated: true)
+              let syncWelcomeViewController = SyncWelcomeViewController(
+                syncAPI: syncAPI,
+                syncProfileServices: syncProfileServices,
+                tabManager: tabManager,
+                windowProtection: windowProtection)
+              
+              self.navigationController?.pushViewController(syncWelcomeViewController, animated: true)
             }
           }, image: UIImage(braveSystemNamed: "leo.sync"), accessory: .disclosureIndicator,
           cellClass: MultilineValue1Cell.self),

--- a/Sources/Brave/Frontend/Sync/SyncAddDeviceViewController.swift
+++ b/Sources/Brave/Frontend/Sync/SyncAddDeviceViewController.swift
@@ -128,7 +128,7 @@ class SyncAddDeviceViewController: SyncViewController {
   init(title: String, type: SyncDeviceType, syncAPI: BraveSyncAPI) {
     self.syncAPI = syncAPI
     qrCodeView = SyncQRCodeView(syncApi: syncAPI)
-    super.init(nibName: nil, bundle: nil)
+    super.init()
 
     pageTitle = title
     deviceType = type

--- a/Sources/Brave/Frontend/Sync/SyncPairCameraViewController.swift
+++ b/Sources/Brave/Frontend/Sync/SyncPairCameraViewController.swift
@@ -32,7 +32,7 @@ class SyncPairCameraViewController: SyncViewController {
 
   init(syncAPI: BraveSyncAPI) {
     self.syncAPI = syncAPI
-    super.init(nibName: nil, bundle: nil)
+    super.init()
   }
 
   @available(*, unavailable)

--- a/Sources/Brave/Frontend/Sync/SyncPairWordsViewController.swift
+++ b/Sources/Brave/Frontend/Sync/SyncPairWordsViewController.swift
@@ -58,7 +58,7 @@ class SyncPairWordsViewController: SyncViewController {
   
   init(syncAPI: BraveSyncAPI) {
     self.syncAPI = syncAPI
-    super.init(nibName: nil, bundle: nil)
+    super.init()
   }
 
   @available(*, unavailable)

--- a/Sources/Brave/Frontend/Sync/SyncSettingsTableViewController.swift
+++ b/Sources/Brave/Frontend/Sync/SyncSettingsTableViewController.swift
@@ -74,13 +74,17 @@ class SyncSettingsTableViewController: SyncViewController, UITableViewDelegate, 
   
   // MARK: Lifecycle
 
-  init(showDoneButton: Bool = false, syncAPI: BraveSyncAPI, syncProfileService: BraveSyncProfileServiceIOS, tabManager: TabManager) {
+  init(showDoneButton: Bool = false,
+       syncAPI: BraveSyncAPI,
+       syncProfileService: BraveSyncProfileServiceIOS,
+       tabManager: TabManager,
+       windowProtection: WindowProtection?) {
     self.showDoneButton = showDoneButton
     self.syncAPI = syncAPI
     self.syncProfileService = syncProfileService
     self.tabManager = tabManager
     
-    super.init()
+    super.init(windowProtection: windowProtection, requiresAuthentication: syncAPI.isInSyncGroup)
   }
 
   required init?(coder: NSCoder) {

--- a/Sources/Brave/Frontend/Sync/SyncSettingsTableViewController.swift
+++ b/Sources/Brave/Frontend/Sync/SyncSettingsTableViewController.swift
@@ -80,7 +80,7 @@ class SyncSettingsTableViewController: SyncViewController, UITableViewDelegate, 
     self.syncProfileService = syncProfileService
     self.tabManager = tabManager
     
-    super.init(nibName: nil, bundle: nil)
+    super.init()
   }
 
   required init?(coder: NSCoder) {

--- a/Sources/Brave/Frontend/Sync/SyncViewController.swift
+++ b/Sources/Brave/Frontend/Sync/SyncViewController.swift
@@ -5,19 +5,30 @@ import Shared
 import BraveShared
 import Data
 
-class RoundInterfaceView: UIView {
-  override func layoutSubviews() {
-    super.layoutSubviews()
-    layer.cornerRadius = min(bounds.height, bounds.width) / 2.0
-  }
-}
-
 class SyncViewController: UIViewController {
 
-  override func viewDidLoad() {
-    super.viewDidLoad()
+  private let windowProtection: WindowProtection?
+  private let requiresAuthentication: Bool
+
+  // MARK: Lifecycle
+
+  init(windowProtection: WindowProtection? = nil, requiresAuthentication: Bool = false) {
+    self.windowProtection = windowProtection
+    self.requiresAuthentication = requiresAuthentication
     
+    super.init(nibName: nil, bundle: nil)
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  override func viewDidLoad() {
     view.backgroundColor = .secondaryBraveBackground
+
+    if requiresAuthentication {
+      askForAuthentication()
+    }
   }
 
   /// Perform a block of code only if user has a network connection, shows an error alert otherwise.
@@ -29,5 +40,42 @@ class SyncViewController: UIViewController {
     }
 
     code()
+  }
+  
+  /// A method to ask biometric authentication to user
+  /// - Parameter completion: block returning authentication status
+  func askForAuthentication(completion: ((Bool) -> Void)? = nil) {
+    guard let windowProtection = windowProtection else {
+      completion?(false)
+      return
+    }
+
+    if !windowProtection.isPassCodeAvailable {
+      showSetPasscodeError() {
+        completion?(false)
+      }
+    } else {
+      windowProtection.presentAuthenticationForViewController(
+        determineLockWithPasscode: false) { status in
+          completion?(status)
+      }
+    }
+  }
+  
+  /// An alert presenter for passcode error to warn user to setup passcode to use feature
+  /// - Parameter completion: block after Ok button is pressed
+  private func showSetPasscodeError(completion: @escaping (() -> Void)) {
+    let alert = UIAlertController(
+      title: "Set a Passcode",
+      message: "To setup sync hain or see settings, you must first set a passcode on your device.",
+      preferredStyle: .alert)
+
+    alert.addAction(
+      UIAlertAction(title: Strings.OKString, style: .default, handler: { _ in
+          completion()
+      })
+    )
+    
+    present(alert, animated: true, completion: nil)
   }
 }

--- a/Sources/Brave/Frontend/Sync/SyncViewController.swift
+++ b/Sources/Brave/Frontend/Sync/SyncViewController.swift
@@ -7,7 +7,7 @@ import Data
 
 class SyncViewController: UIViewController {
 
-  private let windowProtection: WindowProtection?
+  let windowProtection: WindowProtection?
   private let requiresAuthentication: Bool
 
   // MARK: Lifecycle

--- a/Sources/Brave/Frontend/Sync/SyncViewController.swift
+++ b/Sources/Brave/Frontend/Sync/SyncViewController.swift
@@ -66,8 +66,8 @@ class SyncViewController: UIViewController {
   /// - Parameter completion: block after Ok button is pressed
   private func showSetPasscodeError(completion: @escaping (() -> Void)) {
     let alert = UIAlertController(
-      title: "Set a Passcode",
-      message: "To setup sync hain or see settings, you must first set a passcode on your device.",
+      title: Strings.Sync.syncSetPasscodeAlertTitle,
+      message: Strings.Sync.syncSetPasscodeAlertDescription,
       preferredStyle: .alert)
 
     alert.addAction(

--- a/Sources/Brave/Frontend/Sync/SyncWelcomeViewController.swift
+++ b/Sources/Brave/Frontend/Sync/SyncWelcomeViewController.swift
@@ -139,7 +139,7 @@ class SyncWelcomeViewController: SyncViewController {
     self.syncProfileServices = syncProfileServices
     self.tabManager = tabManager
     
-    super.init(nibName: nil, bundle: nil)
+    super.init()
   }
 
   @available(*, unavailable)

--- a/Sources/Brave/Frontend/Sync/SyncWelcomeViewController.swift
+++ b/Sources/Brave/Frontend/Sync/SyncWelcomeViewController.swift
@@ -14,6 +14,11 @@ protocol NavigationPrevention {
 }
 
 class SyncWelcomeViewController: SyncViewController {
+  
+  private enum ActionType {
+    case newUser, existingUser, internalSettings
+  }
+  
   private var overlayView: UIView?
 
   private var isLoading: Bool = false {
@@ -134,12 +139,15 @@ class SyncWelcomeViewController: SyncViewController {
   private let syncAPI: BraveSyncAPI
   private let syncProfileServices: BraveSyncProfileServiceIOS
 
-  init(syncAPI: BraveSyncAPI, syncProfileServices: BraveSyncProfileServiceIOS, tabManager: TabManager) {
+  init(syncAPI: BraveSyncAPI,
+       syncProfileServices: BraveSyncProfileServiceIOS,
+       tabManager: TabManager,
+       windowProtection: WindowProtection?) {
     self.syncAPI = syncAPI
     self.syncProfileServices = syncProfileServices
     self.tabManager = tabManager
     
-    super.init()
+    super.init(windowProtection: windowProtection)
   }
 
   @available(*, unavailable)
@@ -180,9 +188,109 @@ class SyncWelcomeViewController: SyncViewController {
     buttonsStackView.addArrangedSubview(existingUserButton)
     mainStackView.addArrangedSubview(buttonsStackView)
 
-    navigationItem.rightBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "gearshape"), style: .plain, target: self, action: #selector(onSyncInternalsTapped))
+    navigationItem.rightBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "gearshape"), style: .plain, target: self, action: #selector(onSyncInternalsAction))
   }
 
+  // MARK: Actions
+
+  @objc
+  private func newToSyncAction() {
+    askForAuthentication() { [weak self] status in
+      guard let self = self, status else { return }
+      
+      let addDevice = SyncSelectDeviceTypeViewController()
+      addDevice.syncInitHandler = { [weak self] (title, type) in
+        guard let self = self else { return }
+        
+        func pushAddDeviceVC() {
+          self.syncServiceObserver = nil
+          guard self.syncAPI.isInSyncGroup else {
+            addDevice.disableNavigationPrevention()
+            let alert = UIAlertController(title: Strings.syncUnsuccessful, message: Strings.syncUnableCreateGroup, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: Strings.OKString, style: .default, handler: nil))
+            addDevice.present(alert, animated: true, completion: nil)
+            return
+          }
+          
+          let view = SyncAddDeviceViewController(title: title, type: type, syncAPI: self.syncAPI)
+          view.addDeviceHandler = self.pushSettings
+          view.navigationItem.hidesBackButton = true
+          self.navigationController?.pushViewController(view, animated: true)
+        }
+        
+        if self.syncAPI.isInSyncGroup {
+          pushAddDeviceVC()
+          return
+        }
+        
+        addDevice.enableNavigationPrevention()
+        
+        // DidJoinSyncChain result should be also checked when creating a new chain
+        self.syncAPI.setDidJoinSyncChain { result in
+          if result {
+            self.syncDeviceInfoObserver = self.syncAPI.addDeviceStateObserver { [weak self] in
+              guard let self else { return }
+              self.syncServiceObserver = nil
+              self.syncDeviceInfoObserver = nil
+              
+              pushAddDeviceVC()
+            }
+          } else {
+            self.syncAPI.leaveSyncGroup()
+            addDevice.disableNavigationPrevention()
+            self.navigationController?.popViewController(animated: true)
+          }
+        }
+        
+        self.syncAPI.joinSyncGroup(codeWords: self.syncAPI.getSyncCode(), syncProfileService: self.syncProfileServices)
+        self.handleSyncSetupFailure()
+      }
+      
+      self.navigationController?.pushViewController(addDevice, animated: true)
+    }
+  }
+
+  @objc
+  private func existingUserAction() {
+    askForAuthentication() { [weak self] status in
+      guard let self = self, status else { return }
+      
+      let pairCamera = SyncPairCameraViewController(syncAPI: syncAPI)
+      pairCamera.delegate = self
+      self.navigationController?.pushViewController(pairCamera, animated: true)
+    }
+  }
+  
+  @objc
+  private func onSyncInternalsAction() {
+    askForAuthentication() { [weak self] status in
+      guard let self = self, status else { return }
+      
+      let syncInternalsController = syncAPI.createSyncInternalsController().then {
+        $0.title = Strings.braveSyncInternalsTitle
+      }
+      
+      navigationController?.pushViewController(syncInternalsController, animated: true)
+    }
+  }
+
+  // MARK: Internal
+  
+  private func pushSettings() {
+    if !DeviceInfo.hasConnectivity() {
+      present(SyncAlerts.noConnection, animated: true)
+      return
+    }
+
+    let syncSettingsVC = SyncSettingsTableViewController(
+      showDoneButton: true,
+      syncAPI: syncAPI,
+      syncProfileService: syncProfileServices,
+      tabManager: tabManager,
+      windowProtection: windowProtection)
+    navigationController?.pushViewController(syncSettingsVC, animated: true)
+  }
+  
   /// Sync setup failure is handled here because it can happen from few places in children VCs(new chain, qr code, codewords)
   /// This makes all presented Sync View Controllers to dismiss, cleans up any sync setup and shows user a friendly message.
   private func handleSyncSetupFailure() {
@@ -196,87 +304,6 @@ class SyncWelcomeViewController: SyncViewController {
         }
       }
     }
-  }
-
-  @objc
-  private func onSyncInternalsTapped() {
-    let syncInternalsController = syncAPI.createSyncInternalsController().then {
-      $0.title = Strings.braveSyncInternalsTitle
-    }
-
-    navigationController?.pushViewController(syncInternalsController, animated: true)
-  }
-
-  @objc func newToSyncAction() {
-    let addDevice = SyncSelectDeviceTypeViewController()
-    addDevice.syncInitHandler = { [weak self] (title, type) in
-      guard let self = self else { return }
-
-      func pushAddDeviceVC() {
-        self.syncServiceObserver = nil
-        guard self.syncAPI.isInSyncGroup else {
-          addDevice.disableNavigationPrevention()
-          let alert = UIAlertController(title: Strings.syncUnsuccessful, message: Strings.syncUnableCreateGroup, preferredStyle: .alert)
-          alert.addAction(UIAlertAction(title: Strings.OKString, style: .default, handler: nil))
-          addDevice.present(alert, animated: true, completion: nil)
-          return
-        }
-
-        let view = SyncAddDeviceViewController(title: title, type: type, syncAPI: self.syncAPI)
-        view.addDeviceHandler = self.pushSettings
-        view.navigationItem.hidesBackButton = true
-        self.navigationController?.pushViewController(view, animated: true)
-      }
-      
-      if self.syncAPI.isInSyncGroup {
-        pushAddDeviceVC()
-        return
-      }
-
-      addDevice.enableNavigationPrevention()
-
-      // DidJoinSyncChain result should be also checked when creating a new chain
-      self.syncAPI.setDidJoinSyncChain { result in
-        if result {
-          self.syncDeviceInfoObserver = self.syncAPI.addDeviceStateObserver { [weak self] in
-            guard let self else { return }
-            self.syncServiceObserver = nil
-            self.syncDeviceInfoObserver = nil
-            
-            pushAddDeviceVC()
-          }
-        } else {
-          self.syncAPI.leaveSyncGroup()
-          addDevice.disableNavigationPrevention()
-          self.navigationController?.popViewController(animated: true)
-        }
-      }
-
-      self.syncAPI.joinSyncGroup(codeWords: self.syncAPI.getSyncCode(), syncProfileService: self.syncProfileServices)
-      self.handleSyncSetupFailure()
-    }
-
-    self.navigationController?.pushViewController(addDevice, animated: true)
-  }
-
-  @objc func existingUserAction() {
-    let pairCamera = SyncPairCameraViewController(syncAPI: syncAPI)
-    pairCamera.delegate = self
-    self.navigationController?.pushViewController(pairCamera, animated: true)
-  }
-
-  private func pushSettings() {
-    if !DeviceInfo.hasConnectivity() {
-      present(SyncAlerts.noConnection, animated: true)
-      return
-    }
-
-    let syncSettingsVC = SyncSettingsTableViewController(
-      showDoneButton: true,
-      syncAPI: syncAPI,
-      syncProfileService: syncProfileServices,
-      tabManager: tabManager)
-    navigationController?.pushViewController(syncSettingsVC, animated: true)
   }
 }
 

--- a/Sources/BraveStrings/BraveStrings.swift
+++ b/Sources/BraveStrings/BraveStrings.swift
@@ -3062,6 +3062,20 @@ extension Strings {
         "sync.syncChainAccountDeletionErrorDescription", tableName: "BraveShared", bundle: .module,
         value: "Sync Device",
         comment: "Alert description for error while deleting sync chain")
+    public static let syncSetPasscodeAlertTitle =
+      NSLocalizedString(
+        "sync.syncSetPasscodeAlertTitle",
+        tableName: "BraveShared",
+        bundle: .module,
+        value: "Set a Passcode",
+        comment: "The title displayed in alert when a user needs to set passcode")
+    public static let syncSetPasscodeAlertDescription =
+      NSLocalizedString(
+        "login.loginInfoSetPasscodeAlertDescription",
+        tableName: "BraveShared",
+        bundle: .module,
+        value: "To setup sync hain or see settings, you must first set a passcode on your device..",
+        comment: "The message displayed in alert when a user needs to set a passcode")
   }
 }
 

--- a/Sources/BraveStrings/BraveStrings.swift
+++ b/Sources/BraveStrings/BraveStrings.swift
@@ -3074,7 +3074,7 @@ extension Strings {
         "login.loginInfoSetPasscodeAlertDescription",
         tableName: "BraveShared",
         bundle: .module,
-        value: "To setup sync hain or see settings, you must first set a passcode on your device..",
+        value: "To setup sync chain or see settings, you must first set a passcode on your device..",
         comment: "The message displayed in alert when a user needs to set a passcode")
   }
 }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7436

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->

Test Plan 1: A user with no activated sync chain

Route 1: Settings Route

- Open Settings
- Click Sync
- Observe Sync Welcome page opens 
- All actions in the page should trigger Biometric Authentication

Route 2: Tab Tray Route

- Open TabTray and navigate Open tabs segmented part
- Click Start Sync Chain
- Observe Sync Welcome page opens 
- All actions in the page should trigger Biometric Authentication

Test Plan 2: A user with activated sync chain

Route 1: Settings Route

- Open Settings
- Click Sync
- Observe trigger Biometric Authentication
- After Authentication observer sync detail settings screen

Route 2: Tab Tray Route (an activated sync chain but open tabs not anabled)

- Open TabTray and navigate Open tabs segmented part
- Click Enable Tab Syncing
- Observe trigger Biometric Authentication
- After Authentication observer sync detail settings screen



## Screenshots:



https://github.com/brave/brave-ios/assets/6643505/508e111f-5d96-4f28-ac64-8bd33cd0e651



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
