### PR TITLE
Fix #7493 - Ref #7436: Sync Chain Deletion - Authentication problems

### DIFF
--- a/Sources/Brave/Frontend/Browser/Tabs/TabTray/TabTrayController.swift
+++ b/Sources/Brave/Frontend/Browser/Tabs/TabTray/TabTrayController.swift
@@ -650,12 +650,17 @@ class TabTrayController: LoadingViewController {
           return
         }
       
-        openInsideSettingsNavigation(with:
-          SyncSettingsTableViewController(
-            syncAPI: braveCore.syncAPI,
-            syncProfileService: braveCore.syncProfileService,
-            tabManager: tabManager,
-            windowProtection: windowProtection))
+      let syncSettingsScreen = SyncSettingsTableViewController(
+        isModallyPresented: true,
+        syncAPI: braveCore.syncAPI,
+        syncProfileService: braveCore.syncProfileService,
+        tabManager: tabManager,
+        windowProtection: windowProtection,
+        requiresAuthentication: true)
+      
+        syncSettingsScreen.syncStatusDelegate = self
+      
+        openInsideSettingsNavigation(with: syncSettingsScreen)
       default:
         return
     }
@@ -765,5 +770,11 @@ extension TabTrayController: UIScrollViewAccessibilityDelegate {
     } else {
       return String(format: Strings.tabTrayMultiTabPositionFormatVoiceOverText, NSNumber(value: firstTabRow as Int), NSNumber(value: lastTabRow), NSNumber(value: tabCount))
     }
+  }
+}
+
+extension TabTrayController: SyncStatusDelegate {
+  func syncStatusChanged() {
+    tabSyncView.updateSyncStatusPanel(for: emptyPanelState)
   }
 }

--- a/Sources/Brave/Frontend/Settings/SettingsViewController.swift
+++ b/Sources/Brave/Frontend/Settings/SettingsViewController.swift
@@ -332,7 +332,8 @@ class SettingsViewController: TableViewController {
                 syncProfileService:
                   syncProfileServices,
                 tabManager: tabManager,
-                windowProtection: windowProtection)
+                windowProtection: windowProtection,
+                requiresAuthentication: true)
 
               self.navigationController?
                 .pushViewController(syncSettingsViewController, animated: true)

--- a/Sources/Brave/Frontend/Sync/SyncWelcomeViewController.swift
+++ b/Sources/Brave/Frontend/Sync/SyncWelcomeViewController.swift
@@ -283,11 +283,13 @@ class SyncWelcomeViewController: SyncViewController {
     }
 
     let syncSettingsVC = SyncSettingsTableViewController(
-      showDoneButton: true,
+      isModallyPresented: true,
       syncAPI: syncAPI,
       syncProfileService: syncProfileServices,
       tabManager: tabManager,
-      windowProtection: windowProtection)
+      windowProtection: windowProtection,
+      requiresAuthentication: false)
+    
     navigationController?.pushViewController(syncSettingsVC, animated: true)
   }
   


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7493
This pull request references #7436 

This PR is fixing some minor but disturbing problems related with sync chain. 

Fixing the delete sync chain status problem mentioned in https://github.com/brave/brave-ios/issues/7493

and also fixed a problem related with new biometric pass invoked multiple times. It asks for passcode when user first opens Sync, setups a new chain. After that user taps done and it asks for passcode again.

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
Mentioned in Tickets - please ask for additional detail if needed

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
