### PR TITLE
Fix #7386: Allow to add .ics to the calendar app.

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -198,29 +198,12 @@ extension BrowserViewController: WKNavigationDelegate {
     
     // Handling calendar .ics files
     if url.pathExtension.lowercased() == "ics" {
-      let localURL = FileManager.default.temporaryDirectory.appendingPathComponent(url.lastPathComponent)
-      
-      do {
-        let (tempLocalUrl, _) = try await URLSession.shared.download(from: url)
-        if FileManager.default.fileExists(atPath: localURL.path) {
-          try FileManager.default.removeItem(at: localURL)
-        }
-        try FileManager.default.copyItem(at: tempLocalUrl, to: localURL)
-        
-        // This is not ideal. It pushes a new view controller on top of the BVC
-        // and you have to dismiss it manually after you managed the calendar event.
-        // I do not see a workaround for it, Chrome iOS does the same thing.
-        // There is also no good way to know when to clean up the temporary file download.
-        let vc = SFSafariViewController(url: url, configuration: .init())
-        vc.modalPresentationStyle = .formSheet
-        
-        self.present(vc, animated: true)
-      } catch {
-        Logger.module.error("Handling .ics file error: \(error)")
-        if FileManager.default.fileExists(atPath: localURL.path) {
-          try? FileManager.default.removeItem(at: localURL)
-        }
-      }
+      // This is not ideal. It pushes a new view controller on top of the BVC
+      // and you have to dismiss it manually after you managed the calendar event.
+      // I do not see a workaround for it, Chrome iOS does the same thing.
+      let vc = SFSafariViewController(url: url, configuration: .init())
+      vc.modalPresentationStyle = .formSheet
+      self.present(vc, animated: true)
       
       return (.cancel, preferences)
     }

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -197,7 +197,7 @@ extension BrowserViewController: WKNavigationDelegate {
     }
     
     // Handling calendar .ics files
-    if url.pathExtension.lowercased() == "ics" {
+    if navigationAction.targetFrame?.isMainFrame == true, url.pathExtension.lowercased() == "ics" {
       // This is not ideal. It pushes a new view controller on top of the BVC
       // and you have to dismiss it manually after you managed the calendar event.
       // I do not see a workaround for it, Chrome iOS does the same thing.


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7386

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
May be not easy to find a website with .ics urls. What I do to test is:
1. Edit one of the NTP favorites to this url `https://developer.apple.com/wwdc23/WWDC2023.ics`
2. Then you can tap it and it should open a "add calendar event" screen
3. One note, it will open a blank screen over the browser window. This is the only way to make it work unfortunately, chrome iOS does the same thing

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
