### PR TITLE
Fix #7479: Use top page color sampling for status bar overlay view color

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+TabManagerDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+TabManagerDelegate.swift
@@ -99,6 +99,7 @@ extension BrowserViewController: TabManagerDelegate {
     }
 
     updateToolbarUsingTabManager(tabManager)
+    updateStatusBarOverlayColor()
 
     removeAllBars()
     if let bars = selected?.bars {

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -610,7 +610,7 @@ extension BrowserViewController: WKNavigationDelegate {
       // Server Trust and URL is also updated in didCommit
       // However, WebKit does NOT trigger the `serverTrust` observer when the URL changes, but the trust has not.
       // So manually trigger it with the current trust.
-      self.observeValue(forKeyPath: KVOConstants.serverTrust.rawValue,
+      self.observeValue(forKeyPath: KVOConstants.serverTrust.keyPath,
                         of: webView,
                         change: [.newKey: webView.serverTrust, .kindKey: 1],
                         context: nil)

--- a/Sources/Brave/Frontend/Browser/Playlist/Managers & Cache/PlaylistCacheLoader.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/Managers & Cache/PlaylistCacheLoader.swift
@@ -353,7 +353,7 @@ class PlaylistWebLoader: UIView {
       ]
 
       browserViewController.tab(tab, didCreateWebView: webView)
-      KVOs.forEach { webView.removeObserver(browserViewController, forKeyPath: $0.rawValue) }
+      KVOs.forEach { webView.removeObserver(browserViewController, forKeyPath: $0.keyPath) }
 
       // When creating a tab, TabManager automatically adds a uiDelegate
       // This webView is invisible and we don't want any UI being handled.

--- a/Sources/Brave/Frontend/Browser/Tab.swift
+++ b/Sources/Brave/Frontend/Browser/Tab.swift
@@ -311,6 +311,7 @@ class Tab: NSObject {
       // Enables Zoom in website by ignoring their javascript based viewport Scale limits.
       configuration!.ignoresViewportScaleLimits = true
       configuration!.upgradeKnownHostsToHTTPS = Preferences.Shields.httpsEverywhere.value
+      configuration!.enablePageTopColorSampling()
 
       if configuration!.urlSchemeHandler(forURLScheme: InternalURL.scheme) == nil {
         configuration!.setURLSchemeHandler(InternalSchemeHandler(), forURLScheme: InternalURL.scheme)
@@ -330,7 +331,7 @@ class Tab: NSObject {
       restore(webView, restorationData: self.sessionData)
 
       self.webView = webView
-      self.webView?.addObserver(self, forKeyPath: KVOConstants.URL.rawValue, options: .new, context: nil)
+      self.webView?.addObserver(self, forKeyPath: KVOConstants.URL.keyPath, options: .new, context: nil)
       
       tabDelegate?.tab(self, didCreateWebView: webView)
       
@@ -414,7 +415,7 @@ class Tab: NSObject {
     contentScriptManager.uninstall(from: self)
 
     if let webView = webView {
-      webView.removeObserver(self, forKeyPath: KVOConstants.URL.rawValue)
+      webView.removeObserver(self, forKeyPath: KVOConstants.URL.keyPath)
       tabDelegate?.tab(self, willDeleteWebView: webView)
     }
     webView = nil
@@ -744,7 +745,7 @@ class Tab: NSObject {
 
   override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {
     guard let webView = object as? BraveWebView, webView == self.webView,
-      let path = keyPath, path == KVOConstants.URL.rawValue
+      let path = keyPath, path == KVOConstants.URL.keyPath
     else {
       return assertionFailure("Unhandled KVO key: \(keyPath ?? "nil")")
     }

--- a/Sources/Shared/AppConstants.swift
+++ b/Sources/Shared/AppConstants.swift
@@ -39,15 +39,22 @@ public enum AppBuildChannel: String {
   }
 }
 
-public enum KVOConstants: String {
-  case loading = "loading"
-  case estimatedProgress = "estimatedProgress"
-  case URL = "URL"
-  case title = "title"
-  case canGoBack = "canGoBack"
-  case canGoForward = "canGoForward"
-  case hasOnlySecureContent = "hasOnlySecureContent"
-  case serverTrust = "serverTrust"
+public struct KVOConstants: Equatable {
+  public var keyPath: String
+  
+  public init(keyPath: String) {
+    self.keyPath = keyPath
+  }
+  
+  public static let loading: Self = .init(keyPath: "loading")
+  public static let estimatedProgress: Self = .init(keyPath: "estimatedProgress")
+  public static let URL: Self = .init(keyPath: "URL")
+  public static let title: Self = .init(keyPath: "title")
+  public static let canGoBack: Self = .init(keyPath: "canGoBack")
+  public static let canGoForward: Self = .init(keyPath: "canGoForward")
+  public static let hasOnlySecureContent: Self = .init(keyPath: "hasOnlySecureContent")
+  public static let serverTrust: Self = .init(keyPath: "serverTrust")
+  public static let _sampledPageTopColor: Self = .init(keyPath: "_sampl\("edPageTopC")olor")
 }
 
 public struct AppConstants {

--- a/Sources/Shared/Extensions/WKWebViewExtensions.swift
+++ b/Sources/Shared/Extensions/WKWebViewExtensions.swift
@@ -89,4 +89,21 @@ public extension WKWebView {
       }
     }
   }
+  
+  var sampledPageTopColor: UIColor? {
+    let selector = Selector("_sampl\("edPageTopC")olor")
+    if responds(to: selector), let result = perform(selector) {
+      return result.takeUnretainedValue() as? UIColor
+    }
+    return nil
+  }
+}
+
+extension WKWebViewConfiguration {
+  public func enablePageTopColorSampling() {
+    let selector = Selector("_setSa\("mpledPageTopColorMaxDiff")erence:")
+    if responds(to: selector) {
+      perform(selector, with: 5.0 as Double)
+    }
+  }
 }


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #7479 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

- Verify visiting certain pages update the status bar background color to match headers (Note: YouTube's header is technically white, not black which is what you'd expect)
- Verify going back to NTP goes back to toolbar color
- Verify switching between tabs switches the colors accordingly 
- Verify that when the top bar changes to a dark color that the status bar (time/wifi/etc.) shows white text (and that going to other places like tab switcher reverts back)
- Verify that none of the above happens when not using bottom bar

## Screenshots:

| GitHub | 9to5Mac | TheVerge |
| --- | --- | --- |
| ![Simulator Screenshot - iPhone 14 Pro - 2023-05-17 at 17 11 16](https://github.com/brave/brave-ios/assets/529104/3ac5e21b-8436-42c7-98d7-baba9f8cd36f) |  ![Simulator Screenshot - iPhone 14 Pro - 2023-05-17 at 17 13 14](https://github.com/brave/brave-ios/assets/529104/12b11e5b-038f-4016-bf8e-2947998bb361) | ![Simulator Screenshot - iPhone 14 Pro - 2023-05-17 at 17 10 55](https://github.com/brave/brave-ios/assets/529104/5d722bca-0609-44e5-bd26-713830ca7ad4) |

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
