### PR TITLE
Fix #7548: Tab Deallocation on main thread

### DIFF
--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/FaviconScriptHandler.swift
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/FaviconScriptHandler.swift
@@ -85,7 +85,7 @@ class FaviconScriptHandler: NSObject, TabContentScript {
         return
       }
       
-      Task {
+      Task { @MainActor in
         let favicon = await Favicon.renderImage(icon, backgroundColor: .clear, shouldScale: true)
 
         // We can only cache favicons for non-private tabs
@@ -102,7 +102,7 @@ class FaviconScriptHandler: NSObject, TabContentScript {
         Logger.module.error("Website: \(url.absoluteString), has no Favicon")
       }
       
-      Task {
+      Task { @MainActor in
         let favicon = try await FaviconFetcher.monogramIcon(url: url, persistent: !isPrivate)
         FaviconFetcher.updateCache(favicon, for: url, persistent: true)
         


### PR DESCRIPTION
## Summary of Changes
- Access everything from brave-core weakly. If tab deallocates, all of the objects deallocate under the hood. The weak references become nil. If they are still for some reason doing an operation, well it should be cancelled.

- Fix possible favicon crash

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7548

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
