### PR TITLE
Fix #7505: Dismiss pending request screen will dismiss full screen wallet

### DIFF
--- a/Sources/BraveWallet/Crypto/CryptoView.swift
+++ b/Sources/BraveWallet/Crypto/CryptoView.swift
@@ -268,6 +268,19 @@ private struct CryptoContainerView<DismissContent: ToolbarContent>: View {
   var keyringStore: KeyringStore
   @ObservedObject var cryptoStore: CryptoStore
   var toolbarDismissContent: DismissContent
+  @ToolbarContentBuilder
+  // This toolbar content is for `PendingRequestView` which is presented on top of full screen wallet
+  private var pendingRequestToolbarDismissContent: some ToolbarContent {
+    ToolbarItemGroup(placement: .cancellationAction) {
+      Button(action: {
+        cryptoStore.isPresentingPendingRequest = false
+      }) {
+        Image("wallet-dismiss", bundle: .module)
+          .renderingMode(.template)
+          .foregroundColor(Color(.braveBlurpleTint))
+      }
+    }
+  }
 
   var body: some View {
     UIKitNavigationView {
@@ -311,7 +324,7 @@ private struct CryptoContainerView<DismissContent: ToolbarContent>: View {
             RequestContainerView(
               keyringStore: keyringStore,
               cryptoStore: cryptoStore,
-              toolbarDismissContent: toolbarDismissContent,
+              toolbarDismissContent: pendingRequestToolbarDismissContent,
               onDismiss: {
                 cryptoStore.isPresentingPendingRequest = false
               }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
We are creating a new `ToolbarContent` for the pending request screen when its being presented on top of the full screen wallet.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7505

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Please refer to the issue.


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
