### PR TITLE
Fix #7225: Selected network per origin

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
@@ -188,8 +188,10 @@ extension BrowserViewController {
     }
   }
 
+  /// Presents Wallet without an origin (ex. from menu)
   func presentWallet() {
     guard let walletStore = self.walletStore ?? newWalletStore() else { return }
+    walletStore.origin = nil
     let vc = WalletHostingViewController(walletStore: walletStore)
     vc.delegate = self
     self.dismiss(animated: true) {

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
@@ -93,8 +93,10 @@ extension BrowserViewController {
     return walletStore
   }
   
+  /// Presents the Wallet panel for a given origin
   func presentWalletPanel(from origin: URLOrigin, with tabDappStore: TabDappStore) {
     guard let walletStore = self.walletStore ?? newWalletStore() else { return }
+    walletStore.origin = origin
     let controller = WalletPanelHostingController(
       walletStore: walletStore,
       tabDappStore: tabDappStore,
@@ -168,6 +170,14 @@ extension Tab: BraveWalletProviderDelegate {
 
   func getOrigin() -> URLOrigin {
     guard let origin = url?.origin else {
+      // A nil url is possible if multiple tabs are restored but one or more
+      // of the tabs is not opened yet (loaded the url). When a new chain is
+      // assigned for a specific origin, the provider(s) will check origin
+      // of all open Tab's to see if that provider needs(s) updated too.
+      // We can get the url from the SessionTab, and return it's origin.
+      if let sessionTabOrigin = SessionTab.from(tabId: id)?.url.origin {
+        return sessionTabOrigin
+      }
       assert(false, "We should have a valid origin to get to this point")
       return .init()
     }

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
@@ -309,7 +309,7 @@ extension Tab: BraveWalletProviderDelegate {
     )
   }
   
-  func isAccountAllowed(_ type: BraveWallet.CoinType, account: String) async -> Bool {
+  @MainActor func isAccountAllowed(_ type: BraveWallet.CoinType, account: String) async -> Bool {
     return await allowedAccounts(type, accounts: [account]).1.contains(account)
   }
   

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/EthereumProviderScriptHandler.swift
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/EthereumProviderScriptHandler.swift
@@ -99,7 +99,7 @@ class EthereumProviderScriptHandler: TabContentScript {
       firstAllowedAccount: String,
       updateJSProperties: Bool
     ) {
-      Task {
+      Task { @MainActor in
         if updateJSProperties {
           await tab.updateEthereumProperties()
         }

--- a/Sources/BraveWallet/Crypto/Asset Details/AssetDetailHeaderView.swift
+++ b/Sources/BraveWallet/Crypto/Asset Details/AssetDetailHeaderView.swift
@@ -128,7 +128,7 @@ struct AssetDetailHeaderView: View {
   }
   
   @ViewBuilder private var tokenImageNameAndNetwork: some View {
-    AssetIconView(token: assetDetailStore.assetDetailToken, network: assetDetailStore.network ?? networkStore.selectedChain)
+    AssetIconView(token: assetDetailStore.assetDetailToken, network: assetDetailStore.network ?? networkStore.defaultSelectedChain)
     VStack(alignment: .leading) {
       Text(assetDetailStore.assetDetailToken.name)
         .fixedSize(horizontal: false, vertical: true)
@@ -225,7 +225,7 @@ struct AssetDetailHeaderView: View {
         .padding(16)
       } else {
         HStack {
-          AssetIconView(token: assetDetailStore.assetDetailToken, network: networkStore.selectedChain)
+          AssetIconView(token: assetDetailStore.assetDetailToken, network: networkStore.defaultSelectedChain)
           Text(assetDetailStore.assetDetailToken.nftTokenTitle)
             .fixedSize(horizontal: false, vertical: true)
             .font(.title3.weight(.semibold))

--- a/Sources/BraveWallet/Crypto/BuySendSwap/BuyTokenView.swift
+++ b/Sources/BraveWallet/Crypto/BuySendSwap/BuyTokenView.swift
@@ -33,11 +33,11 @@ struct BuyTokenView: View {
           Section(
             header: WalletListHeaderView(title: Text(Strings.Wallet.buy))
           ) {
-            NavigationLink(destination: BuyTokenSearchView(buyTokenStore: buyTokenStore, network: networkStore.selectedChain)
+            NavigationLink(destination: BuyTokenSearchView(buyTokenStore: buyTokenStore, network: networkStore.defaultSelectedChain)
             ) {
               HStack {
                 if let token = buyTokenStore.selectedBuyToken {
-                  AssetIconView(token: token, network: networkStore.selectedChain, length: 26)
+                  AssetIconView(token: token, network: networkStore.defaultSelectedChain, length: 26)
                 }
                 Text(buyTokenStore.selectedBuyToken?.symbol ?? "BAT")
                   .font(.title3.weight(.semibold))

--- a/Sources/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
+++ b/Sources/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
@@ -81,7 +81,7 @@ struct SendTokenView: View {
             destination:
               SendTokenSearchView(
                 sendTokenStore: sendTokenStore,
-                network: networkStore.selectedChain
+                network: networkStore.defaultSelectedChain
               )
           ) {
             HStack {
@@ -89,14 +89,14 @@ struct SendTokenView: View {
                 if token.isErc721 || token.isNft {
                   NFTIconView(
                     token: token,
-                    network: networkStore.selectedChain,
+                    network: networkStore.defaultSelectedChain,
                     url: sendTokenStore.selectedSendNFTMetadata?.imageURL,
                     length: 26
                   )
                 } else {
                   AssetIconView(
                     token: token,
-                    network: networkStore.selectedChain,
+                    network: networkStore.defaultSelectedChain,
                     length: 26
                   )
                 }

--- a/Sources/BraveWallet/Crypto/BuySendSwap/SwapCryptoView.swift
+++ b/Sources/BraveWallet/Crypto/BuySendSwap/SwapCryptoView.swift
@@ -211,7 +211,7 @@ struct SwapCryptoView: View {
   
   /// The DEX Aggregator for the current network.
   var dexAggregator: DEXAggregator {
-    networkStore.selectedChain.coin == .sol ? .jupiter : .zeroX
+    networkStore.defaultSelectedChain.coin == .sol ? .jupiter : .zeroX
   }
 
   @ViewBuilder var unsupportedSwapChainSection: some View {
@@ -219,7 +219,7 @@ struct SwapCryptoView: View {
       VStack(alignment: .leading, spacing: 4.0) {
         Text(Strings.Wallet.swapCryptoUnsupportNetworkTitle)
           .font(.headline)
-        Text(String.localizedStringWithFormat(Strings.Wallet.swapCryptoUnsupportNetworkDescription, networkStore.selectedChain.chainName))
+        Text(String.localizedStringWithFormat(Strings.Wallet.swapCryptoUnsupportNetworkDescription, networkStore.defaultSelectedChain.chainName))
           .font(.subheadline)
           .foregroundColor(Color(.secondaryBraveLabel))
       }
@@ -265,12 +265,12 @@ struct SwapCryptoView: View {
   @ViewBuilder var swapFormSections: some View {
     Section(
     ) {
-      NavigationLink(destination: SwapTokenSearchView(swapTokenStore: swapTokensStore, searchType: .fromToken, network: networkStore.selectedChain)) {
+      NavigationLink(destination: SwapTokenSearchView(swapTokenStore: swapTokensStore, searchType: .fromToken, network: networkStore.defaultSelectedChain)) {
         HStack {
           if let token = swapTokensStore.selectedFromToken {
             AssetIconView(
               token: token,
-              network: networkStore.selectedChain,
+              network: networkStore.defaultSelectedChain,
               length: 26
             )
           }
@@ -328,13 +328,13 @@ struct SwapCryptoView: View {
       header: WalletListHeaderView(title: Text(Strings.Wallet.swapCryptoToTitle))
     ) {
       NavigationLink(
-        destination: SwapTokenSearchView(swapTokenStore: swapTokensStore, searchType: .toToken, network: networkStore.selectedChain)
+        destination: SwapTokenSearchView(swapTokenStore: swapTokensStore, searchType: .toToken, network: networkStore.defaultSelectedChain)
       ) {
         HStack {
           if let token = swapTokensStore.selectedToToken {
             AssetIconView(
               token: token,
-              network: networkStore.selectedChain,
+              network: networkStore.defaultSelectedChain,
               length: 26
             )
           }
@@ -365,7 +365,7 @@ struct SwapCryptoView: View {
         text: $swapTokensStore.buyAmount
       )
       .keyboardType(.decimalPad)
-      .disabled(networkStore.selectedChain.coin == .sol)
+      .disabled(networkStore.defaultSelectedChain.coin == .sol)
       .listRowBackground(Color(.secondaryBraveGroupedBackground))
     }
     Section(

--- a/Sources/BraveWallet/Crypto/NetworkPicker.swift
+++ b/Sources/BraveWallet/Crypto/NetworkPicker.swift
@@ -60,6 +60,13 @@ struct NetworkPicker: View {
     }
   }
   
+  private var chainName: String {
+    if isForOrigin {
+      return networkStore.selectedChainForOrigin.chainName
+    }
+    return networkStore.defaultSelectedChain.chainName
+  }
+  
   var body: some View {
     Button(action: {
       networkSelectionStore = .init(
@@ -68,13 +75,8 @@ struct NetworkPicker: View {
       )
     }) {
       HStack {
-        if isForOrigin {
-          Text(networkStore.selectedChainForOrigin.chainName)
-            .fontWeight(.bold)
-        } else {
-          Text(networkStore.defaultSelectedChain.chainName)
-            .fontWeight(.bold)
-        }
+        Text(chainName)
+          .fontWeight(.bold)
         Image(systemName: "chevron.down.circle")
       }
       .foregroundColor(Color(style.textColor))

--- a/Sources/BraveWallet/Crypto/NetworkSelectionView.swift
+++ b/Sources/BraveWallet/Crypto/NetworkSelectionView.swift
@@ -27,8 +27,11 @@ struct NetworkSelectionView: View {
   
   private var selectedNetwork: NetworkPresentation.Network {
     switch store.mode {
-    case .select:
-      return .network(networkStore.selectedChain)
+    case let .select(isForOrigin):
+      if isForOrigin {
+        return .network(networkStore.selectedChainForOrigin)
+      }
+      return .network(networkStore.defaultSelectedChain)
     case .formSelection:
       return .network(store.networkSelectionInForm ?? .init())
     }

--- a/Sources/BraveWallet/Crypto/Portfolio/AddCustomAssetView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/AddCustomAssetView.swift
@@ -319,7 +319,7 @@ struct AddCustomAssetView: View {
   }
 
   private func addCustomToken() {
-    let network = networkSelectionStore.networkSelectionInForm ?? networkStore.selectedChain
+    let network = networkSelectionStore.networkSelectionInForm ?? networkStore.defaultSelectedChain
     let token: BraveWallet.BlockchainToken
     switch selectedTokenType {
     case .token:

--- a/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -167,9 +167,6 @@ public class CryptoStore: ObservableObject {
     self.keyringService.add(self)
     self.txService.add(self)
     self.rpcService.add(self)
-    Task {
-      await networkStore.setup()
-    }
   }
   
   private var buyTokenStore: BuyTokenStore?

--- a/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -83,6 +83,7 @@ public class CryptoStore: ObservableObject {
       }
     }
   }
+  /// The origin of the active tab (if applicable). Used for fetching/selecting network for the DApp origin.
   public var origin: URLOrigin? {
     didSet {
       networkStore.origin = origin

--- a/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -83,6 +83,11 @@ public class CryptoStore: ObservableObject {
       }
     }
   }
+  public var origin: URLOrigin? {
+    didSet {
+      networkStore.origin = origin
+    }
+  }
   
   private let keyringService: BraveWalletKeyringService
   private let rpcService: BraveWalletJsonRpcService
@@ -105,7 +110,8 @@ public class CryptoStore: ObservableObject {
     txService: BraveWalletTxService,
     ethTxManagerProxy: BraveWalletEthTxManagerProxy,
     solTxManagerProxy: BraveWalletSolanaTxManagerProxy,
-    ipfsApi: IpfsAPI
+    ipfsApi: IpfsAPI,
+    origin: URLOrigin? = nil
   ) {
     self.keyringService = keyringService
     self.rpcService = rpcService
@@ -117,12 +123,14 @@ public class CryptoStore: ObservableObject {
     self.ethTxManagerProxy = ethTxManagerProxy
     self.solTxManagerProxy = solTxManagerProxy
     self.ipfsApi = ipfsApi
+    self.origin = origin
     
     self.networkStore = .init(
       keyringService: keyringService,
       rpcService: rpcService,
       walletService: walletService,
-      swapService: swapService
+      swapService: swapService,
+      origin: origin
     )
     self.portfolioStore = .init(
       keyringService: keyringService,

--- a/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -167,6 +167,9 @@ public class CryptoStore: ObservableObject {
     self.keyringService.add(self)
     self.txService.add(self)
     self.rpcService.add(self)
+    Task {
+      await networkStore.setup()
+    }
   }
   
   private var buyTokenStore: BuyTokenStore?

--- a/Sources/BraveWallet/Crypto/Stores/KeyringStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/KeyringStore.swift
@@ -104,6 +104,7 @@ public class KeyringStore: ObservableObject {
   /// A list of default account with all support coin types
   @Published var defaultAccounts: [BraveWallet.AccountInfo] = []
   
+  /// The origin of the active tab (if applicable). Used for fetching/selecting network for the DApp origin.
   public var origin: URLOrigin?
 
   private let keyringService: BraveWalletKeyringService

--- a/Sources/BraveWallet/Crypto/Stores/KeyringStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/KeyringStore.swift
@@ -103,6 +103,8 @@ public class KeyringStore: ObservableObject {
   
   /// A list of default account with all support coin types
   @Published var defaultAccounts: [BraveWallet.AccountInfo] = []
+  
+  public var origin: URLOrigin?
 
   private let keyringService: BraveWalletKeyringService
   private let walletService: BraveWalletBraveWalletService
@@ -381,8 +383,8 @@ extension KeyringStore: BraveWalletKeyringServiceObserver {
       walletService.setSelectedCoin(coinType)
       if previouslySelectedCoin != coinType || selectedAccount.coin != coinType {
         // update network here in case NetworkStore is closed.
-        let network = await rpcService.network(coinType, origin: nil)
-        await rpcService.setNetwork(network.chainId, coin: coinType, origin: nil)
+        let network = await rpcService.network(coinType, origin: origin)
+        await rpcService.setNetwork(network.chainId, coin: coinType, origin: origin)
       }
       updateKeyringInfo()
     }

--- a/Sources/BraveWallet/Crypto/Stores/NetworkSelectionStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/NetworkSelectionStore.swift
@@ -10,7 +10,7 @@ import SwiftUI
 class NetworkSelectionStore: ObservableObject {
   
   enum Mode: Equatable {
-    case select
+    case select(isForOrigin: Bool)
     case formSelection
   }
   
@@ -30,7 +30,7 @@ class NetworkSelectionStore: ObservableObject {
   @Published var networkSelectionInForm: BraveWallet.NetworkInfo?
   
   init(
-    mode: Mode = .select,
+    mode: Mode = .select(isForOrigin: false),
     networkStore: NetworkStore
   ) {
     self.mode = mode
@@ -60,10 +60,10 @@ class NetworkSelectionStore: ObservableObject {
   
   @MainActor func selectNetwork(_ network: NetworkPresentation.Network) async -> Bool {
     switch mode {
-    case .select:
+    case let .select(isForOrigin):
       guard case let .network(network) = network else { return false }
 
-      let error = await networkStore.setSelectedChain(network)
+      let error = await networkStore.setSelectedChain(network, isForOrigin: isForOrigin)
       switch error {
       case .selectedChainHasNoAccounts:
         isPresentingNextNetworkAlert = true
@@ -99,7 +99,7 @@ class NetworkSelectionStore: ObservableObject {
   @MainActor func handleDismissAddAccount() async -> Bool {
     guard let nextNetwork = nextNetwork else { return false }
     // if it errors it's due to no accounts and we don't want to switch to nextNetwork
-    let result = await networkStore.setSelectedChain(nextNetwork)
+    let result = await networkStore.setSelectedChain(nextNetwork, isForOrigin: false)
     self.nextNetwork = nil
     return result != .selectedChainHasNoAccounts
   }

--- a/Sources/BraveWallet/Crypto/Stores/NetworkStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/NetworkStore.swift
@@ -294,6 +294,14 @@ extension NetworkStore: BraveWalletJsonRpcServiceObserver {
       } else {
         defaultSelectedChainId = chainId
         isSwapSupported = await swapService.isSwapSupported(chainId)
+        if self.origin != nil {
+          // The default network may be used for this origin if no
+          // other network was assigned for this origin. If so, we
+          // need to make sure the `selectedChainIdForOrigin` is updated
+          // to reflect the correct network.
+          let network = await rpcService.network(coin, origin: origin)
+          selectedChainIdForOrigin = network.chainId
+        }
       }
     }
   }

--- a/Sources/BraveWallet/Crypto/Stores/NetworkStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/NetworkStore.swift
@@ -53,6 +53,7 @@ public class NetworkStore: ObservableObject {
   /// If Swap is supported for the current `defaultSelectedChain`.
   @Published private(set) var isSwapSupported: Bool = true
   
+  /// The origin of the active tab (if applicable). Used for fetching/selecting network for the DApp origin.
   public var origin: URLOrigin? {
     didSet {
       guard origin != oldValue else { return }
@@ -135,6 +136,11 @@ public class NetworkStore: ObservableObject {
         if self.defaultSelectedChainId != network.chainId {
           self.defaultSelectedChainId = network.chainId
         }
+      }
+      if isForOrigin && selectedChainIdForOrigin != network.chainId {
+        self.selectedChainIdForOrigin = network.chainId
+      } else if defaultSelectedChainId != network.chainId {
+        self.defaultSelectedChainId = network.chainId
       }
       if selectedCoin != network.coin {
         let success = await rpcService.setNetwork(network.chainId, coin: network.coin, origin: isForOrigin ? origin : nil)

--- a/Sources/BraveWallet/Crypto/Stores/NetworkStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/NetworkStore.swift
@@ -93,23 +93,23 @@ public class NetworkStore: ObservableObject {
   /// Updates the `selectedChainId` and `isSwapSupported` for the network for the current `origin`.
   @MainActor private func updateSelectedChain() async {
     // fetch current selected network
-      let selectedCoin = await walletService.selectedCoin()
-      let chain = await rpcService.network(selectedCoin, origin: nil)
-      // since we are fetch network from JsonRpcService,
-      // we don't need to call `setNetwork` on JsonRpcService
-      self.defaultSelectedChainId = chain.chainId
-      let chainForOrigin = await rpcService.network(selectedCoin, origin: origin)
-      self.selectedChainIdForOrigin = chainForOrigin.chainId
-      // update `isSwapSupported` for Buy/Send/Swap panel
-      self.isSwapSupported = await swapService.isSwapSupported(chain.chainId)
+    let selectedCoin = await walletService.selectedCoin()
+    let chain = await rpcService.network(selectedCoin, origin: nil)
+    // since we are fetch network from JsonRpcService,
+    // we don't need to call `setNetwork` on JsonRpcService
+    self.defaultSelectedChainId = chain.chainId
+    let chainForOrigin = await rpcService.network(selectedCoin, origin: origin)
+    self.selectedChainIdForOrigin = chainForOrigin.chainId
+    // update `isSwapSupported` for Buy/Send/Swap panel
+    self.isSwapSupported = await swapService.isSwapSupported(chain.chainId)
   }
 
   @MainActor private func updateChainList() async {
     // fetch all networks for all coin types
-      self.allChains = await rpcService.allNetworksForSupportedCoins()
-      
-      let customChainIds = await rpcService.customNetworks(.eth) // only support Ethereum custom chains
-      self.customChains = allChains.filter { customChainIds.contains($0.id) }
+    self.allChains = await rpcService.allNetworksForSupportedCoins()
+    
+    let customChainIds = await rpcService.customNetworks(.eth) // only support Ethereum custom chains
+    self.customChains = allChains.filter { customChainIds.contains($0.id) }
   }
   
   func isCustomChain(_ network: BraveWallet.NetworkInfo) -> Bool {
@@ -288,7 +288,7 @@ extension NetworkStore: BraveWalletJsonRpcServiceObserver {
       // since JsonRpcService notify us of change,
       // we don't need to call `setNetwork` on JsonRpcService
       if let origin {
-        if origin == origin {
+        if origin == self.origin {
           selectedChainIdForOrigin = chainId
         }
       } else {

--- a/Sources/BraveWallet/Crypto/Stores/WalletStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/WalletStore.swift
@@ -86,11 +86,17 @@ public class WalletStore {
             ipfsApi: ipfsApi,
             origin: self.origin
           )
-          self.onPendingRequestCancellable = self.cryptoStore?.$pendingRequest
-            .removeDuplicates()
-            .sink { [weak self] _ in
-              self?.onPendingRequestUpdated.send()
+          if let cryptoStore = self.cryptoStore {
+            Task {
+              // if called in `CryptoStore.init` we may crash
+              await cryptoStore.networkStore.setup()
             }
+            self.onPendingRequestCancellable = cryptoStore.$pendingRequest
+              .removeDuplicates()
+              .sink { [weak self] _ in
+                self?.onPendingRequestUpdated.send()
+              }
+          }
         }
       }
   }

--- a/Sources/BraveWallet/Crypto/Stores/WalletStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/WalletStore.swift
@@ -12,6 +12,7 @@ public class WalletStore {
 
   public let keyringStore: KeyringStore
   public var cryptoStore: CryptoStore?
+  /// The origin of the active tab (if applicable). Used for fetching/selecting network for the DApp origin.
   public var origin: URLOrigin? {
     didSet {
       cryptoStore?.origin = origin

--- a/Sources/BraveWallet/Crypto/Stores/WalletStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/WalletStore.swift
@@ -12,6 +12,12 @@ public class WalletStore {
 
   public let keyringStore: KeyringStore
   public var cryptoStore: CryptoStore?
+  public var origin: URLOrigin? {
+    didSet {
+      cryptoStore?.origin = origin
+      keyringStore.origin = origin
+    }
+  }
   
   public let onPendingRequestUpdated = PassthroughSubject<Void, Never>()
 
@@ -77,7 +83,8 @@ public class WalletStore {
             txService: txService,
             ethTxManagerProxy: ethTxManagerProxy,
             solTxManagerProxy: solTxManagerProxy,
-            ipfsApi: ipfsApi
+            ipfsApi: ipfsApi,
+            origin: self.origin
           )
           self.onPendingRequestCancellable = self.cryptoStore?.$pendingRequest
             .removeDuplicates()

--- a/Sources/BraveWallet/Crypto/Transaction Confirmations/EditPermissionsView.swift
+++ b/Sources/BraveWallet/Crypto/Transaction Confirmations/EditPermissionsView.swift
@@ -33,7 +33,7 @@ struct EditPermissionsView: View {
     
     var decimals: Int = 18
     if case .ethErc20Approve(let details) = confirmationStore.activeParsedTransaction.details {
-      decimals = Int(details.token?.decimals ?? networkStore.selectedChain.decimals)
+      decimals = Int(details.token?.decimals ?? networkStore.defaultSelectedChain.decimals)
     }
     let weiFormatter = WeiFormatter(decimalFormatStyle: .decimals(precision: decimals))
     let customAllowanceInWei = weiFormatter.weiString(from: customAllowance, radix: .hex, decimals: decimals) ?? "0"

--- a/Sources/BraveWallet/Panels/Add Suggested Token/AddSuggestedTokenView.swift
+++ b/Sources/BraveWallet/Panels/Add Suggested Token/AddSuggestedTokenView.swift
@@ -31,7 +31,7 @@ struct AddSuggestedTokenView: View {
         .padding(.top)
         VStack {
           VStack {
-            AssetIconView(token: token, network: cryptoStore.networkStore.selectedChain, length: 64)
+            AssetIconView(token: token, network: cryptoStore.networkStore.defaultSelectedChain, length: 64)
             Text(token.symbol)
               .font(.headline)
               .foregroundColor(Color(.bravePrimary))

--- a/Sources/BraveWallet/Panels/Add Suggested Token/AddSuggestedTokenView.swift
+++ b/Sources/BraveWallet/Panels/Add Suggested Token/AddSuggestedTokenView.swift
@@ -17,6 +17,10 @@ struct AddSuggestedTokenView: View {
   @Environment(\.sizeCategory) private var sizeCategory
   @Environment(\.openURL) private var openWalletURL
   
+  private var tokenNetwork: BraveWallet.NetworkInfo? {
+    cryptoStore.networkStore.allChains.first(where: { $0.chainId == token.chainId })
+  }
+  
   var body: some View {
     ScrollView(.vertical) {
       VStack(spacing: 22) {
@@ -31,14 +35,18 @@ struct AddSuggestedTokenView: View {
         .padding(.top)
         VStack {
           VStack {
-            AssetIconView(token: token, network: cryptoStore.networkStore.defaultSelectedChain, length: 64)
+            AssetIconView(
+              token: token,
+              network: tokenNetwork ?? cryptoStore.networkStore.defaultSelectedChain,
+              length: 64
+            )
             Text(token.symbol)
               .font(.headline)
               .foregroundColor(Color(.bravePrimary))
           }
           .accessibilityElement(children: .combine)
           Button(action: {
-            if let tokenNetwork = cryptoStore.networkStore.allChains.first(where: { $0.chainId == token.chainId }),
+            if let tokenNetwork = tokenNetwork,
                let baseURL = tokenNetwork.blockExplorerUrls.first.map(URL.init(string:)),
                let url = baseURL?.appendingPathComponent("token/\(token.contractAddress)") {
               openWalletURL(url)

--- a/Sources/BraveWallet/Panels/Encryption/EncryptionView.swift
+++ b/Sources/BraveWallet/Panels/Encryption/EncryptionView.swift
@@ -69,7 +69,7 @@ struct EncryptionView: View {
   var body: some View {
     ScrollView(.vertical) {
       HStack(alignment: .top) {
-        Text(networkStore.selectedChain.chainName)
+        Text(networkStore.defaultSelectedChain.chainName)
         Spacer()
       }
       .font(.callout)

--- a/Sources/BraveWallet/Panels/WalletPanelView.swift
+++ b/Sources/BraveWallet/Panels/WalletPanelView.swift
@@ -298,6 +298,7 @@ struct WalletPanelView: View {
   private var networkPickerButton: some View {
     NetworkPicker(
       style: .init(textColor: .white, borderColor: .white),
+      isForOrigin: true,
       keyringStore: keyringStore,
       networkStore: networkStore
     )
@@ -452,10 +453,10 @@ struct WalletPanelView: View {
           }
           VStack(spacing: 4) {
             let nativeAsset = accountActivityStore.userVisibleAssets.first(where: {
-              $0.token.symbol == networkStore.selectedChain.symbol
-              && $0.token.chainId == networkStore.selectedChainId
+              $0.token.symbol == networkStore.selectedChainForOrigin.symbol
+              && $0.token.chainId == networkStore.selectedChainIdForOrigin
             })
-            Text(String(format: "%.04f %@", nativeAsset?.decimalBalance ?? 0.0, networkStore.selectedChain.symbol))
+            Text(String(format: "%.04f %@", nativeAsset?.decimalBalance ?? 0.0, networkStore.selectedChainForOrigin.symbol))
               .font(.title2.weight(.bold))
             Text(currencyFormatter.string(from: NSNumber(value: (Double(nativeAsset?.price ?? "") ?? 0) * (nativeAsset?.decimalBalance ?? 0.0))) ?? "")
               .font(.callout)

--- a/Tests/BraveWalletTests/NetworkSelectionStoreTests.swift
+++ b/Tests/BraveWalletTests/NetworkSelectionStoreTests.swift
@@ -153,6 +153,31 @@ import Preferences
     XCTAssertTrue(success, "Expected success for selecting Goerli because we have ethereum accounts.")
   }
   
+  /// Test `setSelectedChain` will call `setNetwork` with the `Mode.select(isForOrigin: true)`.
+  func testSetSelectedNetworkPanel() async {
+    let origin: URLOrigin = .init(url: URL(string: "https://brave.com")!)
+    let (keyringService, rpcService, walletService, swapService) = setupServices()
+    rpcService._setNetwork = { chainId, coin, origin, completion in
+      XCTAssertEqual(origin, origin)
+      completion(true)
+    }
+    
+    let networkStore = NetworkStore(
+      keyringService: keyringService,
+      rpcService: rpcService,
+      walletService: walletService,
+      swapService: swapService,
+      origin: origin
+    )
+    
+    let store = NetworkSelectionStore(
+      mode: .select(isForOrigin: true),
+      networkStore: networkStore
+    )
+    let success = await store.selectNetwork(.network(.mockGoerli))
+    XCTAssertTrue(success, "Expected success for selecting Goerli because we have ethereum accounts.")
+  }
+  
   func testSetSelectedNetworkNoAccounts() async {
     let (keyringService, rpcService, walletService, swapService) = setupServices()
     

--- a/Tests/BraveWalletTests/NetworkSelectionStoreTests.swift
+++ b/Tests/BraveWalletTests/NetworkSelectionStoreTests.swift
@@ -60,7 +60,7 @@ import Preferences
     return (keyringService, rpcService, walletService, swapService)
   }
   
-  func testUpdateSelectMode() {
+  func testUpdateSelectMode() async {
     Preferences.Wallet.showTestNetworks.value = false
 
     let (keyringService, rpcService, walletService, swapService) = setupServices()
@@ -71,16 +71,7 @@ import Preferences
       walletService: walletService,
       swapService: swapService
     )
-    
-    // wait for all chains to populate in `NetworkStore`
-    let allChainsException = expectation(description: "networkStore-allChains")
-    networkStore.$allChains
-      .dropFirst()
-      .sink { allChains in
-        allChainsException.fulfill()
-      }
-      .store(in: &cancellables)
-    wait(for: [allChainsException], timeout: 1)
+    await networkStore.setup()
     
     let store = NetworkSelectionStore(networkStore: networkStore)
     XCTAssertTrue(store.primaryNetworks.isEmpty, "Test setup failed, expected empty primary networks")
@@ -99,7 +90,7 @@ import Preferences
     XCTAssertEqual(store.secondaryNetworks, expectedSecondaryNetworks, "Unexpected secondary networks set")
   }
   
-  func testUpdateTestNetworksEnabledSelectMode() {
+  func testUpdateTestNetworksEnabledSelectMode() async {
     Preferences.Wallet.showTestNetworks.value = true
     
     let (keyringService, rpcService, walletService, swapService) = setupServices()
@@ -110,16 +101,7 @@ import Preferences
       walletService: walletService,
       swapService: swapService
     )
-    
-    // wait for all chains to populate in `NetworkStore`
-    let allChainsException = expectation(description: "networkStore-allChains")
-    networkStore.$allChains
-      .dropFirst()
-      .sink { allChains in
-        allChainsException.fulfill()
-      }
-      .store(in: &cancellables)
-    wait(for: [allChainsException], timeout: 1)
+    await networkStore.setup()
     
     let store = NetworkSelectionStore(networkStore: networkStore)
     XCTAssertTrue(store.primaryNetworks.isEmpty, "Test setup failed, expected empty primary networks")
@@ -147,6 +129,7 @@ import Preferences
       walletService: walletService,
       swapService: swapService
     )
+    await networkStore.setup()
     
     let store = NetworkSelectionStore(networkStore: networkStore)
     let success = await store.selectNetwork(.network(.mockGoerli))
@@ -169,6 +152,7 @@ import Preferences
       swapService: swapService,
       origin: origin
     )
+    await networkStore.setup()
     
     let store = NetworkSelectionStore(
       mode: .select(isForOrigin: true),
@@ -187,6 +171,7 @@ import Preferences
       walletService: walletService,
       swapService: swapService
     )
+    await networkStore.setup()
     
     let store = NetworkSelectionStore(networkStore: networkStore)
     let success = await store.selectNetwork(.network(.mockSolana))
@@ -203,6 +188,7 @@ import Preferences
       walletService: walletService,
       swapService: swapService
     )
+    await networkStore.setup()
     
     let store = NetworkSelectionStore(mode: .formSelection, networkStore: networkStore)
     let success = await store.selectNetwork(.network(.mockGoerli))
@@ -210,7 +196,7 @@ import Preferences
     XCTAssertEqual(store.networkSelectionInForm, .mockGoerli)
   }
   
-  func testAlertResponseCreateAccount() {
+  func testAlertResponseCreateAccount() async {
     let (keyringService, rpcService, walletService, swapService) = setupServices()
     
     let networkStore = NetworkStore(
@@ -219,6 +205,7 @@ import Preferences
       walletService: walletService,
       swapService: swapService
     )
+    await networkStore.setup()
     
     let store = NetworkSelectionStore(networkStore: networkStore)
     
@@ -228,7 +215,7 @@ import Preferences
     XCTAssertTrue(store.isPresentingAddAccount, "Expected to set isPresentingAddAccount to true to present add network")
   }
   
-  func testAlertResponseDontCreateAccount() {
+  func testAlertResponseDontCreateAccount() async {
     let (keyringService, rpcService, walletService, swapService) = setupServices()
     
     let networkStore = NetworkStore(
@@ -237,6 +224,7 @@ import Preferences
       walletService: walletService,
       swapService: swapService
     )
+    await networkStore.setup()
     
     let store = NetworkSelectionStore(networkStore: networkStore)
     store.isPresentingNextNetworkAlert = true
@@ -256,6 +244,7 @@ import Preferences
       walletService: walletService,
       swapService: swapService
     )
+    await networkStore.setup()
     
     let store = NetworkSelectionStore(networkStore: networkStore)
     
@@ -301,6 +290,7 @@ import Preferences
       walletService: walletService,
       swapService: swapService
     )
+    await networkStore.setup()
     
     let store = NetworkSelectionStore(networkStore: networkStore)
     

--- a/Tests/BraveWalletTests/NetworkStoreTests.swift
+++ b/Tests/BraveWalletTests/NetworkStoreTests.swift
@@ -68,7 +68,7 @@ class NetworkStoreTests: XCTestCase {
       swapService: swapService
     )
     
-    let error = await store.setSelectedChain(.mockGoerli)
+    let error = await store.setSelectedChain(.mockGoerli, isForOrigin: false)
     XCTAssertNil(error, "Expected success, accounts exist for ethereum")
   }
   
@@ -82,7 +82,7 @@ class NetworkStoreTests: XCTestCase {
       swapService: swapService
     )
     
-    let error = await store.setSelectedChain(.mockMainnet)
+    let error = await store.setSelectedChain(.mockMainnet, isForOrigin: false)
     XCTAssertEqual(error, .chainAlreadySelected, "Expected chain already selected error")
   }
   
@@ -103,7 +103,7 @@ class NetworkStoreTests: XCTestCase {
       origin: origin
     )
     
-    let error = await store.setSelectedChain(.mockGoerli)
+    let error = await store.setSelectedChain(.mockGoerli, isForOrigin: true)
     XCTAssertNil(error, "Expected success")
   }
   
@@ -117,7 +117,7 @@ class NetworkStoreTests: XCTestCase {
       swapService: swapService
     )
     
-    let error = await store.setSelectedChain(.mockSolana)
+    let error = await store.setSelectedChain(.mockSolana, isForOrigin: false)
     XCTAssertEqual(error, .selectedChainHasNoAccounts, "Expected chain has no accounts error")
   }
   

--- a/Tests/BraveWalletTests/NetworkStoreTests.swift
+++ b/Tests/BraveWalletTests/NetworkStoreTests.swift
@@ -86,6 +86,27 @@ class NetworkStoreTests: XCTestCase {
     XCTAssertEqual(error, .chainAlreadySelected, "Expected chain already selected error")
   }
   
+  /// Test `setSelectedChain` will call `setNetwork` with the store's `origin: URLOrigin?` value.
+  func testSetSelectedNetworkWithOrigin() async {
+    let origin: URLOrigin = .init(url: URL(string: "https://brave.com")!)
+    let (keyringService, rpcService, walletService, swapService) = setupServices()
+    rpcService._setNetwork = { chainId, coin, origin, completion in
+      XCTAssertEqual(origin, origin)
+      completion(true)
+    }
+    
+    let store = NetworkStore(
+      keyringService: keyringService,
+      rpcService: rpcService,
+      walletService: walletService,
+      swapService: swapService,
+      origin: origin
+    )
+    
+    let error = await store.setSelectedChain(.mockGoerli)
+    XCTAssertNil(error, "Expected success")
+  }
+  
   func testSetSelectedNetworkNoAccounts() async {
     let (keyringService, rpcService, walletService, swapService) = setupServices()
     


### PR DESCRIPTION
## Summary of Changes
- Implements selected network per origin on iOS. 
    - This enables having a different network selected for each origin (each DApp can have a different network!).
    - There is still only one selected coin globally. Ex. If a Solana network is selected in one origin/tab, a Solana network will be selected in all origins/tabs (and in native Brave Wallet), however it can be a different Solana network.
- A new `origin: URLOrigin?` property is now stored in `WalletStore`, `CryptoStore`, `NetworkStore` and `KeyringStore`.
   - This is used to determine the current origin of the Tab it applies to (when applicable). This value will be `nil` when the native Brave Wallet is opened from the `...` menu. 
   - This value will be populated for the Wallet panel, and when opening the wallet from the Wallet panel.
- `NetworkStore` has been updated:
    - The `selectedChain` / `selectedChainId` has been renamed to `defaultSelectedChain` / `defaultSelectedChainId`. This is the default selected network, and the network that will be 'selected' in native Brave Wallet buy/send/swap.
   - In `NetworkStore` a new `selectedChainForOrigin` / `selectedChainIdForOrigin` has been added. This will contain the currently selected network for the `origin: URLOrigin?` value. If the `origin` is nil, this will be identical to the `defaultSelectedChain`. This property is used to display the selected network in the Wallet panel.
   - 2 different properties are used because we preserve `WalletStore` when opening the Wallet from the panel to avoid re-initializing all of our data. As such, we need 2 different networks (one for the DApp origin / panel, and one for native Brave Wallet buy/send/swap)
   - NetworkStore initialization has the fetching chain list logic moved to a `setup()` function for improved testability. `NetworkStore.setup()` is called when it is initialized in `CryptoStore`, but this enables us to control `NetworkStore` better in unit tests. See https://github.com/brave/brave-ios/commit/068df7b3a0bda459296a658f2ad51ec9b9d195ac for details.

This pull request fixes #7225

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
### Test different selected network for different dapps
1. Setup a fresh wallet and open Buy/Send/Swap.
2. The selected network will be the default selected network.
    - It should default to Solana Mainnet selected for Solana coin / account type.
3. Tap the **account picker** and change from Solana to Ethereum account.
4. The selected network should switch to the default Ethereum network.
    - It should default to Ethereum Mainnet for Ethereum coin / account type.
5. In the browser, navigate to [app.uniswap.org](https://app.uniswap.org/) and open wallet panel, we should see network for Ethereum account is default network from buy/send/swap.
6. Change the network to "Optimism" and close/reopen the panel, it should still be "Optimism".
7. Navigate to [metamask.github.io/test-dapp/](https://metamask.github.io/test-dapp/), and open wallet panel. We should see the default EVM network from buy/send/swap (not "Optimism").
8.  Change the network to "Goerli" and close/reopen the panel, it should still be "Goerli"
9. Navigate to [app.uniswap.org](https://app.uniswap.org/) and check network should be "Optimism"
10. Navigate to [metamask.github.io/test-dapp/](https://metamask.github.io/test-dapp/) and check network should be "Polygon"
11. Navigate to other sites and network should be default network.
12. Open native Brave Wallet and open Buy/Send/Swap. Network should still be the last network selected in Buy/Send/Swap (note: coin type is preserved, it will be either the last Ethereum/EVM network, or last Solana network).

### Different networks for different transactions
1. In one tab, navigate to [metamask.github.io/test-dapp/](https://metamask.github.io/test-dapp/, open the Wallet panel and select network to be Goerli.
4. In another tab, navigate to [app.uniswap.org](https://app.uniswap.org/), open the Wallet panel and select Ethereum Mainnet.
5. Connect to both DApp.
6. Create transactions from both sites.
7. We can see two transaction requests with different networks in panel (presented when panel opens, or via the bell icon).

### Selected network should not affect Transaction
1. Navigate to https://metamask.github.io/test-dapp/ and select network to be Goerli
8. Connect and approve and send a legacy transaction
9. We should see the network display is Goerli, dismiss the panel
10. Open buy/send/swap and select any network except Goerli
14. Close buy/send/swap and tap the pending transaction button
15. The unapproved transaction should still shows Goerli

### Send Transaction
1. Follow steps of `Selected network should not affect Transaction`
2. And then approve transaction
3. It should show up on Wallet activity as submitted.
4. Wait for a while it should be confirmed.

### Add and switch chain
1. Navigate to https://chainlist.org/ and connect
2. Add any chain that is not in wallet yet.
3. Approve the switch request.
4.  Open panel and check network.
5. Navigate to other domains, they should not be switched.
16. Navigate to wallet page, it should still be default network.


## Screenshots:

Github made me cut the video in half due to file size, sorry.

https://github.com/brave/brave-ios/assets/5314553/3685ad49-d69f-4dcd-97a4-0d683ba06d46


https://github.com/brave/brave-ios/assets/5314553/0d077a0a-d4f0-4212-ae0b-ac8ecbd42370


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).