### PR TITLE
Fix bug where New Tab Page ad viewed events fail on iOS - 1.51.x

### DIFF
--- a/Sources/Brave/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
+++ b/Sources/Brave/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
@@ -315,7 +315,13 @@ class NewTabPageViewController: UIViewController {
   override func viewDidAppear(_ animated: Bool) {
     super.viewDidAppear(animated)
 
-    reportSponsoredImageBackgroundEvent(.viewed)
+    reportSponsoredImageBackgroundEvent(.served)
+
+    DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+      // Temporary fix until 1.53.x because the served event must trigger before viewed events.
+      self.reportSponsoredImageBackgroundEvent(.viewed)
+    }
+
     presentNotification()
 
     DispatchQueue.main.asyncAfter(deadline: .now() + 0.50) {

--- a/Sources/BraveWallet/Preview Content/MockJsonRpcService.swift
+++ b/Sources/BraveWallet/Preview Content/MockJsonRpcService.swift
@@ -214,6 +214,10 @@ class MockJsonRpcService: BraveWalletJsonRpcService {
   func ensGetContentHash(_ domain: String, completion: @escaping ([NSNumber], Bool, BraveWallet.ProviderError, String) -> Void) {
     completion([], false, .internalError, "Error Message")
   }
+  
+  func isSolanaBlockhashValid(_ chainId: String, blockhash: String, commitment: String?, completion: @escaping (Bool, BraveWallet.SolanaProviderError, String) -> Void) {
+    completion(true, .success, "")
+  }
 }
 
 extension BraveWallet.NetworkInfo {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@mozilla/readability": "^0.4.2",
-        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.51.104/brave-core-ios-1.51.104.tgz",
+        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.51.110/brave-core-ios-1.51.110.tgz",
         "leo-sf-symbols": "github:brave/leo-sf-symbols#b66549a239c5d4d9db1bdcc0b847d5b1f1762e10",
         "page-metadata-parser": "^1.1.3",
         "webpack-cli": "^4.8.0"
@@ -356,9 +356,9 @@
       }
     },
     "node_modules/brave-core-ios": {
-      "version": "1.51.104",
-      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.51.104/brave-core-ios-1.51.104.tgz",
-      "integrity": "sha512-mImDCniMroqEsqjoWgxyEWYtu8bUcvwn8u+gUiM5i0MysVjLBn2jcryRwwqnjekM3RqCNLKRUmKfHZ6If7p2ew==",
+      "version": "1.51.110",
+      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.51.110/brave-core-ios-1.51.110.tgz",
+      "integrity": "sha512-W6E4BM3aJF5eZG8bSSPzmjL2Tkhxr35sQJHRpVR+uZfWpeQ+yCw+bRCt7qXgY1Cu/ltBbIKqEiP4CXlfk/4NMg==",
       "license": "ISC"
     },
     "node_modules/browserslist": {
@@ -1738,8 +1738,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-browser/releases/download/v1.51.104/brave-core-ios-1.51.104.tgz",
-      "integrity": "sha512-mImDCniMroqEsqjoWgxyEWYtu8bUcvwn8u+gUiM5i0MysVjLBn2jcryRwwqnjekM3RqCNLKRUmKfHZ6If7p2ew=="
+      "version": "https://github.com/brave/brave-browser/releases/download/v1.51.110/brave-core-ios-1.51.110.tgz",
+      "integrity": "sha512-W6E4BM3aJF5eZG8bSSPzmjL2Tkhxr35sQJHRpVR+uZfWpeQ+yCw+bRCt7qXgY1Cu/ltBbIKqEiP4CXlfk/4NMg=="
     },
     "browserslist": {
       "version": "4.17.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "license": "MPL-2.0",
   "dependencies": {
     "@mozilla/readability": "^0.4.2",
-    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.51.104/brave-core-ios-1.51.104.tgz",
+    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.51.110/brave-core-ios-1.51.110.tgz",
     "leo-sf-symbols": "github:brave/leo-sf-symbols#b66549a239c5d4d9db1bdcc0b847d5b1f1762e10",
     "page-metadata-parser": "^1.1.3",
     "webpack-cli": "^4.8.0"


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7566

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
See #7566 

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
