### PR TITLE
Fix #7572: Sort pending transactions by most recent transaction first

### DIFF
--- a/Tests/BraveWalletTests/TransactionConfirmationStoreTests.swift
+++ b/Tests/BraveWalletTests/TransactionConfirmationStoreTests.swift
@@ -329,10 +329,10 @@ import BraveCore
       .sink { networks in
         defer { networkExpectation.fulfill() }
         XCTAssertEqual(networks.count, 4)
-        XCTAssertEqual(networks[safe: 0], BraveWallet.NetworkInfo.mockGoerli)
-        XCTAssertEqual(networks[safe: 1], BraveWallet.NetworkInfo.mockMainnet)
-        XCTAssertEqual(networks[safe: 2], BraveWallet.NetworkInfo.mockSolana)
-        XCTAssertEqual(networks[safe: 3], BraveWallet.NetworkInfo.mockSolanaTestnet)
+        XCTAssertEqual(networks[safe: 0], BraveWallet.NetworkInfo.mockSolanaTestnet)
+        XCTAssertEqual(networks[safe: 1], BraveWallet.NetworkInfo.mockSolana)
+        XCTAssertEqual(networks[safe: 2], BraveWallet.NetworkInfo.mockMainnet)
+        XCTAssertEqual(networks[safe: 3], BraveWallet.NetworkInfo.mockGoerli)
       }
       .store(in: &cancellables)
     let activeTransactionIdExpectation = expectation(description: "activeTransactionId-expectation")
@@ -342,10 +342,10 @@ import BraveCore
       .sink { activeTransactionIds in
         defer { activeTransactionIdExpectation.fulfill() }
         XCTAssertEqual(activeTransactionIds.count, 4)
-        XCTAssertEqual(activeTransactionIds[safe: 0], pendingTransactions[safe: 0]?.id)
-        XCTAssertEqual(activeTransactionIds[safe: 1], pendingTransactions[safe: 1]?.id)
-        XCTAssertEqual(activeTransactionIds[safe: 2], pendingTransactions[safe: 2]?.id)
-        XCTAssertEqual(activeTransactionIds[safe: 3], pendingTransactions[safe: 3]?.id)
+        XCTAssertEqual(activeTransactionIds[safe: 0], pendingTransactions[safe: 3]?.id)
+        XCTAssertEqual(activeTransactionIds[safe: 1], pendingTransactions[safe: 2]?.id)
+        XCTAssertEqual(activeTransactionIds[safe: 2], pendingTransactions[safe: 1]?.id)
+        XCTAssertEqual(activeTransactionIds[safe: 3], pendingTransactions[safe: 0]?.id)
       }
       .store(in: &cancellables)
     


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #7572

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Submit a transaction on Solana Devnet but don't confirm it
2. Submit a second transaction on Solana Testnet but don't confirm it
3. Submit a third transaction on Goerli Testnet
4. Verify transactions are displayed such that the most recent transaction (Goerli Testnet) is shown as the first transaction in the confirmation modal


## Screenshots:

https://github.com/brave/brave-ios/assets/5314553/7189f966-fcf6-4431-92e6-1c14d6a0bf94


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
