### PR TITLE
Fix #7464: Remove legacy ledger wallet migrations

### DIFF
--- a/Sources/Brave/Frontend/Brave Rewards/Panel/BraveRewardsViewController.swift
+++ b/Sources/Brave/Frontend/Brave Rewards/Panel/BraveRewardsViewController.swift
@@ -18,7 +18,6 @@ class BraveRewardsViewController: UIViewController, PopoverContentComponent {
 
   let tab: Tab
   let rewards: BraveRewards
-  let legacyWallet: BraveLedger?
   var actionHandler: ((Action) -> Void)?
 
   private var ledgerObserver: LedgerObserver?
@@ -45,10 +44,9 @@ class BraveRewardsViewController: UIViewController, PopoverContentComponent {
 
   private var supportedListCount: Int = 0
 
-  init(tab: Tab, rewards: BraveRewards, legacyWallet: BraveLedger?) {
+  init(tab: Tab, rewards: BraveRewards) {
     self.tab = tab
     self.rewards = rewards
-    self.legacyWallet = legacyWallet
 
     super.init(nibName: nil, bundle: nil)
   }
@@ -117,13 +115,7 @@ class BraveRewardsViewController: UIViewController, PopoverContentComponent {
           }
         }
       }
-      if let legacyWallet = self.legacyWallet, !legacyWallet.isInitialized {
-        legacyWallet.initializeLedgerService({
-          self.reloadData()
-        })
-      } else {
-        self.reloadData()
-      }
+      self.reloadData()
     }
 
     view.snp.makeConstraints {

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
@@ -32,7 +32,7 @@ extension BrowserViewController {
   func showRewardsDebugSettings() {
     if AppConstants.buildChannel.isPublic { return }
 
-    let settings = RewardsDebugSettingsViewController(rewards: rewards, legacyWallet: legacyWallet)
+    let settings = RewardsDebugSettingsViewController(rewards: rewards)
     let container = UINavigationController(rootViewController: settings)
     present(container, animated: true)
   }
@@ -67,8 +67,7 @@ extension BrowserViewController {
     
     let braveRewardsPanel = BraveRewardsViewController(
       tab: tab,
-      rewards: rewards,
-      legacyWallet: legacyWallet
+      rewards: rewards
     )
     braveRewardsPanel.actionHandler = { [weak self] action in
       switch action {

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
@@ -177,7 +177,6 @@ extension BrowserViewController {
           tabManager: self.tabManager,
           feedDataSource: self.feedDataSource,
           rewards: self.rewards,
-          legacyWallet: self.legacyWallet,
           windowProtection: self.windowProtection,
           braveCore: self.braveCore,
           keyringStore: keyringStore,

--- a/Sources/Brave/Frontend/Settings/BraveRewardsSettingsViewController.swift
+++ b/Sources/Brave/Frontend/Settings/BraveRewardsSettingsViewController.swift
@@ -14,12 +14,10 @@ import Combine
 class BraveRewardsSettingsViewController: TableViewController {
 
   let rewards: BraveRewards
-  let legacyWallet: BraveLedger?
   var walletTransferLearnMoreTapped: (() -> Void)?
 
-  init(_ rewards: BraveRewards, legacyWallet: BraveLedger?) {
+  init(_ rewards: BraveRewards) {
     self.rewards = rewards
-    self.legacyWallet = legacyWallet
 
     super.init(style: .insetGrouped)
   }
@@ -53,7 +51,7 @@ class BraveRewardsSettingsViewController: TableViewController {
                 text: Strings.RewardsInternals.title,
                 selection: {
                   guard let self = self else { return }
-                  let controller = RewardsInternalsViewController(ledger: ledger, legacyLedger: self.legacyWallet)
+                  let controller = RewardsInternalsViewController(ledger: ledger)
                   self.navigationController?.pushViewController(controller, animated: true)
                 }, accessory: .disclosureIndicator)
             ])
@@ -70,13 +68,7 @@ class BraveRewardsSettingsViewController: TableViewController {
 
     rewards.startLedgerService { [weak self] in
       guard let self = self else { return }
-      if let legacyWallet = self.legacyWallet, !legacyWallet.isInitialized {
-        legacyWallet.initializeLedgerService {
-          self.reloadSections()
-        }
-      } else {
-        self.reloadSections()
-      }
+      self.reloadSections()
     }
   }
 }

--- a/Sources/Brave/Frontend/Settings/Rewards Internals/QA/RewardsDebugSettingsViewController.swift
+++ b/Sources/Brave/Frontend/Settings/Rewards Internals/QA/RewardsDebugSettingsViewController.swift
@@ -16,12 +16,10 @@ private typealias EnvironmentOverride = Preferences.Rewards.EnvironmentOverride
 class RewardsDebugSettingsViewController: TableViewController {
 
   let rewards: BraveRewards
-  let legacyWallet: BraveLedger?
   private var adsInfo: (viewed: Int, amount: Double, paymentDate: Date?)?
 
-  init(rewards: BraveRewards, legacyWallet: BraveLedger?) {
+  init(rewards: BraveRewards) {
     self.rewards = rewards
-    self.legacyWallet = legacyWallet
 
     super.init(style: .grouped)
 
@@ -184,28 +182,6 @@ class RewardsDebugSettingsViewController: TableViewController {
               Task {
                 await self.fetchAndClaimPromotions()
               }
-            }, cellClass: ButtonCell.self),
-        ]
-      ),
-      Section(
-        header: .title("Legacy Wallet"),
-        rows: [
-          Row(
-            text: "Internals",
-            selection: { [unowned self] in
-              guard let legacyWallet = legacyWallet else {
-                let alert = UIAlertController(title: "Legacy Wallet", message: "No Wallet Found. Use \"Create Legacy Wallet\" action below to duplicate the current wallet", preferredStyle: .alert)
-                alert.addAction(.init(title: "OK", style: .default, handler: nil))
-                self.present(alert, animated: true)
-                return
-              }
-              let controller = RewardsInternalsDebugViewController(ledger: legacyWallet)
-              self.navigationController?.pushViewController(controller, animated: true)
-            }, accessory: .disclosureIndicator),
-          Row(
-            text: "Create Legacy Wallet",
-            selection: { [unowned self] in
-              self.createLegacyLedger()
             }, cellClass: ButtonCell.self),
         ]
       ),

--- a/Sources/Brave/Frontend/Settings/SettingsViewController.swift
+++ b/Sources/Brave/Frontend/Settings/SettingsViewController.swift
@@ -52,7 +52,6 @@ class SettingsViewController: TableViewController {
   private let profile: Profile
   private let tabManager: TabManager
   private let rewards: BraveRewards?
-  private let legacyWallet: BraveLedger?
   private let feedDataSource: FeedDataSource
   private let historyAPI: BraveHistoryAPI
   private let passwordAPI: BravePasswordAPI
@@ -72,7 +71,6 @@ class SettingsViewController: TableViewController {
     tabManager: TabManager,
     feedDataSource: FeedDataSource,
     rewards: BraveRewards? = nil,
-    legacyWallet: BraveLedger? = nil,
     windowProtection: WindowProtection?,
     braveCore: BraveCoreMain,
     keyringStore: KeyringStore? = nil,
@@ -82,7 +80,6 @@ class SettingsViewController: TableViewController {
     self.tabManager = tabManager
     self.feedDataSource = feedDataSource
     self.rewards = rewards
-    self.legacyWallet = legacyWallet
     self.windowProtection = windowProtection
     self.historyAPI = braveCore.historyAPI
     self.passwordAPI = braveCore.passwordAPI
@@ -117,7 +114,7 @@ class SettingsViewController: TableViewController {
 
   private func displayRewardsDebugMenu() {
     guard let rewards = rewards else { return }
-    let settings = RewardsDebugSettingsViewController(rewards: rewards, legacyWallet: legacyWallet)
+    let settings = RewardsDebugSettingsViewController(rewards: rewards)
     navigationController?.pushViewController(settings, animated: true)
   }
 
@@ -256,7 +253,7 @@ class SettingsViewController: TableViewController {
         Row(
           text: Strings.braveRewardsTitle,
           selection: { [unowned self] in
-            let rewardsVC = BraveRewardsSettingsViewController(rewards, legacyWallet: self.legacyWallet)
+            let rewardsVC = BraveRewardsSettingsViewController(rewards)
             rewardsVC.walletTransferLearnMoreTapped = { [weak self] in
               guard let self = self else { return }
               self.dismiss(animated: true) {

--- a/Sources/BraveStrings/BraveStrings.swift
+++ b/Sources/BraveStrings/BraveStrings.swift
@@ -3676,7 +3676,6 @@ extension Strings {
   public struct RewardsInternals {
     public static let title = NSLocalizedString("RewardsInternalsTitle", tableName: "BraveShared", bundle: .module, value: "Rewards Internals", comment: "'Rewards' as in 'Brave Rewards'")
     public static let walletInfoHeader = NSLocalizedString("RewardsInternalsWalletInfoHeader", tableName: "BraveShared", bundle: .module, value: "Rewards Profile Info", comment: "")
-    public static let legacyWalletInfoHeader = NSLocalizedString("RewardsInternalsLegacyWalletInfoHeader", tableName: "BraveShared", bundle: .module, value: "Legacy Wallet Info", comment: "")
     public static let keyInfoSeed = NSLocalizedString("RewardsInternalsKeyInfoSeed", tableName: "BraveShared", bundle: .module, value: "Key Info Seed", comment: "")
     public static let valid = NSLocalizedString("RewardsInternalsValid", tableName: "BraveShared", bundle: .module, value: "Valid", comment: "")
     public static let invalid = NSLocalizedString("RewardsInternalsInvalid", tableName: "BraveShared", bundle: .module, value: "Invalid", comment: "")

--- a/Sources/Preferences/GlobalPreferences.swift
+++ b/Sources/Preferences/GlobalPreferences.swift
@@ -66,7 +66,6 @@ extension Preferences {
     public static let rewardsToggledOnce = Option<Bool>(key: "rewards.rewards-toggled-once", default: false)
     public static let isUsingBAP = Option<Bool?>(key: "rewards.is-using-bap", default: nil)
     public static let seenDataMigrationFailureError = Option<Bool>(key: "rewards.seen-data-migration-failure-error", default: false)
-    public static let migratedLegacyWallet = Option<Bool>(key: "rewards.migrated-legacy-wallet", default: false)
     public static let adaptiveCaptchaFailureCount = Option<Int>(key: "rewards.adaptive-captcha-failure-count", default: 0)
     public static let adsEnabledTimestamp = Option<Date?>(key: "rewards.ads.last-time-enabled", default: nil)
     public static let adsDisabledTimestamp = Option<Date?>(key: "rewards.ads.last-time-disabled", default: nil)


### PR DESCRIPTION
The Ledger code in brave-core behaves like a singleton as it uses a global pointer to log, so we can't have more than 1 created. Creating a legacy wallet to do migrations was now crashing because ledger changes in 1.52 to use mojo now expose threading errors.

This migration is very old and can be removed

## Summary of Changes

This pull request fixes #7464 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
