### PR TITLE
Fix #7560: Add native Brave Talk jitsi integration to release builds

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -474,7 +474,11 @@ var braveTarget: PackageDescription.Target = .target(
   plugins: ["LoggerPlugin"]
 )
 
-if ProcessInfo.processInfo.environment["BRAVE_APPSTORE_BUILD"] == nil {
+// Keeping this in case we need to disable it at any time
+// Can use `BRAVE_APPSTORE_BUILD` environment like before to disable only on Release builds as well
+let isNativeTalkEnabled = true
+
+if isNativeTalkEnabled {
   // Not a release build, add BraveTalk integrations
   braveTarget.dependencies.append("BraveTalk")
   braveTarget.resources?.append(

--- a/Sources/BraveTalk/BraveTalkJitsiCoordinator.swift
+++ b/Sources/BraveTalk/BraveTalkJitsiCoordinator.swift
@@ -13,7 +13,8 @@ import JitsiMeetSDK
 @MainActor public class BraveTalkJitsiCoordinator: Sendable {
   /// Whether or not the jitsi SDK integration is enabled
   static var isIntegrationEnabled: Bool {
-    return AppConstants.buildChannel != .release
+    // If needed to disable for certain build channels, check AppConstants.buildChannel here
+    return true
   }
   
   public init() {}

--- a/Tests/BraveTalkTests/BraveTalkTests.swift
+++ b/Tests/BraveTalkTests/BraveTalkTests.swift
@@ -9,9 +9,9 @@ import Shared
 import XCTest
 
 class BraveTalkTests: XCTestCase {
-  @MainActor func testBraveTalkJitsiIntegrationDisabledOnRelease() {
+  @MainActor func testBraveTalkJitsiIntegrationEnabledOnRelease() {
     AppConstants.buildChannel = .release
-    XCTAssertFalse(BraveTalkJitsiCoordinator.isIntegrationEnabled)
+    XCTAssertTrue(BraveTalkJitsiCoordinator.isIntegrationEnabled)
   }
   
   @MainActor func testBraveTalkJitsiIntegrationEnabledOnBeta() {


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #7560 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

- Test that Native brave talk/Jitsi SDK integration exists on prod builds as well as dev

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
