### PR TITLE
Fix #7449-  Ref #7413: VPN Region country flag is not shown when relaunching Brave - VPN profile fails to initialize after purchase

### DIFF
--- a/App/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/GuardianFirewall/GuardianConnect",
       "state" : {
-        "revision" : "b52ab44f1f1fc8593b9b3006a9514a332cbaede7",
-        "version" : "1.8.5-dev-1"
+        "revision" : "2b97ae55edd9642cf721520129e807e576642e4f",
+        "version" : "1.8.5"
       }
     },
     {

--- a/App/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/GuardianFirewall/GuardianConnect",
       "state" : {
-        "revision" : "cf99f1babca17a3d94ea20e2fc56cc48dfd65575",
-        "version" : "1.8.4"
+        "revision" : "b52ab44f1f1fc8593b9b3006a9514a332cbaede7",
+        "version" : "1.8.5-dev-1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -60,7 +60,7 @@ var package = Package(
     .package(url: "https://github.com/apple/swift-algorithms", from: "1.0.0"),
     .package(url: "https://github.com/devxoul/Then", from: "2.7.0"),
     .package(url: "https://github.com/mkrd/Swift-BigInt", from: "2.0.0"),
-    .package(url: "https://github.com/GuardianFirewall/GuardianConnect", exact: "1.8.5-dev-1"),
+    .package(url: "https://github.com/GuardianFirewall/GuardianConnect", exact: "1.8.5"),
     .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "0.6.0"),
     .package(name: "Static", path: "ThirdParty/Static"),
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -60,7 +60,7 @@ var package = Package(
     .package(url: "https://github.com/apple/swift-algorithms", from: "1.0.0"),
     .package(url: "https://github.com/devxoul/Then", from: "2.7.0"),
     .package(url: "https://github.com/mkrd/Swift-BigInt", from: "2.0.0"),
-    .package(url: "https://github.com/GuardianFirewall/GuardianConnect", exact: "1.8.4"),
+    .package(url: "https://github.com/GuardianFirewall/GuardianConnect", exact: "1.8.5-dev-1"),
     .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "0.6.0"),
     .package(name: "Static", path: "ThirdParty/Static"),
   ],

--- a/Sources/BraveVPN/BraveVPN.swift
+++ b/Sources/BraveVPN/BraveVPN.swift
@@ -411,11 +411,14 @@ public class BraveVPN {
     let activeTunnelProtocol = GRDTransportProtocol.getUserPreferredTransportProtocol()
     
     helper.configureFirstTimeUser(for: activeTunnelProtocol, with: region) { success, error in
+      let subcredentials = "Credentials \(GRDKeychain.getPasswordString(forAccount: kKeychainStr_SubscriberCredential) ?? "Empty")"
+      
       if success {
         Logger.module.debug("Changed VPN region to \(region?.regionName ?? "default selection")")
         completion(true)
       } else {
-        Logger.module.debug("connection failed: \(error ?? "nil")")
+        Logger.module.debug("Connection failed: \(error ?? "nil")")
+        Logger.module.debug("Region change connection failed for subcredentials \(subcredentials)")
         completion(false)
       }
     }

--- a/Sources/BraveVPN/InstallVPNViewController.swift
+++ b/Sources/BraveVPN/InstallVPNViewController.swift
@@ -7,6 +7,7 @@ import UIKit
 import Shared
 import Lottie
 import BraveUI
+import GuardianConnect
 
 class InstallVPNViewController: VPNSetupLoadingController {
 
@@ -51,6 +52,10 @@ class InstallVPNViewController: VPNSetupLoadingController {
 
   @objc func installVPNAction() {
     isLoading = true
+    
+    // Used to set whether our current user is actively a paying customer
+    // This has to be set before adding the profile otherwise it might fail
+    GRDSubscriptionManager.setIsPayingUser(true)
     
     installProfileAndConnectVPNFirstTime { [weak self] status in
       guard let self else { return }


### PR DESCRIPTION
Updating Guardian Connect to 1.8.5 and setting user as paying user before fetching a fresh profile

This build will handle cases where Server Region object will not include the details.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7449
This pull request references #7413

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
