### PR TITLE
No Bug: MainActor isolation for configureTab, addTab, removeTab, EthereumProvider

### DIFF
--- a/Sources/Brave/Frontend/Browser/TabManager.swift
+++ b/Sources/Brave/Frontend/Browser/TabManager.swift
@@ -387,7 +387,7 @@ class TabManager: NSObject {
     }
   }
 
-  func addPopupForParentTab(_ parentTab: Tab, configuration: WKWebViewConfiguration) -> Tab {
+  @MainActor func addPopupForParentTab(_ parentTab: Tab, configuration: WKWebViewConfiguration) -> Tab {
     let popup = Tab(configuration: configuration, id: UUID(), type: parentTab.type, tabGeneratorAPI: tabGeneratorAPI)
     configureTab(popup, request: nil, afterTab: parentTab, flushToDisk: true, zombie: false, isPopup: true)
 
@@ -402,13 +402,13 @@ class TabManager: NSObject {
   }
 
   @discardableResult
-  func addTabAndSelect(_ request: URLRequest! = nil, afterTab: Tab? = nil, isPrivate: Bool) -> Tab {
+  @MainActor func addTabAndSelect(_ request: URLRequest! = nil, afterTab: Tab? = nil, isPrivate: Bool) -> Tab {
     let tab = addTab(request, afterTab: afterTab, isPrivate: isPrivate)
     selectTab(tab)
     return tab
   }
 
-  func addTabsForURLs(_ urls: [URL], zombie: Bool, isPrivate: Bool = false) {
+  @MainActor func addTabsForURLs(_ urls: [URL], zombie: Bool, isPrivate: Bool = false) {
     assert(Thread.isMainThread)
 
     if urls.isEmpty {
@@ -452,7 +452,7 @@ class TabManager: NSObject {
   }
 
   @discardableResult
-  func addTab(_ request: URLRequest? = nil, afterTab: Tab? = nil, flushToDisk: Bool = true, zombie: Bool = false, id: UUID? = nil, isPrivate: Bool) -> Tab {
+  @MainActor func addTab(_ request: URLRequest? = nil, afterTab: Tab? = nil, flushToDisk: Bool = true, zombie: Bool = false, id: UUID? = nil, isPrivate: Bool) -> Tab {
     assert(Thread.isMainThread)
 
     let tabId = id ?? UUID()
@@ -492,7 +492,7 @@ class TabManager: NSObject {
     SessionTab.saveTabOrder(tabIds: allTabIds)
   }
 
-  func configureTab(_ tab: Tab, request: URLRequest?, afterTab parent: Tab? = nil, flushToDisk: Bool, zombie: Bool, isPopup: Bool = false) {
+  @MainActor func configureTab(_ tab: Tab, request: URLRequest?, afterTab parent: Tab? = nil, flushToDisk: Bool, zombie: Bool, isPopup: Bool = false) {
     assert(Thread.isMainThread)
 
     let isPrivate = tab.type == .private
@@ -611,7 +611,7 @@ class TabManager: NSObject {
     }
   }
 
-  func removeTab(_ tab: Tab) {
+  @MainActor func removeTab(_ tab: Tab) {
     assert(Thread.isMainThread)
 
     guard let removalIndex = allTabs.firstIndex(where: { $0 === tab }) else {
@@ -734,7 +734,7 @@ class TabManager: NSObject {
       completionHandler: completionHandler)
   }
 
-  func removeTabsWithUndoToast(_ tabs: [Tab]) {
+  @MainActor func removeTabsWithUndoToast(_ tabs: [Tab]) {
     tempTabs = tabs
     var tabsCopy = tabs
 
@@ -769,7 +769,7 @@ class TabManager: NSObject {
     delegates.forEach { $0.get()?.tabManagerDidRemoveAllTabs(self, toast: toast) }
   }
 
-  func undoCloseTabs() {
+  @MainActor func undoCloseTabs() {
     guard let tempTabs = self.tempTabs, !tempTabs.isEmpty else {
       return
     }
@@ -799,17 +799,17 @@ class TabManager: NSObject {
     tempTabs?.removeAll()
   }
 
-  func removeTabs(_ tabs: [Tab]) {
+  @MainActor func removeTabs(_ tabs: [Tab]) {
     for tab in tabs {
       self.removeTab(tab)
     }
   }
 
-  func removeAll() {
+  @MainActor func removeAll() {
     removeTabs(self.allTabs)
   }
   
-  func removeAllForCurrentMode() {
+  @MainActor func removeAllForCurrentMode() {
     removeTabs(tabsForCurrentMode)
   }
 
@@ -905,7 +905,7 @@ class TabManager: NSObject {
     }
   }
 
-  fileprivate var restoreTabsInternal: Tab? {
+  @MainActor fileprivate var restoreTabsInternal: Tab? {
     var savedTabs = [SessionTab]()
 
     if let autocloseTime = Preferences.AutoCloseTabsOption(
@@ -1008,7 +1008,7 @@ class TabManager: NSObject {
 
   /// Restores all tabs.
   /// Returns the tab that has to be selected after restoration.
-  var restoreAllTabs: Tab {
+  @MainActor var restoreAllTabs: Tab {
     defer {
       metricsHeartbeat?.fire()
       RunLoop.current.add(metricsHeartbeat!, forMode: .default)
@@ -1080,7 +1080,7 @@ class TabManager: NSObject {
   /// This function adss a new tab, populates this tab with necessary information
   /// Also executes restore function on this tab to load History Snapshot to the webview
   /// - Parameter recentlyClosed: Recently Closed item to be processed
-  func addAndSelectRecentlyClosed(_ recentlyClosed: RecentlyClosed) {
+  @MainActor func addAndSelectRecentlyClosed(_ recentlyClosed: RecentlyClosed) {
     guard let url = NSURL(idnString: recentlyClosed.url) as? URL ?? URL(string: recentlyClosed.url) else { return }
     
     let tab = addTab(URLRequest(url: url), isPrivate: false)

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/EthereumProviderScriptHandler.swift
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/EthereumProviderScriptHandler.swift
@@ -60,7 +60,7 @@ class EthereumProviderScriptHandler: TabContentScript {
     }
   }
   
-  func userContentController(
+  @MainActor func userContentController(
     _ userContentController: WKUserContentController,
     didReceiveScriptMessage message: WKScriptMessage,
     replyHandler: @escaping (Any?, String?) -> Void
@@ -99,7 +99,7 @@ class EthereumProviderScriptHandler: TabContentScript {
       firstAllowedAccount: String,
       updateJSProperties: Bool
     ) {
-      Task {
+      Task { @MainActor in
         if updateJSProperties {
           await tab.updateEthereumProperties()
         }

--- a/Tests/ClientTests/SearchTests.swift
+++ b/Tests/ClientTests/SearchTests.swift
@@ -9,7 +9,7 @@ import Shared
 
 import XCTest
 
-class SearchTests: XCTestCase {
+@MainActor class SearchTests: XCTestCase {
   
   override func setUp() {
     super.setUp()

--- a/Tests/ClientTests/StringExtensionsTests.swift
+++ b/Tests/ClientTests/StringExtensionsTests.swift
@@ -6,7 +6,7 @@ import Foundation
 import XCTest
 @testable import Brave
 
-class StringExtensionsTests: XCTestCase {
+@MainActor class StringExtensionsTests: XCTestCase {
 
   func testStringByTrimmingLeadingCharactersInSet() {
     XCTAssertEqual("foo   ", "   foo   ".stringByTrimmingLeadingCharactersInSet(.whitespaces))

--- a/Tests/ClientTests/SyncHelperTests.swift
+++ b/Tests/ClientTests/SyncHelperTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 @testable import Brave
 
-class SyncHelperTests: XCTestCase {
+@MainActor class SyncHelperTests: XCTestCase {
   
   func testSyncedSessionPeriodDate() {
     var dateComponents = DateComponents()

--- a/Tests/ClientTests/TabEventHandlerTests.swift
+++ b/Tests/ClientTests/TabEventHandlerTests.swift
@@ -8,7 +8,7 @@ import WebKit
 
 import XCTest
 
-class TabEventHandlerTests: XCTestCase {
+@MainActor class TabEventHandlerTests: XCTestCase {
 
   func testEventDelivery() {
     let tab = Tab(configuration: WKWebViewConfiguration())

--- a/Tests/ClientTests/TabManagerNavDelegateTests.swift
+++ b/Tests/ClientTests/TabManagerNavDelegateTests.swift
@@ -8,7 +8,7 @@ import WebKit
 
 @testable import Brave
 
-class TabManagerNavDelegateTests: XCTestCase {
+@MainActor class TabManagerNavDelegateTests: XCTestCase {
     let navigation = WKNavigation()
 
     func test_webViewDidCommit_sendsCorrectMessage() {

--- a/Tests/ClientTests/TabManagerTests.swift
+++ b/Tests/ClientTests/TabManagerTests.swift
@@ -99,7 +99,7 @@ open class MockTabManagerDelegate: TabManagerDelegate {
   }
 }
 
-class TabManagerTests: XCTestCase {
+@MainActor class TabManagerTests: XCTestCase {
 
   let willRemove = MethodSpy(functionName: "tabManager(_:willRemoveTab:)")
   let didRemove = MethodSpy(functionName: "tabManager(_:didRemoveTab:)")

--- a/Tests/ClientTests/TabSessionTests.swift
+++ b/Tests/ClientTests/TabSessionTests.swift
@@ -74,7 +74,7 @@ private class WebViewNavigationAdapter: NSObject, WKNavigationDelegate {
   }
 }
 
-class TabSessionTests: XCTestCase {
+@MainActor class TabSessionTests: XCTestCase {
   private var tabManager: TabManager!
   private let maxTimeout = 60.0
 

--- a/Tests/ClientTests/TestFavicons.swift
+++ b/Tests/ClientTests/TestFavicons.swift
@@ -10,7 +10,7 @@ import Shared
 import Data
 import Favicon
 
-class TestFavicons: ProfileTest {
+@MainActor class TestFavicons: ProfileTest {
   
   override func setUp() {
     super.setUp()

--- a/Tests/ClientTests/URLFormatTests.swift
+++ b/Tests/ClientTests/URLFormatTests.swift
@@ -11,7 +11,7 @@ import BraveCore
 
 import XCTest
 
-class URLFormatTests: XCTestCase {
+@MainActor class URLFormatTests: XCTestCase {
   
   override func setUp() {
     super.setUp()

--- a/Tests/ClientTests/UniversalLinkManagerTests.swift
+++ b/Tests/ClientTests/UniversalLinkManagerTests.swift
@@ -6,7 +6,7 @@
 import XCTest
 @testable import Brave
 
-class UniversalLinkManagerTests: XCTestCase {
+@MainActor class UniversalLinkManagerTests: XCTestCase {
   private typealias ULM = UniversalLinkManager
 
   func testVpnUniversalLink() throws {

--- a/Tests/ClientTests/User Scripts/FarblingProtectionHelperTests.swift
+++ b/Tests/ClientTests/User Scripts/FarblingProtectionHelperTests.swift
@@ -7,7 +7,7 @@ import XCTest
 import CryptoKit
 @testable import Brave
 
-class FarblingProtectionHelperTests: XCTestCase {
+@MainActor class FarblingProtectionHelperTests: XCTestCase {
   func testGivenTheSameRandomManagerThenSameFakePluginData() throws {
     // Given
     // Same random manager


### PR DESCRIPTION
## Summary of Changes
- EthereumProvider can crash when deinitializing on Tab close; the crash is related to de-initializing the provider on a different thread than it was initialized on. Previously [we updated deinit](https://github.com/brave/brave-ios/pull/7388) to occur on main, so this should guarantee the init to be on main as well.

This pull request fixes #<number>

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

Try a couple DApp interactions, close some tabs; No steps to reproduce crash.

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
