### PR TITLE
Fix #7466: Fix Playlist lockscreen pausing

### DIFF
--- a/Sources/Brave/Frontend/Browser/Playlist/VideoPlayer/MediaPlayer.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/VideoPlayer/MediaPlayer.swift
@@ -423,6 +423,30 @@ extension MediaPlayer {
 extension MediaPlayer {
   /// Registers basic notifications
   private func registerNotifications() {
+    NotificationCenter.default.publisher(for: UIApplication.didEnterBackgroundNotification)
+      .sink { [weak self] _ in
+      guard let self = self else { return }
+
+      if let pictureInPictureController = self.pictureInPictureController,
+        pictureInPictureController.isPictureInPictureActive {
+        return
+      }
+
+      self.playerLayer.player = nil
+    }.store(in: &notificationObservers)
+
+    NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)
+      .sink { [weak self] _ in
+      guard let self = self else { return }
+
+      if let pictureInPictureController = self.pictureInPictureController,
+        pictureInPictureController.isPictureInPictureActive {
+        return
+      }
+
+      self.playerLayer.player = self.player
+    }.store(in: &notificationObservers)
+    
     NotificationCenter.default.publisher(for: AVAudioSession.interruptionNotification, object: AVAudioSession.sharedInstance())
       .sink { [weak self] notification in
 


### PR DESCRIPTION
## Summary of Changes
- Disable rendering of video when the screen locks, so the system plays only the audio track.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7466

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
- Play a video in playlist.
- Lock the screen
- Video should keep playing without pausing!


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
