### PR TITLE
Fix #7506, fix #7501: Remove legacy cosmetic filters engine

### DIFF
--- a/Sources/Brave/WebFilters/AdBlockEngineManager.swift
+++ b/Sources/Brave/WebFilters/AdBlockEngineManager.swift
@@ -16,7 +16,6 @@ public actor AdBlockEngineManager: Sendable {
   /// The source of a resource. In some cases we need to remove all resources for a given source.
   enum Source: Hashable {
     case adBlock
-    case cosmeticFilters
     case filterList(uuid: String)
     case filterListURL(uuid: String)
     
@@ -26,7 +25,6 @@ public actor AdBlockEngineManager: Sendable {
     fileprivate var relativeOrder: Int {
       switch self {
       case .adBlock: return 0
-      case .cosmeticFilters: return 3
       case .filterList: return 100
       case .filterListURL: return 200
       }
@@ -42,7 +40,7 @@ public actor AdBlockEngineManager: Sendable {
     /// All other filter lists are agressive (i.e. are always hidden regardless of 1p status)
     @MainActor func isAlwaysAgressive(given filterLists: [FilterList]) -> Bool {
       switch self {
-      case .adBlock, .cosmeticFilters:
+      case .adBlock:
         // Our default filter lists are not agressive
         return false
       case .filterListURL:
@@ -255,7 +253,6 @@ extension AdBlockEngineManager.Source: CustomDebugStringConvertible {
     case .filterList(let uuid): return "filterList(\(uuid))"
     case .filterListURL(let uuid): return "filterListURL(\(uuid))"
     case .adBlock: return "adBlock"
-    case .cosmeticFilters: return "cosmeticFilters"
     }
   }
 }

--- a/Sources/Brave/WebFilters/AdblockResourceDownloader.swift
+++ b/Sources/Brave/WebFilters/AdblockResourceDownloader.swift
@@ -14,8 +14,11 @@ public actor AdblockResourceDownloader: Sendable {
   
   /// All the different resources this downloader handles
   static let handledResources: [BraveS3Resource] = [
-    .genericContentBlockingBehaviors, .generalCosmeticFilters, .debounceRules
+    .genericContentBlockingBehaviors, .debounceRules
   ]
+  
+  /// A list of old resources that need to be deleted so as not to take up the user's disk space
+  private static let deprecatedResources: [BraveS3Resource] = [.generalCosmeticFilters]
   
   /// A formatter that is used to format a version number
   private let fileVersionDateFormatter: DateFormatter = {
@@ -89,6 +92,18 @@ public actor AdblockResourceDownloader: Sendable {
     for resource in Self.handledResources {
       startFetching(resource: resource, every: fetchInterval)
     }
+    
+    // Remove any old files
+    // We can remove this code in some not-so-distant future
+    for resource in Self.deprecatedResources {
+      do {
+        try resource.removeCacheFolder()
+      } catch {
+        ContentBlockerManager.log.error(
+          "Failed to removed deprecated file \(resource.cacheFileName): \(error)"
+        )
+      }
+    }
   }
   
   /// Start fetching the given resource at regular intervals
@@ -124,13 +139,6 @@ public actor AdblockResourceDownloader: Sendable {
     let version = fileVersionDateFormatter.string(from: downloadResult.date)
     
     switch resource {
-    case .generalCosmeticFilters:
-      await AdBlockEngineManager.shared.add(
-        resource: AdBlockEngineManager.Resource(type: .dat, source: .cosmeticFilters),
-        fileURL: downloadResult.fileURL,
-        version: version
-      )
-      
     case .genericContentBlockingBehaviors:
       let blocklistType = ContentBlockerManager.BlocklistType.generic(.blockAds)
       

--- a/Sources/Brave/WebFilters/AdblockResourceDownloader.swift
+++ b/Sources/Brave/WebFilters/AdblockResourceDownloader.swift
@@ -18,7 +18,7 @@ public actor AdblockResourceDownloader: Sendable {
   ]
   
   /// A list of old resources that need to be deleted so as not to take up the user's disk space
-  private static let deprecatedResources: [BraveS3Resource] = [.generalCosmeticFilters]
+  private static let deprecatedResources: [BraveS3Resource] = [.deprecatedGeneralCosmeticFilters]
   
   /// A formatter that is used to format a version number
   private let fileVersionDateFormatter: DateFormatter = {

--- a/Sources/Brave/WebFilters/BraveS3Resource.swift
+++ b/Sources/Brave/WebFilters/BraveS3Resource.swift
@@ -12,6 +12,7 @@ enum BraveS3Resource: Hashable, DownloadResourceInterface {
   /// Generic iOS only content blocking behaviours used for the iOS content blocker
   case genericContentBlockingBehaviors
   /// Cosmetic filter rules
+  /// - Warning: Do not use this. This is here solely so we can delete the files
   case generalCosmeticFilters
   /// Adblock rules for a filter list
   /// iOS only content blocking behaviours used for the iOS content blocker for a given filter list

--- a/Sources/Brave/WebFilters/BraveS3Resource.swift
+++ b/Sources/Brave/WebFilters/BraveS3Resource.swift
@@ -11,12 +11,13 @@ enum BraveS3Resource: Hashable, DownloadResourceInterface {
   case debounceRules
   /// Generic iOS only content blocking behaviours used for the iOS content blocker
   case genericContentBlockingBehaviors
-  /// Cosmetic filter rules
-  /// - Warning: Do not use this. This is here solely so we can delete the files
-  case generalCosmeticFilters
   /// Adblock rules for a filter list
   /// iOS only content blocking behaviours used for the iOS content blocker for a given filter list
   case filterListContentBlockingBehaviors(uuid: String, componentId: String)
+  
+  /// Cosmetic filter rules
+  /// - Warning: Do not use this. This is here solely so we can delete the files
+  case deprecatedGeneralCosmeticFilters
   
   /// The name of the info plist key that contains the service key
   private static let servicesKeyName = "SERVICES_KEY"
@@ -41,7 +42,7 @@ enum BraveS3Resource: Hashable, DownloadResourceInterface {
       return ["filter-lists", componentId].joined(separator: "/")
     case .genericContentBlockingBehaviors:
       return "abp-data"
-    case .generalCosmeticFilters:
+    case .deprecatedGeneralCosmeticFilters:
       return "cmf-data"
     }
   }
@@ -55,7 +56,7 @@ enum BraveS3Resource: Hashable, DownloadResourceInterface {
       return "\(uuid)-latest.json"
     case .genericContentBlockingBehaviors:
       return "latest.json"
-    case .generalCosmeticFilters:
+    case .deprecatedGeneralCosmeticFilters:
       return "ios-cosmetic-filters.dat"
     }
   }
@@ -69,7 +70,7 @@ enum BraveS3Resource: Hashable, DownloadResourceInterface {
       return Self.baseResourceURL.appendingPathComponent("/ios/\(uuid)-latest.json")
     case .genericContentBlockingBehaviors:
       return Self.baseResourceURL.appendingPathComponent("/ios/latest.json")
-    case .generalCosmeticFilters:
+    case .deprecatedGeneralCosmeticFilters:
       return Self.baseResourceURL.appendingPathComponent("/ios/ios-cosmetic-filters.dat")
     }
   }

--- a/Sources/Brave/WebFilters/ShieldStats/Adblock/CachedAdBlockEngine.swift
+++ b/Sources/Brave/WebFilters/ShieldStats/Adblock/CachedAdBlockEngine.swift
@@ -164,9 +164,6 @@ public class CachedAdBlockEngine {
       // This engine source type is enabled only if shields are enabled
       // for the given domain
       return domain.isShieldExpected(.AdblockAndTp, considerAllShieldsOption: true)
-    case .cosmeticFilters:
-      // The cosmetic filters are always applied
-      return true
     }
   }
   


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
Removed legacy cosmetic filtering code

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7506 
This also fixes #7501

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Test any popular (or important) ad-blocking that we have such as YouTube ad-blocking.

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->
N/A

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
