### PR TITLE
Fix #7523: Select Token to Send view

### DIFF
--- a/Sources/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
@@ -86,7 +86,7 @@ struct AccountActivityView: View {
         Section(content: {
           Group {
             ForEach(activityStore.userVisibleNFTs) { nftAsset in
-              PortfolioNFTAssetView(
+              NFTAssetView(
                 image: NFTIconView(
                   token: nftAsset.token,
                   network: nftAsset.network,

--- a/Sources/BraveWallet/Crypto/AssetIconView.swift
+++ b/Sources/BraveWallet/Crypto/AssetIconView.swift
@@ -144,6 +144,11 @@ struct NFTIconView: View {
     if shouldShowNetworkIcon, let image = network.nativeTokenLogoImage {
       Image(uiImage: image)
         .resizable()
+        .overlay(
+          Circle()
+            .stroke(lineWidth: 2)
+            .foregroundColor(.white)
+        )
         .frame(
           width: min(tokenLogoLength, maxTokenLogoLength ?? tokenLogoLength),
           height: min(tokenLogoLength, maxTokenLogoLength ?? tokenLogoLength)

--- a/Sources/BraveWallet/Crypto/AssetIconView.swift
+++ b/Sources/BraveWallet/Crypto/AssetIconView.swift
@@ -136,13 +136,18 @@ struct NFTIconView: View {
   var shouldShowNetworkIcon: Bool = false
   
   @ScaledMetric var length: CGFloat = 40
+  var maxLength: CGFloat?
   @ScaledMetric var tokenLogoLength: CGFloat = 15
+  var maxTokenLogoLength: CGFloat?
   
   @ViewBuilder private var tokenLogo: some View {
     if shouldShowNetworkIcon, let image = network.nativeTokenLogoImage {
       Image(uiImage: image)
         .resizable()
-        .frame(width: 15, height: 15)
+        .frame(
+          width: min(tokenLogoLength, maxTokenLogoLength ?? tokenLogoLength),
+          height: min(tokenLogoLength, maxTokenLogoLength ?? tokenLogoLength)
+        )
     }
   }
   
@@ -156,7 +161,10 @@ struct NFTIconView: View {
       )
     }
     .cornerRadius(5)
-    .frame(width: length, height: length)
+    .frame(
+      width: min(length, maxLength ?? length),
+      height: min(length, maxLength ?? length)
+    )
     .overlay(tokenLogo, alignment: .bottomTrailing)
     .allowsHitTesting(false)
     .accessibilityHidden(true)

--- a/Sources/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
+++ b/Sources/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
@@ -68,7 +68,27 @@ struct SendTokenView: View {
     NavigationView {
       Form {
         Section(
-          header: WalletListHeaderView(title: Text(Strings.Wallet.sendCryptoFromTitle))
+          header: WalletListHeaderView {
+            HStack {
+              Text("\(Strings.Wallet.sendCryptoFromTitle): \(keyringStore.selectedAccount.name) (\(keyringStore.selectedAccount.address.truncatedAddress))")
+              Spacer()
+              Menu(
+                content: {
+                  Text(keyringStore.selectedAccount.address.zwspOutput)
+                  Button(action: {
+                    UIPasteboard.general.string = keyringStore.selectedAccount.address
+                  }) {
+                    Label(Strings.Wallet.copyAddressButtonTitle, braveSystemImage: "leo.copy.plain-text")
+                  }
+                },
+                label: {
+                  Image(braveSystemName: "leo.more.horizontal")
+                    .padding(6)
+                    .clipShape(Rectangle())
+                }
+              )
+            }
+          }
         ) {
           Button(action: { self.isShowingSelectAccountTokenView = true }) {
             HStack {
@@ -97,14 +117,9 @@ struct SendTokenView: View {
                   .foregroundColor(Color(.secondaryBraveLabel))
               }
               Spacer()
-              VStack(alignment: .trailing) {
-                Text("\(keyringStore.selectedAccount.name):")
-                  .font(.caption)
-                  .foregroundColor(Color(.secondaryBraveLabel))
-                Text("\(sendTokenStore.selectedSendTokenBalance?.decimalDescription.trimmingTrailingZeros ?? "0") \(sendTokenStore.selectedSendToken?.symbol ?? "")")
-                  .font(.title3.weight(.semibold))
-                  .foregroundColor(Color(.braveLabel))
-              }
+              Text("\(sendTokenStore.selectedSendTokenBalance?.decimalDescription.trimmingTrailingZeros ?? "0") \(sendTokenStore.selectedSendToken?.symbol ?? "")")
+                .font(.title3.weight(.semibold))
+                .foregroundColor(Color(.braveLabel))
             }
             .padding(.vertical, 8)
           }

--- a/Sources/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
+++ b/Sources/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
@@ -16,6 +16,7 @@ struct SendTokenView: View {
 
   @State private var isShowingScanner = false
   @State private var isShowingError = false
+  @State private var isShowingSelectAccountTokenView: Bool = false
 
   @ScaledMetric private var length: CGFloat = 16.0
   
@@ -66,7 +67,7 @@ struct SendTokenView: View {
   var body: some View {
     NavigationView {
       Form {
-        Section {
+        Section { // TODO: Remove
           AccountPicker(
             keyringStore: keyringStore,
             networkStore: networkStore
@@ -77,13 +78,7 @@ struct SendTokenView: View {
         Section(
           header: WalletListHeaderView(title: Text(Strings.Wallet.sendCryptoFromTitle))
         ) {
-          NavigationLink(
-            destination:
-              SendTokenSearchView(
-                sendTokenStore: sendTokenStore,
-                network: networkStore.defaultSelectedChain
-              )
-          ) {
+          Button(action: { self.isShowingSelectAccountTokenView = true }) {
             HStack {
               if let token = sendTokenStore.selectedSendToken {
                 if token.isErc721 || token.isNft {
@@ -258,6 +253,16 @@ struct SendTokenView: View {
           address: $sendTokenStore.sendAddress
         )
       }
+      .sheet(isPresented: $isShowingSelectAccountTokenView) {
+        NavigationView {
+          SelectAccountTokenView(
+            store: sendTokenStore.selectTokenStore,
+            networkStore: networkStore
+          )
+          .navigationTitle("Select a Token to Send") // TODO: Localize
+          .navigationBarTitleDisplayMode(.inline)
+        }
+      }
       .navigationTitle(Strings.Wallet.send)
       .navigationBarTitleDisplayMode(.inline)
       .toolbar {
@@ -269,8 +274,9 @@ struct SendTokenView: View {
         }
       }
     }
-    .onAppear {
+    .task {
       sendTokenStore.update()
+      await sendTokenStore.selectTokenStore.update()
     }
     .navigationViewStyle(.stack)
   }

--- a/Sources/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
+++ b/Sources/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
@@ -67,14 +67,6 @@ struct SendTokenView: View {
   var body: some View {
     NavigationView {
       Form {
-        Section { // TODO: Remove
-          AccountPicker(
-            keyringStore: keyringStore,
-            networkStore: networkStore
-          )
-          .listRowBackground(Color(UIColor.braveGroupedBackground))
-          .resetListHeaderStyle()
-        }
         Section(
           header: WalletListHeaderView(title: Text(Strings.Wallet.sendCryptoFromTitle))
         ) {
@@ -96,13 +88,23 @@ struct SendTokenView: View {
                   )
                 }
               }
-              Text(sendTokenStore.selectedSendToken?.symbol ?? "")
-                .font(.title3.weight(.semibold))
-                .foregroundColor(Color(.braveLabel))
+              VStack(alignment: .leading) {
+                Text(sendTokenStore.selectedSendToken?.symbol ?? "")
+                  .font(.title3.weight(.semibold))
+                  .foregroundColor(Color(.braveLabel))
+                Text(networkStore.defaultSelectedChain.chainName)
+                  .font(.caption)
+                  .foregroundColor(Color(.secondaryBraveLabel))
+              }
               Spacer()
-              Text(sendTokenStore.selectedSendTokenBalance?.decimalDescription ?? "0.0000")
-                .font(.title3.weight(.semibold))
-                .foregroundColor(Color(.braveLabel))
+              VStack(alignment: .trailing) {
+                Text("\(keyringStore.selectedAccount.name):")
+                  .font(.caption)
+                  .foregroundColor(Color(.secondaryBraveLabel))
+                Text("\(sendTokenStore.selectedSendTokenBalance?.decimalDescription.trimmingTrailingZeros ?? "0") \(sendTokenStore.selectedSendToken?.symbol ?? "")")
+                  .font(.title3.weight(.semibold))
+                  .foregroundColor(Color(.braveLabel))
+              }
             }
             .padding(.vertical, 8)
           }
@@ -259,7 +261,7 @@ struct SendTokenView: View {
             store: sendTokenStore.selectTokenStore,
             networkStore: networkStore
           )
-          .navigationTitle("Select a Token to Send") // TODO: Localize
+          .navigationTitle(Strings.Wallet.selectTokenToSendTitle)
           .navigationBarTitleDisplayMode(.inline)
         }
       }

--- a/Sources/BraveWallet/Crypto/NetworkFilterView.swift
+++ b/Sources/BraveWallet/Crypto/NetworkFilterView.swift
@@ -61,12 +61,14 @@ struct NetworkFilterView: View {
   }
   
   private func selectNetwork(_ network: NetworkPresentation.Network) {
-    switch network {
-    case .allNetworks:
-      networkFilter = .allNetworks
-    case let .network(network):
-      networkFilter = .network(network)
+    DispatchQueue.main.async {
+      switch network {
+      case .allNetworks:
+        networkFilter = .allNetworks
+      case let .network(network):
+        networkFilter = .network(network)
+      }
+      presentationMode.dismiss()
     }
-    presentationMode.dismiss()
   }
 }

--- a/Sources/BraveWallet/Crypto/Portfolio/PortfolioAssetView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/PortfolioAssetView.swift
@@ -14,28 +14,20 @@ struct PortfolioAssetView: View {
   var quantity: String
 
   var body: some View {
-    HStack {
-      image
-      VStack(alignment: .leading) {
-        Text(title)
-          .font(.footnote)
-          .fontWeight(.semibold)
-          .foregroundColor(Color(.bravePrimary))
-        Text(String.localizedStringWithFormat(Strings.Wallet.userAssetSymbolNetworkDesc, symbol, networkName))
-          .font(.caption)
-          .foregroundColor(Color(.braveLabel))
+    AssetView(
+      image: { image },
+      title: title,
+      symbol: symbol,
+      networkName: networkName,
+      accessoryContent: {
+        VStack(alignment: .trailing) {
+          Text(amount.isEmpty ? "0.0" : amount)
+          Text(verbatim: "\(quantity) \(symbol)")
+        }
+        .font(.footnote)
+        .foregroundColor(Color(.braveLabel))
       }
-      Spacer()
-      VStack(alignment: .trailing) {
-        Text(amount.isEmpty ? "0.0" : amount)
-        Text(verbatim: "\(quantity) \(symbol)")
-      }
-      .font(.footnote)
-      .foregroundColor(Color(.braveLabel))
-    }
-    .frame(maxWidth: .infinity)
-    .padding(.vertical, 6)
-    .accessibilityElement()
+    )
     .accessibilityLabel("\(title), \(quantity) \(symbol), \(amount)")
   }
 }
@@ -57,7 +49,7 @@ struct PortfolioAssetView_Previews: PreviewProvider {
 }
 #endif
 
-struct PortfolioNFTAssetView: View {
+struct NFTAssetView: View {
   
   let image: NFTIconView
   let title: String
@@ -66,33 +58,25 @@ struct PortfolioNFTAssetView: View {
   let quantity: String
   
   var body: some View {
-    HStack {
-      image
-      VStack(alignment: .leading) {
-        Text(title)
+    AssetView(
+      image: { image },
+      title: title,
+      symbol: symbol,
+      networkName: networkName,
+      accessoryContent: {
+        Text(quantity)
           .font(.footnote)
-          .fontWeight(.semibold)
-          .foregroundColor(Color(.bravePrimary))
-        Text(String.localizedStringWithFormat(Strings.Wallet.userAssetSymbolNetworkDesc, symbol, networkName))
-          .font(.caption)
           .foregroundColor(Color(.braveLabel))
       }
-      Spacer()
-      Text(quantity)
-        .font(.footnote)
-        .foregroundColor(Color(.braveLabel))
-    }
-    .frame(maxWidth: .infinity)
-    .padding(.vertical, 6)
-    .accessibilityElement()
+    )
     .accessibilityLabel("\(title), \(quantity) \(symbol)")
   }
 }
 
 #if DEBUG
-struct PortfolioNFTAssetView_Previews: PreviewProvider {
+struct NFTAssetView_Previews: PreviewProvider {
   static var previews: some View {
-    PortfolioNFTAssetView(
+    NFTAssetView(
       image: NFTIconView(token: .previewToken, network: .mockMainnet),
       title: "Invisible Friends #3965",
       symbol: "INVSBLE",
@@ -104,3 +88,32 @@ struct PortfolioNFTAssetView_Previews: PreviewProvider {
   }
 }
 #endif
+
+/// AssetView is used to display an asset image, title, symbol and network with an optional accessory view on the right.
+struct AssetView<ImageView: View, AccessoryContent: View>: View {
+  let image: () -> ImageView
+  let title: String
+  let symbol: String
+  let networkName: String
+  let accessoryContent: () -> AccessoryContent
+
+  var body: some View {
+    HStack {
+      image()
+      VStack(alignment: .leading) {
+        Text(title)
+          .font(.footnote)
+          .fontWeight(.semibold)
+          .foregroundColor(Color(.bravePrimary))
+        Text(String.localizedStringWithFormat(Strings.Wallet.userAssetSymbolNetworkDesc, symbol, networkName))
+          .font(.caption)
+          .foregroundColor(Color(.braveLabel))
+      }
+      Spacer()
+      accessoryContent()
+    }
+    .frame(maxWidth: .infinity)
+    .padding(.vertical, 6)
+    .accessibilityElement()
+  }
+}

--- a/Sources/BraveWallet/Crypto/SelectAccountTokenView.swift
+++ b/Sources/BraveWallet/Crypto/SelectAccountTokenView.swift
@@ -36,7 +36,7 @@ struct SelectAccountTokenView: View {
           .listRowBackground(Color(.secondaryBraveGroupedBackground))
       } else if store.filteredAccountSections.flatMap(\.tokenBalances).isEmpty && !store.isLoadingBalances {
         Section {
-          Text("No available tokens") // TODO: Localize
+          Text(Strings.Wallet.selectTokenToSendNoTokens)
             .multilineTextAlignment(.center)
             .frame(maxWidth: .infinity)
             .listRowBackground(Color(.secondaryBraveGroupedBackground))
@@ -57,7 +57,7 @@ struct SelectAccountTokenView: View {
         networkFilterButton
         Spacer()
         Button(action: { store.isHidingZeroBalances.toggle() }) {
-          Text(store.isHidingZeroBalances ? "Show Zero Balances" : "Hide Zero Balances") // TODO: Localize
+          Text(store.isHidingZeroBalances ? Strings.Wallet.showZeroBalances : Strings.Wallet.hideZeroBalances)
             .foregroundColor(Color(.braveBlurpleTint))
         }
       }
@@ -101,7 +101,7 @@ struct SelectAccountTokenView: View {
                 // until we know which assets have >0 balance.
                 loadingAssetView
               } else {
-                Text("No available tokens") // TODO: Localize
+                Text(Strings.Wallet.selectTokenToSendNoTokens)
               }
             }
             .multilineTextAlignment(.center)

--- a/Sources/BraveWallet/Crypto/SelectAccountTokenView.swift
+++ b/Sources/BraveWallet/Crypto/SelectAccountTokenView.swift
@@ -1,0 +1,240 @@
+// Copyright 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import SwiftUI
+import BraveCore
+
+struct SelectAccountTokenView: View {
+  
+  @ObservedObject var store: SelectAccountTokenStore
+  @ObservedObject var networkStore: NetworkStore
+  
+  @State private var isPresentingNetworkFilter = false
+  @Environment(\.presentationMode) @Binding private var presentationMode
+  
+  // Asset image sizing
+  @ScaledMetric private var assetLogoLength: CGFloat = 40
+  private var maxAssetLogoLength: CGFloat = 80
+  @ScaledMetric private var networkSymbolLength: CGFloat = 15
+  private var maxNetworkSymbolLength: CGFloat = 30
+  
+  init(
+    store: SelectAccountTokenStore,
+    networkStore: NetworkStore
+  ) {
+    self.store = store
+    self.networkStore = networkStore
+  }
+  
+  var body: some View {
+    List {
+      if store.accountSections.isEmpty {
+        // Fetching accounts & assets. Typically won't see this.
+        ProgressView()
+          .listRowBackground(Color(.secondaryBraveGroupedBackground))
+      } else if store.filteredAccountSections.flatMap(\.tokenBalances).isEmpty && !store.isLoadingBalances {
+        Section {
+          Text("No available tokens") // TODO: Localize
+            .multilineTextAlignment(.center)
+            .frame(maxWidth: .infinity)
+            .listRowBackground(Color(.secondaryBraveGroupedBackground))
+        }
+      } else {
+        accountSections
+      }
+    }
+    .listBackgroundColor(Color(UIColor.braveGroupedBackground))
+    .toolbar {
+      ToolbarItemGroup(placement: .cancellationAction) {
+        Button(action: { presentationMode.dismiss() }) {
+          Text(Strings.cancelButtonTitle)
+            .foregroundColor(Color(.braveBlurpleTint))
+        }
+      }
+      ToolbarItemGroup(placement: .bottomBar) {
+        networkFilterButton
+        Spacer()
+        Button(action: { store.isHidingZeroBalances.toggle() }) {
+          Text(store.isHidingZeroBalances ? "Show Zero Balances" : "Hide Zero Balances") // TODO: Localize
+            .foregroundColor(Color(.braveBlurpleTint))
+        }
+      }
+    }
+  }
+  
+  private var networkFilterButton: some View {
+    Button(action: {
+      self.isPresentingNetworkFilter = true
+    }) {
+      HStack {
+        Image(braveSystemName: "leo.list")
+        Text(store.networkFilter.title)
+      }
+      .font(.footnote.weight(.medium))
+      .foregroundColor(Color(.braveBlurpleTint))
+    }
+    .sheet(isPresented: $isPresentingNetworkFilter) {
+      NavigationView {
+        NetworkFilterView(
+          networkFilter: $store.networkFilter,
+          networkStore: networkStore
+        )
+      }
+      .onDisappear {
+        networkStore.closeNetworkSelectionStore()
+      }
+    }
+  }
+  
+  private var accountSections: some View {
+    ForEach(store.filteredAccountSections) { accountSection in
+      Section(
+        content: {
+          if accountSection.tokenBalances.isEmpty {
+            Group {
+              if store.isHidingZeroBalances && store.isLoadingBalances {
+                // We must fetch balance to confirm >0 before
+                // displaying when `isHidingZeroBalances`.
+                // Show an asset with shimmer over all content
+                // until we know which assets have >0 balance.
+                loadingAssetView
+              } else {
+                Text("No available tokens") // TODO: Localize
+              }
+            }
+            .multilineTextAlignment(.center)
+            .frame(maxWidth: .infinity)
+            .listRowBackground(Color(.secondaryBraveGroupedBackground))
+          } else {
+            buildAccountSection(accountSection)
+          }
+        },
+        header: {
+          WalletListHeaderView(title: Text(accountSection.account.name))
+        }
+      )
+    }
+  }
+  
+  private func buildAccountSection(_ accountSection: SelectAccountTokenStore.AccountSection) -> some View {
+    ForEach(accountSection.tokenBalances) { tokenBalance in
+      Button(action: {
+        store.didSelect(accountSection.account, tokenBalance.token)
+        presentationMode.dismiss()
+      }) {
+        if tokenBalance.token.isErc721 || tokenBalance.token.isNft {
+          NFTAssetView(
+            image: NFTIconView(
+              token: tokenBalance.token,
+              network: tokenBalance.network,
+              url: tokenBalance.nftMetadata?.imageURL,
+              shouldShowNetworkIcon: true,
+              length: assetLogoLength,
+              maxLength: maxAssetLogoLength,
+              tokenLogoLength: networkSymbolLength,
+              maxTokenLogoLength: maxNetworkSymbolLength
+            ),
+            title: tokenBalance.token.nftTokenTitle,
+            symbol: tokenBalance.token.symbol,
+            networkName: tokenBalance.network.chainName,
+            quantity: String(Int(tokenBalance.balance ?? 0))
+          )
+        } else {
+          SelectAccountTokenAssetView(
+            image: {
+              AssetIconView(
+                token: tokenBalance.token,
+                network: tokenBalance.network,
+                shouldShowNetworkIcon: true,
+                length: assetLogoLength,
+                maxLength: maxAssetLogoLength,
+                networkSymbolLength: networkSymbolLength,
+                maxNetworkSymbolLength: maxNetworkSymbolLength
+              )
+            },
+            title: tokenBalance.token.name,
+            symbol: tokenBalance.token.symbol,
+            networkName: tokenBalance.network.chainName,
+            quantity: String(format: "%.04f", tokenBalance.balance ?? 0).trimmingTrailingZeros,
+            isLoadingBalance: store.isLoadingBalances && tokenBalance.balance == nil,
+            price: tokenBalance.price ?? "0",
+            isLoadingPrice: (store.isLoadingPrices || store.isLoadingBalances) && tokenBalance.price == nil
+          )
+        }
+      }
+      .listRowBackground(Color(.secondaryBraveGroupedBackground))
+    }
+  }
+  
+  // `SelectAccountTokenAssetView` with shimmering mock content.
+  private var loadingAssetView: some View {
+    SelectAccountTokenAssetView(
+      image: {
+        Circle()
+          .aspectRatio(contentMode: .fit)
+          .foregroundColor(Color(.secondaryBraveLabel))
+          .frame(
+            width: min(assetLogoLength, maxAssetLogoLength),
+            height: min(assetLogoLength, maxAssetLogoLength)
+          )
+          .accessibilityHidden(true)
+      },
+      title: "Ethereum",
+      symbol: "ETH",
+      networkName: "Ethereum Mainnet",
+      quantity: "0.0",
+      isLoadingBalance: false,
+      price: "$0.00",
+      isLoadingPrice: false
+    )
+    .accessibilityHidden(true)
+    .redacted(reason: .placeholder)
+    .shimmer(true)
+  }
+}
+
+struct SelectAccountTokenAssetView<ImageView: View>: View {
+  let image: () -> ImageView
+  let title: String
+  let symbol: String
+  let networkName: String
+  let quantity: String
+  let isLoadingBalance: Bool
+  let price: String
+  let isLoadingPrice: Bool
+  
+  private var priceDisplay: String {
+    if isLoadingPrice { // larger for shimmer effect
+      return "0.000"
+    }
+    if price.isEmpty {
+      return "0.0"
+    }
+    return price
+  }
+  
+  var body: some View {
+    AssetView(
+      image: image,
+      title: title,
+      symbol: symbol,
+      networkName: networkName,
+      accessoryContent: {
+        VStack(alignment: .trailing) {
+          Text(verbatim: "\(quantity) \(symbol)")
+            .bold()
+            .redacted(reason: isLoadingBalance ? .placeholder : [])
+            .shimmer(isLoadingBalance)
+          Text(priceDisplay)
+            .redacted(reason: isLoadingPrice ? .placeholder : [])
+            .shimmer(isLoadingPrice)
+        }
+        .font(.footnote)
+        .foregroundColor(Color(.braveLabel))
+      }
+    )
+    .accessibilityLabel("\(title), \(quantity) \(symbol), \(price)")
+  }
+}

--- a/Sources/BraveWallet/Crypto/SelectAccountTokenView.swift
+++ b/Sources/BraveWallet/Crypto/SelectAccountTokenView.swift
@@ -35,12 +35,14 @@ struct SelectAccountTokenView: View {
         ProgressView()
           .listRowBackground(Color(.secondaryBraveGroupedBackground))
       } else if store.filteredAccountSections.flatMap(\.tokenBalances).isEmpty && !store.isLoadingBalances {
-        Section {
-          Text(Strings.Wallet.selectTokenToSendNoTokens)
-            .multilineTextAlignment(.center)
-            .frame(maxWidth: .infinity)
-            .listRowBackground(Color(.secondaryBraveGroupedBackground))
-        }
+        Text(Strings.Wallet.selectTokenToSendNoTokens)
+          .font(.headline.weight(.semibold))
+          .foregroundColor(Color(.braveLabel))
+          .multilineTextAlignment(.center)
+          .frame(maxWidth: .infinity)
+          .padding(.vertical, 60)
+          .padding(.horizontal, 32)
+          .listRowBackground(Color.clear)
       } else {
         accountSections
       }
@@ -56,12 +58,22 @@ struct SelectAccountTokenView: View {
       ToolbarItemGroup(placement: .bottomBar) {
         networkFilterButton
         Spacer()
-        Button(action: { store.isHidingZeroBalances.toggle() }) {
-          Text(store.isHidingZeroBalances ? Strings.Wallet.showZeroBalances : Strings.Wallet.hideZeroBalances)
-            .foregroundColor(Color(.braveBlurpleTint))
+        if shouldShowZeroBalanceButton {
+          Button(action: { store.isHidingZeroBalances.toggle() }) {
+            Text(store.isHidingZeroBalances ? Strings.Wallet.showZeroBalances : Strings.Wallet.hideZeroBalances)
+              .font(.footnote.weight(.medium))
+              .foregroundColor(Color(.braveBlurpleTint))
+          }
         }
       }
     }
+  }
+  
+  private var shouldShowZeroBalanceButton: Bool {
+    if !store.isHidingZeroBalances {
+      return true
+    }
+    return store.filteredAccountSections.flatMap(\.tokenBalances).isEmpty
   }
   
   private var networkFilterButton: some View {
@@ -101,7 +113,7 @@ struct SelectAccountTokenView: View {
                 // until we know which assets have >0 balance.
                 loadingAssetView
               } else {
-                Text(Strings.Wallet.selectTokenToSendNoTokens)
+                EmptyView()
               }
             }
             .multilineTextAlignment(.center)

--- a/Sources/BraveWallet/Crypto/SelectAccountTokenView.swift
+++ b/Sources/BraveWallet/Crypto/SelectAccountTokenView.swift
@@ -67,6 +67,9 @@ struct SelectAccountTokenView: View {
         }
       }
     }
+    .onDisappear {
+      store.resetFilters()
+    }
   }
   
   private var shouldShowZeroBalanceButton: Bool {

--- a/Sources/BraveWallet/Crypto/SelectAccountTokenView.swift
+++ b/Sources/BraveWallet/Crypto/SelectAccountTokenView.swift
@@ -112,7 +112,27 @@ struct SelectAccountTokenView: View {
           }
         },
         header: {
-          WalletListHeaderView(title: Text(accountSection.account.name))
+          WalletListHeaderView {
+            HStack {
+              Text("\(accountSection.account.name) (\(accountSection.account.address.truncatedAddress))")
+              Spacer()
+              Menu(
+                content: {
+                  Text(accountSection.account.address.zwspOutput)
+                  Button(action: {
+                    UIPasteboard.general.string = accountSection.account.address
+                  }) {
+                    Label(Strings.Wallet.copyAddressButtonTitle, braveSystemImage: "leo.copy.plain-text")
+                  }
+                },
+                label: {
+                  Image(braveSystemName: "leo.more.horizontal")
+                    .padding(6)
+                    .clipShape(Rectangle())
+                }
+              )
+            }
+          }
         }
       )
     }

--- a/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -197,6 +197,7 @@ public class CryptoStore: ObservableObject {
       walletService: walletService,
       txService: txService,
       blockchainRegistry: blockchainRegistry,
+      assetRatioService: assetRatioService,
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: prefilledToken,

--- a/Sources/BraveWallet/Crypto/Stores/NetworkStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/NetworkStore.swift
@@ -300,7 +300,7 @@ extension NetworkStore: BraveWalletJsonRpcServiceObserver {
       } else {
         defaultSelectedChainId = chainId
         isSwapSupported = await swapService.isSwapSupported(chainId)
-        if self.origin != nil {
+        if let origin = self.origin {
           // The default network may be used for this origin if no
           // other network was assigned for this origin. If so, we
           // need to make sure the `selectedChainIdForOrigin` is updated
@@ -315,13 +315,20 @@ extension NetworkStore: BraveWalletJsonRpcServiceObserver {
 
 extension NetworkStore: BraveWalletKeyringServiceObserver {
   public func selectedAccountChanged(_ coin: BraveWallet.CoinType) {
-    Task { @MainActor in
-      // coin type of selected account might have changed
-      let chain = await rpcService.network(coin, origin: nil)
-      await setSelectedChain(chain, isForOrigin: false)
-      if let origin {
-        let chainForOrigin = await rpcService.network(coin, origin: origin)
-        await setSelectedChain(chainForOrigin, isForOrigin: true)
+    walletService.setSelectedCoin(coin)
+    if defaultSelectedChain.coin != coin {
+      // selected coin updated, `NetworkStore` selected network(s) needs updated
+      Task { @MainActor in
+        let selectedNetwork = await rpcService.network(coin, origin: nil)
+        defaultSelectedChainId = selectedNetwork.chainId
+        if let origin = self.origin {
+          // The default network may be used for this origin if no
+          // other network was assigned for this origin. If so, we
+          // need to make sure the `selectedChainIdForOrigin` is updated
+          // to reflect the correct network.
+          let networkForOrigin = await rpcService.network(coin, origin: origin)
+          selectedChainIdForOrigin = networkForOrigin.chainId
+        }
       }
     }
   }

--- a/Sources/BraveWallet/Crypto/Stores/SelectAccountTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SelectAccountTokenStore.swift
@@ -1,0 +1,305 @@
+// Copyright 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import SwiftUI
+import BraveCore
+
+class SelectAccountTokenStore: ObservableObject {
+  
+  struct AccountSection: Equatable, Identifiable {
+    struct TokenBalance: Equatable, Identifiable {
+      var id: String { token.id }
+      let token: BraveWallet.BlockchainToken
+      let network: BraveWallet.NetworkInfo
+      let balance: Double?
+      let price: String?
+      let nftMetadata: NFTMetadata?
+      
+      init(
+        token: BraveWallet.BlockchainToken,
+        network: BraveWallet.NetworkInfo,
+        balance: Double? = nil,
+        price: String? = nil,
+        nftMetadata: NFTMetadata? = nil
+      ) {
+        self.token = token
+        self.network = network
+        self.balance = balance
+        self.price = price
+        self.nftMetadata = nftMetadata
+      }
+    }
+    var id: String { account.id }
+    let account: BraveWallet.AccountInfo
+    let tokenBalances: [TokenBalance]
+  }
+  
+  @Published var networkFilter: NetworkFilter = .allNetworks
+  private var allNetworks: [BraveWallet.NetworkInfo] = []
+  
+  @Published var isLoadingBalances = false
+  @Published var isLoadingPrices = false
+  @Published var isHidingZeroBalances = true
+  @Published var accountSections: [AccountSection] = []
+  
+  var filteredAccountSections: [AccountSection] {
+    let networks: [BraveWallet.NetworkInfo]
+    switch networkFilter {
+    case .allNetworks:
+      networks = allNetworks
+    case let .network(network):
+      networks = [network]
+    }
+    var filteredAccountSections: [AccountSection] = []
+    for accountSection in accountSections {
+      guard networks.contains(where: { $0.coin == accountSection.account.coin }) else {
+        // don't show account section(s) for incompatible network filter selection
+        continue
+      }
+      let updatedAccountSection = AccountSection(
+        account: accountSection.account,
+        tokenBalances: accountSection.tokenBalances
+          .filter { tokenBalance in
+            guard networks.contains(where: { $0.chainId == tokenBalance.network.chainId }) else {
+              return false
+            }
+            if isHidingZeroBalances {
+              return (tokenBalance.balance ?? 0) > 0
+            }
+            return true
+          }
+      )
+      filteredAccountSections.append(updatedAccountSection)
+    }
+    return filteredAccountSections
+  }
+  
+  /// The current default base currency code
+  @Published private(set) var currencyCode: String = CurrencyCode.usd.code {
+    didSet {
+      currencyFormatter.currencyCode = currencyCode
+      guard oldValue != currencyCode else { return }
+      Task {
+        await update()
+      }
+    }
+  }
+  let currencyFormatter: NumberFormatter = .usdCurrencyFormatter
+  
+  /// Cache of balances of each asset for each account. The root key(s) are the account `address`/`id`, and the inner dictionary key(s) are the `BraveWallet.BlockchainToken.assetBalanceId`.
+  private var balancesForAccountsCache: [String: [String: Double]] = [:]
+  /// Cache of prices of assets. The key(s) are the `BraveWallet.BlockchainToken.assetRatioId` lowercased.
+  private var pricesForTokensCache: [String: String] = [:]
+  /// Cache of metadata for NFTs. The key(s) is the token's `id`.
+  private var metadataCache: [String: NFTMetadata] = [:]
+  
+  let didSelect: (BraveWallet.AccountInfo, BraveWallet.BlockchainToken) -> Void
+  private let keyringService: BraveWalletKeyringService
+  private let rpcService: BraveWalletJsonRpcService
+  private let walletService: BraveWalletBraveWalletService
+  private let assetRatioService: BraveWalletAssetRatioService
+  private let ipfsApi: IpfsAPI
+  
+  init(
+    didSelect: @escaping (BraveWallet.AccountInfo, BraveWallet.BlockchainToken) -> Void,
+    keyringService: BraveWalletKeyringService,
+    rpcService: BraveWalletJsonRpcService,
+    walletService: BraveWalletBraveWalletService,
+    assetRatioService: BraveWalletAssetRatioService,
+    ipfsApi: IpfsAPI
+  ) {
+    self.didSelect = didSelect
+    self.keyringService = keyringService
+    self.rpcService = rpcService
+    self.walletService = walletService
+    self.assetRatioService = assetRatioService
+    self.ipfsApi = ipfsApi
+    walletService.add(self)
+  }
+  
+  @MainActor func update() async {
+    let allKeyrings = await keyringService.keyrings(for: WalletConstants.supportedCoinTypes)
+    let allNetworks = await rpcService.allNetworksForSupportedCoins()
+    self.allNetworks = allNetworks
+    let allVisibleUserAssets = await walletService.allUserAssets().filter(\.visible)
+    guard !Task.isCancelled else { return }
+    self.accountSections = allKeyrings.flatMap { keyring in
+      let tokensForCoin = allVisibleUserAssets.filter { $0.coin == keyring.coin }
+      return keyring.accountInfos.map { account in
+        let tokenBalances = tokensForCoin.map { token in
+          AccountSection.TokenBalance(
+            token: token,
+            network: allNetworks.first(where: { $0.chainId == token.chainId }) ?? .init(),
+            balance: cachedBalance(for: token, in: account),
+            price: cachedPrice(for: token, in: account),
+            nftMetadata: cachedMetadata(for: token)
+          )
+        }
+        return AccountSection(
+          account: account,
+          tokenBalances: tokenBalances
+        )
+      }
+    }
+    
+    updateAccountBalances()
+    updateTokenPrices()
+    updateNFTMetadata()
+  }
+  
+  func updateTokenPrices() {
+    guard !accountSections.isEmpty else { return }
+    Task { @MainActor in
+      self.isLoadingPrices = true
+      defer { self.isLoadingPrices = false }
+      let allAssetRatioIds = accountSections
+        .flatMap(\.tokenBalances)
+        .map(\.token)
+        .map(\.assetRatioId)
+      let prices: [String: String] = await assetRatioService.fetchPrices(
+        for: allAssetRatioIds,
+        toAssets: [currencyFormatter.currencyCode],
+        timeframe: .oneDay
+      )
+      self.pricesForTokensCache.merge(with: prices)
+      updateModels()
+    }
+  }
+  
+  private var updateAccountBalancesTask: Task<Void, Never>?
+  func updateAccountBalances() {
+    guard !accountSections.isEmpty else { return }
+    updateAccountBalancesTask?.cancel()
+    updateAccountBalancesTask = Task { @MainActor in
+      self.isLoadingBalances = true
+      defer { isLoadingBalances = false }
+      for accountSection in accountSections {
+        let balancesForTokens: [String: Double] = await withTaskGroup(
+          of: [String: Double].self,
+          body: { @MainActor group in
+            for tokenBalance in accountSection.tokenBalances {
+              group.addTask { @MainActor in
+                let totalBalance = await self.rpcService.balance(
+                  for: tokenBalance.token,
+                  in: accountSection.account,
+                  network: tokenBalance.network
+                )
+                return [tokenBalance.token.assetBalanceId: totalBalance ?? 0]
+              }
+            }
+            return await group.reduce(into: [String: Double](), { partialResult, new in
+              for key in new.keys {
+                partialResult[key] = new[key]
+              }
+            })
+          }
+        )
+        guard !Task.isCancelled else { return }
+        var updatedBalancesForTokens = (self.balancesForAccountsCache[accountSection.account.id] ?? [:])
+        updatedBalancesForTokens.merge(with: balancesForTokens)
+        self.balancesForAccountsCache[accountSection.account.id] = updatedBalancesForTokens
+      }
+      updateModels()
+    }
+  }
+  
+  func updateNFTMetadata() {
+    guard !accountSections.isEmpty else { return }
+    Task { @MainActor in
+      let allNFTs = accountSections.flatMap(\.tokenBalances).map(\.token).filter { $0.isNft || $0.isErc721 }
+      guard !allNFTs.isEmpty else { return }
+      let allMetadata = await rpcService.fetchNFTMetadata(tokens: allNFTs, ipfsApi: ipfsApi)
+      self.metadataCache.merge(with: allMetadata)
+      self.updateModels()
+    }
+  }
+  
+  /// Updates `accountSections` with the available data from `balancesForAccountsCache` &  `pricesForTokensCache`.
+  @MainActor private func updateModels() {
+    self.accountSections = accountSections.map { accountSection in
+      let tokenBalances: [AccountSection.TokenBalance] = accountSection.tokenBalances
+        .map { tokenBalance in
+          return AccountSection.TokenBalance(
+            token: tokenBalance.token,
+            network: tokenBalance.network,
+            balance: cachedBalance(for: tokenBalance.token, in: accountSection.account),
+            price: cachedPrice(for: tokenBalance.token, in: accountSection.account),
+            nftMetadata: cachedMetadata(for: tokenBalance.token)
+          )
+        }
+        .sorted { lhs, rhs in
+          return (lhs.balance ?? 0) > (rhs.balance ?? 0)
+        }
+      return AccountSection(
+        account: accountSection.account,
+        tokenBalances: tokenBalances
+      )
+    }
+  }
+  
+  /// Helper function to get cached balance for a given account & token.
+  private func cachedBalance(
+    for token: BraveWallet.BlockchainToken,
+    in account: BraveWallet.AccountInfo
+  ) -> Double? {
+    balancesForAccountsCache[account.id]?[token.assetBalanceId]
+  }
+  
+  /// Helper function to get the formatted cached price for a given account & token.
+  private func cachedPrice(
+    for token: BraveWallet.BlockchainToken,
+    in account: BraveWallet.AccountInfo
+  ) -> String? {
+    if let tokenPrice = pricesForTokensCache[token.assetRatioId.lowercased()],
+       let tokenBalance = cachedBalance(for: token, in: account) {
+      return currencyFormatter.string(from: NSNumber(value: (Double(tokenPrice) ?? 0) * tokenBalance))
+    }
+    return nil
+  }
+  
+  /// Helper function to get cached metadata for a given token.
+  private func cachedMetadata(
+    for token: BraveWallet.BlockchainToken
+  ) -> NFTMetadata? {
+    metadataCache[token.id]
+  }
+}
+
+#if DEBUG
+extension SelectAccountTokenStore {
+  func setupForTesting() {
+    allNetworks = [.mockMainnet, .mockGoerli, .mockSolana, .mockSolanaTestnet]
+  }
+}
+#endif
+
+extension SelectAccountTokenStore: BraveWalletBraveWalletServiceObserver {
+  func onActiveOriginChanged(_ originInfo: BraveWallet.OriginInfo) { }
+  
+  func onDefaultEthereumWalletChanged(_ wallet: BraveWallet.DefaultWallet) { }
+  
+  func onDefaultSolanaWalletChanged(_ wallet: BraveWallet.DefaultWallet) { }
+  
+  func onDefaultBaseCurrencyChanged(_ currency: String) {
+    currencyCode = currency
+  }
+  
+  func onDefaultBaseCryptocurrencyChanged(_ cryptocurrency: String) { }
+  
+  func onNetworkListChanged() { }
+  
+  func onDiscoverAssetsStarted() { }
+  
+  func onDiscoverAssetsCompleted(_ discoveredAssets: [BraveWallet.BlockchainToken]) { }
+  
+  func onResetWallet() { }
+}
+
+extension Array where Element == SelectAccountTokenStore.AccountSection.TokenBalance {
+  func filterNonZeroBalances(shouldFilter: Bool = true) -> Self {
+    guard shouldFilter else { return self }
+    return filter { ($0.balance ?? 0) > 0 }
+  }
+}

--- a/Sources/BraveWallet/Crypto/Stores/SelectAccountTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SelectAccountTokenStore.swift
@@ -129,6 +129,11 @@ class SelectAccountTokenStore: ObservableObject {
     walletService.add(self)
   }
   
+  func resetFilters() {
+    isHidingZeroBalances = true
+    networkFilter = .allNetworks
+  }
+  
   @MainActor func update() async {
     let allKeyrings = await keyringService.keyrings(for: WalletConstants.supportedCoinTypes)
     let allNetworks = await rpcService.allNetworksForSupportedCoins()

--- a/Sources/BraveWallet/Crypto/Stores/SelectAccountTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SelectAccountTokenStore.swift
@@ -71,9 +71,19 @@ class SelectAccountTokenStore: ObservableObject {
             return true
           }
       )
-      filteredAccountSections.append(updatedAccountSection)
+      if shouldShowSection(accountSection) {
+        filteredAccountSections.append(updatedAccountSection)
+      }
     }
     return filteredAccountSections
+  }
+  
+  private func shouldShowSection(_ accountSection: SelectAccountTokenStore.AccountSection) -> Bool {
+    guard accountSection.tokenBalances.isEmpty else {
+      return true // non-empty
+    }
+    // only if loading, or hiding zero balances.
+    return isHidingZeroBalances && isLoadingBalances
   }
   
   /// The current default base currency code

--- a/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
@@ -121,12 +121,24 @@ public class SendTokenStore: ObservableObject {
       }
     }
   }
+  
+  private(set) lazy var selectTokenStore = SelectAccountTokenStore(
+    didSelect: { [weak self] account, token in
+      self?.didSelect(account: account, token: token)
+    },
+    keyringService: keyringService,
+    rpcService: rpcService,
+    walletService: walletService,
+    assetRatioService: assetRatioService,
+    ipfsApi: ipfsApi
+  )
 
   private let keyringService: BraveWalletKeyringService
   private let rpcService: BraveWalletJsonRpcService
   private let walletService: BraveWalletBraveWalletService
   private let txService: BraveWalletTxService
   private let blockchainRegistry: BraveWalletBlockchainRegistry
+  private let assetRatioService: BraveWalletAssetRatioService
   private let ethTxManagerProxy: BraveWalletEthTxManagerProxy
   private let solTxManagerProxy: BraveWalletSolanaTxManagerProxy
   private var allTokens: [BraveWallet.BlockchainToken] = []
@@ -142,6 +154,7 @@ public class SendTokenStore: ObservableObject {
     walletService: BraveWalletBraveWalletService,
     txService: BraveWalletTxService,
     blockchainRegistry: BraveWalletBlockchainRegistry,
+    assetRatioService: BraveWalletAssetRatioService,
     ethTxManagerProxy: BraveWalletEthTxManagerProxy,
     solTxManagerProxy: BraveWalletSolanaTxManagerProxy,
     prefilledToken: BraveWallet.BlockchainToken?,
@@ -152,6 +165,7 @@ public class SendTokenStore: ObservableObject {
     self.walletService = walletService
     self.txService = txService
     self.blockchainRegistry = blockchainRegistry
+    self.assetRatioService = assetRatioService
     self.ethTxManagerProxy = ethTxManagerProxy
     self.solTxManagerProxy = solTxManagerProxy
     self.prefilledToken = prefilledToken
@@ -169,6 +183,10 @@ public class SendTokenStore: ObservableObject {
       rounded = false
     }
     sendAmount = ((selectedSendTokenBalance ?? 0) * amount.rawValue).decimalExpansion(precisionAfterDecimalPoint: decimalPoint, rounded: rounded)
+  }
+  
+  private func didSelect(account: BraveWallet.AccountInfo, token: BraveWallet.BlockchainToken) {
+    
   }
   
   @MainActor private func validatePrefilledToken(on network: inout BraveWallet.NetworkInfo) async {

--- a/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
@@ -185,7 +185,7 @@ public class SendTokenStore: ObservableObject {
     sendAmount = ((selectedSendTokenBalance ?? 0) * amount.rawValue).decimalExpansion(precisionAfterDecimalPoint: decimalPoint, rounded: rounded)
   }
   
-  private func didSelect(account: BraveWallet.AccountInfo, token: BraveWallet.BlockchainToken) {
+  func didSelect(account: BraveWallet.AccountInfo, token: BraveWallet.BlockchainToken) {
     Task { @MainActor in
       let selectedCoin = await walletService.selectedCoin()
       

--- a/Sources/BraveWallet/Preview Content/MockStores.swift
+++ b/Sources/BraveWallet/Preview Content/MockStores.swift
@@ -108,6 +108,7 @@ extension SendTokenStore {
       walletService: MockBraveWalletService(),
       txService: MockTxService(),
       blockchainRegistry: MockBlockchainRegistry(),
+      assetRatioService: MockAssetRatioService(),
       ethTxManagerProxy: MockEthTxManagerProxy(),
       solTxManagerProxy: BraveWallet.TestSolanaTxManagerProxy.previewProxy,
       prefilledToken: .previewToken,

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -4072,5 +4072,33 @@ extension Strings {
       value: "Import NFT",
       comment: "The title of the button that user clicks to add his/her first NFT"
     )
+    public static let selectTokenToSendTitle = NSLocalizedString(
+      "wallet.selectTokenToSendTitle",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Select a Token to Send",
+      comment: "The title of the view that lets the user select a token & account at the same time in the Send crypto view."
+    )
+    public static let selectTokenToSendNoTokens = NSLocalizedString(
+      "wallet.selectTokenToSendNoTokens",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "No available tokens",
+      comment: "The description of the view that lets the user select a token & account at the same time in the Send crypto view when there are no available tokens."
+    )
+    public static let showZeroBalances = NSLocalizedString(
+      "wallet.showZeroBalances",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Show Zero Balances",
+      comment: "The title of a button that updates the filter to show tokens with zero balances."
+    )
+    public static let hideZeroBalances = NSLocalizedString(
+      "wallet.hideZeroBalances",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Hide Zero Balances",
+      comment: "The title of a button that updates the filter to hide tokens with zero balances."
+    )
   }
 }

--- a/Tests/BraveWalletTests/SelectAccountTokenStoreTests.swift
+++ b/Tests/BraveWalletTests/SelectAccountTokenStoreTests.swift
@@ -1,0 +1,328 @@
+// Copyright 2022 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Combine
+import XCTest
+import BraveCore
+@testable import BraveWallet
+
+@MainActor class SelectAccountTokenStoreTests: XCTestCase {
+  
+  private var cancellables: Set<AnyCancellable> = .init()
+  
+  private let allUserAssets: [BraveWallet.BlockchainToken] = [
+    .previewToken.copy(asVisibleAsset: true),
+    .mockUSDCToken.copy(asVisibleAsset: true).then { $0.chainId = BraveWallet.GoerliChainId },
+    .mockSolToken.copy(asVisibleAsset: true),
+    .mockSpdToken.copy(asVisibleAsset: false), // not visible
+    .mockSolanaNFTToken.copy(asVisibleAsset: true).then { $0.chainId = BraveWallet.SolanaTestnet }
+  ]
+  
+  private let allNetworks: [BraveWallet.NetworkInfo] = [
+    .mockMainnet,
+    .mockGoerli,
+    .mockSolana,
+    .mockSolanaTestnet
+  ]
+  
+  private let mockEthAccount2: BraveWallet.AccountInfo = .init(
+    address: "mock_eth_id_2",
+    name: "Ethereum Account 2",
+    isImported: false,
+    hardware: nil,
+    coin: .eth,
+    keyringId: BraveWallet.DefaultKeyringId
+  )
+  
+  private let formatter = WeiFormatter(decimalFormatStyle: .decimals(precision: 18))
+  private let currencyFormatter = NumberFormatter().then { $0.numberStyle = .currency }
+  
+  /// Test `update()` will update `accountSections` for each account, and verify
+  /// `filteredAccountSections` displays non-zero balance by default.
+  func testUpdate() async {
+    let mockETHBalance: Double = 0.896
+    let mockETHPrice: String = "3059.99" // ETH value = $2741.75104
+    let mockUSDCBalance: Double = 4
+    let mockUSDCPrice: String = "1" // USDC value = $4
+    let mockSOLLamportBalance: UInt64 = 3876535000 // ~3.8765 SOL
+    let mockSOLBalance: Double = 3.8765 // lamports rounded
+    let mockSOLPrice: String = "200" // SOL value = $775.30
+    let mockNFTBalance: Double = 1
+    let mockNFTMetadata: NFTMetadata = .init(
+      imageURLString: "sol.mock.image.url",
+      name: "sol mock nft name",
+      description: "sol mock nft description"
+    )
+    
+    let ethBalanceWei = formatter.weiString(
+      from: mockETHBalance,
+      radix: .hex,
+      decimals: Int(BraveWallet.BlockchainToken.previewToken.decimals)
+    ) ?? ""
+    let mockETHAssetPrice: BraveWallet.AssetPrice = .init(
+      fromAsset: "eth", toAsset: "usd",
+      price: mockETHPrice, assetTimeframeChange: "-57.23")
+    let usdcBalanceWei = formatter.weiString(
+      from: mockUSDCBalance,
+      radix: .hex,
+      decimals: Int(BraveWallet.BlockchainToken.mockUSDCToken.decimals)
+    ) ?? ""
+    let mockUSDCAssetPrice: BraveWallet.AssetPrice = .init(
+      fromAsset: allUserAssets[1].assetRatioId.lowercased(), toAsset: "usd",
+      price: mockUSDCPrice, assetTimeframeChange: "-57.23")
+    let mockSOLAssetPrice: BraveWallet.AssetPrice = .init(
+      fromAsset: "sol", toAsset: "usd",
+      price: mockSOLPrice, assetTimeframeChange: "-57.23")
+    
+    let keyringService = BraveWallet.TestKeyringService()
+    keyringService._keyringInfo = { keyringId, completion in
+      if keyringId == BraveWallet.DefaultKeyringId {
+        let keyring: BraveWallet.KeyringInfo = .init(
+          id: BraveWallet.DefaultKeyringId,
+          isKeyringCreated: true,
+          isLocked: false,
+          isBackedUp: true,
+          accountInfos: [.mockEthAccount, self.mockEthAccount2]
+        )
+        completion(keyring)
+      } else {
+        let keyring: BraveWallet.KeyringInfo = .init(
+          id: BraveWallet.SolanaKeyringId,
+          isKeyringCreated: true,
+          isLocked: false,
+          isBackedUp: true,
+          accountInfos: [.mockSolAccount]
+        )
+        completion(keyring)
+      }
+    }
+    let rpcService = BraveWallet.TestJsonRpcService()
+    rpcService._allNetworks = { coin, completion in
+      completion(self.allNetworks)
+    }
+    rpcService._balance = { accountAddress, _, _, completion in
+      if accountAddress == BraveWallet.AccountInfo.mockEthAccount.address {
+        completion(ethBalanceWei, .success, "") // eth balance for `mockEthAccount`
+        return
+      }
+      completion("0", .success, "") // 0 eth balance for `mockEthAccount2`
+    }
+    rpcService._erc20TokenBalance = { contractAddress, accountAddress, _, completion in
+      if accountAddress == self.mockEthAccount2.address {
+        completion(usdcBalanceWei, .success, "") // usdc balance for `mockEthAccount2`
+        return
+      }
+      completion("0", .success, "") // usdc balance for `mockEthAccount`
+    }
+    rpcService._solanaBalance = { accountAddress, chainId, completion in
+      completion(mockSOLLamportBalance, .success, "") // sol balance
+    }
+    rpcService._splTokenAccountBalance = {_, _, _, completion in
+      completion("\(mockNFTBalance)", UInt8(0), "\(mockNFTBalance)", .success, "") // sol nft balance
+    }
+    rpcService._solTokenMetadata = { tokenChainId, tokenMintAddress, completion in
+      guard tokenChainId == self.allUserAssets[4].chainId,
+            tokenMintAddress == self.allUserAssets[4].contractAddress else {
+        completion("", "", .internalError, "")
+        return
+      }
+      let metadata = """
+      {
+        "image": "\(mockNFTMetadata.imageURLString ?? "")",
+        "name": "\(mockNFTMetadata.name ?? "")",
+        "description": "\(mockNFTMetadata.description ?? "")"
+      }
+      """
+      completion("", metadata, .success, "")
+    }
+    let walletService = BraveWallet.TestBraveWalletService()
+    walletService._addObserver = { _ in }
+    walletService._defaultBaseCurrency = { $0(CurrencyCode.usd.code) }
+    walletService._allUserAssets = { completion in
+      completion(self.allUserAssets)
+    }
+    let assetRatioService = BraveWallet.TestAssetRatioService()
+    assetRatioService._price = { priceIds, _, _, completion in
+      completion(true, [mockETHAssetPrice, mockUSDCAssetPrice, mockSOLAssetPrice])
+    }
+
+    let store = SelectAccountTokenStore(
+      didSelect: { _, _ in },
+      keyringService: keyringService,
+      rpcService: rpcService,
+      walletService: walletService,
+      assetRatioService: assetRatioService,
+      ipfsApi: TestIpfsAPI()
+    )
+
+    XCTAssertTrue(store.accountSections.isEmpty)
+    XCTAssertTrue(store.isHidingZeroBalances) // test expecting zero balances hidden
+    
+    let accountSectionsExpectation = expectation(description: "update-AccountSections")
+    store.$accountSections
+      .dropFirst() // initial
+      .collect(4) // fetch accounts, fetch balance, fetch price, fetchNftMetadata
+      .sink { accountSections in
+        defer { accountSectionsExpectation.fulfill() }
+        guard let accountSections = accountSections.last else {
+          XCTFail("Unexpected test setup")
+          return
+        }
+        XCTAssertEqual(accountSections.count, 3) // 2 eth accounts, 1 sol accounts
+        
+        XCTAssertEqual(accountSections[safe: 0]?.account, .mockEthAccount)
+        XCTAssertEqual(accountSections[safe: 0]?.tokenBalances[safe: 0]?.token, self.allUserAssets[0]) // ETH
+        XCTAssertEqual(accountSections[safe: 0]?.tokenBalances[safe: 1]?.token, self.allUserAssets[1]) // USDC
+        
+        XCTAssertEqual(accountSections[safe: 1]?.account, self.mockEthAccount2)
+        XCTAssertEqual(accountSections[safe: 1]?.tokenBalances[safe: 0]?.token, self.allUserAssets[1]) // USDC
+        XCTAssertEqual(accountSections[safe: 1]?.tokenBalances[safe: 1]?.token, self.allUserAssets[0]) // ETH
+        
+        XCTAssertEqual(accountSections[safe: 2]?.account, .mockSolAccount)
+        XCTAssertEqual(accountSections[safe: 2]?.tokenBalances[safe: 0]?.token, self.allUserAssets[2]) // SOL
+        XCTAssertEqual(accountSections[safe: 2]?.tokenBalances[safe: 1]?.token, self.allUserAssets[4]) // Solana NFT
+        XCTAssertNil(accountSections[safe: 2]?.tokenBalances[safe: 2]) // `mockSpdToken` is not visible
+      }.store(in: &cancellables)
+
+    await store.update()
+    await fulfillment(of: [accountSectionsExpectation], timeout: 1)
+    
+    // verify `filteredAccountSections` which get displayed in UI
+    var accountSections = store.filteredAccountSections
+    XCTAssertEqual(accountSections.count, 3) // 2 eth accounts, 1 sol accounts
+    
+    // Account 1
+    XCTAssertEqual(accountSections[safe: 0]?.account, .mockEthAccount)
+    XCTAssertEqual(accountSections[safe: 0]?.tokenBalances[safe: 0]?.token, self.allUserAssets[0]) // ETH
+    XCTAssertEqual(accountSections[safe: 0]?.tokenBalances[safe: 0]?.network.chainId, BraveWallet.MainnetChainId)
+    XCTAssertEqual(accountSections[safe: 0]?.tokenBalances[safe: 0]?.balance, mockETHBalance)
+    XCTAssertEqual(accountSections[safe: 0]?.tokenBalances[safe: 0]?.price, "$2,741.75")
+    XCTAssertNil(accountSections[safe: 0]?.tokenBalances[safe: 1]) // no USDC balance, token hidden
+    
+    // Ethereum Account 2
+    XCTAssertEqual(accountSections[safe: 1]?.account, self.mockEthAccount2)
+    XCTAssertEqual(accountSections[safe: 1]?.tokenBalances[safe: 0]?.token, self.allUserAssets[1]) // USDC
+    XCTAssertEqual(accountSections[safe: 1]?.tokenBalances[safe: 0]?.network.chainId, BraveWallet.GoerliChainId)
+    XCTAssertEqual(accountSections[safe: 1]?.tokenBalances[safe: 0]?.balance, mockUSDCBalance)
+    XCTAssertEqual(accountSections[safe: 1]?.tokenBalances[safe: 0]?.price, "$4.00")
+    XCTAssertNil(accountSections[safe: 1]?.tokenBalances[safe: 1]) // no ETH balance, token hidden
+    
+    // Solana Account 1
+    XCTAssertEqual(accountSections[safe: 2]?.account, .mockSolAccount)
+    XCTAssertEqual(accountSections[safe: 2]?.tokenBalances[safe: 0]?.token, self.allUserAssets[2]) // SOL
+    XCTAssertEqual(accountSections[safe: 2]?.tokenBalances[safe: 0]?.network.chainId, BraveWallet.SolanaMainnet)
+    XCTAssertEqual(accountSections[safe: 2]?.tokenBalances[safe: 0]?.balance, mockSOLBalance)
+    XCTAssertEqual(accountSections[safe: 2]?.tokenBalances[safe: 0]?.price, "$775.30")
+    XCTAssertEqual(accountSections[safe: 2]?.tokenBalances[safe: 1]?.token, self.allUserAssets[4]) // Solana NFT
+    XCTAssertEqual(accountSections[safe: 2]?.tokenBalances[safe: 1]?.network.chainId, BraveWallet.SolanaTestnet)
+    XCTAssertEqual(accountSections[safe: 2]?.tokenBalances[safe: 1]?.balance, mockNFTBalance)
+    XCTAssertEqual(accountSections[safe: 2]?.tokenBalances[safe: 1]?.nftMetadata, mockNFTMetadata)
+    
+    // Test with zero balances shown
+    store.isHidingZeroBalances = false
+    accountSections = store.filteredAccountSections
+    XCTAssertEqual(accountSections.count, 3) // 2 eth accounts, 1 sol accounts
+    
+    // Account 1
+    XCTAssertEqual(accountSections[safe: 0]?.account, .mockEthAccount)
+    XCTAssertEqual(accountSections[safe: 0]?.tokenBalances[safe: 0]?.token, self.allUserAssets[0]) // ETH
+    XCTAssertEqual(accountSections[safe: 0]?.tokenBalances[safe: 1]?.token, self.allUserAssets[1]) // USDC
+    
+    // Ethereum Account 2
+    XCTAssertEqual(accountSections[safe: 1]?.account, self.mockEthAccount2)
+    XCTAssertEqual(accountSections[safe: 1]?.tokenBalances[safe: 0]?.token, self.allUserAssets[1]) // USDC
+    XCTAssertEqual(accountSections[safe: 1]?.tokenBalances[safe: 1]?.token, self.allUserAssets[0]) // ETH
+    
+    // Solana Account 1
+    XCTAssertEqual(accountSections[safe: 2]?.account, .mockSolAccount)
+    XCTAssertEqual(accountSections[safe: 2]?.tokenBalances[safe: 0]?.token, self.allUserAssets[2]) // SOL
+    XCTAssertEqual(accountSections[safe: 2]?.tokenBalances[safe: 1]?.token, self.allUserAssets[4]) // Solana NFT
+  }
+  
+  func testNetworkFilter() {
+    let keyringService = BraveWallet.TestKeyringService()
+    let rpcService = BraveWallet.TestJsonRpcService()
+    let walletService = BraveWallet.TestBraveWalletService()
+    walletService._addObserver = { _ in }
+    let assetRatioService = BraveWallet.TestAssetRatioService()
+
+    let store = SelectAccountTokenStore(
+      didSelect: { _, _ in },
+      keyringService: keyringService,
+      rpcService: rpcService,
+      walletService: walletService,
+      assetRatioService: assetRatioService,
+      ipfsApi: TestIpfsAPI()
+    )
+    store.setupForTesting()
+    XCTAssertTrue(store.accountSections.isEmpty)
+    XCTAssertTrue(store.filteredAccountSections.isEmpty)
+    store.accountSections = [
+      .init(
+        account: .mockEthAccount,
+        tokenBalances: [
+          .init(
+            token: .previewToken,
+            network: .mockMainnet,
+            balance: 1
+          ),
+          .init(
+            token: .previewDaiToken.copy(asVisibleAsset: true).then { $0.chainId = BraveWallet.GoerliChainId },
+            network: .mockGoerli,
+            balance: 2
+          )
+        ]
+      ),
+      .init(
+        account: .mockSolAccount,
+        tokenBalances: [
+          .init(
+            token: .mockSolToken,
+            network: .mockSolana,
+            balance: 3
+          ),
+          .init(
+            token: .mockSpdToken.copy(asVisibleAsset: true).then { $0.chainId = BraveWallet.SolanaTestnet },
+            network: .mockSolanaTestnet,
+            balance: 4
+          )
+        ]
+      )
+    ]
+    // all networks
+    store.networkFilter = .allNetworks
+    XCTAssertEqual(store.filteredAccountSections, store.accountSections)
+    // Ethereum mainnet
+    store.networkFilter = .network(.mockMainnet)
+    XCTAssertEqual(store.filteredAccountSections.count, 1)
+    XCTAssertEqual(store.filteredAccountSections, [
+      .init(
+        account: .mockEthAccount,
+        tokenBalances: [
+          .init(
+            token: .previewToken,
+            network: .mockMainnet,
+            balance: 1
+          )
+        ]
+      )
+    ])
+    // Solana mainnet
+    store.networkFilter = .network(.mockSolana)
+    XCTAssertEqual(store.filteredAccountSections.count, 1)
+    XCTAssertEqual(store.filteredAccountSections, [
+      .init(
+        account: .mockSolAccount,
+        tokenBalances: [
+          .init(
+            token: .mockSolToken,
+            network: .mockSolana,
+            balance: 3
+          )
+        ]
+      )
+    ])
+  }
+}

--- a/Tests/BraveWalletTests/SendTokenStoreTests.swift
+++ b/Tests/BraveWalletTests/SendTokenStoreTests.swift
@@ -18,6 +18,7 @@ class SendTokenStoreTests: XCTestCase {
     userAssets: [BraveWallet.BlockchainToken] = [.previewToken],
     selectedCoin: BraveWallet.CoinType = .eth,
     selectedNetwork: BraveWallet.NetworkInfo = .mockGoerli,
+    allNetworks: [BraveWallet.NetworkInfo] = [.mockGoerli],
     balance: String = "0",
     erc20Balance: String = "0",
     erc721Balance: String = "0",
@@ -34,7 +35,7 @@ class SendTokenStoreTests: XCTestCase {
     keyringService._checksumEthAddress = { address, completion in completion(address) }
     let rpcService = BraveWallet.TestJsonRpcService()
     rpcService._network = { $2(selectedNetwork) }
-    rpcService._allNetworks = { $1([selectedNetwork]) }
+    rpcService._allNetworks = { $1(allNetworks) }
     rpcService._setNetwork = { _, _, _, completion in completion(true) }
     rpcService._addObserver = { _ in }
     rpcService._balance = { $3(balance, .success, "") }
@@ -1259,5 +1260,238 @@ class SendTokenStoreTests: XCTestCase {
     waitForExpectations(timeout: 1) { error in
       XCTAssertNil(error)
     }
+  }
+  
+  private let account: BraveWallet.AccountInfo = .previewAccount
+  private let ethGoerli: BraveWallet.BlockchainToken = BraveWallet.NetworkInfo.mockGoerli.nativeToken
+    .copy(asVisibleAsset: true)
+  private let usdcGoerli: BraveWallet.BlockchainToken = .mockUSDCToken
+    .copy(asVisibleAsset: true).then {
+      $0.chainId = BraveWallet.GoerliChainId
+    }
+  private lazy var account2: BraveWallet.AccountInfo = (account.copy() as! BraveWallet.AccountInfo).then {
+    $0.name = "Account 2"
+    $0.address = "0x2222222222179E9EC40BC2AFFF9E9EC40BC2AFFF"
+  }
+
+  /// Test `didSelect(account:token:)` with a new token that is on the currently selected account and currently selected network.
+  @MainActor func testDidSelectSameAccountSameNetwork() async {
+    let (keyringService, rpcService, walletService, ethTxManagerProxy, solTxManagerProxy) = setupServices(
+      accountAddress: account.address,
+      userAssets: [ethGoerli, usdcGoerli],
+      selectedCoin: .eth,
+      selectedNetwork: .mockGoerli
+    )
+    let store = SendTokenStore(
+      keyringService: keyringService,
+      rpcService: rpcService,
+      walletService: walletService,
+      txService: MockTxService(),
+      blockchainRegistry: MockBlockchainRegistry(),
+      assetRatioService: MockAssetRatioService(),
+      ethTxManagerProxy: ethTxManagerProxy,
+      solTxManagerProxy: solTxManagerProxy,
+      prefilledToken: ethGoerli,
+      ipfsApi: TestIpfsAPI()
+    )
+    let sendTokenExpectation = expectation(description: "sendTokenExpectation")
+    store.$selectedSendToken
+      .dropFirst()
+      .sink { selectedSendToken in
+        defer { sendTokenExpectation.fulfill() }
+        XCTAssertEqual(selectedSendToken, self.ethGoerli)
+      }
+      .store(in: &cancellables)
+    store.update()
+    // wait for `prefilledToken` to be assigned.
+    await fulfillment(of: [sendTokenExpectation], timeout: 1)
+    cancellables.removeAll()
+    
+    let didSelectSendTokenExpectation = expectation(description: "didSelectSendTokenExpectation")
+    store.$selectedSendToken
+      .dropFirst()
+      .sink { selectedSendToken in
+        defer { didSelectSendTokenExpectation.fulfill() }
+        XCTAssertEqual(selectedSendToken, self.usdcGoerli)
+      }
+      .store(in: &cancellables)
+    store.didSelect(account: account, token: usdcGoerli)
+    await fulfillment(of: [didSelectSendTokenExpectation], timeout: 1)
+  }
+
+  /// Test `didSelect(account:token:)` with a new token that is not on the currently selected account but is on the currently selected network.
+  @MainActor func testDidSelectNewAccountSameNetwork() async {
+    let account: BraveWallet.AccountInfo = .previewAccount
+    let ethGoerli: BraveWallet.BlockchainToken = BraveWallet.NetworkInfo.mockGoerli.nativeToken
+      .copy(asVisibleAsset: true)
+    let (keyringService, rpcService, walletService, ethTxManagerProxy, solTxManagerProxy) = setupServices(
+      accountAddress: account.address,
+      userAssets: [ethGoerli],
+      selectedCoin: .eth,
+      selectedNetwork: .mockGoerli
+    )
+    let setSelectedAccountExpectation = expectation(description: "setSelectedAccountExpectation")
+    keyringService._setSelectedAccount = { coin, keyringId, address, completion in
+      defer { setSelectedAccountExpectation.fulfill() }
+      XCTAssertEqual(address, self.account2.address)
+      completion(true)
+    }
+    let store = SendTokenStore(
+      keyringService: keyringService,
+      rpcService: rpcService,
+      walletService: walletService,
+      txService: MockTxService(),
+      blockchainRegistry: MockBlockchainRegistry(),
+      assetRatioService: MockAssetRatioService(),
+      ethTxManagerProxy: ethTxManagerProxy,
+      solTxManagerProxy: solTxManagerProxy,
+      prefilledToken: ethGoerli,
+      ipfsApi: TestIpfsAPI()
+    )
+    let sendTokenExpectation = expectation(description: "sendTokenExpectation")
+    store.$selectedSendToken
+      .dropFirst()
+      .sink { selectedSendToken in
+        defer { sendTokenExpectation.fulfill() }
+        XCTAssertEqual(selectedSendToken, ethGoerli)
+      }
+      .store(in: &cancellables)
+    store.update()
+    // wait for `prefilledToken` to be assigned.
+    await fulfillment(of: [sendTokenExpectation], timeout: 1)
+    cancellables.removeAll()
+    
+    store.didSelect(account: account2, token: ethGoerli)
+    await fulfillment(of: [setSelectedAccountExpectation], timeout: 1)
+  }
+
+  /// Test `didSelect(account:token:)` with a new token that is not on the currently selected account and not on the currently selected network.
+  @MainActor func testDidSelectNewAccountNewNetwork() async {
+    let ethMainnet: BraveWallet.BlockchainToken = BraveWallet.NetworkInfo.mockMainnet.nativeToken
+      .copy(asVisibleAsset: true)
+    var selectedNetwork: BraveWallet.NetworkInfo = .mockMainnet
+    let allNetworks: [BraveWallet.NetworkInfo] = [.mockMainnet, .mockGoerli]
+    let (keyringService, rpcService, walletService, ethTxManagerProxy, solTxManagerProxy) = setupServices(
+      accountAddress: account.address,
+      userAssets: [ethMainnet, usdcGoerli],
+      selectedCoin: .eth,
+      allNetworks: allNetworks
+    )
+    let setSelectedAccountExpectation = expectation(description: "setSelectedAccountExpectation")
+    keyringService._setSelectedAccount = { coin, keyringId, address, completion in
+      defer { setSelectedAccountExpectation.fulfill() }
+      XCTAssertEqual(address, self.account2.address)
+      completion(true)
+    }
+    let setNetworkExpectation = expectation(description: "setNetworkExpectation")
+    rpcService._setNetwork = { chainId, coin, origin, completion in
+      defer { setNetworkExpectation.fulfill() }
+      XCTAssertEqual(chainId, self.usdcGoerli.chainId)
+      selectedNetwork = allNetworks.first(where: { $0.chainId == chainId }) ?? selectedNetwork
+      completion(true)
+    }
+    rpcService._network = { coin, origin, completion in
+      completion(selectedNetwork)
+    }
+    let store = SendTokenStore(
+      keyringService: keyringService,
+      rpcService: rpcService,
+      walletService: walletService,
+      txService: MockTxService(),
+      blockchainRegistry: MockBlockchainRegistry(),
+      assetRatioService: MockAssetRatioService(),
+      ethTxManagerProxy: ethTxManagerProxy,
+      solTxManagerProxy: solTxManagerProxy,
+      prefilledToken: ethMainnet,
+      ipfsApi: TestIpfsAPI()
+    )
+    let sendTokenExpectation = expectation(description: "sendTokenExpectation")
+    store.$selectedSendToken
+      .dropFirst()
+      .sink { selectedSendToken in
+        defer { sendTokenExpectation.fulfill() }
+        XCTAssertEqual(selectedSendToken, ethMainnet)
+      }
+      .store(in: &cancellables)
+    store.update()
+    // wait for `prefilledToken` to be assigned.
+    await fulfillment(of: [sendTokenExpectation], timeout: 1)
+    cancellables.removeAll()
+    
+    let didSelectSendTokenExpectation = expectation(description: "didSelectSendTokenExpectation")
+    store.$selectedSendToken
+      .dropFirst()
+      .sink { selectedSendToken in
+        defer { didSelectSendTokenExpectation.fulfill() }
+        XCTAssertEqual(selectedSendToken, self.usdcGoerli)
+      }
+      .store(in: &cancellables)
+    store.didSelect(account: account2, token: usdcGoerli)
+    await fulfillment(of: [didSelectSendTokenExpectation, setSelectedAccountExpectation, setNetworkExpectation], timeout: 1)
+  }
+
+  /// Test `didSelect(account:token:)` with a new token that is on a different coin type (ex. Ethereum -> Solana).
+  @MainActor func testDidSelectCoinTypeSwitch() async {
+    let solMainnet: BraveWallet.BlockchainToken = BraveWallet.NetworkInfo.mockSolana.nativeToken
+      .copy(asVisibleAsset: true)
+    var selectedNetwork: BraveWallet.NetworkInfo = .mockGoerli
+    let allNetworks: [BraveWallet.NetworkInfo] = [.mockGoerli, .mockSolana]
+    let (keyringService, rpcService, walletService, ethTxManagerProxy, solTxManagerProxy) = setupServices(
+      accountAddress: account.address,
+      userAssets: [usdcGoerli, solMainnet],
+      selectedCoin: .eth,
+      allNetworks: allNetworks
+    )
+    let setSelectedAccountExpectation = expectation(description: "setSelectedAccountExpectation")
+    keyringService._setSelectedAccount = { coin, keyringId, address, completion in
+      defer { setSelectedAccountExpectation.fulfill() }
+      XCTAssertEqual(address, BraveWallet.AccountInfo.mockSolAccount.address)
+      completion(true)
+    }
+    let setNetworkExpectation = expectation(description: "setNetworkExpectation")
+    rpcService._setNetwork = { chainId, coin, origin, completion in
+      defer { setNetworkExpectation.fulfill() }
+      XCTAssertEqual(chainId, solMainnet.chainId)
+      selectedNetwork = allNetworks.first(where: { $0.chainId == chainId }) ?? selectedNetwork
+      completion(true)
+    }
+    rpcService._network = { coin, origin, completion in
+      completion(selectedNetwork)
+    }
+    let store = SendTokenStore(
+      keyringService: keyringService,
+      rpcService: rpcService,
+      walletService: walletService,
+      txService: MockTxService(),
+      blockchainRegistry: MockBlockchainRegistry(),
+      assetRatioService: MockAssetRatioService(),
+      ethTxManagerProxy: ethTxManagerProxy,
+      solTxManagerProxy: solTxManagerProxy,
+      prefilledToken: usdcGoerli,
+      ipfsApi: TestIpfsAPI()
+    )
+    let sendTokenExpectation = expectation(description: "sendTokenExpectation")
+    store.$selectedSendToken
+      .dropFirst()
+      .sink { selectedSendToken in
+        defer { sendTokenExpectation.fulfill() }
+        XCTAssertEqual(selectedSendToken, self.usdcGoerli)
+      }
+      .store(in: &cancellables)
+    store.update()
+    // wait for `prefilledToken` to be assigned.
+    await fulfillment(of: [sendTokenExpectation], timeout: 1)
+    cancellables.removeAll()
+    
+    let didSelectSendTokenExpectation = expectation(description: "didSelectSendTokenExpectation")
+    store.$selectedSendToken
+      .dropFirst()
+      .sink { selectedSendToken in
+        defer { didSelectSendTokenExpectation.fulfill() }
+        XCTAssertEqual(selectedSendToken, solMainnet)
+      }
+      .store(in: &cancellables)
+    store.didSelect(account: .mockSolAccount, token: solMainnet)
+    await fulfillment(of: [didSelectSendTokenExpectation, setSelectedAccountExpectation, setNetworkExpectation], timeout: 1)
   }
 }

--- a/Tests/BraveWalletTests/SendTokenStoreTests.swift
+++ b/Tests/BraveWalletTests/SendTokenStoreTests.swift
@@ -30,9 +30,12 @@ class SendTokenStoreTests: XCTestCase {
     let keyringService = BraveWallet.TestKeyringService()
     keyringService._addObserver = { _ in }
     keyringService._selectedAccount = { $1(accountAddress) }
+    keyringService._setSelectedAccount = { _, _, _, completion in completion(true) }
+    keyringService._checksumEthAddress = { address, completion in completion(address) }
     let rpcService = BraveWallet.TestJsonRpcService()
     rpcService._network = { $2(selectedNetwork) }
     rpcService._allNetworks = { $1([selectedNetwork]) }
+    rpcService._setNetwork = { _, _, _, completion in completion(true) }
     rpcService._addObserver = { _ in }
     rpcService._balance = { $3(balance, .success, "") }
     rpcService._erc20TokenBalance = { $3(erc20Balance, .success, "") }
@@ -47,6 +50,10 @@ class SendTokenStoreTests: XCTestCase {
     rpcService._ensGetEthAddr = { _, completion in
       completion(ensGetEthAddr, false, .success, "")
     }
+    rpcService._setEnsResolveMethod = { _ in }
+    rpcService._setEnsOffchainLookupResolveMethod = { _ in }
+    rpcService._setSnsResolveMethod = { _ in }
+    rpcService._setUnstoppableDomainsResolveMethod = { _ in }
     rpcService._unstoppableDomainsGetWalletAddr = { _, _, completion in
       completion(unstoppableDomainsGetWalletAddr, .success, "")
     }
@@ -73,6 +80,7 @@ class SendTokenStoreTests: XCTestCase {
     let walletService = BraveWallet.TestBraveWalletService()
     walletService._selectedCoin = { $0(selectedCoin) }
     walletService._userAssets = { $2(userAssets) }
+    walletService._isBase58EncodedSolanaPubkey = { _, completion in completion(true) }
     let ethTxManagerProxy = BraveWallet.TestEthTxManagerProxy()
     ethTxManagerProxy._makeErc20TransferData = { _, _, completion in
       completion(true, .init())
@@ -91,6 +99,7 @@ class SendTokenStoreTests: XCTestCase {
       walletService: MockBraveWalletService(),
       txService: MockTxService(),
       blockchainRegistry: MockBlockchainRegistry(),
+      assetRatioService: MockAssetRatioService(),
       ethTxManagerProxy: MockEthTxManagerProxy(),
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: nil,
@@ -104,6 +113,7 @@ class SendTokenStoreTests: XCTestCase {
       walletService: MockBraveWalletService(),
       txService: MockTxService(),
       blockchainRegistry: MockBlockchainRegistry(),
+      assetRatioService: MockAssetRatioService(),
       ethTxManagerProxy: MockEthTxManagerProxy(),
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: .previewToken,
@@ -150,6 +160,7 @@ class SendTokenStoreTests: XCTestCase {
       walletService: walletService,
       txService: MockTxService(),
       blockchainRegistry: MockBlockchainRegistry(),
+      assetRatioService: MockAssetRatioService(),
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: .mockSolToken,
@@ -185,6 +196,7 @@ class SendTokenStoreTests: XCTestCase {
       walletService: walletService,
       txService: MockTxService(),
       blockchainRegistry: MockBlockchainRegistry(),
+      assetRatioService: MockAssetRatioService(),
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: nil,
@@ -229,6 +241,7 @@ class SendTokenStoreTests: XCTestCase {
       walletService: walletService,
       txService: MockTxService(),
       blockchainRegistry: MockBlockchainRegistry(),
+      assetRatioService: MockAssetRatioService(),
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: .previewToken,
@@ -254,6 +267,7 @@ class SendTokenStoreTests: XCTestCase {
       walletService: walletService,
       txService: MockTxService(),
       blockchainRegistry: MockBlockchainRegistry(),
+      assetRatioService: MockAssetRatioService(),
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: .previewToken,
@@ -279,6 +293,7 @@ class SendTokenStoreTests: XCTestCase {
       walletService: walletService,
       txService: MockTxService(),
       blockchainRegistry: MockBlockchainRegistry(),
+      assetRatioService: MockAssetRatioService(),
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: nil,
@@ -306,6 +321,7 @@ class SendTokenStoreTests: XCTestCase {
       walletService: walletService,
       txService: MockTxService(),
       blockchainRegistry: MockBlockchainRegistry(),
+      assetRatioService: MockAssetRatioService(),
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: .previewToken,
@@ -334,6 +350,7 @@ class SendTokenStoreTests: XCTestCase {
       walletService: walletService,
       txService: MockTxService(),
       blockchainRegistry: MockBlockchainRegistry(),
+      assetRatioService: MockAssetRatioService(),
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: .mockERC721NFTToken,
@@ -384,6 +401,7 @@ class SendTokenStoreTests: XCTestCase {
       walletService: walletService,
       txService: MockTxService(),
       blockchainRegistry: MockBlockchainRegistry(),
+      assetRatioService: MockAssetRatioService(),
       ethTxManagerProxy: MockEthTxManagerProxy(),
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: .previewToken,
@@ -435,6 +453,7 @@ class SendTokenStoreTests: XCTestCase {
       walletService: walletService,
       txService: MockTxService(),
       blockchainRegistry: MockBlockchainRegistry(),
+      assetRatioService: MockAssetRatioService(),
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: BraveWallet.NetworkInfo.mockSolana.nativeToken,
@@ -472,6 +491,7 @@ class SendTokenStoreTests: XCTestCase {
       walletService: walletService,
       txService: MockTxService(),
       blockchainRegistry: MockBlockchainRegistry(),
+      assetRatioService: MockAssetRatioService(),
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: .mockSpdToken,
@@ -512,6 +532,7 @@ class SendTokenStoreTests: XCTestCase {
       walletService: walletService,
       txService: MockTxService(),
       blockchainRegistry: MockBlockchainRegistry(),
+      assetRatioService: MockAssetRatioService(),
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: .mockSolToken,
@@ -553,6 +574,7 @@ class SendTokenStoreTests: XCTestCase {
       walletService: walletService,
       txService: MockTxService(),
       blockchainRegistry: MockBlockchainRegistry(),
+      assetRatioService: MockAssetRatioService(),
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: .mockSpdToken,
@@ -585,6 +607,7 @@ class SendTokenStoreTests: XCTestCase {
       walletService: walletService,
       txService: MockTxService(),
       blockchainRegistry: MockBlockchainRegistry(),
+      assetRatioService: MockAssetRatioService(),
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: nil,
@@ -627,6 +650,7 @@ class SendTokenStoreTests: XCTestCase {
       walletService: walletService,
       txService: MockTxService(),
       blockchainRegistry: MockBlockchainRegistry(),
+      assetRatioService: MockAssetRatioService(),
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: nil,
@@ -672,6 +696,7 @@ class SendTokenStoreTests: XCTestCase {
       walletService: walletService,
       txService: MockTxService(),
       blockchainRegistry: MockBlockchainRegistry(),
+      assetRatioService: MockAssetRatioService(),
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: nil,
@@ -709,6 +734,7 @@ class SendTokenStoreTests: XCTestCase {
       walletService: walletService,
       txService: MockTxService(),
       blockchainRegistry: MockBlockchainRegistry(),
+      assetRatioService: MockAssetRatioService(),
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: nil,
@@ -760,6 +786,7 @@ class SendTokenStoreTests: XCTestCase {
       walletService: walletService,
       txService: MockTxService(),
       blockchainRegistry: MockBlockchainRegistry(),
+      assetRatioService: MockAssetRatioService(),
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: nil,
@@ -807,6 +834,7 @@ class SendTokenStoreTests: XCTestCase {
       walletService: walletService,
       txService: MockTxService(),
       blockchainRegistry: MockBlockchainRegistry(),
+      assetRatioService: MockAssetRatioService(),
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: nil,
@@ -848,6 +876,7 @@ class SendTokenStoreTests: XCTestCase {
       walletService: walletService,
       txService: MockTxService(),
       blockchainRegistry: MockBlockchainRegistry(),
+      assetRatioService: MockAssetRatioService(),
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: nil,
@@ -886,6 +915,7 @@ class SendTokenStoreTests: XCTestCase {
       walletService: walletService,
       txService: MockTxService(),
       blockchainRegistry: MockBlockchainRegistry(),
+      assetRatioService: MockAssetRatioService(),
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: nil,
@@ -937,6 +967,7 @@ class SendTokenStoreTests: XCTestCase {
       walletService: walletService,
       txService: MockTxService(),
       blockchainRegistry: MockBlockchainRegistry(),
+      assetRatioService: MockAssetRatioService(),
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: nil,
@@ -984,6 +1015,7 @@ class SendTokenStoreTests: XCTestCase {
       walletService: walletService,
       txService: MockTxService(),
       blockchainRegistry: MockBlockchainRegistry(),
+      assetRatioService: MockAssetRatioService(),
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: .previewToken,
@@ -1037,6 +1069,7 @@ class SendTokenStoreTests: XCTestCase {
       walletService: walletService,
       txService: MockTxService(),
       blockchainRegistry: MockBlockchainRegistry(),
+      assetRatioService: MockAssetRatioService(),
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: .previewToken,
@@ -1100,6 +1133,7 @@ class SendTokenStoreTests: XCTestCase {
       walletService: walletService,
       txService: MockTxService(),
       blockchainRegistry: MockBlockchainRegistry(),
+      assetRatioService: MockAssetRatioService(),
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: .mockSolToken,
@@ -1160,6 +1194,7 @@ class SendTokenStoreTests: XCTestCase {
       walletService: walletService,
       txService: MockTxService(),
       blockchainRegistry: MockBlockchainRegistry(),
+      assetRatioService: MockAssetRatioService(),
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: .previewToken,


### PR DESCRIPTION
## Summary of Changes
- Update Send token view to remove the account & network picker, and instead use a single modal for selecting Account to send from, Token to send, and which network.
- The modal contains a network filter, and by default will only show tokens with an available balance.
    - If there are no tokens with an available balance, a `Show Zero Balances` button is displayed that will reveal all user assets for all accounts regardless of balance.
- Designs will change with Wallet v2. Design improvement suggestions for this v1 style are welcome 🙂.

This pull request fixes #7523

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

1. Open Send in native Brave Wallet on a Wallet with some token balance(s) on multiple accounts.
2. Tap on the selected token to send from
3. Verify all accounts are displayed, and all of their visible tokens with balances load in as expected. NFTs should be displayed too (assuming you own it / have balance!).
4. Tap on the network filter and select a network to filter by.
5. Verify the displayed accounts / tokens are filtered appropriately.
6. Tap on the network filter and select a network you do not have any token balance on any account.
7. Verify `Show Zero Balances` button is shown in the toolbar. Tap it.
8. Verify zero balance tokens (visible assets) are now displayed for all accounts.
9. Tap on any token in Select Token to Send modal.
10. Verify the selected token, account and network update as expected.
11. Tap on the from token
12. Pick a token on a different account and network. Repeat step 11 as appropriate.
13. Create a send transaction & verify the expected network, account and token is displayed.


## Screenshots:

Send (light) | Send (dark) | Select Token to Send (light) | Select Token to Send (dark)
--|--|--|--
![Send - light mode](https://github.com/brave/brave-ios/assets/5314553/600535f8-5b9d-46fb-97b7-ee900df9bb0c) | ![Send - dark mode](https://github.com/brave/brave-ios/assets/5314553/eae8951a-4f14-4dac-ac79-268800feada2) | ![Select Token to Send - light mode](https://github.com/brave/brave-ios/assets/5314553/75388c1c-4671-44ec-963d-be0ca6970279) | ![Select Token to Send - dark mode](https://github.com/brave/brave-ios/assets/5314553/2c69083a-21c0-435d-94b3-b4dec20b95ff)

Select Token to Send (w/ NFT) | Send (w/ NFT)
--|--
![Select Token to Send - NFT](https://github.com/brave/brave-ios/assets/5314553/d6bfcd9f-e103-42b6-b4b2-6cc8216867b3) | ![Send - NFT](https://github.com/brave/brave-ios/assets/5314553/f1072bf6-4169-4b33-a433-03027db9420b)


https://github.com/brave/brave-ios/assets/5314553/2d853275-d50f-436d-81b2-f79192796c90


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
