### PR TITLE
Fix #7448, fix #7413: VPN Initialize and Connect issues

### DIFF
--- a/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/VPNMenuButton.swift
+++ b/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/VPNMenuButton.swift
@@ -110,7 +110,12 @@ struct VPNMenuButton: View {
     }
     .onReceive(NotificationCenter.default.publisher(for: .NEVPNStatusDidChange)) { _ in
       isVPNEnabled = BraveVPN.isConnected
-      isVPNStatusChanging = BraveVPN.reconnectPending
+      
+      if BraveVPN.isConnected {
+        isVPNStatusChanging = false
+      } else {
+        isVPNStatusChanging = BraveVPN.reconnectPending
+      }
     }
   }
 }

--- a/Sources/BraveVPN/BraveVPN.swift
+++ b/Sources/BraveVPN/BraveVPN.swift
@@ -279,9 +279,10 @@ public class BraveVPN {
           logAndStoreError("configureAndConnectVPN: \(error)")
         }
         
+        reconnectPending = false
+        
         // Re-connected user should update last used region - detail is pulled
         fetchLastUsedRegionDetail() { _, _ in
-          reconnectPending = false
           DispatchQueue.main.async {
             completion?(status == .success)
           }
@@ -302,9 +303,10 @@ public class BraveVPN {
           helper.ikev2VPNManager.removeFromPreferences()
         }
          
+        reconnectPending = false
+          
         // First time user will connect automatic region - detail is pulled
         fetchLastUsedRegionDetail() { _, _ in
-          reconnectPending = false
           DispatchQueue.main.async {  
             completion?(success)
           }

--- a/Sources/BraveVPN/BuyVPNViewController.swift
+++ b/Sources/BraveVPN/BuyVPNViewController.swift
@@ -9,7 +9,7 @@ import Preferences
 import StoreKit
 import os.log
 
-class BuyVPNViewController: UIViewController {
+class BuyVPNViewController: VPNSetupLoadingController {
     
   let iapObserver: IAPObserver
   
@@ -27,40 +27,6 @@ class BuyVPNViewController: UIViewController {
 
   override func loadView() {
     view = View()
-  }
-
-  /// View to show when the vpn purchase is pending.
-  private var overlayView: UIView?
-
-  private var isLoading: Bool = false {
-    didSet {
-      overlayView?.removeFromSuperview()
-
-      // Toggle 'restore' button.
-      navigationItem.rightBarButtonItem?.isEnabled = !isLoading
-
-      // Prevent dismissing the modal by swipe when the VPN is being configured
-      navigationController?.isModalInPresentation = isLoading == true
-
-      if !isLoading { return }
-
-      let overlay = UIView().then {
-        $0.backgroundColor = UIColor.black.withAlphaComponent(0.5)
-        let activityIndicator = UIActivityIndicatorView().then { indicator in
-          indicator.startAnimating()
-          indicator.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-        }
-
-        $0.addSubview(activityIndicator)
-      }
-
-      buyVPNView.addSubview(overlay)
-      overlay.snp.makeConstraints {
-        $0.edges.equalToSuperview()
-      }
-
-      overlayView = overlay
-    }
   }
 
   override func viewDidLoad() {
@@ -172,6 +138,44 @@ extension BuyVPNViewController: IAPObserverDelegate {
       let ok = UIAlertAction(title: Strings.OKString, style: .default, handler: nil)
       alert.addAction(ok)
       self.present(alert, animated: true)
+    }
+  }
+}
+
+class VPNSetupLoadingController: UIViewController {
+  
+  private var overlayView: UIView?
+
+  var isLoading: Bool = false {
+    didSet {
+      overlayView?.removeFromSuperview()
+
+      // Disable Action bar button while loading
+      navigationItem.rightBarButtonItem?.isEnabled = !isLoading
+
+      // Prevent dismissing the modal by swipe
+      navigationController?.isModalInPresentation = isLoading == true
+
+      if !isLoading { return }
+
+      let overlay = UIView().then {
+        $0.backgroundColor = UIColor.black.withAlphaComponent(0.5)
+        let activityIndicator = UIActivityIndicatorView().then {
+          $0.startAnimating()
+          $0.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+          $0.style = .large
+          $0.color = .white
+        }
+
+        $0.addSubview(activityIndicator)
+      }
+
+      view.addSubview(overlay)
+      overlay.snp.makeConstraints {
+        $0.edges.equalToSuperview()
+      }
+
+      overlayView = overlay
     }
   }
 }

--- a/Sources/BraveVPN/InstallVPNViewController.swift
+++ b/Sources/BraveVPN/InstallVPNViewController.swift
@@ -59,9 +59,14 @@ class InstallVPNViewController: VPNSetupLoadingController {
         self.dismiss(animated: true) {
           self.showSuccessAlert()
         }
-      } else if self.installVPNProfileRetryCount < 2 {
-        // Retry installing profile if it fails first time
-        presentErrorVPNInstallProfile()
+      } else {
+        // Retry installing profile twice if it fails
+        // Error generated is WireGuard capabilities are not yet enabled on this node
+        if self.installVPNProfileRetryCount < 2 {
+          installVPNAction()
+        } else {
+          presentErrorVPNInstallProfile()
+        }
       }
     }
  
@@ -83,7 +88,7 @@ class InstallVPNViewController: VPNSetupLoadingController {
     
     BraveVPN.connectToVPN() { [weak self] status in
       DispatchQueue.main.async {
-        self?.isLoading = true
+        self?.isLoading = false
       }
 
       completion(status)


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

Pull request fixes the problem with infinite loading indicator when connection is successful. In addition it is adding a proper loading to Install profile and buy vpn screens, to handle problem with Profile install, it is added a retry mechanism to silently try to connect again since the tests how additional try will always succeed for install.

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7448
This pull request fixes #7413

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [ ] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:

7448

Launch Brave > Three Dot Menu
Enable VPN
Don't close the panel > Observe

7413

Install 1.51.x, 1.50.x
Complete IAP (Sandbox)
Install VPN Profile
Observe


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


7448

https://github.com/brave/brave-ios/assets/6643505/51855d2e-b9d1-412d-b43d-83edd1e34a2b


7413

https://github.com/brave/brave-ios/assets/6643505/007cba7d-e6f9-4368-a2ae-677563fceb5b


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
