### PR TITLE
Fix #7556: NFT importing improvement

### DIFF
--- a/Sources/BraveWallet/Crypto/NFT/NFTView.swift
+++ b/Sources/BraveWallet/Crypto/NFT/NFTView.swift
@@ -104,8 +104,8 @@ struct NFTView: View {
       self.isPresentingNetworkFilter = true
     }) {
       HStack {
-        Text(nftStore.networkFilter.title)
         Image(braveSystemName: "leo.list")
+        Text(nftStore.networkFilter.title)
       }
       .font(.footnote.weight(.medium))
       .foregroundColor(Color(.braveBlurpleTint))
@@ -128,16 +128,27 @@ struct NFTView: View {
       Text(Strings.Wallet.assetsTitle)
         .font(.footnote)
         .foregroundColor(Color(.secondaryBraveLabel))
+        .padding(.leading, 16)
       if nftStore.isLoadingDiscoverAssets && isNFTDiscoveryEnabled {
         ProgressView()
           .padding(.leading, 5)
       }
       Spacer()
       networkFilterButton
+        .padding(.trailing, 10)
+      addCustomAssetButton
     }
     .textCase(nil)
     .padding(.horizontal, 10)
     .frame(maxWidth: .infinity, alignment: .leading)
+  }
+  
+  private var addCustomAssetButton: some View {
+    Button(action: {
+      isShowingAddCustomNFT = true
+    }) {
+      Image(systemName: "plus")
+    }
   }
   
   private var nftDiscoveryDescriptionText: NSAttributedString? {
@@ -156,44 +167,57 @@ struct NFTView: View {
     return attributedString
   }
   
+  @ViewBuilder var nftGridsView: some View {
+    if nftStore.userVisibleNFTs.isEmpty {
+      emptyView
+        .listRowBackground(Color(.clear))
+    } else {
+      LazyVGrid(columns: nftGrids) {
+        ForEach(nftStore.userVisibleNFTs) { nft in
+          Button(action: {
+            selectedNFTViewModel = nft
+          }) {
+            VStack(alignment: .leading, spacing: 4) {
+              nftImage(nft)
+                .contextMenu {
+                  Button(action: {
+                    nftStore.updateVisibility(nft.token, visible: false)
+                  }) {
+                    Label(Strings.recentSearchHide, braveSystemImage: "leo.eye.off")
+                  }
+                }
+                .padding(.bottom, 8)
+              Text(nft.token.nftTokenTitle)
+                .font(.callout.weight(.medium))
+                .foregroundColor(Color(.braveLabel))
+                .multilineTextAlignment(.leading)
+              if !nft.token.symbol.isEmpty {
+                Text(nft.token.symbol)
+                  .font(.caption)
+                  .foregroundColor(Color(.secondaryBraveLabel))
+                  .multilineTextAlignment(.leading)
+              }
+            }
+          }
+        }
+      }
+      VStack(spacing: 16) {
+        Divider()
+        editUserAssetsButton
+      }
+      .padding(.top, 20)
+    }
+  }
+  
   var body: some View {
     ScrollView {
       VStack {
         nftHeaderView
-        if nftStore.userVisibleNFTs.isEmpty {
-          emptyView
-            .listRowBackground(Color(.clear))
-        } else {
-          LazyVGrid(columns: nftGrids) {
-            ForEach(nftStore.userVisibleNFTs) { nft in
-              Button(action: {
-                selectedNFTViewModel = nft
-              }) {
-                VStack(alignment: .leading, spacing: 4) {
-                  nftImage(nft)
-                    .padding(.bottom, 8)
-                  Text(nft.token.nftTokenTitle)
-                    .font(.callout.weight(.medium))
-                    .foregroundColor(Color(.braveLabel))
-                    .multilineTextAlignment(.leading)
-                  if !nft.token.symbol.isEmpty {
-                    Text(nft.token.symbol)
-                      .font(.caption)
-                      .foregroundColor(Color(.secondaryBraveLabel))
-                      .multilineTextAlignment(.leading)
-                  }
-                }
-              }
-            }
-          }
-          VStack(spacing: 16) {
-            Divider()
-            editUserAssetsButton
-          }
-          .padding(.top, 20)
-        }
+          .padding(.horizontal, 8)
+        nftGridsView
+          .padding(.horizontal, 24)
       }
-      .padding(24)
+      .padding(.vertical, 24)
     }
     .background(Color(UIColor.braveGroupedBackground))
     .background(

--- a/Sources/BraveWallet/Crypto/NFT/NFTView.swift
+++ b/Sources/BraveWallet/Crypto/NFT/NFTView.swift
@@ -179,13 +179,6 @@ struct NFTView: View {
           }) {
             VStack(alignment: .leading, spacing: 4) {
               nftImage(nft)
-                .contextMenu {
-                  Button(action: {
-                    nftStore.updateVisibility(nft.token, visible: false)
-                  }) {
-                    Label(Strings.recentSearchHide, braveSystemImage: "leo.eye.off")
-                  }
-                }
                 .padding(.bottom, 8)
               Text(nft.token.nftTokenTitle)
                 .font(.callout.weight(.medium))
@@ -197,6 +190,13 @@ struct NFTView: View {
                   .foregroundColor(Color(.secondaryBraveLabel))
                   .multilineTextAlignment(.leading)
               }
+            }
+          }
+          .contextMenu {
+            Button(action: {
+              nftStore.updateVisibility(nft.token, visible: false)
+            }) {
+              Label(Strings.recentSearchHide, braveSystemImage: "leo.eye.off")
             }
           }
         }

--- a/Sources/BraveWallet/Crypto/Portfolio/AddCustomAssetView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/AddCustomAssetView.swift
@@ -78,6 +78,33 @@ struct AddCustomAssetView: View {
           }
         }
         Section(
+          header: WalletListHeaderView(title: networkSelectionStore.networkSelectionInForm?.coin == .sol ? Text(Strings.Wallet.tokenMintAddress) : Text(Strings.Wallet.tokenAddress))
+        ) {
+          TextField(Strings.Wallet.enterAddress, text: $addressInput)
+            .onChange(of: addressInput) { newValue in
+              guard !newValue.isEmpty else { return }
+              userAssetStore.tokenInfo(address: newValue) { token in
+                guard let token else { return }
+                if nameInput.isEmpty {
+                  nameInput = token.name
+                }
+                if symbolInput.isEmpty {
+                  symbolInput = token.symbol
+                }
+                if !token.isErc721, !token.isNft, decimalsInput.isEmpty {
+                  decimalsInput = "\(token.decimals)"
+                }
+                if let network = networkStore.allChains.first(where: { $0.chainId == token.chainId }) {
+                  networkSelectionStore.networkSelectionInForm = network
+                }
+              }
+            }
+            .autocapitalization(.none)
+            .autocorrectionDisabled()
+            .disabled(userAssetStore.isSearchingToken)
+            .listRowBackground(Color(.secondaryBraveGroupedBackground))
+        }
+        Section(
           header: WalletListHeaderView(title: Text(Strings.Wallet.customTokenNetworkHeader))
         ) {
           HStack {
@@ -106,33 +133,6 @@ struct AddCustomAssetView: View {
             }
           }
           .listRowBackground(Color(.secondaryBraveGroupedBackground))
-        }
-        Section(
-          header: WalletListHeaderView(title: networkSelectionStore.networkSelectionInForm?.coin == .sol ? Text(Strings.Wallet.tokenMintAddress) : Text(Strings.Wallet.tokenAddress))
-        ) {
-          TextField(Strings.Wallet.enterAddress, text: $addressInput)
-            .onChange(of: addressInput) { newValue in
-              guard !newValue.isEmpty else { return }
-              userAssetStore.tokenInfo(address: newValue) { token in
-                guard let token else { return }
-                if nameInput.isEmpty {
-                  nameInput = token.name
-                }
-                if symbolInput.isEmpty {
-                  symbolInput = token.symbol
-                }
-                if !token.isErc721, !token.isNft, decimalsInput.isEmpty {
-                  decimalsInput = "\(token.decimals)"
-                }
-                if let network = networkStore.allChains.first(where: { $0.chainId == token.chainId }) {
-                  networkSelectionStore.networkSelectionInForm = network
-                }
-              }
-            }
-            .autocapitalization(.none)
-            .autocorrectionDisabled()
-            .disabled(userAssetStore.isSearchingToken)
-            .listRowBackground(Color(.secondaryBraveGroupedBackground))
         }
         Section(
           header: WalletListHeaderView(title: Text(Strings.Wallet.tokenSymbol))

--- a/Sources/BraveWallet/Crypto/Stores/NFTStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/NFTStore.swift
@@ -151,6 +151,14 @@ public class NFTStore: ObservableObject {
   func enableNFTDiscovery() {
     walletService.setNftDiscoveryEnabled(true)
   }
+  
+  func updateVisibility(_ token: BraveWallet.BlockchainToken, visible: Bool) {
+    walletService.setUserAssetVisible(token, visible: visible) { [weak self] success in
+      if success {
+        self?.update()
+      }
+    }
+  }
 }
 
 extension NFTStore: BraveWalletJsonRpcServiceObserver {


### PR DESCRIPTION
## Summary of Changes
Add context menu on NFT item to quickly hide. add a quick button to import new NFT. move token address to the top in add custom asset screen.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7556

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
1. now you can long press to quick hide NFT item
2. there will be a `+` button beside network filter to quickly open `Add Custom Asset` screen
3. inside `Add Custom Asset`, token contract address has been moved to the top of the form


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->
![simulator_screenshot_B55C35CF-3573-49EA-A4A0-9CF03FAE3EBC](https://github.com/brave/brave-ios/assets/1187676/9e4ef995-f6ae-4da1-b7cc-2f0c63c2fdfb) | ![simulator_screenshot_323F1830-C734-41DB-9D8E-4306CB9B0BCE](https://github.com/brave/brave-ios/assets/1187676/03116e64-b90f-424c-b350-448ffbea16f0) | ![simulator_screenshot_D0FDE11E-145E-4202-B4EF-DA840EF57DF6](https://github.com/brave/brave-ios/assets/1187676/6bc85f07-dcad-4ab9-8d04-0202e246b657)
--|--|--

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
