### PR TITLE
Fix #7583: Filecoin EVM Testnet showing in Secondary Networks list

### DIFF
--- a/Sources/BraveWallet/Crypto/Stores/NetworkStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/NetworkStore.swift
@@ -170,7 +170,6 @@ public class NetworkStore: ObservableObject {
     }
     return allChains.filter {
       $0.coin == network.coin
-      && $0.symbol == network.symbol
       && !isCustomChain($0)
       && isPrimaryOrTestnetChainId($0.chainId)
     }

--- a/Sources/BraveWallet/WalletConstants.swift
+++ b/Sources/BraveWallet/WalletConstants.swift
@@ -60,7 +60,8 @@ public struct WalletConstants {
     BraveWallet.LocalhostChainId,
     BraveWallet.SolanaDevnet,
     BraveWallet.SolanaTestnet,
-    BraveWallet.FilecoinTestnet
+    BraveWallet.FilecoinTestnet,
+    BraveWallet.FilecoinEthereumTestnetChainId
   ]
   
   /// Primary network chain ids


### PR DESCRIPTION
## Summary of Changes
- Added `FilecoinEthereumTestnetChainId` to our `supportedTestNetworkChainIds`, fixed logic that required a test network symbol to match the native token symbol (coin type match is sufficient).
 
This pull request fixes #7583

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Toggle `Show Test Networks` in Web3 settings -> Networks
2. Tap network filter button on Portfolio tab / NFT tab / Activity tab.
3. Verify `Filecoin EVM Testnet` is not shown in `Secondary Networks` list.
4. Tap the arrow beside Solana and verify `Filecoin EVM Testnet` is not shown in the Solana test network list
5. Tap the arrow beside Ethereum and verify `Filecoin EVM Testnet` is shown & selectable.
6. Open Buy/Send/Swap and tap the network picker button
7. Verify `Filecoin EVM Testnet` is not shown in `Secondary Networks` list, but is shown under Ethereum test networks the same as network filter.


## Screenshots:

https://github.com/brave/brave-ios/assets/5314553/f818bd2a-a639-43bf-8cb3-b327a2450f43



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
