### PR TITLE
Fix #7455: Tx links does not respect tx's chain id

### DIFF
--- a/Sources/BraveWallet/Crypto/Accounts/AccountTransactionListView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/AccountTransactionListView.swift
@@ -43,7 +43,8 @@ struct AccountTransactionListView: View {
               .contextMenu {
                 if !txSummary.txHash.isEmpty {
                   Button(action: {
-                    if let baseURL = self.networkStore.selectedChain.blockExplorerUrls.first.map(URL.init(string:)),
+                    if let txNetwork = self.networkStore.allChains.first(where: { $0.chainId == txSummary.txInfo.chainId }),
+                       let baseURL = txNetwork.blockExplorerUrls.first.map(URL.init(string:)),
                        let url = baseURL?.appendingPathComponent("tx/\(txSummary.txHash)") {
                       openWalletURL(url)
                     }

--- a/Sources/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
@@ -121,7 +121,8 @@ struct AccountActivityView: View {
               .contextMenu {
                 if !txSummary.txHash.isEmpty {
                   Button(action: {
-                    if let baseURL = self.networkStore.selectedChain.blockExplorerUrls.first.map(URL.init(string:)),
+                    if let txNetwork = self.networkStore.allChains.first(where: { $0.chainId == txSummary.txInfo.chainId }),
+                       let baseURL = txNetwork.blockExplorerUrls.first.map(URL.init(string:)),
                        let url = baseURL?.appendingPathComponent("tx/\(txSummary.txHash)") {
                       openWalletURL(url)
                     }

--- a/Sources/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
+++ b/Sources/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
@@ -103,7 +103,8 @@ struct AssetDetailView: View {
             .contextMenu {
               if !txSummary.txHash.isEmpty {
                 Button(action: {
-                  if let baseURL = self.networkStore.selectedChain.blockExplorerUrls.first.map(URL.init(string:)),
+                  if let txNetwork = self.networkStore.allChains.first(where: { $0.chainId == txSummary.txInfo.chainId }),
+                     let baseURL = txNetwork.blockExplorerUrls.first.map(URL.init(string:)),
                      let url = baseURL?.appendingPathComponent("tx/\(txSummary.txHash)") {
                     openWalletURL(url)
                   }

--- a/Sources/BraveWallet/Crypto/Transaction Confirmations/TransactionStatusView.swift
+++ b/Sources/BraveWallet/Crypto/Transaction Confirmations/TransactionStatusView.swift
@@ -39,8 +39,9 @@ struct TransactionStatusView: View {
           .padding(.top, 40)
           .buttonStyle(BraveFilledButtonStyle(size: .large))
           Button {
-            if let baseURL = networkStore.selectedChain.blockExplorerUrls.first.map(URL.init(string:)),
-               let tx = confirmationStore.allTxs.first(where: { $0.id == confirmationStore.activeTransactionId }),
+            if let tx = confirmationStore.allTxs.first(where: { $0.id == confirmationStore.activeTransactionId }),
+               let txNetwork = networkStore.allChains.first(where: { $0.chainId == tx.chainId }),
+               let baseURL = txNetwork.blockExplorerUrls.first.map(URL.init(string:)),
                let url = baseURL?.appendingPathComponent("tx/\(tx.txHash)") {
               openWalletURL(url)
             }

--- a/Sources/BraveWallet/Crypto/Transactions/TransactionDetailsView.swift
+++ b/Sources/BraveWallet/Crypto/Transactions/TransactionDetailsView.swift
@@ -61,7 +61,8 @@ struct TransactionDetailsView: View {
           detailRow(title: Strings.Wallet.transactionDetailsDateTitle, value: dateFormatter.string(from: transactionDetailsStore.transaction.createdTime))
           if !transactionDetailsStore.transaction.txHash.isEmpty {
             Button(action: {
-              if let baseURL = self.networkStore.selectedChain.blockExplorerUrls.first.map(URL.init(string:)),
+              if let txNetwork = self.networkStore.allChains.first(where: { $0.chainId == transactionDetailsStore.transaction.chainId }),
+                 let baseURL = txNetwork.blockExplorerUrls.first.map(URL.init(string:)),
                  let url = baseURL?.appendingPathComponent("tx/\(transactionDetailsStore.transaction.txHash)") {
                 openWalletURL(url)
               }

--- a/Sources/BraveWallet/Panels/Add Suggested Token/AddSuggestedTokenView.swift
+++ b/Sources/BraveWallet/Panels/Add Suggested Token/AddSuggestedTokenView.swift
@@ -38,7 +38,8 @@ struct AddSuggestedTokenView: View {
           }
           .accessibilityElement(children: .combine)
           Button(action: {
-            if let baseURL = cryptoStore.networkStore.selectedChain.blockExplorerUrls.first.map(URL.init(string:)),
+            if let tokenNetwork = cryptoStore.networkStore.allChains.first(where: { $0.chainId == token.chainId }),
+               let baseURL = tokenNetwork.blockExplorerUrls.first.map(URL.init(string:)),
                let url = baseURL?.appendingPathComponent("token/\(token.contractAddress)") {
               openWalletURL(url)
             }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
Currently, front-end is using the current selected network to get the base url for transaction and suggested token page.
But this is wrong since we have already support displaying transactions and assets in different networks. 
This PR is to using transaction/token's chainId to fetch the correct base url to build the correct transaction/token page for users to explore. 

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7455

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
Please follow the issues description to verify transaction links are correct in 
- Transactions List view (shown from Wallet Panel)
- Account Details
- Asset Detail view
- Transaction Details view
- Transaction Status view displayed after transaction is confirmed
There is one more case when dapp request a suggested token to add 
- go to a dapp that will trigger add suggested token request panel 
- in this panel, there will be a link to go this token's page. click this link
- verify the page is using the correct network's url (eth mainnet: https://etherscan.io/ goerli: https://goerli.etherscan.io/ bsc: https://www.bscscan.com/)
- Please note that this case is based on the assumption that dapps sending the request with correct token network information. If it is not correct network information, core will fallback to the default network information of that token's coin type.


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
