### PR TITLE
Fix #7502: Test additional privacy scripts

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -321,6 +321,7 @@ var package = Package(
         .copy("Resources/html/index.html"),
         .copy("Resources/scripts/farbling-tests.js"),
         .copy("Resources/scripts/request-blocking-tests.js"),
+        .copy("Resources/scripts/cosmetic-filter-tests.js"),
         .copy("blocking-summary-test.json"),
       ]
     ),

--- a/Package.swift
+++ b/Package.swift
@@ -320,6 +320,7 @@ var package = Package(
         .copy("Resources/filter-rules/rs-AC023D22-AE88-4060-A978-4FEEEC4221693.dat"),
         .copy("Resources/html/index.html"),
         .copy("Resources/scripts/farbling-tests.js"),
+        .copy("Resources/scripts/request-blocking-tests.js"),
         .copy("blocking-summary-test.json"),
       ]
     ),

--- a/Sources/Brave/Frontend/Browser/User Scripts/ScriptFactory.swift
+++ b/Sources/Brave/Frontend/Browser/User Scripts/ScriptFactory.swift
@@ -131,6 +131,27 @@ class ScriptFactory {
     case .domainUserScript(let domainUserScript):
       resultingScript = try self.makeScript(for: domainUserScript)
       
+    case .selectorsPoller(let setup):
+      let encoder = JSONEncoder()
+      let data = try encoder.encode(setup)
+      let args = String(data: data, encoding: .utf8)!
+      let source = try ScriptFactory.shared.makeScriptSource(of: .selectorsPoller)
+        .replacingOccurrences(of: "$<args>", with: args)
+      
+      let secureSource = CosmeticFiltersScriptHandler.secureScript(
+        handlerNamesMap: [
+          "$<message_handler>": CosmeticFiltersScriptHandler.messageHandlerName,
+          "$<partiness_message_handler>": URLPartinessScriptHandler.messageHandlerName
+        ],
+        securityToken: CosmeticFiltersScriptHandler.scriptId,
+        script: source
+      )
+      
+      resultingScript = WKUserScript(
+        source: secureSource, injectionTime: .atDocumentEnd, forMainFrameOnly: false,
+        in: CosmeticFiltersScriptHandler.scriptSandbox
+      )
+      
     case .engineScript(let configuration):
       let source = [
         "(function(){",

--- a/Sources/Brave/Frontend/Browser/User Scripts/UserScriptType.swift
+++ b/Sources/Brave/Frontend/Browser/User Scripts/UserScriptType.swift
@@ -14,12 +14,6 @@ enum UserScriptType: Hashable {
       let selector: String
       var rules: Set<String>
     }
-    
-    /// The url of the frame this script belongs to
-    ///
-    /// We need this to control which script gets executed on which frame
-    /// on the JS side since we cannot control this on the iOS side
-    let frameURL: URL
     /// Determines if we hide first party content or not. This is controlled via agressive or standard mode
     /// Standard mode may unhide 1p content for certain filter lists.
     let hideFirstPartyContent: Bool
@@ -34,7 +28,7 @@ enum UserScriptType: Hashable {
     let fetchNewClassIdRulesThrottlingMs: Int?
     /// These are agressive hide selectors that will get automatically processed when the script loads.
     /// Agressive selectors may never be unhidden even on standard mode
-    let agressiveSelectors: Set<String>
+    let aggressiveSelectors: Set<String>
     /// These are standard hide selectors that will get automatically processed when the script loads.
     /// Standard selectors may be unhidden on standard mode if they contain 1p content
     let standardSelectors: Set<String>
@@ -66,6 +60,9 @@ enum UserScriptType: Hashable {
   case domainUserScript(DomainUserScript)
   /// An engine script on the main frame
   case engineScript(EngineScriptConfiguration)
+  /// Selectors poller script (aka cosmetic filtering script) is responsible for hiding and unhiding css elements as dictated by the ad-block engines.
+  /// This script is actually executed rather than injected and this type is solely used for the creation rather than the injection of the script.
+  case selectorsPoller(SelectorsPollerSetup)
 
   /// The order in which we want to inject the scripts
   var order: Int {
@@ -74,7 +71,8 @@ enum UserScriptType: Hashable {
     case .farblingProtection: return 1
     case .domainUserScript: return 2
     case .siteStateListener: return 3
-    case .engineScript(let configuration): return 4 + configuration.order
+    case .selectorsPoller: return 4
+    case .engineScript(let configuration): return 5 + configuration.order
     }
   }
 }

--- a/Sources/Brave/Frontend/Browser/UserScriptManager.swift
+++ b/Sources/Brave/Frontend/Browser/UserScriptManager.swift
@@ -329,6 +329,8 @@ extension UserScriptType: CustomDebugStringConvertible {
       return "nacl"
     case .siteStateListener:
       return "siteStateListener"
+    case .selectorsPoller:
+      return "selectorsPoller"
     }
   }
 }

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/CosmeticFiltersScriptHandler.swift
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/CosmeticFiltersScriptHandler.swift
@@ -13,7 +13,7 @@ import os.log
 ///
 /// The ids and classes are collected in the `SelectorsPollerScript.js` file.
 class CosmeticFiltersScriptHandler: TabContentScript {
-  private struct CosmeticFiltersDTO: Decodable {
+  struct CosmeticFiltersDTO: Decodable {
     struct CosmeticFiltersDTOData: Decodable, Hashable {
       let sourceURL: String
       let ids: [String]
@@ -70,21 +70,21 @@ class CosmeticFiltersScriptHandler: TabContentScript {
         }
         
         var standardSelectors: Set<String> = []
-        var agressiveSelectors: Set<String> = []
+        var aggressiveSelectors: Set<String> = []
         for tuple in selectorArrays {
           let isAgressive = tuple.source.isAlwaysAgressive(
             given: FilterListStorage.shared.filterLists
           )
           
           if isAgressive {
-            agressiveSelectors = agressiveSelectors.union(tuple.selectors)
+            aggressiveSelectors = aggressiveSelectors.union(tuple.selectors)
           } else {
             standardSelectors = standardSelectors.union(tuple.selectors)
           }
         }
         
         replyHandler([
-          "agressiveSelectors": Array(agressiveSelectors),
+          "aggressiveSelectors": Array(aggressiveSelectors),
           "standardSelectors": Array(standardSelectors)
         ], nil)
       }

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/RequestBlockingContentScriptHandler.swift
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/RequestBlockingContentScriptHandler.swift
@@ -12,7 +12,7 @@ import Preferences
 import Data
 
 class RequestBlockingContentScriptHandler: TabContentScript {
-  private struct RequestBlockingDTO: Decodable {
+  struct RequestBlockingDTO: Decodable {
     struct RequestBlockingDTOData: Decodable, Hashable {
       let resourceType: AdblockEngine.ResourceType
       let resourceURL: String

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/URLPartinessScriptHandler.swift
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/URLPartinessScriptHandler.swift
@@ -13,7 +13,7 @@ import os.log
 ///
 /// The urls are collected in the `SelectorsPollerScript.js` file.
 class URLPartinessScriptHandler: TabContentScript {
-  private struct PartinessDTO: Decodable {
+  struct PartinessDTO: Decodable {
     struct PartinessDTOData: Decodable, Hashable {
       let sourceURL: String
       let urls: [String]

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Sandboxed/SelectorsPollerScript.js
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Sandboxed/SelectorsPollerScript.js
@@ -131,8 +131,8 @@ window.__firefox__.execute(function($) {
       }
     }
 
-    if (results.agressiveSelectors && results.agressiveSelectors.length > 0) {
-      if (processHideSelectors(results.agressiveSelectors, false)) {
+    if (results.aggressiveSelectors && results.aggressiveSelectors.length > 0) {
+      if (processHideSelectors(results.aggressiveSelectors, false)) {
         hasChanges = true
       }
     }
@@ -1049,8 +1049,8 @@ window.__firefox__.execute(function($) {
     processHideSelectors(args.standardSelectors, !args.hideFirstPartyContent)
   }
 
-  if (args.agressiveSelectors) {
-    processHideSelectors(args.agressiveSelectors, false)
+  if (args.aggressiveSelectors) {
+    processHideSelectors(args.aggressiveSelectors, false)
   }
 
   // Load some static style selectors if they are defined

--- a/Sources/Shared/Extensions/WKWebViewExtensions.swift
+++ b/Sources/Shared/Extensions/WKWebViewExtensions.swift
@@ -74,6 +74,7 @@ public extension WKWebView {
   @discardableResult @MainActor func evaluateSafeJavaScript(
     functionName: String,
     args: [Any] = [],
+    frame: WKFrameInfo? = nil,
     contentWorld: WKContentWorld,
     escapeArgs: Bool = true,
     asFunction: Bool = true
@@ -82,11 +83,37 @@ public extension WKWebView {
       evaluateSafeJavaScript(
         functionName: functionName,
         args: args,
+        frame: frame,
         contentWorld: contentWorld,
         escapeArgs: escapeArgs,
         asFunction: asFunction) { value, error in
           continuation.resume(returning: (value, error))
-      }
+        }
+    }
+  }
+  
+  @discardableResult
+  @MainActor func evaluateSafeJavaScriptThrowing(
+    functionName: String,
+    args: [Any] = [],
+    frame: WKFrameInfo? = nil,
+    contentWorld: WKContentWorld,
+    escapeArgs: Bool = true,
+    asFunction: Bool = true
+  ) async throws -> Any? {
+    let result = await evaluateSafeJavaScript(
+      functionName: functionName,
+      args: args,
+      frame: frame,
+      contentWorld: contentWorld,
+      escapeArgs: escapeArgs,
+      asFunction: asFunction
+    )
+    
+    if let error = result.1 {
+      throw error
+    } else {
+      return result.0
     }
   }
   

--- a/Tests/ClientTests/Resources/html/index.html
+++ b/Tests/ClientTests/Resources/html/index.html
@@ -6,6 +6,79 @@
   </head>
 
   <body>
-    Test content
+    <h1>Test Ads</h1>
+    
+    <div>
+      <div id="test-ad-aggressive">
+        <img src="http://1st_party.localhost/image.gif">
+        This element should be hidden (standard or aggressive mode) even though it's a 1st party ad.
+        This is because it comes back as part of the aggressive selectors list.
+        The aggressive selectors list are ones that come from 
+        non-default and non-regional filter lists such as the cookie consent blocking list
+        and are ignored when unhiding 1st party content on standard mode.
+      </div>
+      
+      <div id="test-ad-1st-party">
+        <img src="http://1st_party.localhost/image.gif">
+        This element should be unhidden (after the pump) only on standard mode because it is a 1st party ad.
+        Standard selectors are ones that come from the the default filter list or any regional filter lists.
+        These can be unhidden on standard mode if they are 1st party ads.
+      </div>
+      
+      <div id="test-ad-3rd-party">
+        <img src="http://3rd_party.localhost/image.gif">
+        This element should be always hidden (standard or aggressive mode) because it's a 3rd party ad.
+      </div>
+      
+      <div id="test-ad-simple">
+        Hide b/c little txt
+      </div>
+    </div>
+
+    <div>
+      <div class="test-ads-primary-standard">
+        The elements below all belong to the ".test-ads-primary-standard div" selector.
+        This selector is returned as part of the standard selector list 
+        which is given to the CF script during its initialization.
+        Because they all share the same selector, 
+        one unhidden means all are unhidden regardless of 1st or 3rd party.
+        And as the first element is a 1st party ad, all are unhidden.
+        Finally, because this selector is fed into the script right away,
+        the unhiding doesn't need to wait for the pump.
+
+        <div id="test-ad-primary-standard-1st-party">
+          <img src="http://1st_party.localhost/image.gif">
+          This element should be unhidden on standard mode because it is a 1st party ad.
+          Because of this element. All of its div siblings will be unhidden because they all belong to the 
+          .test-ads-primary-standard div selector.
+        </div>
+
+        <div id="test-ad-primary-standard-3rd-party">
+          <img src="http://3rd_party.localhost/image.gif">
+          Even though it's a 3rd party ad, this element should be unhidden on standard mode.
+          This is because it belongs to the .test-ads-primary-standard div selector which is unhidden 
+          due to the 1st party element above
+        </div>
+      </div>
+
+      <div class="test-ads-primary-aggressive">
+        These div children below should be hidden because they belong to an aggressive selector
+        regardless of mode or 1st/3rd party status.
+        Because this selector is fed into the script right away, 
+        the unhiding doesn't need to wait for the pump.
+        
+        <div id="test-ad-primary-aggressive-1st-party">
+          <img src="http://1st_party.localhost/image.gif">
+          This element should be hidden always regardless of aggressive or standard mode 
+          because it is a div child of the .test-ads-primary-aggressive class
+        </div>
+
+        <div id="test-ad-primary-aggressive-3rd-party">
+          <img src="http://3rd_party.localhost/image.gif">
+          This element should be hidden always regardless of aggressive or standard mode 
+          because it is a div child of the .test-ads-primary-aggressive class
+        </div>
+      </div>
+    </div>
   </body>
 </html>

--- a/Tests/ClientTests/Resources/scripts/cosmetic-filter-tests.js
+++ b/Tests/ClientTests/Resources/scripts/cosmetic-filter-tests.js
@@ -1,0 +1,46 @@
+// Copyright 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+(() => {
+  "use strict"
+  
+  /**
+   * Send the results of farbled APIs to iOS so it can see if its properly farbled
+   * @param {Array} hiddenIds All the ids that are hidden
+   * @param {Array} unhiddenIds All the ids that are not hidden
+   * @returns A Promise that resolves new hide selectors
+   */
+  const sendTestResults = (hiddenIds, unhiddenIds) => {
+    return webkit.messageHandlers['SendCosmeticFiltersResult'].postMessage({
+      'hiddenIds': hiddenIds,
+      'unhiddenIds': unhiddenIds
+    })
+  }
+
+  const getHideResults = () => {
+    const elements = document.querySelectorAll('[id]')
+    const results = {
+      hiddenIds: [],
+      unhiddenIds: []
+    }
+
+    elements.forEach((node) => {
+      if (!node.hasAttribute('id')) {
+        return
+      }
+
+      if (window.getComputedStyle(node).display === 'none') {
+        results.hiddenIds.push(node.id)
+      } else {
+        results.unhiddenIds.push(node.id)
+      }
+    })
+
+    return results
+  }
+  
+  let results = getHideResults()
+  sendTestResults(results.hiddenIds, results.unhiddenIds)
+})()

--- a/Tests/ClientTests/Resources/scripts/request-blocking-tests.js
+++ b/Tests/ClientTests/Resources/scripts/request-blocking-tests.js
@@ -1,0 +1,49 @@
+(() => {
+  "use strict"
+  /**
+   * Send the results of farbled APIs to iOS so it can see if its properly farbled
+   * @param {boolean} isBlocked A boolean indicating if the request was blocked
+   * @returns A Promise that resolves new hide selectors
+   */
+  const sendTestResults = (blockedFetch, blockedXHR) => {
+    return webkit.messageHandlers['SendTestRequestResult'].postMessage({
+      'blockedFetch': blockedFetch,
+      'blockedXHR': blockedXHR
+    })
+  }
+
+  const testXHR = () => {
+    return new Promise((resolve, _) => {
+      const req = new XMLHttpRequest()
+      req.addEventListener("load", () => {
+        resolve(false)
+      })
+      req.addEventListener("error", () => {
+        resolve(true)
+      })
+      req.open("GET", "http://example.com/movies.json", true)
+      req.send()
+    })
+  }
+  
+  const testFetch = async () => {
+    let blockedFetch = false
+    let blockedXHR = false
+    
+    try {
+      const response = await fetch("http://example.com/movies.json")
+      return false
+    } catch (error) {
+      return true
+    }
+  }
+
+  const testAPIs = async () => {
+    let blockedFetch = await testFetch()
+    let blockedXHR = await testXHR()
+
+    sendTestResults(blockedFetch, blockedXHR)
+  }
+
+  testAPIs()
+})()

--- a/Tests/ClientTests/User Scripts/MockMessageHandler.swift
+++ b/Tests/ClientTests/User Scripts/MockMessageHandler.swift
@@ -9,6 +9,9 @@ import WebKit
 class MockMessageHandler: NSObject, WKScriptMessageHandlerWithReply {
   typealias Callback = (WKScriptMessage) -> Any?
   private let callback: Callback
+  private var streamCallback: ((WKScriptMessage) -> Void)?
+  private var streamTimer: Timer?
+  private var messages: [WKScriptMessage] = []
   
   init(callback: @escaping Callback) {
     self.callback = callback
@@ -18,5 +21,38 @@ class MockMessageHandler: NSObject, WKScriptMessageHandlerWithReply {
   func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage, replyHandler: @escaping (Any?, String?) -> Void) {
     let reply = callback(message)
     replyHandler(reply, nil)
+    
+    if let callback = streamCallback {
+      callback(message)
+    } else {
+      messages.append(message)
+    }
+  }
+  
+  func messagesStream(timeout: TimeInterval = 10) -> AsyncStream<WKScriptMessage> {
+    return AsyncStream { continuation in
+      if messages.isEmpty {
+        // Add a timeout in case the script is bad and the handler never triggers
+        // (so we don't the test hang for ever)
+        streamTimer = Timer.scheduledTimer(withTimeInterval: timeout, repeats: false, block: { _ in
+          self.streamCallback = nil
+          continuation.finish()
+        })
+      }
+      
+      while !messages.isEmpty {
+        continuation.yield(messages.removeFirst())
+      }
+      
+      streamCallback = { message in
+        self.streamTimer?.invalidate()
+        continuation.yield(message)
+      }
+      
+      continuation.onTermination = { @Sendable _ in
+        self.streamTimer?.invalidate()
+        self.streamCallback = nil
+      }
+    }
   }
 }

--- a/Tests/ClientTests/User Scripts/MockScriptsViewController.swift
+++ b/Tests/ClientTests/User Scripts/MockScriptsViewController.swift
@@ -109,6 +109,14 @@ class MockScriptsViewController: UIViewController {
       )
     }
   }
+  
+  func attachScriptHandler(contentWorld: WKContentWorld, name: String, messageHandler: MockMessageHandler) {
+    webView.configuration.userContentController.addScriptMessageHandler(
+      messageHandler,
+      contentWorld: contentWorld,
+      name: name
+    )
+  }
 }
 
 // MARK: - WKNavigationDelegate

--- a/Tests/ClientTests/User Scripts/MockScriptsViewController.swift
+++ b/Tests/ClientTests/User Scripts/MockScriptsViewController.swift
@@ -93,15 +93,14 @@ class MockScriptsViewController: UIViewController {
         continuation.finish()
       })
       
+      continuation.onTermination = { @Sendable _ in
+        userContentController.removeScriptMessageHandler(forName: name)
+      }
+      
       userContentController.addScriptMessageHandler(
         MockMessageHandler { message in
           timer.invalidate()
           continuation.yield(message)
-          
-          continuation.onTermination = { @Sendable _ in
-            userContentController.removeScriptMessageHandler(forName: name)
-          }
-          
           return nil
         },
         contentWorld: contentWorld,
@@ -110,12 +109,15 @@ class MockScriptsViewController: UIViewController {
     }
   }
   
-  func attachScriptHandler(contentWorld: WKContentWorld, name: String, messageHandler: MockMessageHandler) {
+  @discardableResult
+  func attachScriptHandler(contentWorld: WKContentWorld, name: String, messageHandler: MockMessageHandler) -> MockMessageHandler {
     webView.configuration.userContentController.addScriptMessageHandler(
       messageHandler,
       contentWorld: contentWorld,
       name: name
     )
+    
+    return messageHandler
   }
 }
 

--- a/Tests/ClientTests/User Scripts/ScriptExecutionTests.swift
+++ b/Tests/ClientTests/User Scripts/ScriptExecutionTests.swift
@@ -22,6 +22,11 @@ final class ScriptExecutionTests: XCTestCase {
     let blockedXHR: Bool
   }
   
+  struct CosmeticFilteringTestDTO: Decodable {
+    let hiddenIds: [String]
+    let unhiddenIds: [String]
+  }
+  
   @MainActor func testSiteStateListenerScript() async throws {
     // Given
     let viewController = MockScriptsViewController()
@@ -174,7 +179,7 @@ final class ScriptExecutionTests: XCTestCase {
     
     // Load the sample htmls page and await the first page load result
     let htmlURL = Bundle.module.url(forResource: "index", withExtension: "html")!
-    let htmlString = try! String(contentsOf: htmlURL, encoding: .utf8)
+    let htmlString = try String(contentsOf: htmlURL, encoding: .utf8)
     try await viewController.loadHTMLString(htmlString)
     
     // Then
@@ -196,5 +201,156 @@ final class ScriptExecutionTests: XCTestCase {
     XCTAssertNotNil(foundMessage)
     XCTAssertEqual(foundMessage?.blockedFetch, true)
     XCTAssertEqual(foundMessage?.blockedXHR, true)
+  }
+  
+  @MainActor func testCosmeticFilteringScript() async throws {
+    // Given
+    let viewController = MockScriptsViewController()
+    let initialStandardSelectors = Set([".test-ads-primary-standard div"])
+    let initialAggressiveSelectors = Set([".test-ads-primary-aggressive div"])
+    let polledAggressiveIds = ["test-ad-aggressive"]
+    let polledStandardIds = ["test-ad-1st-party", "test-ad-3rd-party", "test-ad-simple"]
+    let nestedIds = [
+      "test-ad-primary-standard-1st-party", "test-ad-primary-standard-3rd-party",
+      "test-ad-primary-aggressive-1st-party", "test-ad-primary-aggressive-3rd-party"
+    ]
+    let setup = UserScriptType.SelectorsPollerSetup(
+      hideFirstPartyContent: false,
+      genericHide: false,
+      firstSelectorsPollingDelayMs: nil,
+      switchToSelectorsPollingThreshold: 1000,
+      fetchNewClassIdRulesThrottlingMs: 100,
+      aggressiveSelectors: initialAggressiveSelectors,
+      standardSelectors: initialStandardSelectors,
+      styleSelectors: []
+    )
+    
+    // Attach fake message handlers for our CF script
+    let selectorsMessageHandler = viewController.attachScriptHandler(
+      contentWorld: CosmeticFiltersScriptHandler.scriptSandbox,
+      name: CosmeticFiltersScriptHandler.messageHandlerName,
+      messageHandler: MockMessageHandler(callback: { message in
+        do {
+          let data = try JSONSerialization.data(withJSONObject: message.body)
+          let dto = try JSONDecoder().decode(CosmeticFiltersScriptHandler.CosmeticFiltersDTO.self, from: data)
+          
+          XCTAssertEqual(dto.data.ids.count, polledAggressiveIds.count + polledStandardIds.count + nestedIds.count)
+          for id in polledAggressiveIds {
+            XCTAssertTrue(dto.data.ids.contains(id))
+          }
+          for id in polledStandardIds {
+            XCTAssertTrue(dto.data.ids.contains(id))
+          }
+          for id in nestedIds {
+            XCTAssertTrue(dto.data.ids.contains(id))
+          }
+          
+          // Return selectors to hide
+          return [
+            "aggressiveSelectors": polledAggressiveIds.map({ "#\($0)" }),
+            "standardSelectors": polledStandardIds.map({ "#\($0)" })
+          ]
+        } catch {
+          XCTFail(String(describing: error))
+          return nil
+        }
+      })
+    )
+    
+    viewController.attachScriptHandler(
+      contentWorld: URLPartinessScriptHandler.scriptSandbox,
+      name: URLPartinessScriptHandler.messageHandlerName,
+      messageHandler: MockMessageHandler(callback: { message in
+        do {
+          let data = try JSONSerialization.data(withJSONObject: message.body)
+          let dto = try JSONDecoder().decode(URLPartinessScriptHandler.PartinessDTO.self, from: data)
+          
+          XCTAssertEqual(dto.data.urls.count, 2)
+          XCTAssertTrue(dto.data.urls.contains("http://1st_party.localhost"))
+          XCTAssertTrue(dto.data.urls.contains("http://3rd_party.localhost"))
+          
+          // Return fake partiness information
+          return [
+            "http://1st_party.localhost": true,
+            "http://3rd_party.localhost": false
+          ]
+        } catch {
+          XCTFail(String(describing: error))
+          return nil
+        }
+      })
+    )
+    
+    // When
+    // Attach a result message handler
+    let testResultMessageHandler = viewController.attachScriptHandler(
+      contentWorld: CosmeticFiltersScriptHandler.scriptSandbox,
+      name: "SendCosmeticFiltersResult",
+      messageHandler: MockMessageHandler(callback: { message in
+        return nil
+      })
+    )
+    
+    // Load the view and add scripts
+    viewController.loadViewIfNeeded()
+    
+    // Load the sample htmls page and await the first page load result
+    let htmlURL = Bundle.module.url(forResource: "index", withExtension: "html")!
+    let htmlString = try String(contentsOf: htmlURL, encoding: .utf8)
+    try await viewController.loadHTMLString(htmlString)
+    
+    // Execute the selectors poller script
+    let script = try ScriptFactory.shared.makeScript(for: .selectorsPoller(setup))
+    try await viewController.webView.evaluateSafeJavaScriptThrowing(
+      functionName: script.source,
+      contentWorld: CosmeticFiltersScriptHandler.scriptSandbox,
+      asFunction: false
+    )
+    
+    // Await the execution of the selectors message handler
+    // (so we know we already hid our elements)
+    for await _ in selectorsMessageHandler.messagesStream() {
+      // We only care about the first script handler result
+      break
+    }
+    
+    // Now wait for the pump which takes a few seconds.
+    // The pump unhides 1st party elements.
+    try await Task.sleep(seconds: 5)
+    
+    // Then
+    // Execute a script that will test the cosmetic filters page
+    let testURL = Bundle.module.url(forResource: "cosmetic-filter-tests", withExtension: "js")!
+    let source = try String(contentsOf: testURL)
+    try await viewController.webView.evaluateSafeJavaScriptThrowing(
+      functionName: source,
+      contentWorld: CosmeticFiltersScriptHandler.scriptSandbox,
+      asFunction: false
+    )
+    
+    // Await the results of the test script
+    var resultsAfterPump: CosmeticFilteringTestDTO?
+    for await message in testResultMessageHandler.messagesStream() {
+      do {
+        let data = try JSONSerialization.data(withJSONObject: message.body)
+        resultsAfterPump = try JSONDecoder().decode(CosmeticFilteringTestDTO.self, from: data)
+      } catch {
+        XCTFail(String(describing: error))
+      }
+      
+      // We don't listen for ever. Just the first test result
+      break
+    }
+    
+    XCTAssertNotNil(resultsAfterPump)
+    XCTAssertEqual(resultsAfterPump?.unhiddenIds.contains("test-ad-1st-party"), true)
+    XCTAssertEqual(resultsAfterPump?.unhiddenIds.contains("test-ad-primary-standard-1st-party"), true)
+    XCTAssertEqual(resultsAfterPump?.unhiddenIds.contains("test-ad-primary-standard-3rd-party"), true)
+    XCTAssertEqual(resultsAfterPump?.unhiddenIds.contains("test-ad-1st-party"), true)
+    XCTAssertEqual(resultsAfterPump?.hiddenIds.contains("test-ad-aggressive"), true)
+    XCTAssertEqual(resultsAfterPump?.hiddenIds.contains("test-ad-3rd-party"), true)
+    XCTAssertEqual(resultsAfterPump?.hiddenIds.contains("test-ad-simple"), true)
+    XCTAssertEqual(resultsAfterPump?.hiddenIds.contains("test-ad-primary-aggressive-1st-party"), true)
+    XCTAssertEqual(resultsAfterPump?.hiddenIds.contains("test-ad-primary-aggressive-3rd-party"), true)
   }
 }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7502

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
This is mostly adding some unit tests which don't need to be tested. There was however some minor changes to the initialization of the cosmetic filtering script. So while we test the scripts itself the initialization of this script is not. So we just need to check that the scripts are injected properly into websites.

Hence we need to:
- [ ] Navigate to several sites and ensure the CF script is hiding elements. No need to test the quality of the script. just that it's working.

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
