### PR TITLE
Fix #7468 Bottom Bar Callout is blocking Cookie Consent Callout

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Callout.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Callout.swift
@@ -47,7 +47,7 @@ extension BrowserViewController {
   // MARK: Conditional Callout Methods
   
   private func presentP3AScreenCallout() {
-    // Check the blockCookieConsentNotices callout can be shown
+    // Check the p3a callout can be shown
     guard shouldShowCallout(calloutType: .p3a) else {
       return
     }
@@ -93,8 +93,8 @@ extension BrowserViewController {
   private func presentBottomBarCallout() {
     guard traitCollection.userInterfaceIdiom == .phone else { return }
     
-    // Check the blockCookieConsentNotices callout can be shown
-    guard shouldShowCallout(calloutType: .blockCookieConsentNotices) else {
+    // Check the bottom bar callout can be shown
+    guard shouldShowCallout(calloutType: .bottomBar) else {
       return
     }
 
@@ -163,7 +163,7 @@ extension BrowserViewController {
   }
   
   private func presentDefaultBrowserScreenCallout() {
-    // Check the blockCookieConsentNotices callout can be shown
+    // Check the defaultbrowser callout can be shown
     guard shouldShowCallout(calloutType: .defaultBrowser) else {
       return
     }
@@ -201,7 +201,7 @@ extension BrowserViewController {
   }
   
   private func presentBraveRewardsScreenCallout() {
-    // Check the blockCookieConsentNotices callout can be shown
+    // Check the rewards callout can be shown
     guard shouldShowCallout(calloutType: .rewards) else {
       return
     }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

Fixing check method call in order to to show proper callout 

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7468

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
