### PR TITLE
Fix #7211: Display address lookup table account for unknown instruction types

### DIFF
--- a/Sources/BraveWallet/Crypto/Transactions/TransactionParser.swift
+++ b/Sources/BraveWallet/Crypto/Transactions/TransactionParser.swift
@@ -508,12 +508,10 @@ enum TransactionParser {
       let title = Strings.Wallet.solanaUnknownInstructionName
       let programId = SolanaTxDetails.ParsedSolanaInstruction.KeyValue(
         key: Strings.Wallet.solanaInstructionProgramId, value: instruction.programId)
-      let accountPubkeys = instruction.accountMetas.map(\.pubkey)
-      let accounts = SolanaTxDetails.ParsedSolanaInstruction.KeyValue(
-        key: Strings.Wallet.solanaInstructionAccounts, value: accountPubkeys.isEmpty ? "[]" : accountPubkeys.joined(separator: "\n"))
+      let accounts = instruction.accountKeyValues
       let data = SolanaTxDetails.ParsedSolanaInstruction.KeyValue(
         key: Strings.Wallet.solanaInstructionData, value: "\(instruction.data)")
-      return .init(name: title, details: [programId, accounts, data], instruction: instruction)
+      return .init(name: title, details: [programId] + accounts + [data], instruction: instruction)
     }
     let formatter = WeiFormatter(decimalFormatStyle: decimalFormatStyle ?? .decimals(precision: 9))
     var details: [SolanaTxDetails.ParsedSolanaInstruction.KeyValue] = []


### PR DESCRIPTION
## Summary of Changes
- Noticed the logic for address table lookup accounts was missing for Unknown Instruction types (we currently only decode System program and Token program).
- Updated the logic so it can be re-used for both known and unknown instruction types as it doesn't rely on `decodedData` on the instruction to match desktop.

This pull request fixes #7211

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
Same test plan as original issue to verify regressions, but also check for `Address Lookup Table Account/Index` for unknown instruction type.

1. All cases with v0 keyword in https://pwgoom.csb.app/ should work.
    - Verify `Address Lookup Table Account:` and `Address Lookup Table Index:` are shown under the `To Account:` label in the details for all `v0 + lookup table` cases. 
    - For `Sign and Send Transaction (v0 + lookup table) (devnet only)`, the transaction header (in Tx Confirmation and in Tx detail modal) and transaction summary should only display the from account; it should not show the 'to account' as a destination.
2. Three Send Transactions cases in the bottom row in https://solana-labs.github.io/wallet-adapter/example/ should all work.
    - For `Send V0 Transaction using Address Lookup Table (devnet)` option, verify the `Address Lookup Table Account/Index` are displayed now. This should match desktop behaviour.

## Screenshots:

https://github.com/brave/brave-ios/assets/5314553/63a65d53-04f0-4e4e-998b-f2255f4e5b38

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
