### PR TITLE
Fix #7541: Fixing CarPlay Next and Previous steering wheel buttons

### DIFF
--- a/Sources/Brave/Frontend/Browser/Playlist/Controllers/PlaylistCarplayController.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/Controllers/PlaylistCarplayController.swift
@@ -68,17 +68,6 @@ class PlaylistCarplayController: NSObject {
   }
 
   func observeFolderStates() {
-    PlaylistCarplayManager.shared.onCarplayUIChangedToRoot.eraseToAnyPublisher()
-      .receive(on: DispatchQueue.main)
-      .sink { [weak self] in
-        guard let self = self else { return }
-        self.interfaceController.popToRootTemplate(animated: true) { success, error in
-          if !success, let error = error {
-            Logger.module.error("\(error.localizedDescription)")
-          }
-        }
-      }.store(in: &playlistObservers)
-
     PlaylistManager.shared.onCurrentFolderDidChange
       .receive(on: DispatchQueue.main)
       .sink { [weak self] in
@@ -124,26 +113,8 @@ class PlaylistCarplayController: NSObject {
       guard let tabTemplate = self.interfaceController.rootTemplate as? CPTabBarTemplate else {
         return
       }
-
-      // The folder is already showing all its items
-      var currentTemplate = self.interfaceController.topTemplate as? CPListTemplate
-
-      // If the folder's items isn't showing, then we're either on the folder view or settings view
-      // Therefore we need to push the folder view onto the stack
-      if currentTemplate == nil || (currentTemplate?.userInfo as? [String: String])?["id"] != PlaylistCarPlayTemplateID.itemsList.rawValue {
-
-        // Fetch the root playlistTabTemplate
-        currentTemplate = tabTemplate.templates.compactMap({ $0 as? CPListTemplate }).first(where: {
-          ($0.userInfo as? [String: String])?["id"] == PlaylistCarPlayTemplateID.itemsList.rawValue
-        })
-      }
-
-      // We need to ensure the template that is showing is the list of playlist items
-      guard (currentTemplate?.userInfo as? [String: String])?["id"] == PlaylistCarPlayTemplateID.itemsList.rawValue else {
-        return
-      }
-
-      if let playlistTabTemplate = currentTemplate {
+      
+      if let playlistTabTemplate = self.getItemListTemplate() {
         let items = playlistTabTemplate.sections.flatMap({ $0.items }).compactMap({ $0 as? CPListItem })
 
         items.forEach({
@@ -162,7 +133,7 @@ class PlaylistCarplayController: NSObject {
           }
         })
       }
-
+      
       tabTemplate.updateTemplates(tabTemplate.templates)
 
       if self.interfaceController.topTemplate != CPNowPlayingTemplate.shared {
@@ -239,6 +210,29 @@ class PlaylistCarplayController: NSObject {
         reloadData()
       }.store(in: &playlistObservers)
   }
+  
+  private func getFolderTemplateList() -> CPListTemplate? {
+    // Retrieve the tab-bar
+    guard let tabTemplate = self.interfaceController.rootTemplate as? CPTabBarTemplate else {
+      return nil
+    }
+
+    // Retrieve the folder list item
+    let folderTemplate = tabTemplate.templates.compactMap({ $0 as? CPListTemplate }).first(where: {
+      ($0.userInfo as? [String: String])?["id"] == PlaylistCarPlayTemplateID.folders.rawValue
+    })
+    
+    return folderTemplate
+  }
+  
+  private func getItemListTemplate() -> CPListTemplate? {
+    // Retrieve the item-list
+    let listTemplate = interfaceController.templates.compactMap({ $0 as? CPListTemplate }).first(where: {
+      ($0.userInfo as? [String: String])?["id"] == PlaylistCarPlayTemplateID.itemsList.rawValue
+    })
+    
+    return listTemplate
+  }
 
   private func doLayout() {
     do {
@@ -273,48 +267,19 @@ class PlaylistCarplayController: NSObject {
   }
 
   private func reloadData() {
-    guard let tabBarTemplate = interfaceController.rootTemplate as? CPTabBarTemplate else {
-      return
-    }
-
-    // Need to unwind the navigation stack to the root before attempting any modifications
-    // Some cars will crash if we replace or modify the RootTemplate while
-    // an alert of CPNowPlayingTemplate.shared is being displayed
-    // interfaceController.pop(to: tabBarTemplate, animated: true)
-
     // Update Currently Playing Index before layout (so we can show the playing indicator)
     if let itemId = PlaylistCarplayManager.shared.currentPlaylistItem?.tagId {
       PlaylistCarplayManager.shared.currentlyPlayingItemIndex = PlaylistManager.shared.index(of: itemId) ?? -1
     }
-
-    do {
-      try foldersFRC.performFetch()
-      try sharedFoldersFRC.performFetch()
-    } catch {
-      Logger.module.error("\(error.localizedDescription)")
-    }
-
+    
     // FOLDERS TEMPLATE
-    let foldersTemplate = generatePlaylistFolderListTemplate()
-
-    // SETTINGS TEMPLATE
-    let settingsTemplate = generateSettingsTemplate()
-
-    // ALL TEMPLATES
-    let tabTemplates: [CPTemplate] = [
-      foldersTemplate,
-      settingsTemplate,
-    ]
-
-    // If we have any controllers presented, we need to remove them.
-    interfaceController.popToRootTemplate(animated: true) { success, error in
-      if !success, let error = error {
-        Logger.module.error("\(error.localizedDescription)")
-      }
+    guard let foldersTemplate = generatePlaylistFolderListTemplate() as? CPListTemplate else {
+      Logger.module.error("Invalid Folders Template - NOT A CPListTemplate!")
+      return
     }
-
-    // Reload the templates instead of replacing the RootTemplate
-    tabBarTemplate.updateTemplates(tabTemplates)
+    
+    let oldFoldersTemplate = getFolderTemplateList()
+    oldFoldersTemplate?.updateSections(foldersTemplate.sections)
   }
 
   private func generatePlaylistFolderListTemplate() -> CPTemplate {
@@ -413,7 +378,7 @@ class PlaylistCarplayController: NSObject {
         let listItem = selectableItem as? CPListItem ?? listItem
         listItem?.accessoryType = .none
         
-        Task { @MainActor [listItems] in
+        Task { @MainActor in
           do {
             try await self.initiatePlaybackOfItem(itemId: itemId)
           } catch {
@@ -428,12 +393,6 @@ class PlaylistCarplayController: NSObject {
           }
 
           listItem.accessoryType = PlaylistManager.shared.state(for: itemId) != .downloaded ? .cloud : .none
-
-          let isPlaying = self.player.isPlaying || self.player.isWaitingToPlay
-          for item in listItems.enumerated() {
-            let userInfo = item.element.userInfo as? [String: Any] ?? [:]
-            item.element.isPlaying = isPlaying && (PlaylistCarplayManager.shared.currentPlaylistItem?.src == userInfo["id"] as? String)
-          }
 
           let userInfo = listItem.userInfo as? [String: Any]
           PlaylistMediaStreamer.setNowPlayingMediaArtwork(image: userInfo?["icon"] as? UIImage)
@@ -558,13 +517,6 @@ class PlaylistCarplayController: NSObject {
 extension PlaylistCarplayController: CPInterfaceControllerDelegate {
   func templateWillAppear(_ aTemplate: CPTemplate, animated: Bool) {
     Logger.module.debug("Template \(aTemplate.classForCoder) will appear.")
-
-    if interfaceController.topTemplate != CPNowPlayingTemplate.shared,
-      (aTemplate.userInfo as? [String: String])?["id"] == PlaylistCarPlayTemplateID.folders.rawValue {
-      self.stop()
-
-      PlaylistCarplayManager.shared.onCarplayUIChangedToRoot.send()
-    }
   }
 
   func templateDidAppear(_ aTemplate: CPTemplate, animated: Bool) {
@@ -635,12 +587,16 @@ extension PlaylistCarplayController {
 
     // Reset Now Playing when playback is starting.
     PlaylistMediaStreamer.clearNowPlayingInfo()
-
-    PlaylistCarplayManager.shared.currentPlaylistItem = item
-    PlaylistCarplayManager.shared.currentlyPlayingItemIndex = index
     
     do {
+      PlaylistCarplayManager.shared.currentPlaylistItem = item
+      PlaylistCarplayManager.shared.currentlyPlayingItemIndex = index
+      
       try await playItem(item: item)
+      
+      if let item = PlaylistCarplayManager.shared.currentPlaylistItem {
+        updateLastPlayedItem(item: item)
+      }
     } catch {
       PlaylistCarplayManager.shared.currentPlaylistItem = nil
       PlaylistCarplayManager.shared.currentlyPlayingItemIndex = -1
@@ -751,6 +707,14 @@ extension PlaylistCarplayController {
     PlaylistManager.shared.playbackTask?.cancel()
     PlaylistManager.shared.playbackTask = nil
   }
+  
+  private func clear() {
+    PlaylistMediaStreamer.clearNowPlayingInfo()
+    player.clear()
+    
+    PlaylistManager.shared.playbackTask?.cancel()
+    PlaylistManager.shared.playbackTask = nil
+  }
 
   private func seekBackwards() {
     player.seekBackwards()
@@ -778,7 +742,7 @@ extension PlaylistCarplayController {
 
   @MainActor
   func load(asset: AVURLAsset, autoPlayEnabled: Bool) async throws {
-    player.stop()
+    self.clear()
     
     let isNewItem = try await player.load(asset: asset)
     
@@ -867,8 +831,7 @@ extension PlaylistCarplayController {
       return
     }
     
-    let lastPlayedTime = Preferences.Playlist.playbackLeftOff.value ? playTime.seconds : 0.0
-    PlaylistItem.updateLastPlayed(itemId: item.tagId, pageSrc: item.pageSrc, lastPlayedOffset: lastPlayedTime)
+    PlaylistManager.shared.updateLastPlayed(item: item, playTime: playTime.seconds)
   }
 
   func displayExpiredResourceError(item: PlaylistInfo?) {

--- a/Sources/Brave/Frontend/Browser/Playlist/Managers & Cache/PlaylistManager.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/Managers & Cache/PlaylistManager.swift
@@ -131,6 +131,12 @@ public class PlaylistManager: NSObject {
   var fetchedObjects: [PlaylistItem] {
     frc.fetchedObjects ?? []
   }
+  
+  func updateLastPlayed(item: PlaylistInfo, playTime: Double) {
+    let lastPlayedTime = Preferences.Playlist.playbackLeftOff.value ? playTime : 0.0
+    Preferences.Playlist.lastPlayedItemUrl.value = item.pageSrc
+    PlaylistItem.updateLastPlayed(itemId: item.tagId, pageSrc: item.pageSrc, lastPlayedOffset: lastPlayedTime)
+  }
 
   func itemAtIndex(_ index: Int) -> PlaylistInfo? {
     if index >= 0 && index < numberOfAssets {

--- a/Sources/Brave/Frontend/Browser/Playlist/VideoPlayer/MediaPlayer.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/VideoPlayer/MediaPlayer.swift
@@ -119,6 +119,11 @@ class MediaPlayer: NSObject {
     // Stop receiving remote commands
     UIApplication.shared.endReceivingRemoteControlEvents()
   }
+  
+  func clear() {
+    player.replaceCurrentItem(with: nil)
+    pendingMediaItem = nil
+  }
 
   func load(url: URL) async throws -> Bool {
     try await load(asset: AVURLAsset(url: url, options: AVAsset.defaultOptions))


### PR DESCRIPTION
## Summary of Changes
- Fixes CarPlay Next and Previous steering wheel buttons
- Fixes Playback with AsyncAwait issues.
- Fixes NowPlaying
- Fixes syncing UI between phone and car
- Fixes updating the UI when an item is played in the car

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7541

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
- In the Ticket


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
