### PR TITLE
Fix #7476: QR Code Scanning erroneously hides Scrolling Tabs Bar

### DIFF
--- a/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
+++ b/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
@@ -630,8 +630,8 @@ class TopToolbarView: UIView, ToolbarProtocol {
   }
 
   @objc func topToolbarDidPressQrCodeButton() {
-    leaveOverlayMode(didCancel: true)
     delegate?.topToolbarDidPressQrCodeButton(self)
+    leaveOverlayMode(didCancel: true)
   }
   
   @objc private func swipedLocationView() {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
When a QR button is pressed, we call `leaveOverlayMode` before popping up a QR Scanner:
https://github.com/brave/brave-ios/blob/c12d49888206c6aa0d848b23f37f846b067ebb28/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift#L632-L635
`leaveOverlayMode` calls `shouldShowTabBar` to determine if it should show the tab bar:
https://github.com/brave/brave-ios/blob/c12d49888206c6aa0d848b23f37f846b067ebb28/Sources/Brave/Frontend/Browser/BrowserViewController.swift#L1436-L1454
At this point `keyboardState` is not `nil` so the function returns `false` and the tab bar remains hidden. Next `topToolbarDidPressQrCodeButton` will be called and `shouldShowTabBar` is not called again.
So the proposed fix is to call `topToolbarDidPressQrCodeButton` first which will collapse the keyboard and after `leaveOverlayMode` is called `keyboardState` will be `nil`, so `shouldShowTabBar` will return `true`
<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7476

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

https://github.com/brave/brave-ios/assets/10810135/128868a1-8561-487e-9221-8282a3f5a029



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
