### PR TITLE
Fix #7481: Login List View Background Color Issue

### DIFF
--- a/Sources/Brave/Frontend/Login/LoginListViewController.swift
+++ b/Sources/Brave/Frontend/Login/LoginListViewController.swift
@@ -192,7 +192,8 @@ extension LoginListViewController {
         $0.detailTextLabel?.font = .preferredFont(forTextStyle: .subheadline)
         $0.setLines(loginInfo.displayURLString, detailText: loginInfo.usernameValue)
         $0.selectionStyle = .none
-         $0.accessoryType = .disclosureIndicator
+        $0.accessoryType = .disclosureIndicator
+        $0.backgroundColor = .braveBackground
       }
 
       cell.imageIconView.do {
@@ -431,8 +432,6 @@ private class LoginListTableViewCell: UITableViewCell, TableViewReusable {
   
   override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
     super.init(style: style, reuseIdentifier: reuseIdentifier)
-
-    contentView.backgroundColor = UIColor { $0.userInterfaceStyle == .dark ? .black : .white }
     
     contentView.addSubview(imageIconView)
     contentView.addSubview(labelStackView)


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
Fixing Login List cell background color

This pull request fixes #7481

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
- Add a login item to saved
- Check login & passwords view

## Screenshots:

![1 1 1 2](https://github.com/brave/brave-ios/assets/6643505/74116bc5-0aac-4f88-86ac-bb836c3c9394)


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
