### PR TITLE
Fix #5543: Relax SSL Certificate Validation to match all other browsers

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController.swift
@@ -1721,17 +1721,45 @@ public class BrowserViewController: UIViewController {
         break
       }
       
-      let host = tab.webView?.url?.host
+      guard let scheme = tab.webView?.url?.scheme,
+            let host = tab.webView?.url?.host else {
+        tab.secureContentState = .insecure
+        self.updateURLBar()
+        return
+      }
       
-      Task {
+      let port: Int
+      if let urlPort = tab.webView?.url?.port {
+        port = urlPort
+      } else if scheme == "https" {
+        port = 443
+      } else {
+        port = 80
+      }
+      
+      Task.detached {
         do {
-          try await BraveCertificateUtils.evaluateTrust(serverTrust, for: host)
-          tab.secureContentState = .secure
+          let result = BraveCertificateUtility.verifyTrust(serverTrust,
+                                                           host: host,
+                                                           port: port)
+          // Cert is valid!
+          if result == 0 {
+            tab.secureContentState = .secure
+          } else if result == Int32.min {
+            // Cert is valid but should be validated by the system
+            // Let the system handle it and we'll show an error if the system cannot validate it
+            try await BraveCertificateUtils.evaluateTrust(serverTrust, for: host)
+            tab.secureContentState = .secure
+          } else {
+            tab.secureContentState = .insecure
+          }
         } catch {
           tab.secureContentState = .insecure
         }
         
-        self.updateURLBar()
+        Task { @MainActor in
+          self.updateURLBar()
+        }
       }
     case ._sampledPageTopColor:
       updateStatusBarOverlayColor()

--- a/Sources/CertificateUtilities/BraveCertificateUtils.swift
+++ b/Sources/CertificateUtilities/BraveCertificateUtils.swift
@@ -206,7 +206,6 @@ public extension BraveCertificateUtils {
   
   static func evaluateTrust(_ trust: SecTrust, for host: String?) async throws {
     let policies = [
-      SecPolicyCreateBasicX509(),
       SecPolicyCreateSSL(true, host as CFString?),
     ]
 


### PR DESCRIPTION
## Security Review
- https://github.com/brave/security/issues/1302

## Summary of Changes
- Relax SSL validation. 
- Use Chromium validation over Apple's validation.
- If Chromium returns a value indicating that the system should handle it, then we use Apple's validation. 
- Disable Apple's X509 validation and only validate it for SSL to match other browsers (including Safari).

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5543

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
- Visit https://office.harrisisi.com/index.jsp
- It should show "SECURE" in the URL bar, if Safari and all other browsers show it is secure.


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
