### PR TITLE
No Bug: Remove failing test case

### DIFF
--- a/Tests/ClientTests/User Scripts/ScriptExecutionTests.swift
+++ b/Tests/ClientTests/User Scripts/ScriptExecutionTests.swift
@@ -136,6 +136,5 @@ final class ScriptExecutionTests: XCTestCase {
     // Ensure farbled and unfarbled results are not the same
     XCTAssertNotEqual(farblingResult?.voiceNames, controlResult?.voiceNames)
     XCTAssertNotEqual(farblingResult?.pluginNames, controlResult?.pluginNames)
-    XCTAssertNotEqual(farblingResult?.hardwareConcurrency, controlResult?.hardwareConcurrency)
   }
 }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
Unfortunately I had to remove this one small test case because there is no way for me to guarantee a value due to the nature of the randomness of this feature. 

This test fails 25% of the time because hardware concurrency is fabled to change the value of hardware concurrency from 4 to a value between 2-4. 25% of the time this value ends up being 4.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #<number>

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
