### PR TITLE
Fix #7463: Accounts changed event not emitting correctly

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController.swift
@@ -419,22 +419,7 @@ public class BrowserViewController: UIViewController {
     updateApplicationShortcuts()
     tabManager.addDelegate(self)
     tabManager.addNavigationDelegate(self)
-    if let ethJS = braveCore.braveWalletAPI.providerScripts(for: .eth)[.ethereum] {
-      let providerJS = """
-      window.__firefox__.execute(function($, $Object) {
-        if (window.isSecureContext) {
-          \(ethJS)
-        }
-      });
-      """
-      UserScriptManager.shared.walletEthProviderScript = WKUserScript(
-        source: providerJS,
-        injectionTime: .atDocumentStart,
-        forMainFrameOnly: true,
-        in: EthereumProviderScriptHandler.scriptSandbox
-      )
-    }
-    UserScriptManager.shared.walletSolProviderScripts = braveCore.braveWalletAPI.providerScripts(for: .sol)
+    UserScriptManager.shared.fetchWalletScripts(from: braveCore.braveWalletAPI)
     downloadQueue.delegate = self
 
     // Observe some user preferences

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
@@ -435,11 +435,6 @@ extension Tab: BraveWalletEventsListener {
   func accountsChangedEvent(_ accounts: [String]) {
     guard !isPrivate else { return }
     
-    // Temporary fix for #5402.
-    // If we emit from one account directly to another we're not seeing dapp sites
-    // update our selected account. If we emit an undefined/empty string before
-    // emitting the new account, we're seeing correct account change behaviour
-    emitEthereumEvent(.ethereumAccountsChanged(accounts: []))
     emitEthereumEvent(.ethereumAccountsChanged(accounts: accounts))
     
     Task {

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
@@ -271,15 +271,15 @@ extension Tab: BraveWalletProviderDelegate {
     }
   }
   
-  /// Returns the selected account if present in `accounts`, otherwise returns `accounts`
-  private func filterAccounts(
-    _ accounts: [String],
+  /// Returns the selected account if present in `allowedAccounts`, otherwise returns `allowedAccounts`
+  private func filterAllowedAccounts(
+    _ allowedAccounts: [String],
     selectedAccount: String?
   ) -> [String] {
-    if let selectedAccount = selectedAccount, accounts.contains(selectedAccount) {
+    if let selectedAccount = selectedAccount, allowedAccounts.contains(selectedAccount) {
       return [selectedAccount]
     }
-    return accounts
+    return allowedAccounts
   }
 
   /// Helper to fetch the allowed accounts for the current coin. Unlike `allowedAccounts(_:accounts:)`
@@ -296,7 +296,7 @@ extension Tab: BraveWalletProviderDelegate {
       return (false, [])
     }
     let selectedAccounts = await keyringService.selectedAccount(coin)
-    return (true, filterAccounts(allowedAccounts, selectedAccount: selectedAccounts))
+    return (true, filterAllowedAccounts(allowedAccounts, selectedAccount: selectedAccounts))
   }
   
   /// Fetches all allowed accounts for the current origin.
@@ -498,7 +498,7 @@ extension Tab: BraveWalletEventsListener {
       if success {
         // Assign the selected account if it's permitted / allowed
         let selectedAccountForCoin = await keyringService.selectedAccount(coin)
-        let filteredAllowedAccounts = filterAccounts(allowedAccounts, selectedAccount: selectedAccountForCoin)
+        let filteredAllowedAccounts = filterAllowedAccounts(allowedAccounts, selectedAccount: selectedAccountForCoin)
         selectedAccount = valueOrUndefined(filteredAllowedAccounts.first)
       } else {
         selectedAccount = valueOrUndefined(Optional<String>.none)

--- a/Sources/Brave/Frontend/Browser/Tab.swift
+++ b/Sources/Brave/Frontend/Browser/Tab.swift
@@ -86,9 +86,7 @@ class Tab: NSObject {
   var sslPinningError: Error?
 
   var walletEthProvider: BraveWalletEthereumProvider?
-  var walletEthProviderScript: WKUserScript?
   var walletSolProvider: BraveWalletSolanaProvider?
-  var walletSolProviderScripts: [BraveWalletProviderScriptKey: String] = [:]
   var tabDappStore: TabDappStore = .init()
   var isWalletIconVisible: Bool = false {
     didSet {
@@ -1070,8 +1068,6 @@ extension Tab {
   private func updateInjectedScripts() {
     UserScriptManager.shared.loadCustomScripts(into: self,
                                                userScripts: userScripts,
-                                               customScripts: customUserScripts,
-                                               walletEthProviderScript: walletEthProviderScript,
-                                               walletSolProviderScripts: walletSolProviderScripts)
+                                               customScripts: customUserScripts)
   }
 }

--- a/Sources/Brave/Frontend/Browser/TabManager.swift
+++ b/Sources/Brave/Frontend/Browser/TabManager.swift
@@ -87,8 +87,8 @@ class TabManager: NSObject {
   var tempTabs: [Tab]?
   private weak var rewards: BraveRewards?
   private weak var tabGeneratorAPI: BraveTabGeneratorAPI?
-  var makeWalletEthProvider: ((Tab) -> (BraveWalletEthereumProvider, js: String)?)?
-  var makeWalletSolProvider: ((Tab) -> (BraveWalletSolanaProvider, jsScripts: [BraveWalletProviderScriptKey: String])?)?
+//  var makeWalletEthJS: (() -> String?)?
+//  var makeWalletSolJSScripts: (() -> [BraveWalletProviderScriptKey: String]?)?
   private var domainFrc = Domain.frc()
   private let syncedTabsQueue = DispatchQueue(label: "synced-tabs-queue")
   private var syncTabsTask: DispatchWorkItem?
@@ -500,29 +500,6 @@ class TabManager: NSObject {
       SessionTab.createIfNeeded(tabId: tab.id,
                                 title: Strings.newTab,
                                 tabURL: request?.url ?? TabManager.ntpInteralURL)
-      
-      if let (provider, js) = makeWalletEthProvider?(tab) {
-        let providerJS = """
-        window.__firefox__.execute(function($, $Object) {
-          if (window.isSecureContext) {
-            \(js)
-          }
-        });
-        """
-        
-        tab.walletEthProvider = provider
-        tab.walletEthProvider?.`init`(tab)
-        tab.walletEthProviderScript = WKUserScript(source: providerJS,
-                                                   injectionTime: .atDocumentStart,
-                                                   forMainFrameOnly: true,
-                                                   in: EthereumProviderScriptHandler.scriptSandbox)
-      }
-      
-      if let (provider, jsScripts) = makeWalletSolProvider?(tab) {
-        tab.walletSolProvider = provider
-        tab.walletSolProvider?.`init`(tab)
-        tab.walletSolProviderScripts = jsScripts
-      }
     }
     
     delegates.forEach { $0.get()?.tabManager(self, willAddTab: tab) }

--- a/Sources/Brave/Frontend/Browser/TabManager.swift
+++ b/Sources/Brave/Frontend/Browser/TabManager.swift
@@ -87,8 +87,6 @@ class TabManager: NSObject {
   var tempTabs: [Tab]?
   private weak var rewards: BraveRewards?
   private weak var tabGeneratorAPI: BraveTabGeneratorAPI?
-//  var makeWalletEthJS: (() -> String?)?
-//  var makeWalletSolJSScripts: (() -> [BraveWalletProviderScriptKey: String]?)?
   private var domainFrc = Domain.frc()
   private let syncedTabsQueue = DispatchQueue(label: "synced-tabs-queue")
   private var syncTabsTask: DispatchWorkItem?

--- a/Sources/Brave/Wallet/WalletProviderConstants.swift
+++ b/Sources/Brave/Wallet/WalletProviderConstants.swift
@@ -27,6 +27,6 @@ extension Web3ProviderEvent {
     .init("chainChanged", arguments: chainId)
   }
   static func ethereumAccountsChanged(accounts: [String]) -> Self {
-    .init("accountsChanged", arguments: accounts.first ?? "")
+    .init("accountsChanged", arguments: [accounts.first].compactMap { $0 })
   }
 }

--- a/Sources/BraveWallet/Extensions/BraveWalletExtensions.swift
+++ b/Sources/BraveWallet/Extensions/BraveWalletExtensions.swift
@@ -93,7 +93,7 @@ extension BraveWallet.OriginInfo {
 }
 
 extension BraveWallet.CoinType {
-  var keyringId: String {
+  public var keyringId: String {
     switch self {
     case .eth:
       return BraveWallet.DefaultKeyringId

--- a/Tests/ClientTests/TabSessionTests.swift
+++ b/Tests/ClientTests/TabSessionTests.swift
@@ -618,7 +618,7 @@ private class WebViewNavigationAdapter: NSObject, WKNavigationDelegate {
     let group = DispatchGroup()
     for tab in self.tabManager.allTabs {
       // include all scripts
-      UserScriptManager.shared.loadCustomScripts(into: tab, userScripts: scripts, customScripts: customScripts, walletEthProviderScript: nil, walletSolProviderScripts: [:])
+      UserScriptManager.shared.loadCustomScripts(into: tab, userScripts: scripts, customScripts: customScripts)
 
       group.enter()
     }


### PR DESCRIPTION
## Summary of Changes
- First bug: The `accountsChanged` event is emitting as a String, but [the provider documentation states](https://docs.metamask.io/wallet/reference/provider-api/#accountschanged) it should be an array.
    - [Desktop/BraveCore implementation](https://github.com/brave/brave-core/blob/master/components/brave_wallet/renderer/js_ethereum_provider.cc#L622-L633) where `event_args` is a `List`.
    - This also removes & resolves the temporary fix implemented for #5402 🎉 .
- Second bug: The first selected account change might not emit under certain conditions. This bug has 2 parts:
    - Our `BraveWalletProviderDelegate` method `func allowedAccounts(_:accounts:) async -> (Bool, [String])` currently checks locked status and filters the selected account. This logic occurs in the BraveCore [Ethereum Provider](https://github.com/brave/brave-core/blob/1.52.x/components/brave_wallet/browser/ethereum_provider_impl.cc#L1463-L1480) implementation, and by duplicating it we cause an issue with the `AccountsChangedEvent` emitting because it may have an inaccurate list of allowed accounts.
    - The Ethereum Provider and Solana Provider both need to be initialized/re-initialized when origin changes to sync with desktop and the expected behaviour of these providers. Currently they are both initialized once when the Tab is created.
        - Desktop/core is initializing these providers in [`BraveContentBrowserClient::RegisterBrowserInterfaceBindersForFrame`](https://github.com/brave/brave-core/blob/1.52.x/browser/brave_content_browser_client.cc#L608). [Chromium Source header for this function](https://source.chromium.org/chromium/chromium/src/+/main:content/public/browser/content_browser_client.h;l=1247-1252?q=RegisterBrowserInterfaceBindersForFrame&ss=chromium)
        - This function is called `When you first navigate to a site or navigate away to others`. 
        - As such, we need to re-initialize these when the origin changes. I've moved initialization into [webView(_:didCommit:)](https://developer.apple.com/documentation/webkit/wknavigationdelegate/1455635-webview) to resolve this.

This pull request fixes #7463

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Setup a Web3 BraveTalk call on a different device than you are testing on.
2. Share the link to the iOS device you are testing this change on.
3. Connect to the BraveTalk call with 2 or more accounts.
4. Open the wallet panel and change your selected account.
5. Verify the account changes as expected and no `0` is displayed for account address.
6. Navigate to another DApp, for example https://app.uniswap.org/
7. Connect to the DApp with 2 or more accounts.
8. If using Uniswap, tap the blockie in the top-right to see the connect account address. 
9. Open the wallet panel and change accounts
10. Verify the account address updates.
    - Note: Uniswap doesn't seem to finish loading the selected account on this side-panel, but the address should update; Reproducible on desktop so seems unrelated to these changes.


## Screenshots:

https://github.com/brave/brave-ios/assets/5314553/9b644d75-0ba7-472a-9f21-dbf030d46674



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
