### PR TITLE
Fix #7491: Change the recovery phrase protection overlay

### DIFF
--- a/Sources/BraveUI/SwiftUI/CustomPrivacySensitiveModifier.swift
+++ b/Sources/BraveUI/SwiftUI/CustomPrivacySensitiveModifier.swift
@@ -18,8 +18,10 @@ private struct CustomPrivacySensitiveModifier: ViewModifier {
       if isBackgrounded || isCaptured {
         content
           .opacity(0)
-          .overlay(alignment: .center) {RoundedRectangle(cornerRadius: 2)
-              .fill(Color.black.opacity(0.1)).frame(width: 64).padding(.vertical, 2.5)}
+          .overlay(alignment: .center) {
+            RoundedRectangle(cornerRadius: 2)
+              .fill(Color.black.opacity(0.1)).frame(width: 64).padding(.vertical, 2.5)
+            }
       } else {
         content
       }

--- a/Sources/BraveUI/SwiftUI/CustomPrivacySensitiveModifier.swift
+++ b/Sources/BraveUI/SwiftUI/CustomPrivacySensitiveModifier.swift
@@ -17,7 +17,9 @@ private struct CustomPrivacySensitiveModifier: ViewModifier {
     Group {
       if isBackgrounded || isCaptured {
         content
-          .redacted(reason: .placeholder)
+          .opacity(0)
+          .overlay(alignment: .center) {RoundedRectangle(cornerRadius: 2)
+              .fill(Color.black.opacity(0.1)).frame(width: 64).padding(.vertical, 2.5)}
       } else {
         content
       }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
Changes the default `.redacted(reason: .placeholder)` recovery phrase blur protection with a custom fixed-size overlay.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes https://github.com/brave/internal/issues/915 , https://github.com/brave/brave-ios/issues/7491

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Follow the steps in https://github.com/brave/internal/issues/915

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->
<img src="https://github.com/brave/brave-ios/assets/10810135/6340babc-a2f3-4815-a8bd-b8147f42b72e" width=600)/>


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
