### PR TITLE
Fix #7435 : Fixed typo in localization key of shared strings

### DIFF
--- a/App/BraveWidgets/WidgetStrings.swift
+++ b/App/BraveWidgets/WidgetStrings.swift
@@ -76,7 +76,7 @@ extension Strings {
                                                               value: "Brave Wallet",
                                                               comment: "Description for the Brave Wallet option on the 'shortcuts' widget.")
     public static let bookmarksMenuItem = NSLocalizedString("widgets.BookmarksMenuItem", bundle: widgetBundle, value: "Bookmarks", comment: "Title for bookmarks menu item")
-    public static let historyMenuItem = NSLocalizedString("widgets.HistortMenuItem", bundle: widgetBundle, value: "History", comment: "Title for history menu item")
+    public static let historyMenuItem = NSLocalizedString("widgets.HistoryMenuItem", bundle: widgetBundle, value: "History", comment: "Title for history menu item")
     public static let downloadsMenuItem = NSLocalizedString("widgets.DownloadsMenuItem", bundle: widgetBundle, value: "Downloads", comment: "Title for downloads menu item")
     public static let QRCode = NSLocalizedString("widgets.QRCode", bundle: widgetBundle, value: "QR Code", comment: "QR Code section title")
     public static let newsClusteringWidgetTitle = NSLocalizedString(


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7435 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [ ] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
