### PR TITLE
Fix #7537: Fix Youtube adding audio files to Playlist

### DIFF
--- a/Sources/Brave/Frontend/Browser/Playlist/Managers & Cache/PlaylistManager.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/Managers & Cache/PlaylistManager.swift
@@ -729,7 +729,8 @@ extension PlaylistManager {
               detected: item.detected,
               dateAdded: item.dateAdded,
               tagId: item.tagId,
-              order: item.order)
+              order: item.order,
+              isInvisible: item.isInvisible)
 
             if PlaylistItem.itemExists(uuid: item.tagId) || PlaylistItem.itemExists(pageSrc: item.pageSrc) {
               PlaylistItem.updateItem(newItem) {

--- a/Sources/Brave/Frontend/Browser/Playlist/PlaylistSharedFolder.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/PlaylistSharedFolder.swift
@@ -41,7 +41,8 @@ struct PlaylistSharedFolderModel: Decodable {
                    detected: true,
                    dateAdded: Date(),
                    tagId: item.mediaItemId,
-                   order: Int32(item.order) ?? -1)
+                   order: Int32(item.order) ?? -1,
+                   isInvisible: false)
     }.sorted(by: { $0.order < $1.order })
   }
   
@@ -178,7 +179,8 @@ struct PlaylistSharedFolderNetwork {
                                   detected: newItem.detected,
                                   dateAdded: newItem.dateAdded,
                                   tagId: item.tagId,
-                                  order: item.order)
+                                  order: item.order,
+                                  isInvisible: newItem.isInvisible)
           
           // Destroy the web loader when the callback is complete.
           webLoader.stop()

--- a/Sources/Brave/Frontend/Browser/Playlist/Utilities/PlaylistMediaStreamer.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/Utilities/PlaylistMediaStreamer.swift
@@ -124,7 +124,8 @@ class PlaylistMediaStreamer {
                                      detected: newItem.detected,
                                      dateAdded: item.dateAdded, // Keep the same dateAdded
                                      tagId: item.tagId,  // Keep the same tagId
-                                     order: item.order) // Keep the same order
+                                     order: item.order,
+                                     isInvisible: item.isInvisible) // Keep the same order
       
       let item = try await withCheckedThrowingContinuation { continuation in
         PlaylistItem.updateItem(updatedItem) {

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/PlaylistScriptHandler.swift
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/PlaylistScriptHandler.swift
@@ -119,6 +119,13 @@ class PlaylistScriptHandler: NSObject, TabContentScript {
       return
     }
     
+    if handler.url?.baseDomain != "soundcloud.com", item.isInvisible {
+      DispatchQueue.main.async {
+        handler.delegate?.updatePlaylistURLBar(tab: handler.tab, state: .none, item: nil)
+      }
+      return
+    }
+    
     // Copy the item but use the web-view's title and location instead, if available
     // This is due to a iFrames security
     item = PlaylistInfo(name: item.name,
@@ -131,7 +138,8 @@ class PlaylistScriptHandler: NSObject, TabContentScript {
                         detected: item.detected,
                         dateAdded: item.dateAdded,
                         tagId: item.tagId,
-                        order: item.order)
+                        order: item.order,
+                        isInvisible: item.isInvisible)
 
     Self.queue.async { [weak handler] in
       guard let handler = handler else { return }

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Paged/PlaylistScript.js
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Paged/PlaylistScript.js
@@ -87,7 +87,8 @@ window.__firefox__.includeOnce("Playlist", function($) {
         "mimeType": type,
         "duration": clamp_duration(target.duration),
         "detected": detected,
-        "tagId": target.$<tagUUID>
+        "tagId": target.$<tagUUID>,
+        "invisible": !target.parentNode
       });
     })();
   });
@@ -130,7 +131,7 @@ window.__firefox__.includeOnce("Playlist", function($) {
           if (node.src && node.src !== "") {
             if ((node.closest('video') === target) || (node.closest('audio') === target)) {
               tagNode(target);
-              sendMessage(name, node, target, type, detected);
+              sendMessage(name, target, target, type, detected);
             }
           }
         });

--- a/Sources/Data/models/PlaylistInfo.swift
+++ b/Sources/Data/models/PlaylistInfo.swift
@@ -20,6 +20,7 @@ public struct PlaylistInfo: Codable, Identifiable, Hashable, Equatable {
   public let dateAdded: Date
   public let tagId: String
   public let order: Int32
+  public let isInvisible: Bool
   
   public var id: String {
     tagId
@@ -37,6 +38,7 @@ public struct PlaylistInfo: Codable, Identifiable, Hashable, Equatable {
     self.detected = false
     self.tagId = UUID().uuidString
     self.order = Int32.min
+    self.isInvisible = false
   }
 
   public init(item: PlaylistItem) {
@@ -51,9 +53,10 @@ public struct PlaylistInfo: Codable, Identifiable, Hashable, Equatable {
     self.detected = false
     self.tagId = item.uuid ?? UUID().uuidString
     self.order = item.order
+    self.isInvisible = false
   }
 
-  public init(name: String, src: String, pageSrc: String, pageTitle: String, mimeType: String, duration: TimeInterval, lastPlayedOffset: TimeInterval, detected: Bool, dateAdded: Date, tagId: String, order: Int32) {
+  public init(name: String, src: String, pageSrc: String, pageTitle: String, mimeType: String, duration: TimeInterval, lastPlayedOffset: TimeInterval, detected: Bool, dateAdded: Date, tagId: String, order: Int32, isInvisible: Bool) {
     self.name = name
     self.src = src
     self.pageSrc = pageSrc
@@ -65,6 +68,7 @@ public struct PlaylistInfo: Codable, Identifiable, Hashable, Equatable {
     self.dateAdded = dateAdded
     self.tagId = tagId.isEmpty ? UUID().uuidString : tagId
     self.order = order
+    self.isInvisible = isInvisible
   }
 
   public init(from decoder: Decoder) throws {
@@ -81,6 +85,7 @@ public struct PlaylistInfo: Codable, Identifiable, Hashable, Equatable {
     self.dateAdded = Date()
     self.src = PlaylistInfo.fixSchemelessURLs(src: src, pageSrc: pageSrc)
     self.order = try container.decodeIfPresent(Int32.self, forKey: .order) ?? Int32.min
+    self.isInvisible = try container.decodeIfPresent(Bool.self, forKey: .isInvisible) ?? false
   }
 
   public static func from(message: WKScriptMessage) -> PlaylistInfo? {
@@ -131,5 +136,6 @@ public struct PlaylistInfo: Codable, Identifiable, Hashable, Equatable {
     case tagId
     case dateAdded
     case order
+    case isInvisible = "invisible"
   }
 }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Fix youtube showing audio files in Playlist by checking if the file being added is "invisible" on the page.
- Limit invisible audio files to SoundCloud only.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7537

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
