### PR TITLE
Fix bug where New Tab Page ad viewed events fail on iOS

### DIFF
--- a/Sources/Brave/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
+++ b/Sources/Brave/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
@@ -315,7 +315,17 @@ class NewTabPageViewController: UIViewController {
   override func viewDidAppear(_ animated: Bool) {
     super.viewDidAppear(animated)
 
-    reportSponsoredImageBackgroundEvent(.viewed)
+    reportSponsoredImageBackgroundEvent(.served)
+
+    DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+      // As a temporary fix until 1.53.x, we trigger the .viewed event after 1 second to
+      // give time for the .served event to be triggered; otherwise, the sponsored image
+      // viewed event will fail because it needs a corresponding served event. In 1.53.x
+      // and above we should trigger the .served event and in the completion block if
+      // successful we should trigger a .viewed event.
+      self.reportSponsoredImageBackgroundEvent(.viewed)
+    }
+
     presentNotification()
 
     DispatchQueue.main.asyncAfter(deadline: .now() + 0.50) {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7566

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
See #7566 

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
