### PR TITLE
Fix #7512: Rewards script crash when in Desktop Mode

### DIFF
--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Paged/RewardsReportingScript.js
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Paged/RewardsReportingScript.js
@@ -11,10 +11,6 @@ window.__firefox__.includeOnce("RewardsReporting", function($) {
     'https://www.youtube.com', 'https://m.youtube.com',
     'https://vimeo.com',
   ]
-
-  if (mediaPublisherOrigins.includes(document.location.origin) && webkit.messageHandlers.$<message_handler>) {
-    install();
-  }
   
   const install = () => {
     const sendMessage = $(function(method, url, data, referrerUrl) {
@@ -99,5 +95,9 @@ window.__firefox__.includeOnce("RewardsReporting", function($) {
       enumerable: true,
       configurable: true
     });
+  }
+  
+  if (mediaPublisherOrigins.includes(document.location.origin) && webkit.messageHandlers.$<message_handler>) {
+    install();
   }
 });


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Fix rewards reporting not working in Desktop mode.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7512

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
- None. You need the developer console to verify it.

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
