### PR TITLE
Fix #7495: Remove network label in encryption and decryption request panel

### DIFF
--- a/Sources/BraveWallet/Panels/Encryption/EncryptionView.swift
+++ b/Sources/BraveWallet/Panels/Encryption/EncryptionView.swift
@@ -35,7 +35,6 @@ struct EncryptionView: View {
   var request: EncryptionType
   @ObservedObject var cryptoStore: CryptoStore
   @ObservedObject var keyringStore: KeyringStore
-  @ObservedObject var networkStore: NetworkStore
   var onDismiss: () -> Void
   
   @State private var isShowingDecryptMessage = false
@@ -68,12 +67,6 @@ struct EncryptionView: View {
   
   var body: some View {
     ScrollView(.vertical) {
-      HStack(alignment: .top) {
-        Text(networkStore.defaultSelectedChain.chainName)
-        Spacer()
-      }
-      .font(.callout)
-      .padding(.bottom, 6)
       VStack(spacing: 12) {
         VStack(spacing: 8) {
           Blockie(address: request.address)
@@ -267,7 +260,6 @@ struct EncryptionView_Previews: PreviewProvider {
           request: request,
           cryptoStore: .previewStore,
           keyringStore: .previewStoreWithWalletCreated,
-          networkStore: .previewStore,
           onDismiss: { }
         )
       }

--- a/Sources/BraveWallet/Panels/RequestContainerView.swift
+++ b/Sources/BraveWallet/Panels/RequestContainerView.swift
@@ -66,7 +66,6 @@ struct RequestContainerView<DismissContent: ToolbarContent>: View {
               request: .getEncryptionPublicKey(request),
               cryptoStore: cryptoStore,
               keyringStore: keyringStore,
-              networkStore: cryptoStore.networkStore,
               onDismiss: onDismiss
             )
           case let .decrypt(request):
@@ -74,7 +73,6 @@ struct RequestContainerView<DismissContent: ToolbarContent>: View {
               request: .decrypt(request),
               cryptoStore: cryptoStore,
               keyringStore: keyringStore,
-              networkStore: cryptoStore.networkStore,
               onDismiss: onDismiss
             )
           case let .signTransaction(requests):


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
Network label is irrelevant to encryption or decryption request panel. we are removing this label to avoid any confusion if users changes network 

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7495

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
1. make any encryption or decryption request from a dapp
2. check if network label has been removed from the request panel 

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->
![Simulator Screenshot - iPhone SE (3rd generation) - 2023-06-02 at 16 26 59](https://github.com/brave/brave-ios/assets/1187676/44e854cb-0737-4601-9b11-03f0b5204a98)

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
