### PR TITLE
Fix #7544: Add 1.52 translations

### DIFF
--- a/Sources/BraveShields/Resources/de.lproj/BraveShared.strings
+++ b/Sources/BraveShields/Resources/de.lproj/BraveShared.strings
@@ -1,0 +1,15 @@
+/* The option the user can select to do aggressive ad and tracker blocking */
+"BlockAdsAndTrackingAggressive" = "Aggressiv";
+
+/* A description for a shield options that allows you to switch between different blocking levels for trackers and ads blocking. Options include disabled, standard and aggressive. */
+"BlockAdsAndTrackingDescription" = "Verhindert das Laden von Anzeigen, Popups und Trackern.";
+
+/* The option the user can select to disable ad and tracker blocking */
+"BlockAdsAndTrackingDisabled" = "Deaktiviert";
+
+/* The option the user can select to do standard (non-aggressive) ad and tracker blocking */
+"BlockAdsAndTrackingStandard" = "Standard";
+
+/* A label for a shield option that allows you to switch between different blocking levels for tracker and ads blocking. Options include disabled, standard and aggressive. */
+"TrackersAndAdsBlocking" = "Blockierung von Trackern und Anzeigen";
+

--- a/Sources/BraveShields/Resources/es.lproj/BraveShared.strings
+++ b/Sources/BraveShields/Resources/es.lproj/BraveShared.strings
@@ -1,0 +1,15 @@
+/* The option the user can select to do aggressive ad and tracker blocking */
+"BlockAdsAndTrackingAggressive" = "Agresivo";
+
+/* A description for a shield options that allows you to switch between different blocking levels for trackers and ads blocking. Options include disabled, standard and aggressive. */
+"BlockAdsAndTrackingDescription" = "Impide que salten anuncios, ventanas emergentes y rastreadores.";
+
+/* The option the user can select to disable ad and tracker blocking */
+"BlockAdsAndTrackingDisabled" = "Deshabilitado";
+
+/* The option the user can select to do standard (non-aggressive) ad and tracker blocking */
+"BlockAdsAndTrackingStandard" = "Estándar";
+
+/* A label for a shield option that allows you to switch between different blocking levels for tracker and ads blocking. Options include disabled, standard and aggressive. */
+"TrackersAndAdsBlocking" = "Bloqueo de rastreadores y anuncios";
+

--- a/Sources/BraveShields/Resources/fr.lproj/BraveShared.strings
+++ b/Sources/BraveShields/Resources/fr.lproj/BraveShared.strings
@@ -1,0 +1,15 @@
+/* The option the user can select to do aggressive ad and tracker blocking */
+"BlockAdsAndTrackingAggressive" = "Agressif";
+
+/* A description for a shield options that allows you to switch between different blocking levels for trackers and ads blocking. Options include disabled, standard and aggressive. */
+"BlockAdsAndTrackingDescription" = "Bloque le chargement des publicités, des pop-ups et des traqueurs.";
+
+/* The option the user can select to disable ad and tracker blocking */
+"BlockAdsAndTrackingDisabled" = "Désactivé";
+
+/* The option the user can select to do standard (non-aggressive) ad and tracker blocking */
+"BlockAdsAndTrackingStandard" = "Standard";
+
+/* A label for a shield option that allows you to switch between different blocking levels for tracker and ads blocking. Options include disabled, standard and aggressive. */
+"TrackersAndAdsBlocking" = "Blocage des traqueurs et des publicités";
+

--- a/Sources/BraveShields/Resources/id-ID.lproj/BraveShared.strings
+++ b/Sources/BraveShields/Resources/id-ID.lproj/BraveShared.strings
@@ -1,0 +1,15 @@
+/* The option the user can select to do aggressive ad and tracker blocking */
+"BlockAdsAndTrackingAggressive" = "Agresif";
+
+/* A description for a shield options that allows you to switch between different blocking levels for trackers and ads blocking. Options include disabled, standard and aggressive. */
+"BlockAdsAndTrackingDescription" = "Mencegah dimuatnya iklan, popup, dan pelacak.";
+
+/* The option the user can select to disable ad and tracker blocking */
+"BlockAdsAndTrackingDisabled" = "Dinonaktifkan";
+
+/* The option the user can select to do standard (non-aggressive) ad and tracker blocking */
+"BlockAdsAndTrackingStandard" = "Standar";
+
+/* A label for a shield option that allows you to switch between different blocking levels for tracker and ads blocking. Options include disabled, standard and aggressive. */
+"TrackersAndAdsBlocking" = "Pemblokiran Pelacak & Iklan";
+

--- a/Sources/BraveShields/Resources/it.lproj/BraveShared.strings
+++ b/Sources/BraveShields/Resources/it.lproj/BraveShared.strings
@@ -1,0 +1,15 @@
+/* The option the user can select to do aggressive ad and tracker blocking */
+"BlockAdsAndTrackingAggressive" = "Aggressivo";
+
+/* A description for a shield options that allows you to switch between different blocking levels for trackers and ads blocking. Options include disabled, standard and aggressive. */
+"BlockAdsAndTrackingDescription" = "Impedisce il caricamento di annunci, popup e tracker.";
+
+/* The option the user can select to disable ad and tracker blocking */
+"BlockAdsAndTrackingDisabled" = "Funzione disattivata";
+
+/* The option the user can select to do standard (non-aggressive) ad and tracker blocking */
+"BlockAdsAndTrackingStandard" = "Standard";
+
+/* A label for a shield option that allows you to switch between different blocking levels for tracker and ads blocking. Options include disabled, standard and aggressive. */
+"TrackersAndAdsBlocking" = "Anti-tracker e blocco degli annunci";
+

--- a/Sources/BraveShields/Resources/ja.lproj/BraveShared.strings
+++ b/Sources/BraveShields/Resources/ja.lproj/BraveShared.strings
@@ -1,0 +1,15 @@
+/* The option the user can select to do aggressive ad and tracker blocking */
+"BlockAdsAndTrackingAggressive" = "積極的";
+
+/* A description for a shield options that allows you to switch between different blocking levels for trackers and ads blocking. Options include disabled, standard and aggressive. */
+"BlockAdsAndTrackingDescription" = "広告、ポップアップ、トラッキングの読み込みをブロックします。";
+
+/* The option the user can select to disable ad and tracker blocking */
+"BlockAdsAndTrackingDisabled" = "無効";
+
+/* The option the user can select to do standard (non-aggressive) ad and tracker blocking */
+"BlockAdsAndTrackingStandard" = "標準";
+
+/* A label for a shield option that allows you to switch between different blocking levels for tracker and ads blocking. Options include disabled, standard and aggressive. */
+"TrackersAndAdsBlocking" = "トラッカー & 広告ブロック";
+

--- a/Sources/BraveShields/Resources/ko-KR.lproj/BraveShared.strings
+++ b/Sources/BraveShields/Resources/ko-KR.lproj/BraveShared.strings
@@ -1,0 +1,15 @@
+/* The option the user can select to do aggressive ad and tracker blocking */
+"BlockAdsAndTrackingAggressive" = "강력";
+
+/* A description for a shield options that allows you to switch between different blocking levels for trackers and ads blocking. Options include disabled, standard and aggressive. */
+"BlockAdsAndTrackingDescription" = "광고, 팝업, 트래커가 로드되지 않도록 차단합니다.";
+
+/* The option the user can select to disable ad and tracker blocking */
+"BlockAdsAndTrackingDisabled" = "비활성화됨";
+
+/* The option the user can select to do standard (non-aggressive) ad and tracker blocking */
+"BlockAdsAndTrackingStandard" = "표준";
+
+/* A label for a shield option that allows you to switch between different blocking levels for tracker and ads blocking. Options include disabled, standard and aggressive. */
+"TrackersAndAdsBlocking" = "트래커 및 광고 차단";
+

--- a/Sources/BraveShields/Resources/ms.lproj/BraveShared.strings
+++ b/Sources/BraveShields/Resources/ms.lproj/BraveShared.strings
@@ -1,0 +1,15 @@
+/* The option the user can select to do aggressive ad and tracker blocking */
+"BlockAdsAndTrackingAggressive" = "Agresif";
+
+/* A description for a shield options that allows you to switch between different blocking levels for trackers and ads blocking. Options include disabled, standard and aggressive. */
+"BlockAdsAndTrackingDescription" = "Menghalang iklan, halaman timbul dan penjejak daripada dimuatkan.";
+
+/* The option the user can select to disable ad and tracker blocking */
+"BlockAdsAndTrackingDisabled" = "Dinyahaktif";
+
+/* The option the user can select to do standard (non-aggressive) ad and tracker blocking */
+"BlockAdsAndTrackingStandard" = "Standard";
+
+/* A label for a shield option that allows you to switch between different blocking levels for tracker and ads blocking. Options include disabled, standard and aggressive. */
+"TrackersAndAdsBlocking" = "Penjejak & Penyekatan Iklan";
+

--- a/Sources/BraveShields/Resources/nb.lproj/BraveShared.strings
+++ b/Sources/BraveShields/Resources/nb.lproj/BraveShared.strings
@@ -1,0 +1,15 @@
+/* The option the user can select to do aggressive ad and tracker blocking */
+"BlockAdsAndTrackingAggressive" = "Aggressiv";
+
+/* A description for a shield options that allows you to switch between different blocking levels for trackers and ads blocking. Options include disabled, standard and aggressive. */
+"BlockAdsAndTrackingDescription" = "Forhindrer at annonser, popup-vinduer og sporere lastes inn.";
+
+/* The option the user can select to disable ad and tracker blocking */
+"BlockAdsAndTrackingDisabled" = "Deaktivert";
+
+/* The option the user can select to do standard (non-aggressive) ad and tracker blocking */
+"BlockAdsAndTrackingStandard" = "Standard";
+
+/* A label for a shield option that allows you to switch between different blocking levels for tracker and ads blocking. Options include disabled, standard and aggressive. */
+"TrackersAndAdsBlocking" = "Sporings- og annonseblokkering";
+

--- a/Sources/BraveShields/Resources/pl.lproj/BraveShared.strings
+++ b/Sources/BraveShields/Resources/pl.lproj/BraveShared.strings
@@ -1,0 +1,15 @@
+/* The option the user can select to do aggressive ad and tracker blocking */
+"BlockAdsAndTrackingAggressive" = "Agresywnie";
+
+/* A description for a shield options that allows you to switch between different blocking levels for trackers and ads blocking. Options include disabled, standard and aggressive. */
+"BlockAdsAndTrackingDescription" = "Zapobiega wczytywaniu się reklam, wyskakujących okienek i trackerów.";
+
+/* The option the user can select to disable ad and tracker blocking */
+"BlockAdsAndTrackingDisabled" = "Wyłączono";
+
+/* The option the user can select to do standard (non-aggressive) ad and tracker blocking */
+"BlockAdsAndTrackingStandard" = "Standardowo";
+
+/* A label for a shield option that allows you to switch between different blocking levels for tracker and ads blocking. Options include disabled, standard and aggressive. */
+"TrackersAndAdsBlocking" = "Blokowanie modułów śledzących i reklam";
+

--- a/Sources/BraveShields/Resources/pt-BR.lproj/BraveShared.strings
+++ b/Sources/BraveShields/Resources/pt-BR.lproj/BraveShared.strings
@@ -1,0 +1,15 @@
+/* The option the user can select to do aggressive ad and tracker blocking */
+"BlockAdsAndTrackingAggressive" = "Agressivo";
+
+/* A description for a shield options that allows you to switch between different blocking levels for trackers and ads blocking. Options include disabled, standard and aggressive. */
+"BlockAdsAndTrackingDescription" = "Impede o carregamento de anúncios, pop-ups e rastreadores.";
+
+/* The option the user can select to disable ad and tracker blocking */
+"BlockAdsAndTrackingDisabled" = "Desativado";
+
+/* The option the user can select to do standard (non-aggressive) ad and tracker blocking */
+"BlockAdsAndTrackingStandard" = "Padrão";
+
+/* A label for a shield option that allows you to switch between different blocking levels for tracker and ads blocking. Options include disabled, standard and aggressive. */
+"TrackersAndAdsBlocking" = "Rastreadores e bloqueio de anúncios";
+

--- a/Sources/BraveShields/Resources/ru.lproj/BraveShared.strings
+++ b/Sources/BraveShields/Resources/ru.lproj/BraveShared.strings
@@ -1,0 +1,15 @@
+/* The option the user can select to do aggressive ad and tracker blocking */
+"BlockAdsAndTrackingAggressive" = "Агрессивный";
+
+/* A description for a shield options that allows you to switch between different blocking levels for trackers and ads blocking. Options include disabled, standard and aggressive. */
+"BlockAdsAndTrackingDescription" = "Блокирует загрузку рекламы, всплывающих окон и трекеров.";
+
+/* The option the user can select to disable ad and tracker blocking */
+"BlockAdsAndTrackingDisabled" = "Отключено";
+
+/* The option the user can select to do standard (non-aggressive) ad and tracker blocking */
+"BlockAdsAndTrackingStandard" = "Стандартный";
+
+/* A label for a shield option that allows you to switch between different blocking levels for tracker and ads blocking. Options include disabled, standard and aggressive. */
+"TrackersAndAdsBlocking" = "Блокировка трекеров и рекламы";
+

--- a/Sources/BraveShields/Resources/sv.lproj/BraveShared.strings
+++ b/Sources/BraveShields/Resources/sv.lproj/BraveShared.strings
@@ -1,0 +1,15 @@
+/* The option the user can select to do aggressive ad and tracker blocking */
+"BlockAdsAndTrackingAggressive" = "Aggressiv";
+
+/* A description for a shield options that allows you to switch between different blocking levels for trackers and ads blocking. Options include disabled, standard and aggressive. */
+"BlockAdsAndTrackingDescription" = "Förhindrar att annonser, popups och spårare läses in.";
+
+/* The option the user can select to disable ad and tracker blocking */
+"BlockAdsAndTrackingDisabled" = "Inaktiverad";
+
+/* The option the user can select to do standard (non-aggressive) ad and tracker blocking */
+"BlockAdsAndTrackingStandard" = "Standard";
+
+/* A label for a shield option that allows you to switch between different blocking levels for tracker and ads blocking. Options include disabled, standard and aggressive. */
+"TrackersAndAdsBlocking" = "Spårare och annonser blockerade";
+

--- a/Sources/BraveShields/Resources/tr.lproj/BraveShared.strings
+++ b/Sources/BraveShields/Resources/tr.lproj/BraveShared.strings
@@ -1,5 +1,5 @@
 /* The option the user can select to do aggressive ad and tracker blocking */
-"BlockAdsAndTrackingAggressive" = "Katı";
+"BlockAdsAndTrackingAggressive" = "Agresif";
 
 /* A description for a shield options that allows you to switch between different blocking levels for trackers and ads blocking. Options include disabled, standard and aggressive. */
 "BlockAdsAndTrackingDescription" = "Reklamların, açılır pencerelerin ve izleyicilerin yüklenmesini engeller.";

--- a/Sources/BraveShields/Resources/tr.lproj/BraveShared.strings
+++ b/Sources/BraveShields/Resources/tr.lproj/BraveShared.strings
@@ -1,0 +1,15 @@
+/* The option the user can select to do aggressive ad and tracker blocking */
+"BlockAdsAndTrackingAggressive" = "Katı";
+
+/* A description for a shield options that allows you to switch between different blocking levels for trackers and ads blocking. Options include disabled, standard and aggressive. */
+"BlockAdsAndTrackingDescription" = "Reklamların, açılır pencerelerin ve izleyicilerin yüklenmesini engeller.";
+
+/* The option the user can select to disable ad and tracker blocking */
+"BlockAdsAndTrackingDisabled" = "Devre Dışı";
+
+/* The option the user can select to do standard (non-aggressive) ad and tracker blocking */
+"BlockAdsAndTrackingStandard" = "Standart";
+
+/* A label for a shield option that allows you to switch between different blocking levels for tracker and ads blocking. Options include disabled, standard and aggressive. */
+"TrackersAndAdsBlocking" = "İzleyiciler ve Reklamlar için Engelleme";
+

--- a/Sources/BraveShields/Resources/uk.lproj/BraveShared.strings
+++ b/Sources/BraveShields/Resources/uk.lproj/BraveShared.strings
@@ -1,0 +1,15 @@
+/* The option the user can select to do aggressive ad and tracker blocking */
+"BlockAdsAndTrackingAggressive" = "Агресивно";
+
+/* A description for a shield options that allows you to switch between different blocking levels for trackers and ads blocking. Options include disabled, standard and aggressive. */
+"BlockAdsAndTrackingDescription" = "Блокує завантаження реклами, спливаючих вікон і трекерів.";
+
+/* The option the user can select to disable ad and tracker blocking */
+"BlockAdsAndTrackingDisabled" = "Вимкнено";
+
+/* The option the user can select to do standard (non-aggressive) ad and tracker blocking */
+"BlockAdsAndTrackingStandard" = "Стандартно";
+
+/* A label for a shield option that allows you to switch between different blocking levels for tracker and ads blocking. Options include disabled, standard and aggressive. */
+"TrackersAndAdsBlocking" = "Трекери й блокування реклами";
+

--- a/Sources/BraveShields/Resources/zh-TW.lproj/BraveShared.strings
+++ b/Sources/BraveShields/Resources/zh-TW.lproj/BraveShared.strings
@@ -1,0 +1,15 @@
+/* The option the user can select to do aggressive ad and tracker blocking */
+"BlockAdsAndTrackingAggressive" = "積極";
+
+/* A description for a shield options that allows you to switch between different blocking levels for trackers and ads blocking. Options include disabled, standard and aggressive. */
+"BlockAdsAndTrackingDescription" = "禁止載入廣告、彈出式視窗和追蹤器。";
+
+/* The option the user can select to disable ad and tracker blocking */
+"BlockAdsAndTrackingDisabled" = "已停用";
+
+/* The option the user can select to do standard (non-aggressive) ad and tracker blocking */
+"BlockAdsAndTrackingStandard" = "標準";
+
+/* A label for a shield option that allows you to switch between different blocking levels for tracker and ads blocking. Options include disabled, standard and aggressive. */
+"TrackersAndAdsBlocking" = "追蹤器和廣告封鎖";
+

--- a/Sources/BraveShields/Resources/zh.lproj/BraveShared.strings
+++ b/Sources/BraveShields/Resources/zh.lproj/BraveShared.strings
@@ -1,0 +1,15 @@
+/* The option the user can select to do aggressive ad and tracker blocking */
+"BlockAdsAndTrackingAggressive" = "積極";
+
+/* A description for a shield options that allows you to switch between different blocking levels for trackers and ads blocking. Options include disabled, standard and aggressive. */
+"BlockAdsAndTrackingDescription" = "防止加载广告、弹出窗口和跟踪器。";
+
+/* The option the user can select to disable ad and tracker blocking */
+"BlockAdsAndTrackingDisabled" = "已阻止";
+
+/* The option the user can select to do standard (non-aggressive) ad and tracker blocking */
+"BlockAdsAndTrackingStandard" = "標準";
+
+/* A label for a shield option that allows you to switch between different blocking levels for tracker and ads blocking. Options include disabled, standard and aggressive. */
+"TrackersAndAdsBlocking" = "跟踪器和广告屏蔽";
+

--- a/Sources/BraveStrings/Resources/de.lproj/BraveShared.strings
+++ b/Sources/BraveStrings/Resources/de.lproj/BraveShared.strings
@@ -100,12 +100,6 @@
 /* cookie settings option */
 "Block3rdPartyCookies" = "Cookies von Dritten blockieren";
 
-/* No comment provided by engineer. */
-"BlockAdsAndTracking" = "Website-übergreifende Tracker blockieren";
-
-/* No comment provided by engineer. */
-"BlockAdsAndTrackingDescription" = "Verhindert das Laden von Anzeigen, Popups und Trackern.";
-
 /* Title for setting to block all website cookies. */
 "BlockAllCookies" = "Alle Cookies blockieren";
 
@@ -138,9 +132,6 @@
 
 /* A title for setting which blocks 'switch to app' popups */
 "blockMobileAnnoyances" = "Hinweise zum Wechseln zur App blockieren";
-
-/* Brave panel individual toggle title */
-"BlockPhishing" = "Phishing blockieren";
 
 /* Setting to enable popup blocking */
 "BlockPopups" = "Pop-ups blockieren";
@@ -318,15 +309,6 @@
 
 /* Title for toggle for enabling p3a (Privacy Preserving Analytics) Full Screen Callout */
 "callout.p3aCalloutToggleTitle" = "Teilen Sie völlig private und anonyme Produkteinblicke.";
-
-/* Button title for Playlist Onboarding View */
-"callout.playlistOnboardingViewButtonTitle" = "Video ansehen";
-
-/* Description for Playlist Onboarding View */
-"callout.playlistOnboardingViewDescription" = "… geben Sie es überall und jederzeit wieder, im Hintergrund, Bild im Bild oder sogar offline. Natürlich werbefrei.";
-
-/* Title for Playlist Onboarding View */
-"callout.playlistOnboardingViewTitle" = "Fügen Sie das Video zur Playlist hinzu …";
 
 /* Subtitle - Description for Privacy Everywhere Full Screen Callout */
 "callout.privacyEverywhereCalloutDescription" = "Nutzen Sie den Brave-Datenschutz jetzt für Ihren Computer oder Ihr Tablet und synchronisieren Sie Lesezeichen und Erweiterungen zwischen Ihren Geräten.";
@@ -899,7 +881,7 @@
 "GoogleSafeBrowsing" = "Gefährliche Websites blockieren";
 
 /* No comment provided by engineer. */
-"GoogleSafeBrowsingUsingWebKitDescription" = "Sendet verschleierte URLs einiger Seiten, die Sie besuchen, an den Dienst Google Safe Browsing, wenn Ihre Sicherheit gefährdet ist.";
+"GoogleSafeBrowsingUsingWebKitDescription" = "Safe Browsing bietet Schutz vor Websites, die bekanntermaßen gefährlich sind. [Mehr erfahren](%@)";
 
 /* Grand camera access */
 "GrantCameraAccess" = "Kamera aktivieren";
@@ -986,7 +968,7 @@
 "login.loginInfoDetailsWebsiteFieldTitle" = "Website";
 
 /* The message displayed in alert when a user needs to set a passcode */
-"login.loginInfoSetPasscodeAlertDescription" = "Um Passwörter anzuzeigen, müssen Sie zunächst einen Passcode auf Ihrem Gerät festlegen.";
+"login.loginInfoSetPasscodeAlertDescription" = "Um die Synchronisierungskette einzurichten oder die Einstellungen anzuzeigen, müssen Sie zunächst einen Passcode auf Ihrem Gerät festlegen.";
 
 /* The title displayed in alert when a user needs to set passcode */
 "login.loginInfoSetPasscodeAlertTitle" = "Passcode festlegen";
@@ -1504,6 +1486,9 @@
 /* Label that says who took a photograph that will be displayed to the user. '%@' is a placeholder and will include be a specific person's name, example 'Bill Gates'. */
 "PhotoBy" = "Foto von %@";
 
+/* A message shown when the user adds media to the playlist. '%@' will be replaced by the folder it was added to. Example: 'Added to Play Later' */
+"playList.addedToPlaylistMessage" = "Zu %@ hinzugefügt";
+
 /* Alert Description for adding videos to playlist */
 "playList.addToPlayListAlertDescription" = "Möchten Sie dieses Video zu Ihrer Playlist hinzufügen?";
 
@@ -1530,6 +1515,9 @@
 
 /* The title of the playlist when in Carplay mode */
 "playlist.carplayTitle" = "Brave-Playlist";
+
+/* Title for changing the folder of the current media playlist item */
+"playList.changeFoldersButtonTitle" = "Playlist ändern";
 
 /* The title of the button indicating that the user delete the offline data. (deletes the data that allows them to play offline) */
 "playlist.deleteForOfflineButtonTitle" = "Offline-Cache löschen";
@@ -1566,6 +1554,9 @@
 
 /* Okay Alert button title */
 "playList.okayButtonTitle" = "Okay";
+
+/* Title for opening the playlist */
+"playList.openInPlaylistButtonTitle" = "In Playlist öffnen";
 
 /* The title for the alert that shows up when an item is expired */
 "playList.pictureInPictureErrorTitle" = "Es tut uns leid, bei der Bild-im-Bild-Darstellung ist ein Fehler aufgetreten.";
@@ -1614,6 +1605,9 @@
 
 /* Text for Playlist Offline Data Toggle while clearing the offline data storage in settings */
 "playlist.playlistOfflineDataToggleOption" = "Offlinedaten der Playlist";
+
+/* Title of a button displayed when first adding some media to Playlist. Its shown next to the name of a folder that the item is recently added to to imply that you are changing the folder it was saved to */
+"playlist.playlistPopoverChangeFoldersButtonTitle" = "Ändern";
 
 /* The title for the alert that shows up when removing all videos and their offline mode storage. */
 "playList.playlistResetAlertTitle" = "Zurücksetzen";
@@ -1672,6 +1666,9 @@
 /* Title for removing offline mode storage */
 "playList.removeActionButtonTitle" = "Entfernen";
 
+/* A message shown when the user removes media from the playlist. '%@' will be replaced by the folder it was added to. Example: 'Removed from Play Later' */
+"playList.removedFromPlaylistMessage" = "Aus %@ entfernt";
+
 /* Message for the alert shown when the user tries to remove offline data of an item from playlist */
 "playlist.removePlaylistOfflineDataAlertMessage" = "Hierdurch werden die Offline-Medien gelöscht. Wollen Sie wirklich fortfahren?";
 
@@ -1688,7 +1685,7 @@
 "playList.reopenButtonTitle" = "Erneut öffnen";
 
 /* Text indicator on the table cell while saving a video for offline with percentage eg: %25 Saved for Offline */
-"playList.savedForOfflineLabelTitle" = "Offline gespeichert";
+"playList.savedForOfflineLabelTitle" = "Zur Offline-Wiedergabe hinzugefügt";
 
 /* The title of the button indicating that the user can save a video for offline playback. (playing without internet) */
 "playlist.saveForOfflineButtonTitle" = "Für Offline-Wiedergabe speichern";
@@ -1732,11 +1729,23 @@
 /* The title for the toast that shows up on a page when an item that has already been added, was updated. */
 "playList.toastExitingItemPlaylistTitle" = "In Brave-Playlist anzeigen";
 
+/* A button title that when tapped will re-add the media item (undo the removal) that the user recently removed. */
+"playList.undoRemoveButtonTitle" = "Rückgängig machen";
+
 /* Footer for option to disable URL-Bar button */
 "playlist.urlBarButtonOptionFooter" = "Fügt neben der Adressleiste im Brave-Browser eine Playlist-Schaltfläche hinzu (sieht aus wie vier Linien mit einem Plussymbol). Mit dieser Schaltfläche können Sie Ihre Playlist ganz einfach öffnen oder Medien hinzufügen oder entfernen.";
 
 /* Title for option to disable URL-Bar button */
 "playlist.urlBarButtonOptionTitle" = "Schaltfläche für den Schnellzugriff aktivieren";
+
+/* The title of the screen that allows you to change the folder where a playlist item was saved to */
+"playlistFolders.changeFoldersTitle" = "Verschieben in";
+
+/* A label shown above the text field that allows the user to type a name of the playlist they are going to create */
+"playlistFolders.createFolderTextFieldLabel" = "Name der Playlist";
+
+/* A label shown above the text field that allows the user to type a name of the playlist they are going to create */
+"playlistFolders.createFolderTextFieldPlaceholder" = "Namen der Playlist eingeben";
 
 /* The title of the button to create a new folder */
 "playlistFolders.createNewFolderButtonTitle" = "Erstellen";
@@ -1747,11 +1756,17 @@
 /* The title of the screen where the user edits folder names */
 "playlistFolders.editFolderScreenTitle" = "Ordner bearbeiten";
 
+/* The title of the menu option that allows the user to edit the name of a folder */
+"playlistFolders.editMenuTitle" = "Playlist bearbeiten";
+
 /* The error shown to the user when we cannot save their changes made on a folder */
 "playlistFolders.errorSavingMessage" = "Leider konnten wir die Änderungen, die Sie an diesem Ordner vorgenommen haben, nicht speichern";
 
 /* The title of the button where the user will move an item from one folder to another folder. */
 "playlistFolders.moveFolderButtonTitle" = "Verschieben";
+
+/* The title of the section indicating the currently selected folder */
+"playlistFolders.moveFolderCurrentSectionTitle" = "Aktuelle Playlist";
 
 /* The title of the screen where the user will move an item from one folder to another folder. */
 "playlistFolders.moveFolderScreenTitle" = "Verschieben";
@@ -1768,14 +1783,35 @@
 /* %@ and %lld Should NOT be localized. They are placeholders. Example: Brave Folder and 3 more items. Music and 2 more items. */
 "playlistFolders.moveMultipleItemDescription" = "%1$@ und %2$lld weitere Elemente";
 
+/* The title of the button to create a new folder */
+"playlistFolders.newFolderButtonTitle" = "Neue Playlist";
+
+/* The title of the screen to create a new folder */
+"playlistFolders.newFolderScreenTitle" = "Neue Playlist";
+
 /* The sub-title of the section where the user can select videos to add to the new folder being created */
 "playlistFolders.newFolderSectionSubtitle" = "Tippen, um Videos auszuwählen";
+
+/* The title of the section where the user can select videos to add to the new folder being created */
+"playlistFolders.newFolderSectionTitle" = "Videos zu dieser Playlist hinzufügen";
+
+/* The title of the default playlist folder */
+"playlistFolders.savedFolderTitle" = "Später abspielen";
+
+/* The title of the section indicating that the user should select a folder to move `%zu` items to. %lld should not be translated. It will be replaced by a number so the sentence becomes: 'Select a folder to move 10 items to.' */
+"playlistFolders.selectAFolderTitle" = "Wählen Sie eine Playlist aus, in die %lld Elemente verschoben werden sollen";
+
+/* The title of the section indicating that the user should select a folder to move 1 item to. */
+"playlistFolders.selectASingleFolderTitle" = "Wählen Sie eine Playlist aus, in die 1 Element verschoben werden soll";
 
 /* The sub-title of the folder. Example: This folder contains 10 Items. This folder contains 3 Items. */
 "playlistFolders.subtitleItemCount" = "%lld Elemente";
 
 /* The sub-title of the folder. Example: This folder contains ONE item. This folder contains 1 Item. */
 "playlistFolders.subtitleItemSingleCount" = "Ein Element";
+
+/* The title of a folder when the user enters no name (untitled) */
+"playlistFolders.untitledFolderTitle" = "Unbenannte Playlist";
 
 /* Accessibility Title for the button that adds the playlist to the database. */
 "playlistFolderSharing.addButtonAccessibilityTitle" = "Schaltfläche „Zur Brave-Playlist hinzufügen“";
@@ -2307,9 +2343,6 @@
 
 /* No comment provided by engineer. */
 "RewardsInternalsLegacyPromotion" = "Alte Werbeaktion";
-
-/* No comment provided by engineer. */
-"RewardsInternalsLegacyWalletInfoHeader" = "Informationen zum alten Wallet";
 
 /* %d will be the number of logs currently being shown, i.e. '10 logs shown' */
 "RewardsInternalsLogsCount" = "%d Protokolle angezeigt";
@@ -2854,6 +2887,9 @@
 /* Part 2 Description for Alert used action Delete Sync Account. */
 "sync.syncDeleteAccountAlertDescriptionPart2" = "Diese Löschung ist dauerhaft und die Daten können nicht wiederhergestellt werden. Falls Sie die Synchronisierung wieder verwenden möchten, müssen Sie ein neues Konto erstellen und jedes Gerät einzeln hinzufügen.";
 
+/* The title displayed in alert when a user needs to set passcode */
+"sync.syncSetPasscodeAlertTitle" = "Passcode festlegen";
+
 /* Title for Sync Settings Toggle Header */
 "sync.syncSettingsTitle" = "Synchronisierungseinstellungen";
 
@@ -3049,7 +3085,8 @@
 /* Accessibility Label for the browser toolbar Menu button */
 "TabToolbarMenuButtonAccessibilityLabel" = "Menü";
 
-/* Accessibility Label for the tab toolbar Playlist button */
+/* Accessibility Label for the tab toolbar Add to Playlist button
+   Accessibility Label for the tab toolbar Playlist button */
 "TabToolbarPlaylistButtonAccessibilityLabel" = "Playlist";
 
 /* Accessibility label for the Reader View button */

--- a/Sources/BraveStrings/Resources/es.lproj/BraveShared.strings
+++ b/Sources/BraveStrings/Resources/es.lproj/BraveShared.strings
@@ -100,12 +100,6 @@
 /* cookie settings option */
 "Block3rdPartyCookies" = "Bloquear cookies de terceros";
 
-/* No comment provided by engineer. */
-"BlockAdsAndTracking" = "Bloquear los rastreadores en los sitios";
-
-/* No comment provided by engineer. */
-"BlockAdsAndTrackingDescription" = "Impide que salten anuncios, ventanas emergentes y rastreadores.";
-
 /* Title for setting to block all website cookies. */
 "BlockAllCookies" = "Bloquear todas las cookies";
 
@@ -138,9 +132,6 @@
 
 /* A title for setting which blocks 'switch to app' popups */
 "blockMobileAnnoyances" = "Bloquear avisos de cambiar a aplicación";
-
-/* Brave panel individual toggle title */
-"BlockPhishing" = "Bloquear suplantaciones de identidad";
 
 /* Setting to enable popup blocking */
 "BlockPopups" = "Bloquear ventanas emergentes";
@@ -318,15 +309,6 @@
 
 /* Title for toggle for enabling p3a (Privacy Preserving Analytics) Full Screen Callout */
 "callout.p3aCalloutToggleTitle" = "Comparte opiniones totalmente anónimas y privadas sobre los productos.";
-
-/* Button title for Playlist Onboarding View */
-"callout.playlistOnboardingViewButtonTitle" = "Ver el vídeo";
-
-/* Description for Playlist Onboarding View */
-"callout.playlistOnboardingViewDescription" = "… reproduce donde y cuando quieras en segundo plano, con la imagen superpuesta o incluso sin conexión. Y, por supuesto, olvídate de los anuncios.";
-
-/* Title for Playlist Onboarding View */
-"callout.playlistOnboardingViewTitle" = "Añade el vídeo a Lista de reproducción…";
 
 /* Subtitle - Description for Privacy Everywhere Full Screen Callout */
 "callout.privacyEverywhereCalloutDescription" = "Disfruta de la privacidad de Brave en tu ordenador o tableta, y mantén los marcadores y extensiones sincronizados en todos los dispositivos.";
@@ -896,10 +878,10 @@
 "genericErrorTitle" = "Error";
 
 /* No comment provided by engineer. */
-"GoogleSafeBrowsing" = "Bloquear sitios peligrosos";
+"GoogleSafeBrowsing" = "Bloquear sitios web peligrosos";
 
 /* No comment provided by engineer. */
-"GoogleSafeBrowsingUsingWebKitDescription" = "Envía al servicio de navegación segura de Google URL confusas de algunas de las páginas que visitas cuando tu seguridad está en riesgo.";
+"GoogleSafeBrowsingUsingWebKitDescription" = "La navegación segura te protege frente a sitios web conocidos por ser peligrosos. [Más información](%@)";
 
 /* Grand camera access */
 "GrantCameraAccess" = "Activar cámara";
@@ -986,7 +968,7 @@
 "login.loginInfoDetailsWebsiteFieldTitle" = "Sitio web";
 
 /* The message displayed in alert when a user needs to set a passcode */
-"login.loginInfoSetPasscodeAlertDescription" = "Para ver las contraseñas, primero debes fijar una clave de acceso en tu dispositivo.";
+"login.loginInfoSetPasscodeAlertDescription" = "Para configurar una cadena de sincronización o ver la configuración, primero debes establecer una clave de acceso en tu dispositivo.";
 
 /* The title displayed in alert when a user needs to set passcode */
 "login.loginInfoSetPasscodeAlertTitle" = "Fija una clave de acceso";
@@ -1504,6 +1486,9 @@
 /* Label that says who took a photograph that will be displayed to the user. '%@' is a placeholder and will include be a specific person's name, example 'Bill Gates'. */
 "PhotoBy" = "Foto de %@";
 
+/* A message shown when the user adds media to the playlist. '%@' will be replaced by the folder it was added to. Example: 'Added to Play Later' */
+"playList.addedToPlaylistMessage" = "Se ha añadido a %@";
+
 /* Alert Description for adding videos to playlist */
 "playList.addToPlayListAlertDescription" = "¿Te gustaría añadir este vídeo a tu lista de reproducción?";
 
@@ -1530,6 +1515,9 @@
 
 /* The title of the playlist when in Carplay mode */
 "playlist.carplayTitle" = "Lista de reproducción de Brave";
+
+/* Title for changing the folder of the current media playlist item */
+"playList.changeFoldersButtonTitle" = "Cambiar lista de reproducción";
 
 /* The title of the button indicating that the user delete the offline data. (deletes the data that allows them to play offline) */
 "playlist.deleteForOfflineButtonTitle" = "Eliminar caché sin conexión";
@@ -1566,6 +1554,9 @@
 
 /* Okay Alert button title */
 "playList.okayButtonTitle" = "Aceptar";
+
+/* Title for opening the playlist */
+"playList.openInPlaylistButtonTitle" = "Abrir lista de reproducción";
 
 /* The title for the alert that shows up when an item is expired */
 "playList.pictureInPictureErrorTitle" = "Vaya, se ha producido un error al tratar de mostrar la imagen superpuesta.";
@@ -1614,6 +1605,9 @@
 
 /* Text for Playlist Offline Data Toggle while clearing the offline data storage in settings */
 "playlist.playlistOfflineDataToggleOption" = "Datos sin conexión de la lista de reproducción";
+
+/* Title of a button displayed when first adding some media to Playlist. Its shown next to the name of a folder that the item is recently added to to imply that you are changing the folder it was saved to */
+"playlist.playlistPopoverChangeFoldersButtonTitle" = "Cambiar";
 
 /* The title for the alert that shows up when removing all videos and their offline mode storage. */
 "playList.playlistResetAlertTitle" = "Restablecer";
@@ -1672,6 +1666,9 @@
 /* Title for removing offline mode storage */
 "playList.removeActionButtonTitle" = "Eliminar";
 
+/* A message shown when the user removes media from the playlist. '%@' will be replaced by the folder it was added to. Example: 'Removed from Play Later' */
+"playList.removedFromPlaylistMessage" = "Se ha eliminado de %@";
+
 /* Message for the alert shown when the user tries to remove offline data of an item from playlist */
 "playlist.removePlaylistOfflineDataAlertMessage" = "Esto eliminará los contenidos audiovisuales del almacenamiento sin conexión. ¿Seguro que quieres continuar?";
 
@@ -1688,7 +1685,7 @@
 "playList.reopenButtonTitle" = "Volver a abrir";
 
 /* Text indicator on the table cell while saving a video for offline with percentage eg: %25 Saved for Offline */
-"playList.savedForOfflineLabelTitle" = "Guardado para sin conexión";
+"playList.savedForOfflineLabelTitle" = "Se ha añadido al modo sin conexión";
 
 /* The title of the button indicating that the user can save a video for offline playback. (playing without internet) */
 "playlist.saveForOfflineButtonTitle" = "Guardar para sin conexión";
@@ -1732,11 +1729,23 @@
 /* The title for the toast that shows up on a page when an item that has already been added, was updated. */
 "playList.toastExitingItemPlaylistTitle" = "Ver en Brave Playlist";
 
+/* A button title that when tapped will re-add the media item (undo the removal) that the user recently removed. */
+"playList.undoRemoveButtonTitle" = "Deshacer";
+
 /* Footer for option to disable URL-Bar button */
 "playlist.urlBarButtonOptionFooter" = "Añade un botón de lista de reproducción (formado por cuatro líneas y el signo +) junto a la barra de direcciones del navegador de Brave. Este botón te permite acceder rápidamente a la lista de reproducción que tengas abierta, así como añadir o eliminar contenidos multimedia.";
 
 /* Title for option to disable URL-Bar button */
 "playlist.urlBarButtonOptionTitle" = "Habilitar botón de acceso rápido";
+
+/* The title of the screen that allows you to change the folder where a playlist item was saved to */
+"playlistFolders.changeFoldersTitle" = "Mover a";
+
+/* A label shown above the text field that allows the user to type a name of the playlist they are going to create */
+"playlistFolders.createFolderTextFieldLabel" = "Nombre de la lista de reproducción";
+
+/* A label shown above the text field that allows the user to type a name of the playlist they are going to create */
+"playlistFolders.createFolderTextFieldPlaceholder" = "Introduce el nombre de tu lista de reproducción";
 
 /* The title of the button to create a new folder */
 "playlistFolders.createNewFolderButtonTitle" = "Crear";
@@ -1747,11 +1756,17 @@
 /* The title of the screen where the user edits folder names */
 "playlistFolders.editFolderScreenTitle" = "Editar carpeta";
 
+/* The title of the menu option that allows the user to edit the name of a folder */
+"playlistFolders.editMenuTitle" = "Editar lista de reproducción";
+
 /* The error shown to the user when we cannot save their changes made on a folder */
 "playlistFolders.errorSavingMessage" = "Lo sentimos, no hemos podido guardar los cambios que has hecho en esta carpeta";
 
 /* The title of the button where the user will move an item from one folder to another folder. */
 "playlistFolders.moveFolderButtonTitle" = "Mover";
+
+/* The title of the section indicating the currently selected folder */
+"playlistFolders.moveFolderCurrentSectionTitle" = "Lista de reproducción actual";
 
 /* The title of the screen where the user will move an item from one folder to another folder. */
 "playlistFolders.moveFolderScreenTitle" = "Mover";
@@ -1768,14 +1783,35 @@
 /* %@ and %lld Should NOT be localized. They are placeholders. Example: Brave Folder and 3 more items. Music and 2 more items. */
 "playlistFolders.moveMultipleItemDescription" = "%1$@ y %2$lld elementos más";
 
+/* The title of the button to create a new folder */
+"playlistFolders.newFolderButtonTitle" = "Nueva lista de reproducción";
+
+/* The title of the screen to create a new folder */
+"playlistFolders.newFolderScreenTitle" = "Nueva lista de reproducción";
+
 /* The sub-title of the section where the user can select videos to add to the new folder being created */
 "playlistFolders.newFolderSectionSubtitle" = "Pulsa los vídeos que quieras seleccionar";
+
+/* The title of the section where the user can select videos to add to the new folder being created */
+"playlistFolders.newFolderSectionTitle" = "Añade vídeos a esta lista de reproducción";
+
+/* The title of the default playlist folder */
+"playlistFolders.savedFolderTitle" = "Reproducir más tarde";
+
+/* The title of the section indicating that the user should select a folder to move `%zu` items to. %lld should not be translated. It will be replaced by a number so the sentence becomes: 'Select a folder to move 10 items to.' */
+"playlistFolders.selectAFolderTitle" = "Selecciona una lista de reproducción para mover %lld elementos";
+
+/* The title of the section indicating that the user should select a folder to move 1 item to. */
+"playlistFolders.selectASingleFolderTitle" = "Selecciona una lista de reproducción para mover 1 elemento";
 
 /* The sub-title of the folder. Example: This folder contains 10 Items. This folder contains 3 Items. */
 "playlistFolders.subtitleItemCount" = "%lld elementos";
 
 /* The sub-title of the folder. Example: This folder contains ONE item. This folder contains 1 Item. */
 "playlistFolders.subtitleItemSingleCount" = "1 elemento";
+
+/* The title of a folder when the user enters no name (untitled) */
+"playlistFolders.untitledFolderTitle" = "Lista de reproducción sin título";
 
 /* Accessibility Title for the button that adds the playlist to the database. */
 "playlistFolderSharing.addButtonAccessibilityTitle" = "Botón para añadir a Lista de reproducción de Brave";
@@ -2307,9 +2343,6 @@
 
 /* No comment provided by engineer. */
 "RewardsInternalsLegacyPromotion" = "Promoción antigua";
-
-/* No comment provided by engineer. */
-"RewardsInternalsLegacyWalletInfoHeader" = "Información sobre la cartera heredada";
 
 /* %d will be the number of logs currently being shown, i.e. '10 logs shown' */
 "RewardsInternalsLogsCount" = "%d registros mostrados";
@@ -2854,6 +2887,9 @@
 /* Part 2 Description for Alert used action Delete Sync Account. */
 "sync.syncDeleteAccountAlertDescriptionPart2" = "Esta eliminación es permanente, y no se pueden recuperar los datos. Si decides volver a utilizar Sincronización, tendrás que crear una cuenta nueva y volver a añadir cada dispositivo uno por uno.";
 
+/* The title displayed in alert when a user needs to set passcode */
+"sync.syncSetPasscodeAlertTitle" = "Fija una clave de acceso";
+
 /* Title for Sync Settings Toggle Header */
 "sync.syncSettingsTitle" = "Ajustes de sincronización";
 
@@ -3049,7 +3085,8 @@
 /* Accessibility Label for the browser toolbar Menu button */
 "TabToolbarMenuButtonAccessibilityLabel" = "Menú";
 
-/* Accessibility Label for the tab toolbar Playlist button */
+/* Accessibility Label for the tab toolbar Add to Playlist button
+   Accessibility Label for the tab toolbar Playlist button */
 "TabToolbarPlaylistButtonAccessibilityLabel" = "Lista de reproducción";
 
 /* Accessibility label for the Reader View button */

--- a/Sources/BraveStrings/Resources/fr.lproj/BraveShared.strings
+++ b/Sources/BraveStrings/Resources/fr.lproj/BraveShared.strings
@@ -100,12 +100,6 @@
 /* cookie settings option */
 "Block3rdPartyCookies" = "Bloquer les cookies tiers";
 
-/* No comment provided by engineer. */
-"BlockAdsAndTracking" = "Bloquer les traqueurs d'un site à un autre";
-
-/* No comment provided by engineer. */
-"BlockAdsAndTrackingDescription" = "Bloque le chargement des publicités, des pop-ups et des traqueurs.";
-
 /* Title for setting to block all website cookies. */
 "BlockAllCookies" = "Bloquer tous les cookies";
 
@@ -138,9 +132,6 @@
 
 /* A title for setting which blocks 'switch to app' popups */
 "blockMobileAnnoyances" = "Bloquer les avis « Changer d'app »";
-
-/* Brave panel individual toggle title */
-"BlockPhishing" = "Bloquer l'hameçonnage";
 
 /* Setting to enable popup blocking */
 "BlockPopups" = "Bloquer les fenêtres contextuelles";
@@ -318,15 +309,6 @@
 
 /* Title for toggle for enabling p3a (Privacy Preserving Analytics) Full Screen Callout */
 "callout.p3aCalloutToggleTitle" = "Partagez des données de produits complètement privées et anonymes.";
-
-/* Button title for Playlist Onboarding View */
-"callout.playlistOnboardingViewButtonTitle" = "Regarder la vidéo";
-
-/* Description for Playlist Onboarding View */
-"callout.playlistOnboardingViewDescription" = "…jouez partout, à tout moment. En arrière-plan, en mode Picture-in-Picture ou même hors ligne. Et bien sûr, sans publicités.";
-
-/* Title for Playlist Onboarding View */
-"callout.playlistOnboardingViewTitle" = "Ajouter la vidéo à la liste de lecture…";
 
 /* Subtitle - Description for Privacy Everywhere Full Screen Callout */
 "callout.privacyEverywhereCalloutDescription" = "Bénéficiez de la confidentialité de Brave sur votre ordinateur ou tablette et synchronisez les marque-pages et les extensions entre les appareils.";
@@ -896,10 +878,10 @@
 "genericErrorTitle" = "Erreur";
 
 /* No comment provided by engineer. */
-"GoogleSafeBrowsing" = "Bloquer les sites dangereux";
+"GoogleSafeBrowsing" = "Bloquer les sites Web dangereux";
 
 /* No comment provided by engineer. */
-"GoogleSafeBrowsingUsingWebKitDescription" = "Envoie les URL obfusquées de certaines pages que vous visitez au service Safe Browsing de Google lorsque votre sécurité est à risque.";
+"GoogleSafeBrowsingUsingWebKitDescription" = "La navigation sécurisée vous protège contre les sites Web connus pour être dangereux. [En savoir plus](%@)";
 
 /* Grand camera access */
 "GrantCameraAccess" = "Activer l'appareil photo";
@@ -986,7 +968,7 @@
 "login.loginInfoDetailsWebsiteFieldTitle" = "Site Web";
 
 /* The message displayed in alert when a user needs to set a passcode */
-"login.loginInfoSetPasscodeAlertDescription" = "Pour afficher les mots de passe, vous devez d'abord définir un code d'accès sur votre appareil.";
+"login.loginInfoSetPasscodeAlertDescription" = "Pour configurer une chaîne de synchronisation, vous devez d'abord définir un code d'accès sur votre appareil.";
 
 /* The title displayed in alert when a user needs to set passcode */
 "login.loginInfoSetPasscodeAlertTitle" = "Définir un code d'accès";
@@ -1504,6 +1486,9 @@
 /* Label that says who took a photograph that will be displayed to the user. '%@' is a placeholder and will include be a specific person's name, example 'Bill Gates'. */
 "PhotoBy" = "Photo par %@";
 
+/* A message shown when the user adds media to the playlist. '%@' will be replaced by the folder it was added to. Example: 'Added to Play Later' */
+"playList.addedToPlaylistMessage" = "Ajouté à %@";
+
 /* Alert Description for adding videos to playlist */
 "playList.addToPlayListAlertDescription" = "Souhaitez-vous ajouter cette vidéo à votre liste de lecture ?";
 
@@ -1530,6 +1515,9 @@
 
 /* The title of the playlist when in Carplay mode */
 "playlist.carplayTitle" = "Liste de lecture Brave";
+
+/* Title for changing the folder of the current media playlist item */
+"playList.changeFoldersButtonTitle" = "Modifier la liste de lecture";
 
 /* The title of the button indicating that the user delete the offline data. (deletes the data that allows them to play offline) */
 "playlist.deleteForOfflineButtonTitle" = "Supprimer le cache hors ligne";
@@ -1566,6 +1554,9 @@
 
 /* Okay Alert button title */
 "playList.okayButtonTitle" = "OK";
+
+/* Title for opening the playlist */
+"playList.openInPlaylistButtonTitle" = "Ouvrir dans la liste de lecture";
 
 /* The title for the alert that shows up when an item is expired */
 "playList.pictureInPictureErrorTitle" = "Une erreur est survenue lors de la tentative d’affichage Picture-in-Picture.";
@@ -1614,6 +1605,9 @@
 
 /* Text for Playlist Offline Data Toggle while clearing the offline data storage in settings */
 "playlist.playlistOfflineDataToggleOption" = "Données hors ligne de la liste de lecture";
+
+/* Title of a button displayed when first adding some media to Playlist. Its shown next to the name of a folder that the item is recently added to to imply that you are changing the folder it was saved to */
+"playlist.playlistPopoverChangeFoldersButtonTitle" = "Modifier";
 
 /* The title for the alert that shows up when removing all videos and their offline mode storage. */
 "playList.playlistResetAlertTitle" = "Réinitialiser";
@@ -1672,6 +1666,9 @@
 /* Title for removing offline mode storage */
 "playList.removeActionButtonTitle" = "Supprimer";
 
+/* A message shown when the user removes media from the playlist. '%@' will be replaced by the folder it was added to. Example: 'Removed from Play Later' */
+"playList.removedFromPlaylistMessage" = "Supprimé de %@";
+
 /* Message for the alert shown when the user tries to remove offline data of an item from playlist */
 "playlist.removePlaylistOfflineDataAlertMessage" = "Le fichier sera supprimé du stockage hors ligne. Voulez-vous vraiment continuer ?";
 
@@ -1688,7 +1685,7 @@
 "playList.reopenButtonTitle" = "Rouvrir";
 
 /* Text indicator on the table cell while saving a video for offline with percentage eg: %25 Saved for Offline */
-"playList.savedForOfflineLabelTitle" = "Enregistrés pour une utilisation hors ligne";
+"playList.savedForOfflineLabelTitle" = "Ajouté pour une utilisation hors ligne";
 
 /* The title of the button indicating that the user can save a video for offline playback. (playing without internet) */
 "playlist.saveForOfflineButtonTitle" = "Enregistrer pour lecture hors ligne";
@@ -1732,11 +1729,23 @@
 /* The title for the toast that shows up on a page when an item that has already been added, was updated. */
 "playList.toastExitingItemPlaylistTitle" = "Afficher dans Brave Playlist";
 
+/* A button title that when tapped will re-add the media item (undo the removal) that the user recently removed. */
+"playList.undoRemoveButtonTitle" = "Annuler";
+
 /* Footer for option to disable URL-Bar button */
 "playlist.urlBarButtonOptionFooter" = "Ajoute un bouton de liste de lecture (il ressemble à 4 lignes avec un symbole « + ») à côté de la barre d'adresse dans le navigateur Brave. Ce bouton vous offre un accès rapide pour ouvrir la liste de lecture, ou ajouter ou retirer du contenu multimédia.";
 
 /* Title for option to disable URL-Bar button */
 "playlist.urlBarButtonOptionTitle" = "Activer le bouton d'accès rapide";
+
+/* The title of the screen that allows you to change the folder where a playlist item was saved to */
+"playlistFolders.changeFoldersTitle" = "Déplacer vers";
+
+/* A label shown above the text field that allows the user to type a name of the playlist they are going to create */
+"playlistFolders.createFolderTextFieldLabel" = "Nom de la liste de lecture";
+
+/* A label shown above the text field that allows the user to type a name of the playlist they are going to create */
+"playlistFolders.createFolderTextFieldPlaceholder" = "Saisissez le nom de votre liste de lecture";
 
 /* The title of the button to create a new folder */
 "playlistFolders.createNewFolderButtonTitle" = "Créer";
@@ -1747,11 +1756,17 @@
 /* The title of the screen where the user edits folder names */
 "playlistFolders.editFolderScreenTitle" = "Modifier le dossier";
 
+/* The title of the menu option that allows the user to edit the name of a folder */
+"playlistFolders.editMenuTitle" = "Modifier la liste de lecture";
+
 /* The error shown to the user when we cannot save their changes made on a folder */
 "playlistFolders.errorSavingMessage" = "Les modifications apportées à ce dossier n'ont pas pu être enregistrées";
 
 /* The title of the button where the user will move an item from one folder to another folder. */
 "playlistFolders.moveFolderButtonTitle" = "Déplacer";
+
+/* The title of the section indicating the currently selected folder */
+"playlistFolders.moveFolderCurrentSectionTitle" = "Liste de lecture actuelle";
 
 /* The title of the screen where the user will move an item from one folder to another folder. */
 "playlistFolders.moveFolderScreenTitle" = "Déplacer";
@@ -1768,14 +1783,35 @@
 /* %@ and %lld Should NOT be localized. They are placeholders. Example: Brave Folder and 3 more items. Music and 2 more items. */
 "playlistFolders.moveMultipleItemDescription" = "%1$@ et %2$lld autres éléments";
 
+/* The title of the button to create a new folder */
+"playlistFolders.newFolderButtonTitle" = "Nouvelle liste de lecture";
+
+/* The title of the screen to create a new folder */
+"playlistFolders.newFolderScreenTitle" = "Nouvelle liste de lecture";
+
 /* The sub-title of the section where the user can select videos to add to the new folder being created */
 "playlistFolders.newFolderSectionSubtitle" = "Appuyez pour sélectionner des vidéos";
+
+/* The title of the section where the user can select videos to add to the new folder being created */
+"playlistFolders.newFolderSectionTitle" = "Ajouter des vidéos à cette liste de lecture";
+
+/* The title of the default playlist folder */
+"playlistFolders.savedFolderTitle" = "Lire plus tard";
+
+/* The title of the section indicating that the user should select a folder to move `%zu` items to. %lld should not be translated. It will be replaced by a number so the sentence becomes: 'Select a folder to move 10 items to.' */
+"playlistFolders.selectAFolderTitle" = "Sélectionner une liste de lecture vers laquelle déplacer %lld éléments";
+
+/* The title of the section indicating that the user should select a folder to move 1 item to. */
+"playlistFolders.selectASingleFolderTitle" = "Sélectionner une liste de lecture vers laquelle déplacer 1 élément";
 
 /* The sub-title of the folder. Example: This folder contains 10 Items. This folder contains 3 Items. */
 "playlistFolders.subtitleItemCount" = "%lld éléments";
 
 /* The sub-title of the folder. Example: This folder contains ONE item. This folder contains 1 Item. */
 "playlistFolders.subtitleItemSingleCount" = "1 élément";
+
+/* The title of a folder when the user enters no name (untitled) */
+"playlistFolders.untitledFolderTitle" = "Liste de lecture sans titre";
 
 /* Accessibility Title for the button that adds the playlist to the database. */
 "playlistFolderSharing.addButtonAccessibilityTitle" = "Bouton Ajouter à la liste de lecture Brave";
@@ -2307,9 +2343,6 @@
 
 /* No comment provided by engineer. */
 "RewardsInternalsLegacyPromotion" = "Ancienne promotion";
-
-/* No comment provided by engineer. */
-"RewardsInternalsLegacyWalletInfoHeader" = "Informations de l'ancien portefeuille";
 
 /* %d will be the number of logs currently being shown, i.e. '10 logs shown' */
 "RewardsInternalsLogsCount" = "%d journaux affichés";
@@ -2854,6 +2887,9 @@
 /* Part 2 Description for Alert used action Delete Sync Account. */
 "sync.syncDeleteAccountAlertDescriptionPart2" = "Cette suppression est définitive et il n'est pas possible de récupérer les données. Si vous décidez de recommencer à utiliser la fonction Synchronisation, vous devrez créer un nouveau compte et ajouter à nouveau chaque appareil un par un.";
 
+/* The title displayed in alert when a user needs to set passcode */
+"sync.syncSetPasscodeAlertTitle" = "Définir un code d'accès";
+
 /* Title for Sync Settings Toggle Header */
 "sync.syncSettingsTitle" = "Paramètres de synchronisation";
 
@@ -3049,7 +3085,8 @@
 /* Accessibility Label for the browser toolbar Menu button */
 "TabToolbarMenuButtonAccessibilityLabel" = "Menu";
 
-/* Accessibility Label for the tab toolbar Playlist button */
+/* Accessibility Label for the tab toolbar Add to Playlist button
+   Accessibility Label for the tab toolbar Playlist button */
 "TabToolbarPlaylistButtonAccessibilityLabel" = "Liste de lecture";
 
 /* Accessibility label for the Reader View button */

--- a/Sources/BraveStrings/Resources/id-ID.lproj/BraveShared.strings
+++ b/Sources/BraveStrings/Resources/id-ID.lproj/BraveShared.strings
@@ -100,12 +100,6 @@
 /* cookie settings option */
 "Block3rdPartyCookies" = "Blokir cookie pihak ke-3";
 
-/* No comment provided by engineer. */
-"BlockAdsAndTracking" = "Blokir Pelacak Lintas Situs";
-
-/* No comment provided by engineer. */
-"BlockAdsAndTrackingDescription" = "Mencegah dimuatnya iklan, popup, dan pelacak.";
-
 /* Title for setting to block all website cookies. */
 "BlockAllCookies" = "Blokir semua Kuki";
 
@@ -138,9 +132,6 @@
 
 /* A title for setting which blocks 'switch to app' popups */
 "blockMobileAnnoyances" = "Pemberitahuan Blokir 'Beralih ke Aplikasi'";
-
-/* Brave panel individual toggle title */
-"BlockPhishing" = "Blokir Phishing";
 
 /* Setting to enable popup blocking */
 "BlockPopups" = "Blokir Pop-up";
@@ -318,15 +309,6 @@
 
 /* Title for toggle for enabling p3a (Privacy Preserving Analytics) Full Screen Callout */
 "callout.p3aCalloutToggleTitle" = "Bagikan Pandangan Produk Paling Rahasia dan Anonim.";
-
-/* Button title for Playlist Onboarding View */
-"callout.playlistOnboardingViewButtonTitle" = "Tonton video";
-
-/* Description for Playlist Onboarding View */
-"callout.playlistOnboardingViewDescription" = "...putar di mana saja, kapan saja. Pada latar belakang, gambar-ke-gambar, atau bahkan luring. Dan tentu saja, bebas iklan.";
-
-/* Title for Playlist Onboarding View */
-"callout.playlistOnboardingViewTitle" = "Tambahkan video ke Daftar Putar...";
 
 /* Subtitle - Description for Privacy Everywhere Full Screen Callout */
 "callout.privacyEverywhereCalloutDescription" = "Dapatkan privasi Brave pada komputer atau tablet Anda, dan sinkronisasikan markah & ekstensi antar perangkat.";
@@ -896,10 +878,10 @@
 "genericErrorTitle" = "Kesalahan";
 
 /* No comment provided by engineer. */
-"GoogleSafeBrowsing" = "Memblokir Situs Berbahaya";
+"GoogleSafeBrowsing" = "Memblokir Situs Web Berbahaya";
 
 /* No comment provided by engineer. */
-"GoogleSafeBrowsingUsingWebKitDescription" = "Mengirimkan URL yang membingungkan dari beberapa halaman yang Anda kunjungi ke layanan Google Safe Browsing, ketika keamanan Anda berisiko.";
+"GoogleSafeBrowsingUsingWebKitDescription" = "Perambanan Aman melindungi terhadap situs web yang dikenal berbahaya. [Pelajari Lebih Lanjut](%@)";
 
 /* Grand camera access */
 "GrantCameraAccess" = "Aktifkan Kamera";
@@ -986,7 +968,7 @@
 "login.loginInfoDetailsWebsiteFieldTitle" = "Situs Web";
 
 /* The message displayed in alert when a user needs to set a passcode */
-"login.loginInfoSetPasscodeAlertDescription" = "Untuk melihat kata sandi, Anda harus terlebih dahulu mengatur kode masuk ke perangkat Anda.";
+"login.loginInfoSetPasscodeAlertDescription" = "Untuk menyiapkan rantai sinkronisasi atau melihat pengaturan, Anda pertama-tama harus menetapkan kode pas pada perangkat Anda.";
 
 /* The title displayed in alert when a user needs to set passcode */
 "login.loginInfoSetPasscodeAlertTitle" = "Atur Kode Masuk";
@@ -1504,6 +1486,9 @@
 /* Label that says who took a photograph that will be displayed to the user. '%@' is a placeholder and will include be a specific person's name, example 'Bill Gates'. */
 "PhotoBy" = "Foto oleh %@";
 
+/* A message shown when the user adds media to the playlist. '%@' will be replaced by the folder it was added to. Example: 'Added to Play Later' */
+"playList.addedToPlaylistMessage" = "Ditambahkan ke %@";
+
 /* Alert Description for adding videos to playlist */
 "playList.addToPlayListAlertDescription" = "Apakah Anda ingin menambahkan video ini ke daftar putar Anda?";
 
@@ -1530,6 +1515,9 @@
 
 /* The title of the playlist when in Carplay mode */
 "playlist.carplayTitle" = "Daftar Putar Brave";
+
+/* Title for changing the folder of the current media playlist item */
+"playList.changeFoldersButtonTitle" = "Ubah Daftar Putar";
 
 /* The title of the button indicating that the user delete the offline data. (deletes the data that allows them to play offline) */
 "playlist.deleteForOfflineButtonTitle" = "Hapus Cache Luring";
@@ -1566,6 +1554,9 @@
 
 /* Okay Alert button title */
 "playList.okayButtonTitle" = "Oke";
+
+/* Title for opening the playlist */
+"playList.openInPlaylistButtonTitle" = "Buka di Daftar Putar";
 
 /* The title for the alert that shows up when an item is expired */
 "playList.pictureInPictureErrorTitle" = "Maaf, telah terjadi kesalahan saat mencoba menampilkan gambar-dalam-gambar.";
@@ -1614,6 +1605,9 @@
 
 /* Text for Playlist Offline Data Toggle while clearing the offline data storage in settings */
 "playlist.playlistOfflineDataToggleOption" = "Data Luring Daftar Putar";
+
+/* Title of a button displayed when first adding some media to Playlist. Its shown next to the name of a folder that the item is recently added to to imply that you are changing the folder it was saved to */
+"playlist.playlistPopoverChangeFoldersButtonTitle" = "Ubah";
 
 /* The title for the alert that shows up when removing all videos and their offline mode storage. */
 "playList.playlistResetAlertTitle" = "Atur ulang";
@@ -1672,6 +1666,9 @@
 /* Title for removing offline mode storage */
 "playList.removeActionButtonTitle" = "Hapus";
 
+/* A message shown when the user removes media from the playlist. '%@' will be replaced by the folder it was added to. Example: 'Removed from Play Later' */
+"playList.removedFromPlaylistMessage" = "Hapus dari %@";
+
 /* Message for the alert shown when the user tries to remove offline data of an item from playlist */
 "playlist.removePlaylistOfflineDataAlertMessage" = "Ini akan menghapus media dari penyimpanan luring. Anda yakin ingin melanjutkan?";
 
@@ -1688,7 +1685,7 @@
 "playList.reopenButtonTitle" = "Buka Ulang";
 
 /* Text indicator on the table cell while saving a video for offline with percentage eg: %25 Saved for Offline */
-"playList.savedForOfflineLabelTitle" = "Disimpan untuk Luring";
+"playList.savedForOfflineLabelTitle" = "Ditambahkan ke Luring";
 
 /* The title of the button indicating that the user can save a video for offline playback. (playing without internet) */
 "playlist.saveForOfflineButtonTitle" = "Simpan untuk Luring";
@@ -1732,11 +1729,23 @@
 /* The title for the toast that shows up on a page when an item that has already been added, was updated. */
 "playList.toastExitingItemPlaylistTitle" = "Lihat di Brave Playlist";
 
+/* A button title that when tapped will re-add the media item (undo the removal) that the user recently removed. */
+"playList.undoRemoveButtonTitle" = "Urungkan";
+
 /* Footer for option to disable URL-Bar button */
 "playlist.urlBarButtonOptionFooter" = "Tambahkan tombol daftar putar (seperti 4 garis dengan simbol +) di samping bilah alamat pada peramban Brave. Tombol ini memberikan Anda akses cepat untuk membuka Daftar Putar, atau menambahkan atau menyingkirkan media.";
 
 /* Title for option to disable URL-Bar button */
 "playlist.urlBarButtonOptionTitle" = "Aktifkan tombol akses cepat";
+
+/* The title of the screen that allows you to change the folder where a playlist item was saved to */
+"playlistFolders.changeFoldersTitle" = "Berpindah Ke";
+
+/* A label shown above the text field that allows the user to type a name of the playlist they are going to create */
+"playlistFolders.createFolderTextFieldLabel" = "Nama Daftar Putar";
+
+/* A label shown above the text field that allows the user to type a name of the playlist they are going to create */
+"playlistFolders.createFolderTextFieldPlaceholder" = "Masukkan nama daftar putar Anda";
 
 /* The title of the button to create a new folder */
 "playlistFolders.createNewFolderButtonTitle" = "Buat";
@@ -1747,11 +1756,17 @@
 /* The title of the screen where the user edits folder names */
 "playlistFolders.editFolderScreenTitle" = "Sunting Folder";
 
+/* The title of the menu option that allows the user to edit the name of a folder */
+"playlistFolders.editMenuTitle" = "Edit Daftar Putar";
+
 /* The error shown to the user when we cannot save their changes made on a folder */
 "playlistFolders.errorSavingMessage" = "Maaf, kami tidak dapat menyimpan perubahan yang Anda buat di folder ini";
 
 /* The title of the button where the user will move an item from one folder to another folder. */
 "playlistFolders.moveFolderButtonTitle" = "Pindahkan";
+
+/* The title of the section indicating the currently selected folder */
+"playlistFolders.moveFolderCurrentSectionTitle" = "Daftar Putar Saat Ini";
 
 /* The title of the screen where the user will move an item from one folder to another folder. */
 "playlistFolders.moveFolderScreenTitle" = "Pindahkan";
@@ -1768,14 +1783,35 @@
 /* %@ and %lld Should NOT be localized. They are placeholders. Example: Brave Folder and 3 more items. Music and 2 more items. */
 "playlistFolders.moveMultipleItemDescription" = "%1$@ dan %2$lld hal lagi";
 
+/* The title of the button to create a new folder */
+"playlistFolders.newFolderButtonTitle" = "Daftar Putar Baru";
+
+/* The title of the screen to create a new folder */
+"playlistFolders.newFolderScreenTitle" = "Daftar Putar Baru";
+
 /* The sub-title of the section where the user can select videos to add to the new folder being created */
 "playlistFolders.newFolderSectionSubtitle" = "Tap untuk memilih video";
+
+/* The title of the section where the user can select videos to add to the new folder being created */
+"playlistFolders.newFolderSectionTitle" = "Tambahkan video ke daftar putar ini";
+
+/* The title of the default playlist folder */
+"playlistFolders.savedFolderTitle" = "Putar Nanti";
+
+/* The title of the section indicating that the user should select a folder to move `%zu` items to. %lld should not be translated. It will be replaced by a number so the sentence becomes: 'Select a folder to move 10 items to.' */
+"playlistFolders.selectAFolderTitle" = "Pilih daftar putar untuk memindahkan %lld hal ke";
+
+/* The title of the section indicating that the user should select a folder to move 1 item to. */
+"playlistFolders.selectASingleFolderTitle" = "Pilih daftar putar untuk memindahkan 1 hal ke";
 
 /* The sub-title of the folder. Example: This folder contains 10 Items. This folder contains 3 Items. */
 "playlistFolders.subtitleItemCount" = "%lld hal";
 
 /* The sub-title of the folder. Example: This folder contains ONE item. This folder contains 1 Item. */
 "playlistFolders.subtitleItemSingleCount" = "1 hal";
+
+/* The title of a folder when the user enters no name (untitled) */
+"playlistFolders.untitledFolderTitle" = "Daftar Putar Tanpa Judul";
 
 /* Accessibility Title for the button that adds the playlist to the database. */
 "playlistFolderSharing.addButtonAccessibilityTitle" = "Tambahkan ke Tombol Daftar Putar Brave";
@@ -2307,9 +2343,6 @@
 
 /* No comment provided by engineer. */
 "RewardsInternalsLegacyPromotion" = "Promosi Dasar";
-
-/* No comment provided by engineer. */
-"RewardsInternalsLegacyWalletInfoHeader" = "Info Dompet Legacy";
 
 /* %d will be the number of logs currently being shown, i.e. '10 logs shown' */
 "RewardsInternalsLogsCount" = "%d log ditampilkan";
@@ -2854,6 +2887,9 @@
 /* Part 2 Description for Alert used action Delete Sync Account. */
 "sync.syncDeleteAccountAlertDescriptionPart2" = "Penghapusan ini bersifat permanen dan data tidak akan mungkin dipulihkan. Jika Anda memutuskan untuk kembali menggunakan Sinkronisasi, Anda perlu membuat akun baru dan menambahkan ulang setiap perangkat satu per satu.";
 
+/* The title displayed in alert when a user needs to set passcode */
+"sync.syncSetPasscodeAlertTitle" = "Atur Kode Masuk";
+
 /* Title for Sync Settings Toggle Header */
 "sync.syncSettingsTitle" = "Pengaturan Sinkronisasi";
 
@@ -3049,7 +3085,8 @@
 /* Accessibility Label for the browser toolbar Menu button */
 "TabToolbarMenuButtonAccessibilityLabel" = "Menu";
 
-/* Accessibility Label for the tab toolbar Playlist button */
+/* Accessibility Label for the tab toolbar Add to Playlist button
+   Accessibility Label for the tab toolbar Playlist button */
 "TabToolbarPlaylistButtonAccessibilityLabel" = "Daftar Putar";
 
 /* Accessibility label for the Reader View button */

--- a/Sources/BraveStrings/Resources/it.lproj/BraveShared.strings
+++ b/Sources/BraveStrings/Resources/it.lproj/BraveShared.strings
@@ -100,12 +100,6 @@
 /* cookie settings option */
 "Block3rdPartyCookies" = "Blocca cookie di terze parti";
 
-/* No comment provided by engineer. */
-"BlockAdsAndTracking" = "Blocca il tracciamento tra più siti";
-
-/* No comment provided by engineer. */
-"BlockAdsAndTrackingDescription" = "Impedisce il caricamento di annunci, popup e tracker.";
-
 /* Title for setting to block all website cookies. */
 "BlockAllCookies" = "Blocca tutti i cookie";
 
@@ -138,9 +132,6 @@
 
 /* A title for setting which blocks 'switch to app' popups */
 "blockMobileAnnoyances" = "Blocca gli avvisi “Passa all’app”";
-
-/* Brave panel individual toggle title */
-"BlockPhishing" = "Blocca phishing";
 
 /* Setting to enable popup blocking */
 "BlockPopups" = "Blocca popup";
@@ -318,15 +309,6 @@
 
 /* Title for toggle for enabling p3a (Privacy Preserving Analytics) Full Screen Callout */
 "callout.p3aCalloutToggleTitle" = "Condividi informazioni di prodotto totalmente private e anonime.";
-
-/* Button title for Playlist Onboarding View */
-"callout.playlistOnboardingViewButtonTitle" = "Guarda il video";
-
-/* Description for Playlist Onboarding View */
-"callout.playlistOnboardingViewDescription" = "… riproduci ovunque, in qualsiasi momento. In background, picture-in-picture o anche offline. E, naturalmente, senza pubblicità.";
-
-/* Title for Playlist Onboarding View */
-"callout.playlistOnboardingViewTitle" = "Aggiungi video alla playlist…";
 
 /* Subtitle - Description for Privacy Everywhere Full Screen Callout */
 "callout.privacyEverywhereCalloutDescription" = "Ottieni la privacy di Brave sul tuo computer o tablet e sincronizza segnalibri ed estensioni tra i dispositivi.";
@@ -896,10 +878,10 @@
 "genericErrorTitle" = "Errore";
 
 /* No comment provided by engineer. */
-"GoogleSafeBrowsing" = "Blocca i siti pericolosi";
+"GoogleSafeBrowsing" = "Blocca i siti web pericolosi";
 
 /* No comment provided by engineer. */
-"GoogleSafeBrowsingUsingWebKitDescription" = "Invia URL offuscati di alcune delle pagine che visiti al servizio di Navigazione sicura di Google quando la tua sicurezza è a rischio.";
+"GoogleSafeBrowsingUsingWebKitDescription" = "La navigazione sicura ti protegge dai siti web che sono noti come siti pericolosi. [Scopri di più](%@)";
 
 /* Grand camera access */
 "GrantCameraAccess" = "Attiva Fotocamera";
@@ -986,7 +968,7 @@
 "login.loginInfoDetailsWebsiteFieldTitle" = "Sito web";
 
 /* The message displayed in alert when a user needs to set a passcode */
-"login.loginInfoSetPasscodeAlertDescription" = "Per vedere le password, devi prima impostare un codice sul tuo dispositivo.";
+"login.loginInfoSetPasscodeAlertDescription" = "Per configurare la catena di sincronizzazione o vedere le impostazioni, devi prima impostare un passcode sul tuo dispositivo.";
 
 /* The title displayed in alert when a user needs to set passcode */
 "login.loginInfoSetPasscodeAlertTitle" = "Imposta un codice";
@@ -1504,6 +1486,9 @@
 /* Label that says who took a photograph that will be displayed to the user. '%@' is a placeholder and will include be a specific person's name, example 'Bill Gates'. */
 "PhotoBy" = "Photo di %@";
 
+/* A message shown when the user adds media to the playlist. '%@' will be replaced by the folder it was added to. Example: 'Added to Play Later' */
+"playList.addedToPlaylistMessage" = "Aggiunto a %@";
+
 /* Alert Description for adding videos to playlist */
 "playList.addToPlayListAlertDescription" = "Vuoi aggiungere questo video alla playlist?";
 
@@ -1530,6 +1515,9 @@
 
 /* The title of the playlist when in Carplay mode */
 "playlist.carplayTitle" = "Playlist di Brave";
+
+/* Title for changing the folder of the current media playlist item */
+"playList.changeFoldersButtonTitle" = "Cambia playlist";
 
 /* The title of the button indicating that the user delete the offline data. (deletes the data that allows them to play offline) */
 "playlist.deleteForOfflineButtonTitle" = "Elimina la cache offline";
@@ -1566,6 +1554,9 @@
 
 /* Okay Alert button title */
 "playList.okayButtonTitle" = "OK";
+
+/* Title for opening the playlist */
+"playList.openInPlaylistButtonTitle" = "Apri nella playlist";
 
 /* The title for the alert that shows up when an item is expired */
 "playList.pictureInPictureErrorTitle" = "Ci dispiace, si è verificato un errore nel tentativo di mostrare il picture-in-picture.";
@@ -1614,6 +1605,9 @@
 
 /* Text for Playlist Offline Data Toggle while clearing the offline data storage in settings */
 "playlist.playlistOfflineDataToggleOption" = "Dati offline per playlist";
+
+/* Title of a button displayed when first adding some media to Playlist. Its shown next to the name of a folder that the item is recently added to to imply that you are changing the folder it was saved to */
+"playlist.playlistPopoverChangeFoldersButtonTitle" = "Cambia";
 
 /* The title for the alert that shows up when removing all videos and their offline mode storage. */
 "playList.playlistResetAlertTitle" = "Azzera";
@@ -1672,6 +1666,9 @@
 /* Title for removing offline mode storage */
 "playList.removeActionButtonTitle" = "Rimuovi";
 
+/* A message shown when the user removes media from the playlist. '%@' will be replaced by the folder it was added to. Example: 'Removed from Play Later' */
+"playList.removedFromPlaylistMessage" = "Rimosso da %@";
+
 /* Message for the alert shown when the user tries to remove offline data of an item from playlist */
 "playlist.removePlaylistOfflineDataAlertMessage" = "Questo eliminerà l’elemento dallo spazio di archiviazione offline. Vuoi continuare?";
 
@@ -1688,7 +1685,7 @@
 "playList.reopenButtonTitle" = "Aprire di nuovo";
 
 /* Text indicator on the table cell while saving a video for offline with percentage eg: %25 Saved for Offline */
-"playList.savedForOfflineLabelTitle" = "salvato offline";
+"playList.savedForOfflineLabelTitle" = "Aggiunti offline";
 
 /* The title of the button indicating that the user can save a video for offline playback. (playing without internet) */
 "playlist.saveForOfflineButtonTitle" = "Salva offline";
@@ -1732,11 +1729,23 @@
 /* The title for the toast that shows up on a page when an item that has already been added, was updated. */
 "playList.toastExitingItemPlaylistTitle" = "Visualizza nella Brave Playlist";
 
+/* A button title that when tapped will re-add the media item (undo the removal) that the user recently removed. */
+"playList.undoRemoveButtonTitle" = "Annulla";
+
 /* Footer for option to disable URL-Bar button */
 "playlist.urlBarButtonOptionFooter" = "Aggiunge un pulsante per la playlist (4 linee con il simbolo +) accanto alla barra dell’indirizzo nel browser Brave. Questo pulsante ti consente di accedere rapidamente alla playlist per aprirla oppure per aggiungere o rimuovere elementi multimediali.";
 
 /* Title for option to disable URL-Bar button */
 "playlist.urlBarButtonOptionTitle" = "Abilita il pulsante di accesso rapido";
+
+/* The title of the screen that allows you to change the folder where a playlist item was saved to */
+"playlistFolders.changeFoldersTitle" = "Sposta in";
+
+/* A label shown above the text field that allows the user to type a name of the playlist they are going to create */
+"playlistFolders.createFolderTextFieldLabel" = "Nome della playlist";
+
+/* A label shown above the text field that allows the user to type a name of the playlist they are going to create */
+"playlistFolders.createFolderTextFieldPlaceholder" = "Inserisci il nome della tua playlist";
 
 /* The title of the button to create a new folder */
 "playlistFolders.createNewFolderButtonTitle" = "Crea";
@@ -1747,11 +1756,17 @@
 /* The title of the screen where the user edits folder names */
 "playlistFolders.editFolderScreenTitle" = "Modifica cartella";
 
+/* The title of the menu option that allows the user to edit the name of a folder */
+"playlistFolders.editMenuTitle" = "Modifica la playlist";
+
 /* The error shown to the user when we cannot save their changes made on a folder */
 "playlistFolders.errorSavingMessage" = "Ci spiace ma non siamo riusciti a salvare le modifiche che hai apportato a questa cartella";
 
 /* The title of the button where the user will move an item from one folder to another folder. */
 "playlistFolders.moveFolderButtonTitle" = "Sposta";
+
+/* The title of the section indicating the currently selected folder */
+"playlistFolders.moveFolderCurrentSectionTitle" = "Playlist attuale";
 
 /* The title of the screen where the user will move an item from one folder to another folder. */
 "playlistFolders.moveFolderScreenTitle" = "Sposta";
@@ -1768,14 +1783,35 @@
 /* %@ and %lld Should NOT be localized. They are placeholders. Example: Brave Folder and 3 more items. Music and 2 more items. */
 "playlistFolders.moveMultipleItemDescription" = "%1$@ e altri %2$lld elementi";
 
+/* The title of the button to create a new folder */
+"playlistFolders.newFolderButtonTitle" = "Nuova playlist";
+
+/* The title of the screen to create a new folder */
+"playlistFolders.newFolderScreenTitle" = "Nuova playlist";
+
 /* The sub-title of the section where the user can select videos to add to the new folder being created */
 "playlistFolders.newFolderSectionSubtitle" = "Premi per selezionare i video";
+
+/* The title of the section where the user can select videos to add to the new folder being created */
+"playlistFolders.newFolderSectionTitle" = "Aggiungi dei video a questa playlist";
+
+/* The title of the default playlist folder */
+"playlistFolders.savedFolderTitle" = "Riproduci più tardi";
+
+/* The title of the section indicating that the user should select a folder to move `%zu` items to. %lld should not be translated. It will be replaced by a number so the sentence becomes: 'Select a folder to move 10 items to.' */
+"playlistFolders.selectAFolderTitle" = "Seleziona una playlist per spostare %lld articoli in";
+
+/* The title of the section indicating that the user should select a folder to move 1 item to. */
+"playlistFolders.selectASingleFolderTitle" = "Seleziona una playlist per spostare 1 articolo in";
 
 /* The sub-title of the folder. Example: This folder contains 10 Items. This folder contains 3 Items. */
 "playlistFolders.subtitleItemCount" = "%lld elementi";
 
 /* The sub-title of the folder. Example: This folder contains ONE item. This folder contains 1 Item. */
 "playlistFolders.subtitleItemSingleCount" = "1 elemento";
+
+/* The title of a folder when the user enters no name (untitled) */
+"playlistFolders.untitledFolderTitle" = "Playlist senza titolo";
 
 /* Accessibility Title for the button that adds the playlist to the database. */
 "playlistFolderSharing.addButtonAccessibilityTitle" = "Pulsante Aggiungi alla Brave Playlist";
@@ -2307,9 +2343,6 @@
 
 /* No comment provided by engineer. */
 "RewardsInternalsLegacyPromotion" = "Promozione legacy";
-
-/* No comment provided by engineer. */
-"RewardsInternalsLegacyWalletInfoHeader" = "Dati del portafoglio esistente";
 
 /* %d will be the number of logs currently being shown, i.e. '10 logs shown' */
 "RewardsInternalsLogsCount" = "%d log mostrati";
@@ -2854,6 +2887,9 @@
 /* Part 2 Description for Alert used action Delete Sync Account. */
 "sync.syncDeleteAccountAlertDescriptionPart2" = "L’eliminazione è definitiva e non c’è modo di recuperare i dati. Chi vuole ricominciare a usare la sincronizzazione dovrà creare un nuovo account e riaggiungere uno alla volta ciascun dispositivo.";
 
+/* The title displayed in alert when a user needs to set passcode */
+"sync.syncSetPasscodeAlertTitle" = "Imposta un codice";
+
 /* Title for Sync Settings Toggle Header */
 "sync.syncSettingsTitle" = "Sincronizza le impostazioni";
 
@@ -3049,7 +3085,8 @@
 /* Accessibility Label for the browser toolbar Menu button */
 "TabToolbarMenuButtonAccessibilityLabel" = "Menu";
 
-/* Accessibility Label for the tab toolbar Playlist button */
+/* Accessibility Label for the tab toolbar Add to Playlist button
+   Accessibility Label for the tab toolbar Playlist button */
 "TabToolbarPlaylistButtonAccessibilityLabel" = "Playlist";
 
 /* Accessibility label for the Reader View button */

--- a/Sources/BraveStrings/Resources/ja.lproj/BraveShared.strings
+++ b/Sources/BraveStrings/Resources/ja.lproj/BraveShared.strings
@@ -100,12 +100,6 @@
 /* cookie settings option */
 "Block3rdPartyCookies" = "サードパーティの Cookie をブロック";
 
-/* No comment provided by engineer. */
-"BlockAdsAndTracking" = "クロスサイトトラッキングをブロックする";
-
-/* No comment provided by engineer. */
-"BlockAdsAndTrackingDescription" = "広告、ポップアップ、トラッキングの読み込みをブロックします。";
-
 /* Title for setting to block all website cookies. */
 "BlockAllCookies" = "すべてのクッキーをブロック";
 
@@ -138,9 +132,6 @@
 
 /* A title for setting which blocks 'switch to app' popups */
 "blockMobileAnnoyances" = "「アプリに切り替える」通知をブロック";
-
-/* Brave panel individual toggle title */
-"BlockPhishing" = "フィッシングをブロック";
 
 /* Setting to enable popup blocking */
 "BlockPopups" = "ポップアップをブロック";
@@ -318,15 +309,6 @@
 
 /* Title for toggle for enabling p3a (Privacy Preserving Analytics) Full Screen Callout */
 "callout.p3aCalloutToggleTitle" = "完全非公開、匿名で製品のインサイトを共有します。";
-
-/* Button title for Playlist Onboarding View */
-"callout.playlistOnboardingViewButtonTitle" = "説明を見る";
-
-/* Description for Playlist Onboarding View */
-"callout.playlistOnboardingViewDescription" = "どこでも、好きなときに動画を楽しめます。バックグラウンド再生、ピクチャーインピクチャー再生、オフライン再生も可能です。そしてもちろん、広告は表示されません。";
-
-/* Title for Playlist Onboarding View */
-"callout.playlistOnboardingViewTitle" = "動画をPlaylistに追加しよう";
 
 /* Subtitle - Description for Privacy Everywhere Full Screen Callout */
 "callout.privacyEverywhereCalloutDescription" = "Braveによるプライバシー保護を、パソコンやタブレットでも活用しよう。ブックマークや拡張機能をデバイス間で同期することもできます。";
@@ -710,7 +692,7 @@
 "Earlier" = "さらに前";
 
 /* No comment provided by engineer. */
-"Edit" = "動画の管理";
+"Edit" = "編集";
 
 /* Button to edit a bookmark */
 "EditBookmark" = "ブックマークを編集";
@@ -836,7 +818,7 @@
 "FilterListsDownloadPending" = "ダウンロード待ち";
 
 /* This is a button on the top navigation that takes the user to an add custom filter list url to the list */
-"FilterListsEdit" = "動画の管理";
+"FilterListsEdit" = "編集";
 
 /* This is a placeholder for an input field that takes a custom filter list URL. */
 "FilterListsEnterFilterListURL" = "フィルターリストのURLを入力";
@@ -896,10 +878,10 @@
 "genericErrorTitle" = "エラー";
 
 /* No comment provided by engineer. */
-"GoogleSafeBrowsing" = "危険なサイトをブロック";
+"GoogleSafeBrowsing" = "危険なウェブサイトをブロック";
 
 /* No comment provided by engineer. */
-"GoogleSafeBrowsingUsingWebKitDescription" = "セキュリティ上の危険が存在する場合、訪問したページの難読化されたURLの一部をGoogle セーフ ブラウジング サービスに送信します";
+"GoogleSafeBrowsingUsingWebKitDescription" = "セーフ ブラウジングは、危険だと考えられるウェブサイトからブラウザを保護します。[詳細はこちら](%@)";
 
 /* Grand camera access */
 "GrantCameraAccess" = "カメラを有効にする";
@@ -986,7 +968,7 @@
 "login.loginInfoDetailsWebsiteFieldTitle" = "ウェブサイト";
 
 /* The message displayed in alert when a user needs to set a passcode */
-"login.loginInfoSetPasscodeAlertDescription" = "パスワードを見るには、まずあなたのデバイスにパスコードが設定されている必要があります。";
+"login.loginInfoSetPasscodeAlertDescription" = "シンクチェーンの設定や設定を見るには、まず端末にパスコードを設定する必要があります。";
 
 /* The title displayed in alert when a user needs to set passcode */
 "login.loginInfoSetPasscodeAlertTitle" = "パスコードを設定する";
@@ -1504,6 +1486,9 @@
 /* Label that says who took a photograph that will be displayed to the user. '%@' is a placeholder and will include be a specific person's name, example 'Bill Gates'. */
 "PhotoBy" = "Photo by %@";
 
+/* A message shown when the user adds media to the playlist. '%@' will be replaced by the folder it was added to. Example: 'Added to Play Later' */
+"playList.addedToPlaylistMessage" = "%@に追加しました";
+
 /* Alert Description for adding videos to playlist */
 "playList.addToPlayListAlertDescription" = "この動画をPlaylistに追加しますか？";
 
@@ -1530,6 +1515,9 @@
 
 /* The title of the playlist when in Carplay mode */
 "playlist.carplayTitle" = "Brave Playlist";
+
+/* Title for changing the folder of the current media playlist item */
+"playList.changeFoldersButtonTitle" = "プレイリストを変更";
 
 /* The title of the button indicating that the user delete the offline data. (deletes the data that allows them to play offline) */
 "playlist.deleteForOfflineButtonTitle" = "オフラインキャッシュを削除";
@@ -1566,6 +1554,9 @@
 
 /* Okay Alert button title */
 "playList.okayButtonTitle" = "OK";
+
+/* Title for opening the playlist */
+"playList.openInPlaylistButtonTitle" = "プレイリストで開く";
 
 /* The title for the alert that shows up when an item is expired */
 "playList.pictureInPictureErrorTitle" = "すみません、エラーによりピクチャ・イン・ピクチャで表示できません。";
@@ -1614,6 +1605,9 @@
 
 /* Text for Playlist Offline Data Toggle while clearing the offline data storage in settings */
 "playlist.playlistOfflineDataToggleOption" = "Playlistオフラインデータ";
+
+/* Title of a button displayed when first adding some media to Playlist. Its shown next to the name of a folder that the item is recently added to to imply that you are changing the folder it was saved to */
+"playlist.playlistPopoverChangeFoldersButtonTitle" = "変更";
 
 /* The title for the alert that shows up when removing all videos and their offline mode storage. */
 "playList.playlistResetAlertTitle" = "リセット";
@@ -1672,6 +1666,9 @@
 /* Title for removing offline mode storage */
 "playList.removeActionButtonTitle" = "削除";
 
+/* A message shown when the user removes media from the playlist. '%@' will be replaced by the folder it was added to. Example: 'Removed from Play Later' */
+"playList.removedFromPlaylistMessage" = "%@から削除しました";
+
 /* Message for the alert shown when the user tries to remove offline data of an item from playlist */
 "playlist.removePlaylistOfflineDataAlertMessage" = "メディアをオフライン再生用のストレージから消去します。本当によろしいですか？";
 
@@ -1688,7 +1685,7 @@
 "playList.reopenButtonTitle" = "再度開く";
 
 /* Text indicator on the table cell while saving a video for offline with percentage eg: %25 Saved for Offline */
-"playList.savedForOfflineLabelTitle" = "オフライン再生の準備中";
+"playList.savedForOfflineLabelTitle" = "オフラインに追加";
 
 /* The title of the button indicating that the user can save a video for offline playback. (playing without internet) */
 "playlist.saveForOfflineButtonTitle" = "オフライン再生可能にする";
@@ -1732,11 +1729,23 @@
 /* The title for the toast that shows up on a page when an item that has already been added, was updated. */
 "playList.toastExitingItemPlaylistTitle" = "Brave Playlistで見る";
 
+/* A button title that when tapped will re-add the media item (undo the removal) that the user recently removed. */
+"playList.undoRemoveButtonTitle" = "元に戻す";
+
 /* Footer for option to disable URL-Bar button */
 "playlist.urlBarButtonOptionFooter" = "Braveブラウザのアドレスバーの横に、Playlistボタンを追加します。（4本の線と+が組み合わさったような見た目です。）このボタンにより、Playlistを開いたり、メディアを追加したり削除したりすることが素早く行えるようになります。";
 
 /* Title for option to disable URL-Bar button */
 "playlist.urlBarButtonOptionTitle" = "クイックアクセスボタンを有効にする";
+
+/* The title of the screen that allows you to change the folder where a playlist item was saved to */
+"playlistFolders.changeFoldersTitle" = "次に移動:";
+
+/* A label shown above the text field that allows the user to type a name of the playlist they are going to create */
+"playlistFolders.createFolderTextFieldLabel" = "プレイリスト名";
+
+/* A label shown above the text field that allows the user to type a name of the playlist they are going to create */
+"playlistFolders.createFolderTextFieldPlaceholder" = "プレイリスト名を入力";
 
 /* The title of the button to create a new folder */
 "playlistFolders.createNewFolderButtonTitle" = "作成";
@@ -1747,11 +1756,17 @@
 /* The title of the screen where the user edits folder names */
 "playlistFolders.editFolderScreenTitle" = "フォルダを編集";
 
+/* The title of the menu option that allows the user to edit the name of a folder */
+"playlistFolders.editMenuTitle" = "プレイリストを編集";
+
 /* The error shown to the user when we cannot save their changes made on a folder */
 "playlistFolders.errorSavingMessage" = "このフォルダへの変更を保存できませんでした";
 
 /* The title of the button where the user will move an item from one folder to another folder. */
 "playlistFolders.moveFolderButtonTitle" = "移動";
+
+/* The title of the section indicating the currently selected folder */
+"playlistFolders.moveFolderCurrentSectionTitle" = "現在のプレイリスト";
 
 /* The title of the screen where the user will move an item from one folder to another folder. */
 "playlistFolders.moveFolderScreenTitle" = "移動";
@@ -1768,14 +1783,35 @@
 /* %@ and %lld Should NOT be localized. They are placeholders. Example: Brave Folder and 3 more items. Music and 2 more items. */
 "playlistFolders.moveMultipleItemDescription" = "%1$@ほか%2$lld件のアイテム";
 
+/* The title of the button to create a new folder */
+"playlistFolders.newFolderButtonTitle" = "新しいプレイリスト";
+
+/* The title of the screen to create a new folder */
+"playlistFolders.newFolderScreenTitle" = "新しいプレイリスト";
+
 /* The sub-title of the section where the user can select videos to add to the new folder being created */
 "playlistFolders.newFolderSectionSubtitle" = "タップして動画を選択";
+
+/* The title of the section where the user can select videos to add to the new folder being created */
+"playlistFolders.newFolderSectionTitle" = "このプレイリストに動画を追加";
+
+/* The title of the default playlist folder */
+"playlistFolders.savedFolderTitle" = "後で再生する";
+
+/* The title of the section indicating that the user should select a folder to move `%zu` items to. %lld should not be translated. It will be replaced by a number so the sentence becomes: 'Select a folder to move 10 items to.' */
+"playlistFolders.selectAFolderTitle" = "%lld件のアイテムを移動するプレイリストを選択";
+
+/* The title of the section indicating that the user should select a folder to move 1 item to. */
+"playlistFolders.selectASingleFolderTitle" = "1件のアイテムを移動するプレイリストを選択";
 
 /* The sub-title of the folder. Example: This folder contains 10 Items. This folder contains 3 Items. */
 "playlistFolders.subtitleItemCount" = "%lld件のアイテム";
 
 /* The sub-title of the folder. Example: This folder contains ONE item. This folder contains 1 Item. */
 "playlistFolders.subtitleItemSingleCount" = "1件のアイテム";
+
+/* The title of a folder when the user enters no name (untitled) */
+"playlistFolders.untitledFolderTitle" = "無題のプレイリスト";
 
 /* Accessibility Title for the button that adds the playlist to the database. */
 "playlistFolderSharing.addButtonAccessibilityTitle" = "ボタンをクリックするとBrave Playlistに追加します";
@@ -2307,9 +2343,6 @@
 
 /* No comment provided by engineer. */
 "RewardsInternalsLegacyPromotion" = "過去のプロモーション";
-
-/* No comment provided by engineer. */
-"RewardsInternalsLegacyWalletInfoHeader" = "旧ウォレットの情報";
 
 /* %d will be the number of logs currently being shown, i.e. '10 logs shown' */
 "RewardsInternalsLogsCount" = "ログが%d 件表示中";
@@ -2854,6 +2887,9 @@
 /* Part 2 Description for Alert used action Delete Sync Account. */
 "sync.syncDeleteAccountAlertDescriptionPart2" = "これによりデータが完全に削除されるため、復元はできません。同期を再度使用する場合は、新しいアカウントを作成して、デバイスごとに追加し直す必要があります。";
 
+/* The title displayed in alert when a user needs to set passcode */
+"sync.syncSetPasscodeAlertTitle" = "パスコードを設定する";
+
 /* Title for Sync Settings Toggle Header */
 "sync.syncSettingsTitle" = "Sync設定";
 
@@ -3049,7 +3085,8 @@
 /* Accessibility Label for the browser toolbar Menu button */
 "TabToolbarMenuButtonAccessibilityLabel" = "メニュー";
 
-/* Accessibility Label for the tab toolbar Playlist button */
+/* Accessibility Label for the tab toolbar Add to Playlist button
+   Accessibility Label for the tab toolbar Playlist button */
 "TabToolbarPlaylistButtonAccessibilityLabel" = "Playlist";
 
 /* Accessibility label for the Reader View button */

--- a/Sources/BraveStrings/Resources/ko-KR.lproj/BraveShared.strings
+++ b/Sources/BraveStrings/Resources/ko-KR.lproj/BraveShared.strings
@@ -100,12 +100,6 @@
 /* cookie settings option */
 "Block3rdPartyCookies" = "제3자 쿠키 차단";
 
-/* No comment provided by engineer. */
-"BlockAdsAndTracking" = "크로스사이트 트래커 차단";
-
-/* No comment provided by engineer. */
-"BlockAdsAndTrackingDescription" = "광고, 팝업, 트래커가 로드되지 않도록 차단합니다.";
-
 /* Title for setting to block all website cookies. */
 "BlockAllCookies" = "모든 쿠키 차단";
 
@@ -138,9 +132,6 @@
 
 /* A title for setting which blocks 'switch to app' popups */
 "blockMobileAnnoyances" = "'앱으로 전환' 요청 차단";
-
-/* Brave panel individual toggle title */
-"BlockPhishing" = "피싱 차단";
 
 /* Setting to enable popup blocking */
 "BlockPopups" = "팝업 차단";
@@ -318,15 +309,6 @@
 
 /* Title for toggle for enabling p3a (Privacy Preserving Analytics) Full Screen Callout */
 "callout.p3aCalloutToggleTitle" = "프라이버시가 완전 보장되는 익명 제품 인사이트를 공유합니다.";
-
-/* Button title for Playlist Onboarding View */
-"callout.playlistOnboardingViewButtonTitle" = "동영상 보기";
-
-/* Description for Playlist Onboarding View */
-"callout.playlistOnboardingViewDescription" = "…언제 어디서든 재생. 백그라운드, PIP(Picture-In-Picture), 오프라인도 가능. 당연히 광고 없음.";
-
-/* Title for Playlist Onboarding View */
-"callout.playlistOnboardingViewTitle" = "재생목록에 동영상 추가...";
 
 /* Subtitle - Description for Privacy Everywhere Full Screen Callout */
 "callout.privacyEverywhereCalloutDescription" = "프라이버시가 뛰어난 Brave를 컴퓨터/태블릿에서 이용하고 기기 간 북마크와 확장 프로그램을 동기화하세요.";
@@ -896,10 +878,10 @@
 "genericErrorTitle" = "오류";
 
 /* No comment provided by engineer. */
-"GoogleSafeBrowsing" = "위험한 사이트 차단";
+"GoogleSafeBrowsing" = "위험한 웹사이트 차단";
 
 /* No comment provided by engineer. */
-"GoogleSafeBrowsingUsingWebKitDescription" = "사용자의 보안이 위험할 때, 방문하는 일부 페이지의 난독화된 URL을 Google 세이프 브라우징 서비스로 보냅니다.";
+"GoogleSafeBrowsingUsingWebKitDescription" = "세이프 브라우징은 위험한 것으로 알려진 웹사이트로부터 보호합니다. [자세히 알아보기](%@)";
 
 /* Grand camera access */
 "GrantCameraAccess" = "카메라 활성화";
@@ -986,7 +968,7 @@
 "login.loginInfoDetailsWebsiteFieldTitle" = "웹사이트";
 
 /* The message displayed in alert when a user needs to set a passcode */
-"login.loginInfoSetPasscodeAlertDescription" = "비밀번호를 보려면 먼저 기기에서 패스코드를 설정해야 합니다.";
+"login.loginInfoSetPasscodeAlertDescription" = "동기화 체인을 설정하거나 기존 설정을 확인하려면 먼저 기기에서 패스코드를 설정해야 합니다.";
 
 /* The title displayed in alert when a user needs to set passcode */
 "login.loginInfoSetPasscodeAlertTitle" = "패스코드 설정";
@@ -1504,6 +1486,9 @@
 /* Label that says who took a photograph that will be displayed to the user. '%@' is a placeholder and will include be a specific person's name, example 'Bill Gates'. */
 "PhotoBy" = "사진 제공: %@";
 
+/* A message shown when the user adds media to the playlist. '%@' will be replaced by the folder it was added to. Example: 'Added to Play Later' */
+"playList.addedToPlaylistMessage" = "%@에 추가됨";
+
 /* Alert Description for adding videos to playlist */
 "playList.addToPlayListAlertDescription" = "이 동영상을 재생목록에 추가하시겠습니까?";
 
@@ -1530,6 +1515,9 @@
 
 /* The title of the playlist when in Carplay mode */
 "playlist.carplayTitle" = "Brave 재생목록";
+
+/* Title for changing the folder of the current media playlist item */
+"playList.changeFoldersButtonTitle" = "재생목록 변경";
 
 /* The title of the button indicating that the user delete the offline data. (deletes the data that allows them to play offline) */
 "playlist.deleteForOfflineButtonTitle" = "오프라인 캐시 삭제";
@@ -1566,6 +1554,9 @@
 
 /* Okay Alert button title */
 "playList.okayButtonTitle" = "확인";
+
+/* Title for opening the playlist */
+"playList.openInPlaylistButtonTitle" = "재생목록에서 열기";
 
 /* The title for the alert that shows up when an item is expired */
 "playList.pictureInPictureErrorTitle" = "PIP(Picture-In-Picture)를 표시하려는 중에 오류가 발생했습니다.";
@@ -1614,6 +1605,9 @@
 
 /* Text for Playlist Offline Data Toggle while clearing the offline data storage in settings */
 "playlist.playlistOfflineDataToggleOption" = "재생목록 오프라인 데이터";
+
+/* Title of a button displayed when first adding some media to Playlist. Its shown next to the name of a folder that the item is recently added to to imply that you are changing the folder it was saved to */
+"playlist.playlistPopoverChangeFoldersButtonTitle" = "변경";
 
 /* The title for the alert that shows up when removing all videos and their offline mode storage. */
 "playList.playlistResetAlertTitle" = "재설정";
@@ -1672,6 +1666,9 @@
 /* Title for removing offline mode storage */
 "playList.removeActionButtonTitle" = "제거";
 
+/* A message shown when the user removes media from the playlist. '%@' will be replaced by the folder it was added to. Example: 'Removed from Play Later' */
+"playList.removedFromPlaylistMessage" = "%@에서 제거됨";
+
 /* Message for the alert shown when the user tries to remove offline data of an item from playlist */
 "playlist.removePlaylistOfflineDataAlertMessage" = "오프라인 저장소에서 미디어가 삭제됩니다. 계속하시겠습니까?";
 
@@ -1688,7 +1685,7 @@
 "playList.reopenButtonTitle" = "다시 열기";
 
 /* Text indicator on the table cell while saving a video for offline with percentage eg: %25 Saved for Offline */
-"playList.savedForOfflineLabelTitle" = "오프라인용으로 저장됨";
+"playList.savedForOfflineLabelTitle" = "오프라인에 추가됨";
 
 /* The title of the button indicating that the user can save a video for offline playback. (playing without internet) */
 "playlist.saveForOfflineButtonTitle" = "오프라인용으로 저장";
@@ -1732,11 +1729,23 @@
 /* The title for the toast that shows up on a page when an item that has already been added, was updated. */
 "playList.toastExitingItemPlaylistTitle" = "Brave Playlist에서 보기";
 
+/* A button title that when tapped will re-add the media item (undo the removal) that the user recently removed. */
+"playList.undoRemoveButtonTitle" = "실행 취소";
+
 /* Footer for option to disable URL-Bar button */
 "playlist.urlBarButtonOptionFooter" = "Brave 브라우저 주소창 옆에 재생목록 버튼(줄 4개에 + 기호가 더해진 모양)을 추가합니다. 이 빠른 액세스 버튼을 이용하면 신속하게 재생목록을 열거나 미디어를 추가 또는 제거할 수 있습니다.";
 
 /* Title for option to disable URL-Bar button */
 "playlist.urlBarButtonOptionTitle" = "빠른 액세스 버튼 활성화";
+
+/* The title of the screen that allows you to change the folder where a playlist item was saved to */
+"playlistFolders.changeFoldersTitle" = "다음으로 이동";
+
+/* A label shown above the text field that allows the user to type a name of the playlist they are going to create */
+"playlistFolders.createFolderTextFieldLabel" = "재생목록 이름";
+
+/* A label shown above the text field that allows the user to type a name of the playlist they are going to create */
+"playlistFolders.createFolderTextFieldPlaceholder" = "재생목록 이름 입력";
 
 /* The title of the button to create a new folder */
 "playlistFolders.createNewFolderButtonTitle" = "만들기";
@@ -1747,11 +1756,17 @@
 /* The title of the screen where the user edits folder names */
 "playlistFolders.editFolderScreenTitle" = "폴더 편집";
 
+/* The title of the menu option that allows the user to edit the name of a folder */
+"playlistFolders.editMenuTitle" = "재생목록 편집";
+
 /* The error shown to the user when we cannot save their changes made on a folder */
 "playlistFolders.errorSavingMessage" = "이 폴더에서 변경한 내용을 저장할 수 없음";
 
 /* The title of the button where the user will move an item from one folder to another folder. */
 "playlistFolders.moveFolderButtonTitle" = "이동";
+
+/* The title of the section indicating the currently selected folder */
+"playlistFolders.moveFolderCurrentSectionTitle" = "현재 재생목록";
 
 /* The title of the screen where the user will move an item from one folder to another folder. */
 "playlistFolders.moveFolderScreenTitle" = "이동";
@@ -1768,14 +1783,35 @@
 /* %@ and %lld Should NOT be localized. They are placeholders. Example: Brave Folder and 3 more items. Music and 2 more items. */
 "playlistFolders.moveMultipleItemDescription" = "%1$@ 외 %2$lld개 항목";
 
+/* The title of the button to create a new folder */
+"playlistFolders.newFolderButtonTitle" = "새 재생목록";
+
+/* The title of the screen to create a new folder */
+"playlistFolders.newFolderScreenTitle" = "새 재생목록";
+
 /* The sub-title of the section where the user can select videos to add to the new folder being created */
 "playlistFolders.newFolderSectionSubtitle" = "동영상을 선택하려면 탭";
+
+/* The title of the section where the user can select videos to add to the new folder being created */
+"playlistFolders.newFolderSectionTitle" = "이 재생목록에 동영상 추가";
+
+/* The title of the default playlist folder */
+"playlistFolders.savedFolderTitle" = "나중에 재생";
+
+/* The title of the section indicating that the user should select a folder to move `%zu` items to. %lld should not be translated. It will be replaced by a number so the sentence becomes: 'Select a folder to move 10 items to.' */
+"playlistFolders.selectAFolderTitle" = "%lld개 항목을 이동할 재생목록 선택";
+
+/* The title of the section indicating that the user should select a folder to move 1 item to. */
+"playlistFolders.selectASingleFolderTitle" = "1개 항목을 이동할 재생목록 선택";
 
 /* The sub-title of the folder. Example: This folder contains 10 Items. This folder contains 3 Items. */
 "playlistFolders.subtitleItemCount" = "%lld개 항목";
 
 /* The sub-title of the folder. Example: This folder contains ONE item. This folder contains 1 Item. */
 "playlistFolders.subtitleItemSingleCount" = "1개 항목";
+
+/* The title of a folder when the user enters no name (untitled) */
+"playlistFolders.untitledFolderTitle" = "무제 재생목록";
 
 /* Accessibility Title for the button that adds the playlist to the database. */
 "playlistFolderSharing.addButtonAccessibilityTitle" = "Brave 재생목록에 추가 버튼";
@@ -2307,9 +2343,6 @@
 
 /* No comment provided by engineer. */
 "RewardsInternalsLegacyPromotion" = "레거시 프로모션";
-
-/* No comment provided by engineer. */
-"RewardsInternalsLegacyWalletInfoHeader" = "레거시 월렛 정보";
 
 /* %d will be the number of logs currently being shown, i.e. '10 logs shown' */
 "RewardsInternalsLogsCount" = "로그 %d개 표시됨 ";
@@ -2854,6 +2887,9 @@
 /* Part 2 Description for Alert used action Delete Sync Account. */
 "sync.syncDeleteAccountAlertDescriptionPart2" = "삭제는 영구적이며 데이터를 복구할 수 있는 방법이 없습니다. 동기화를 다시 시작하려면 새 계정을 만들고 디바이스 하나씩 다시 추가해야 합니다.";
 
+/* The title displayed in alert when a user needs to set passcode */
+"sync.syncSetPasscodeAlertTitle" = "패스코드 설정";
+
 /* Title for Sync Settings Toggle Header */
 "sync.syncSettingsTitle" = "동기화 설정";
 
@@ -3049,7 +3085,8 @@
 /* Accessibility Label for the browser toolbar Menu button */
 "TabToolbarMenuButtonAccessibilityLabel" = "메뉴";
 
-/* Accessibility Label for the tab toolbar Playlist button */
+/* Accessibility Label for the tab toolbar Add to Playlist button
+   Accessibility Label for the tab toolbar Playlist button */
 "TabToolbarPlaylistButtonAccessibilityLabel" = "재생목록";
 
 /* Accessibility label for the Reader View button */

--- a/Sources/BraveStrings/Resources/ms.lproj/BraveShared.strings
+++ b/Sources/BraveStrings/Resources/ms.lproj/BraveShared.strings
@@ -100,12 +100,6 @@
 /* cookie settings option */
 "Block3rdPartyCookies" = "Sekat kuki pihak ke 3";
 
-/* No comment provided by engineer. */
-"BlockAdsAndTracking" = "Sekat Penjejak Rentas Tapak";
-
-/* No comment provided by engineer. */
-"BlockAdsAndTrackingDescription" = "Menghalang iklan, halaman timbul dan penjejak daripada dimuatkan.";
-
 /* Title for setting to block all website cookies. */
 "BlockAllCookies" = "Sekat semua Kuki";
 
@@ -138,9 +132,6 @@
 
 /* A title for setting which blocks 'switch to app' popups */
 "blockMobileAnnoyances" = "Sekat Notis 'Tukar kepada Aplikasi'";
-
-/* Brave panel individual toggle title */
-"BlockPhishing" = "Sekat Pemalsuan";
 
 /* Setting to enable popup blocking */
 "BlockPopups" = "Sekat Halaman Timbul";
@@ -318,15 +309,6 @@
 
 /* Title for toggle for enabling p3a (Privacy Preserving Analytics) Full Screen Callout */
 "callout.p3aCalloutToggleTitle" = "Kongsi Cerapan Produk Peribadi dan Awanama Menyeluruh";
-
-/* Button title for Playlist Onboarding View */
-"callout.playlistOnboardingViewButtonTitle" = "Tonton video";
-
-/* Description for Playlist Onboarding View */
-"callout.playlistOnboardingViewDescription" = "…bermain di mana jua, pada bila-bila masa. Di latar belakang, gambar dalam gambar, atau di luar talian juga. Dan, tentu sekali tanpa iklan.";
-
-/* Title for Playlist Onboarding View */
-"callout.playlistOnboardingViewTitle" = "Tambahkan video pada Senarai Main…";
 
 /* Subtitle - Description for Privacy Everywhere Full Screen Callout */
 "callout.privacyEverywhereCalloutDescription" = "Dapatkan ciri privasi Brave pada komputer atau tablet anda, dan segerakkan penanda halaman & sambungan antara peranti.";
@@ -896,10 +878,10 @@
 "genericErrorTitle" = "Ralat";
 
 /* No comment provided by engineer. */
-"GoogleSafeBrowsing" = "Sekat Tapak Berbahaya";
+"GoogleSafeBrowsing" = "Sekat Laman Web Berbahaya";
 
 /* No comment provided by engineer. */
-"GoogleSafeBrowsingUsingWebKitDescription" = "Menghantar URL mengelirukan bagi sesetengah halaman yang anda lawati ke perkhidmatan Penyemakan Lalu Selamat Google, apabila eselamatan anda berisiko.";
+"GoogleSafeBrowsingUsingWebKitDescription" = "Pelayaran Selamat melindungi anda daripada laman web yang dikenal pasti sebagai berbahaya. [Ketahui Lebih Lanjut](%@)";
 
 /* Grand camera access */
 "GrantCameraAccess" = "Aktifkan Kamera";
@@ -986,7 +968,7 @@
 "login.loginInfoDetailsWebsiteFieldTitle" = "Laman web";
 
 /* The message displayed in alert when a user needs to set a passcode */
-"login.loginInfoSetPasscodeAlertDescription" = "Untuk melihat kata laluan, anda mesti tetapkan kod laluan terlebih dahulu pada peranti anda.";
+"login.loginInfoSetPasscodeAlertDescription" = "Untuk menyediakan rantaian segerak atau melihat tetapan, anda mesti menetapkan kata laluan pada peranti anda dahulu.";
 
 /* The title displayed in alert when a user needs to set passcode */
 "login.loginInfoSetPasscodeAlertTitle" = "Tetapkan Kod Laluan";
@@ -1504,6 +1486,9 @@
 /* Label that says who took a photograph that will be displayed to the user. '%@' is a placeholder and will include be a specific person's name, example 'Bill Gates'. */
 "PhotoBy" = "Foto oleh %@";
 
+/* A message shown when the user adds media to the playlist. '%@' will be replaced by the folder it was added to. Example: 'Added to Play Later' */
+"playList.addedToPlaylistMessage" = "Ditambah kepada %@";
+
 /* Alert Description for adding videos to playlist */
 "playList.addToPlayListAlertDescription" = "Adakah anda mahu menambah video ini ke senarai main anda?";
 
@@ -1530,6 +1515,9 @@
 
 /* The title of the playlist when in Carplay mode */
 "playlist.carplayTitle" = "Senarai Main Brave";
+
+/* Title for changing the folder of the current media playlist item */
+"playList.changeFoldersButtonTitle" = "Tukar senarai main";
 
 /* The title of the button indicating that the user delete the offline data. (deletes the data that allows them to play offline) */
 "playlist.deleteForOfflineButtonTitle" = "Padamkan Cache Luar Talian";
@@ -1566,6 +1554,9 @@
 
 /* Okay Alert button title */
 "playList.okayButtonTitle" = "Okey";
+
+/* Title for opening the playlist */
+"playList.openInPlaylistButtonTitle" = "Buka Dalam Senarai Main";
 
 /* The title for the alert that shows up when an item is expired */
 "playList.pictureInPictureErrorTitle" = "Maaf, ralat berlaku semasa cuba memaparkan gambar-dalam-gambar.";
@@ -1614,6 +1605,9 @@
 
 /* Text for Playlist Offline Data Toggle while clearing the offline data storage in settings */
 "playlist.playlistOfflineDataToggleOption" = "Data Luar Talian Senarai Main";
+
+/* Title of a button displayed when first adding some media to Playlist. Its shown next to the name of a folder that the item is recently added to to imply that you are changing the folder it was saved to */
+"playlist.playlistPopoverChangeFoldersButtonTitle" = "Tukar";
 
 /* The title for the alert that shows up when removing all videos and their offline mode storage. */
 "playList.playlistResetAlertTitle" = "Tetapkan semula";
@@ -1672,6 +1666,9 @@
 /* Title for removing offline mode storage */
 "playList.removeActionButtonTitle" = "Alih Keluar";
 
+/* A message shown when the user removes media from the playlist. '%@' will be replaced by the folder it was added to. Example: 'Removed from Play Later' */
+"playList.removedFromPlaylistMessage" = "Dialih keluar daripada %@";
+
 /* Message for the alert shown when the user tries to remove offline data of an item from playlist */
 "playlist.removePlaylistOfflineDataAlertMessage" = "Ini akan memadamkan media dari storan luar talian. Adakah anda pasti mahu meneruskan?";
 
@@ -1688,7 +1685,7 @@
 "playList.reopenButtonTitle" = "Buka Semula";
 
 /* Text indicator on the table cell while saving a video for offline with percentage eg: %25 Saved for Offline */
-"playList.savedForOfflineLabelTitle" = "Disimpan untuk Luar Talian";
+"playList.savedForOfflineLabelTitle" = "Ditambah kepada Luar Talian";
 
 /* The title of the button indicating that the user can save a video for offline playback. (playing without internet) */
 "playlist.saveForOfflineButtonTitle" = "Simpan untuk Luar Talian";
@@ -1732,11 +1729,23 @@
 /* The title for the toast that shows up on a page when an item that has already been added, was updated. */
 "playList.toastExitingItemPlaylistTitle" = "Lihat dalam Senarai Main Brave";
 
+/* A button title that when tapped will re-add the media item (undo the removal) that the user recently removed. */
+"playList.undoRemoveButtonTitle" = "Buat Asal";
+
 /* Footer for option to disable URL-Bar button */
 "playlist.urlBarButtonOptionFooter" = "Menambah butang senarai main (nampak seperti 4 baris dengan simbol +) di sebelah bar alamat di penyemak imbas Brave. Butang ini memberi anda akses pantas untuk membuka Senarai Main, atau menambah atau mengalih keluar media.";
 
 /* Title for option to disable URL-Bar button */
 "playlist.urlBarButtonOptionTitle" = "Dayakan butang akses pantas";
+
+/* The title of the screen that allows you to change the folder where a playlist item was saved to */
+"playlistFolders.changeFoldersTitle" = "Alihkan Kepada";
+
+/* A label shown above the text field that allows the user to type a name of the playlist they are going to create */
+"playlistFolders.createFolderTextFieldLabel" = "Nama Senarai Main";
+
+/* A label shown above the text field that allows the user to type a name of the playlist they are going to create */
+"playlistFolders.createFolderTextFieldPlaceholder" = "Masukkan nama senarai main anda";
 
 /* The title of the button to create a new folder */
 "playlistFolders.createNewFolderButtonTitle" = "Cipta";
@@ -1747,11 +1756,17 @@
 /* The title of the screen where the user edits folder names */
 "playlistFolders.editFolderScreenTitle" = "Edit Folder";
 
+/* The title of the menu option that allows the user to edit the name of a folder */
+"playlistFolders.editMenuTitle" = "Edit Senarai Main";
+
 /* The error shown to the user when we cannot save their changes made on a folder */
 "playlistFolders.errorSavingMessage" = "Maaf, kami tidak dapat menyimpan perubahan yang anda lakukan pada folder ini";
 
 /* The title of the button where the user will move an item from one folder to another folder. */
 "playlistFolders.moveFolderButtonTitle" = "Alih";
+
+/* The title of the section indicating the currently selected folder */
+"playlistFolders.moveFolderCurrentSectionTitle" = "Senarai Main Semasa";
 
 /* The title of the screen where the user will move an item from one folder to another folder. */
 "playlistFolders.moveFolderScreenTitle" = "Alih";
@@ -1768,14 +1783,35 @@
 /* %@ and %lld Should NOT be localized. They are placeholders. Example: Brave Folder and 3 more items. Music and 2 more items. */
 "playlistFolders.moveMultipleItemDescription" = "%1$@ dan %2$lld lagi item";
 
+/* The title of the button to create a new folder */
+"playlistFolders.newFolderButtonTitle" = "Senarai Main Baharu";
+
+/* The title of the screen to create a new folder */
+"playlistFolders.newFolderScreenTitle" = "Senarai Main Baharu";
+
 /* The sub-title of the section where the user can select videos to add to the new folder being created */
 "playlistFolders.newFolderSectionSubtitle" = "Ketik untuk memilih video";
+
+/* The title of the section where the user can select videos to add to the new folder being created */
+"playlistFolders.newFolderSectionTitle" = "Tambah video kepada senarai main ini";
+
+/* The title of the default playlist folder */
+"playlistFolders.savedFolderTitle" = "Main Kemudian";
+
+/* The title of the section indicating that the user should select a folder to move `%zu` items to. %lld should not be translated. It will be replaced by a number so the sentence becomes: 'Select a folder to move 10 items to.' */
+"playlistFolders.selectAFolderTitle" = "Pilih senarai main untuk mengalihkan %lld item kepada";
+
+/* The title of the section indicating that the user should select a folder to move 1 item to. */
+"playlistFolders.selectASingleFolderTitle" = "Pilih senarai main untuk mengalihkan 1 item kepada";
 
 /* The sub-title of the folder. Example: This folder contains 10 Items. This folder contains 3 Items. */
 "playlistFolders.subtitleItemCount" = "%lld Item";
 
 /* The sub-title of the folder. Example: This folder contains ONE item. This folder contains 1 Item. */
 "playlistFolders.subtitleItemSingleCount" = "1 Item";
+
+/* The title of a folder when the user enters no name (untitled) */
+"playlistFolders.untitledFolderTitle" = "Senarai Main Tidak Bertajuk";
 
 /* Accessibility Title for the button that adds the playlist to the database. */
 "playlistFolderSharing.addButtonAccessibilityTitle" = "Butang Tambahkan pada Senarai Main Brave";
@@ -2307,9 +2343,6 @@
 
 /* No comment provided by engineer. */
 "RewardsInternalsLegacyPromotion" = "Promosi Legasi";
-
-/* No comment provided by engineer. */
-"RewardsInternalsLegacyWalletInfoHeader" = "Maklumat Dompet Legasi";
 
 /* %d will be the number of logs currently being shown, i.e. '10 logs shown' */
 "RewardsInternalsLogsCount" = "%d log ditunjukkan";
@@ -2854,6 +2887,9 @@
 /* Part 2 Description for Alert used action Delete Sync Account. */
 "sync.syncDeleteAccountAlertDescriptionPart2" = "Pemadaman ini kekal dan tiada cara lain untuk memulihkan data. Jika anda memutuskan untuk mula menggunakan Segerak sekali lagi, anda akan perlu mencipta akaun baharu dan menambahkan semula setiap peranti satu persatu.";
 
+/* The title displayed in alert when a user needs to set passcode */
+"sync.syncSetPasscodeAlertTitle" = "Tetapkan Kod Laluan";
+
 /* Title for Sync Settings Toggle Header */
 "sync.syncSettingsTitle" = "Tetapan Penyegerakan";
 
@@ -3049,7 +3085,8 @@
 /* Accessibility Label for the browser toolbar Menu button */
 "TabToolbarMenuButtonAccessibilityLabel" = "Menu";
 
-/* Accessibility Label for the tab toolbar Playlist button */
+/* Accessibility Label for the tab toolbar Add to Playlist button
+   Accessibility Label for the tab toolbar Playlist button */
 "TabToolbarPlaylistButtonAccessibilityLabel" = "Senarai Main";
 
 /* Accessibility label for the Reader View button */

--- a/Sources/BraveStrings/Resources/nb.lproj/BraveShared.strings
+++ b/Sources/BraveStrings/Resources/nb.lproj/BraveShared.strings
@@ -100,12 +100,6 @@
 /* cookie settings option */
 "Block3rdPartyCookies" = "Blokker tredjeparts informasjonskapsler";
 
-/* No comment provided by engineer. */
-"BlockAdsAndTracking" = "Blokker sporere på tvers av nettsteder";
-
-/* No comment provided by engineer. */
-"BlockAdsAndTrackingDescription" = "Forhindrer at annonser, popup-vinduer og sporere lastes inn.";
-
 /* Title for setting to block all website cookies. */
 "BlockAllCookies" = "Blokker alle informasjonskapsler";
 
@@ -138,9 +132,6 @@
 
 /* A title for setting which blocks 'switch to app' popups */
 "blockMobileAnnoyances" = "Blokker varsler om å bytte til app";
-
-/* Brave panel individual toggle title */
-"BlockPhishing" = "Blokker nettfiske";
 
 /* Setting to enable popup blocking */
 "BlockPopups" = "Blokker sprettoppvinduer";
@@ -318,15 +309,6 @@
 
 /* Title for toggle for enabling p3a (Privacy Preserving Analytics) Full Screen Callout */
 "callout.p3aCalloutToggleTitle" = "Del helt anonyme og private produktinnsikter.";
-
-/* Button title for Playlist Onboarding View */
-"callout.playlistOnboardingViewButtonTitle" = "Se på videoen";
-
-/* Description for Playlist Onboarding View */
-"callout.playlistOnboardingViewDescription" = "… spill av spillelisten hvor som helst – i bakgrunnen, som bilde-i-bilde eller offline – og selvsagt uten annonser.";
-
-/* Title for Playlist Onboarding View */
-"callout.playlistOnboardingViewTitle" = "Legg til video i Spillelisten …";
 
 /* Subtitle - Description for Privacy Everywhere Full Screen Callout */
 "callout.privacyEverywhereCalloutDescription" = "Få Brave-personvernfunksjonalitet på datamaskinen eller nettbrettet, og synkroniser bokmerker og utvidelser mellom enheter.";
@@ -899,7 +881,7 @@
 "GoogleSafeBrowsing" = "Blokker farlige nettsteder";
 
 /* No comment provided by engineer. */
-"GoogleSafeBrowsingUsingWebKitDescription" = "Sender tilslørte nettadresser til enkelte sider du besøker til Googles Safe Browsing-tjeneste når sikkerheten din er i fare.";
+"GoogleSafeBrowsingUsingWebKitDescription" = "Trygg surfing beskytter deg mot nettsteder som er kjent for å være farlige. [Finn ut mer](%@)";
 
 /* Grand camera access */
 "GrantCameraAccess" = "Aktiver kamera";
@@ -986,7 +968,7 @@
 "login.loginInfoDetailsWebsiteFieldTitle" = "Nettsted";
 
 /* The message displayed in alert when a user needs to set a passcode */
-"login.loginInfoSetPasscodeAlertDescription" = "For å se passord må du først angi en passkode på enheten din.";
+"login.loginInfoSetPasscodeAlertDescription" = "For å konfigurere synkroniseringskjeden eller se innstillingene, må du først angi et passord på enheten din.";
 
 /* The title displayed in alert when a user needs to set passcode */
 "login.loginInfoSetPasscodeAlertTitle" = "Angi en passkode";
@@ -1504,6 +1486,9 @@
 /* Label that says who took a photograph that will be displayed to the user. '%@' is a placeholder and will include be a specific person's name, example 'Bill Gates'. */
 "PhotoBy" = "Bilde av %@";
 
+/* A message shown when the user adds media to the playlist. '%@' will be replaced by the folder it was added to. Example: 'Added to Play Later' */
+"playList.addedToPlaylistMessage" = "Lagt til i %@";
+
 /* Alert Description for adding videos to playlist */
 "playList.addToPlayListAlertDescription" = "Vil du legge til denne videoen i spillelisten din?";
 
@@ -1530,6 +1515,9 @@
 
 /* The title of the playlist when in Carplay mode */
 "playlist.carplayTitle" = "Brave-spilleliste";
+
+/* Title for changing the folder of the current media playlist item */
+"playList.changeFoldersButtonTitle" = "Endre spilleliste";
 
 /* The title of the button indicating that the user delete the offline data. (deletes the data that allows them to play offline) */
 "playlist.deleteForOfflineButtonTitle" = "Slett offline-bufferdata";
@@ -1566,6 +1554,9 @@
 
 /* Okay Alert button title */
 "playList.okayButtonTitle" = "OK";
+
+/* Title for opening the playlist */
+"playList.openInPlaylistButtonTitle" = "Åpne i spilleliste";
 
 /* The title for the alert that shows up when an item is expired */
 "playList.pictureInPictureErrorTitle" = "Beklager, det oppsto en feil under forsøk på å vise et bilde-i-bilde.";
@@ -1614,6 +1605,9 @@
 
 /* Text for Playlist Offline Data Toggle while clearing the offline data storage in settings */
 "playlist.playlistOfflineDataToggleOption" = "Data om spilleliste i frakoblet modus";
+
+/* Title of a button displayed when first adding some media to Playlist. Its shown next to the name of a folder that the item is recently added to to imply that you are changing the folder it was saved to */
+"playlist.playlistPopoverChangeFoldersButtonTitle" = "Endre";
 
 /* The title for the alert that shows up when removing all videos and their offline mode storage. */
 "playList.playlistResetAlertTitle" = "Tilbakestill";
@@ -1672,6 +1666,9 @@
 /* Title for removing offline mode storage */
 "playList.removeActionButtonTitle" = "Fjern";
 
+/* A message shown when the user removes media from the playlist. '%@' will be replaced by the folder it was added to. Example: 'Removed from Play Later' */
+"playList.removedFromPlaylistMessage" = "Fjernet fra %@";
+
 /* Message for the alert shown when the user tries to remove offline data of an item from playlist */
 "playlist.removePlaylistOfflineDataAlertMessage" = "Dette sletter media fra den frakoblede lagringsplassen. Er du sikker på at du vil fortsette?";
 
@@ -1688,7 +1685,7 @@
 "playList.reopenButtonTitle" = "Åpne på nytt";
 
 /* Text indicator on the table cell while saving a video for offline with percentage eg: %25 Saved for Offline */
-"playList.savedForOfflineLabelTitle" = "Lagret for frakoblet modus";
+"playList.savedForOfflineLabelTitle" = "Lagt til i frakoblet";
 
 /* The title of the button indicating that the user can save a video for offline playback. (playing without internet) */
 "playlist.saveForOfflineButtonTitle" = "Lagre for offline avspilling";
@@ -1732,11 +1729,23 @@
 /* The title for the toast that shows up on a page when an item that has already been added, was updated. */
 "playList.toastExitingItemPlaylistTitle" = "Vis i Brave Playlist";
 
+/* A button title that when tapped will re-add the media item (undo the removal) that the user recently removed. */
+"playList.undoRemoveButtonTitle" = "Angre";
+
 /* Footer for option to disable URL-Bar button */
 "playlist.urlBarButtonOptionFooter" = "Legger til en spilleliste-knapp (den ser ut som 4 linjer med et +-symbol) ved siden av adresselinjen i Brave-nettleseren. Denne knappen gir deg rask tilgang til å åpne spillelisten, eller legge til eller fjerne medier.";
 
 /* Title for option to disable URL-Bar button */
 "playlist.urlBarButtonOptionTitle" = "Aktiver hurtigtilgangsknapp";
+
+/* The title of the screen that allows you to change the folder where a playlist item was saved to */
+"playlistFolders.changeFoldersTitle" = "Flytt til";
+
+/* A label shown above the text field that allows the user to type a name of the playlist they are going to create */
+"playlistFolders.createFolderTextFieldLabel" = "Navn på spilleliste";
+
+/* A label shown above the text field that allows the user to type a name of the playlist they are going to create */
+"playlistFolders.createFolderTextFieldPlaceholder" = "Angi navnet på spillelisten din";
 
 /* The title of the button to create a new folder */
 "playlistFolders.createNewFolderButtonTitle" = "Opprett";
@@ -1747,11 +1756,17 @@
 /* The title of the screen where the user edits folder names */
 "playlistFolders.editFolderScreenTitle" = "Rediger mappe";
 
+/* The title of the menu option that allows the user to edit the name of a folder */
+"playlistFolders.editMenuTitle" = "Rediger spilleliste";
+
 /* The error shown to the user when we cannot save their changes made on a folder */
 "playlistFolders.errorSavingMessage" = "Beklager - vi kunne ikke lagre endringene i mappen";
 
 /* The title of the button where the user will move an item from one folder to another folder. */
 "playlistFolders.moveFolderButtonTitle" = "Flytt";
+
+/* The title of the section indicating the currently selected folder */
+"playlistFolders.moveFolderCurrentSectionTitle" = "Gjeldende spilleliste";
 
 /* The title of the screen where the user will move an item from one folder to another folder. */
 "playlistFolders.moveFolderScreenTitle" = "Flytt";
@@ -1768,14 +1783,35 @@
 /* %@ and %lld Should NOT be localized. They are placeholders. Example: Brave Folder and 3 more items. Music and 2 more items. */
 "playlistFolders.moveMultipleItemDescription" = "%1$@ og %2$lld flere enheter";
 
+/* The title of the button to create a new folder */
+"playlistFolders.newFolderButtonTitle" = "Ny spilleliste";
+
+/* The title of the screen to create a new folder */
+"playlistFolders.newFolderScreenTitle" = "Ny spilleliste";
+
 /* The sub-title of the section where the user can select videos to add to the new folder being created */
 "playlistFolders.newFolderSectionSubtitle" = "Trykk for å velge videoer";
+
+/* The title of the section where the user can select videos to add to the new folder being created */
+"playlistFolders.newFolderSectionTitle" = "Legg til videoer i denne spillelisten";
+
+/* The title of the default playlist folder */
+"playlistFolders.savedFolderTitle" = "Spill av senere";
+
+/* The title of the section indicating that the user should select a folder to move `%zu` items to. %lld should not be translated. It will be replaced by a number so the sentence becomes: 'Select a folder to move 10 items to.' */
+"playlistFolders.selectAFolderTitle" = "Velg en spilleliste du vil flytte %lld elementer til";
+
+/* The title of the section indicating that the user should select a folder to move 1 item to. */
+"playlistFolders.selectASingleFolderTitle" = "Velg en spilleliste du vil flytte ett element til";
 
 /* The sub-title of the folder. Example: This folder contains 10 Items. This folder contains 3 Items. */
 "playlistFolders.subtitleItemCount" = "%lld elementer";
 
 /* The sub-title of the folder. Example: This folder contains ONE item. This folder contains 1 Item. */
 "playlistFolders.subtitleItemSingleCount" = "1 element";
+
+/* The title of a folder when the user enters no name (untitled) */
+"playlistFolders.untitledFolderTitle" = "Spilleliste uten navn";
 
 /* Accessibility Title for the button that adds the playlist to the database. */
 "playlistFolderSharing.addButtonAccessibilityTitle" = "Legg til i Brave Playlist-knapp";
@@ -2307,9 +2343,6 @@
 
 /* No comment provided by engineer. */
 "RewardsInternalsLegacyPromotion" = "Legacy-kampanje";
-
-/* No comment provided by engineer. */
-"RewardsInternalsLegacyWalletInfoHeader" = "Informasjon om Legacy-lommebok";
 
 /* %d will be the number of logs currently being shown, i.e. '10 logs shown' */
 "RewardsInternalsLogsCount" = "%d logger vist";
@@ -2854,6 +2887,9 @@
 /* Part 2 Description for Alert used action Delete Sync Account. */
 "sync.syncDeleteAccountAlertDescriptionPart2" = "Denne slettingen er permanent, og det finnes ingen måte å gjenopprette dataene på. Hvis du bestemmer deg for å bruke Synkronisering igjen, må du opprette en ny konto og legge til hver enkelt enhet på nytt.";
 
+/* The title displayed in alert when a user needs to set passcode */
+"sync.syncSetPasscodeAlertTitle" = "Angi en passkode";
+
 /* Title for Sync Settings Toggle Header */
 "sync.syncSettingsTitle" = "Synkroniser innstillinger";
 
@@ -3049,7 +3085,8 @@
 /* Accessibility Label for the browser toolbar Menu button */
 "TabToolbarMenuButtonAccessibilityLabel" = "Meny";
 
-/* Accessibility Label for the tab toolbar Playlist button */
+/* Accessibility Label for the tab toolbar Add to Playlist button
+   Accessibility Label for the tab toolbar Playlist button */
 "TabToolbarPlaylistButtonAccessibilityLabel" = "Spilleliste";
 
 /* Accessibility label for the Reader View button */

--- a/Sources/BraveStrings/Resources/pl.lproj/BraveShared.strings
+++ b/Sources/BraveStrings/Resources/pl.lproj/BraveShared.strings
@@ -100,12 +100,6 @@
 /* cookie settings option */
 "Block3rdPartyCookies" = "Blokuj 3rd party cookies";
 
-/* No comment provided by engineer. */
-"BlockAdsAndTracking" = "Zablokuj trackery działające pomiędzy witrynami";
-
-/* No comment provided by engineer. */
-"BlockAdsAndTrackingDescription" = "Zapobiega wczytywaniu się reklam, wyskakujących okienek i trackerów.";
-
 /* Title for setting to block all website cookies. */
 "BlockAllCookies" = "Blokuj wszystkie pliki cookie";
 
@@ -138,9 +132,6 @@
 
 /* A title for setting which blocks 'switch to app' popups */
 "blockMobileAnnoyances" = "Zablokuj powiadomienia „Przełącz na aplikację”";
-
-/* Brave panel individual toggle title */
-"BlockPhishing" = "Blokuj phishing";
 
 /* Setting to enable popup blocking */
 "BlockPopups" = "Blokuj wyskakujące okienka";
@@ -318,15 +309,6 @@
 
 /* Title for toggle for enabling p3a (Privacy Preserving Analytics) Full Screen Callout */
 "callout.p3aCalloutToggleTitle" = "Dziel się zupełnie anonimowo uwagami na temat produktów.";
-
-/* Button title for Playlist Onboarding View */
-"callout.playlistOnboardingViewButtonTitle" = "Zobacz film";
-
-/* Description for Playlist Onboarding View */
-"callout.playlistOnboardingViewDescription" = "...odtwarzaj gdziekolwiek, kiedykolwiek. W tle, jako obraz w obrazie, a nawet offline. I oczywiście bez reklam.";
-
-/* Title for Playlist Onboarding View */
-"callout.playlistOnboardingViewTitle" = "Dodaj film do listy odtwarzania...";
 
 /* Subtitle - Description for Privacy Everywhere Full Screen Callout */
 "callout.privacyEverywhereCalloutDescription" = "Korzystaj z ochrony prywatności Brave na komputerze lub tablecie i synchronizuj zakładki i rozszerzenia między urządzeniami.";
@@ -896,10 +878,10 @@
 "genericErrorTitle" = "Błąd";
 
 /* No comment provided by engineer. */
-"GoogleSafeBrowsing" = "Blokuje niebezpieczne strony";
+"GoogleSafeBrowsing" = "Blokuj niebezpieczne strony";
 
 /* No comment provided by engineer. */
-"GoogleSafeBrowsingUsingWebKitDescription" = "Wysyła zaciemnione adresy URL niektórych stron, które odwiedzasz w usłudze Bezpieczne przeglądanie Google, gdy Twoje bezpieczeństwo jest zagrożone.";
+"GoogleSafeBrowsingUsingWebKitDescription" = "Funkcja bezpiecznego przeglądania chroni przed stronami, o których wiadomo, że są niebezpieczne. [Dowiedz się więcej](%@)";
 
 /* Grand camera access */
 "GrantCameraAccess" = "Włącz aparat";
@@ -986,7 +968,7 @@
 "login.loginInfoDetailsWebsiteFieldTitle" = "Strona";
 
 /* The message displayed in alert when a user needs to set a passcode */
-"login.loginInfoSetPasscodeAlertDescription" = "Aby zobaczyć hasła, musisz najpierw ustawić kod dostępu na urządzeniu.";
+"login.loginInfoSetPasscodeAlertDescription" = "Aby skonfigurować łańcuch synchronizacji lub zobaczyć ustawienia, najpierw należy ustawić kod dostępu na swoim urządzeniu.";
 
 /* The title displayed in alert when a user needs to set passcode */
 "login.loginInfoSetPasscodeAlertTitle" = "Ustaw kod dostępu";
@@ -1504,6 +1486,9 @@
 /* Label that says who took a photograph that will be displayed to the user. '%@' is a placeholder and will include be a specific person's name, example 'Bill Gates'. */
 "PhotoBy" = "Zdjęcie zrobione przez %@";
 
+/* A message shown when the user adds media to the playlist. '%@' will be replaced by the folder it was added to. Example: 'Added to Play Later' */
+"playList.addedToPlaylistMessage" = "Dodano do %@";
+
 /* Alert Description for adding videos to playlist */
 "playList.addToPlayListAlertDescription" = "Czy chcesz dodać ten film do swojej listy odtwarzania?";
 
@@ -1530,6 +1515,9 @@
 
 /* The title of the playlist when in Carplay mode */
 "playlist.carplayTitle" = "Lista odtwarzania Brave";
+
+/* Title for changing the folder of the current media playlist item */
+"playList.changeFoldersButtonTitle" = "Zmień listę odtwarzania";
 
 /* The title of the button indicating that the user delete the offline data. (deletes the data that allows them to play offline) */
 "playlist.deleteForOfflineButtonTitle" = "Usuń pliki offline";
@@ -1566,6 +1554,9 @@
 
 /* Okay Alert button title */
 "playList.okayButtonTitle" = "Ok";
+
+/* Title for opening the playlist */
+"playList.openInPlaylistButtonTitle" = "Otwórz w liście odtwarzania";
 
 /* The title for the alert that shows up when an item is expired */
 "playList.pictureInPictureErrorTitle" = "Przepraszamy, wystąpił błąd podczas próby wyświetlenia obrazu w obrazie.";
@@ -1614,6 +1605,9 @@
 
 /* Text for Playlist Offline Data Toggle while clearing the offline data storage in settings */
 "playlist.playlistOfflineDataToggleOption" = "Dane listy odtwarzania w trybie offline";
+
+/* Title of a button displayed when first adding some media to Playlist. Its shown next to the name of a folder that the item is recently added to to imply that you are changing the folder it was saved to */
+"playlist.playlistPopoverChangeFoldersButtonTitle" = "Zmień";
 
 /* The title for the alert that shows up when removing all videos and their offline mode storage. */
 "playList.playlistResetAlertTitle" = "Resetuj";
@@ -1672,6 +1666,9 @@
 /* Title for removing offline mode storage */
 "playList.removeActionButtonTitle" = "Usuń";
 
+/* A message shown when the user removes media from the playlist. '%@' will be replaced by the folder it was added to. Example: 'Removed from Play Later' */
+"playList.removedFromPlaylistMessage" = "Usunięto z: %@";
+
 /* Message for the alert shown when the user tries to remove offline data of an item from playlist */
 "playlist.removePlaylistOfflineDataAlertMessage" = "Spowoduje to usunięcie pliku z dysku. Kontynuować?";
 
@@ -1688,7 +1685,7 @@
 "playList.reopenButtonTitle" = "Otwórz ponownie";
 
 /* Text indicator on the table cell while saving a video for offline with percentage eg: %25 Saved for Offline */
-"playList.savedForOfflineLabelTitle" = "% Zapisane do użytku w trybie offline";
+"playList.savedForOfflineLabelTitle" = "Dodano do trybu offline";
 
 /* The title of the button indicating that the user can save a video for offline playback. (playing without internet) */
 "playlist.saveForOfflineButtonTitle" = "Zapisz w trybie offline";
@@ -1732,11 +1729,23 @@
 /* The title for the toast that shows up on a page when an item that has already been added, was updated. */
 "playList.toastExitingItemPlaylistTitle" = "Przeglądaj na Brave Playlist";
 
+/* A button title that when tapped will re-add the media item (undo the removal) that the user recently removed. */
+"playList.undoRemoveButtonTitle" = "Cofnij";
+
 /* Footer for option to disable URL-Bar button */
 "playlist.urlBarButtonOptionFooter" = "Dodaje przycisk listy odtwarzania (wygląda jak cztery linie z symbolem +) obok paska z adresem w przeglądarce Brave. Przycisk umożliwia szybkie przejście do Listy odtwarzania i dodawanie lub usuwanie multimediów.";
 
 /* Title for option to disable URL-Bar button */
 "playlist.urlBarButtonOptionTitle" = "Włącz przycisk szybkiego dostępu";
+
+/* The title of the screen that allows you to change the folder where a playlist item was saved to */
+"playlistFolders.changeFoldersTitle" = "Przenieś do";
+
+/* A label shown above the text field that allows the user to type a name of the playlist they are going to create */
+"playlistFolders.createFolderTextFieldLabel" = "Nazwa listy odtwarzania";
+
+/* A label shown above the text field that allows the user to type a name of the playlist they are going to create */
+"playlistFolders.createFolderTextFieldPlaceholder" = "Wprowadź nazwę listy odtwarzania";
 
 /* The title of the button to create a new folder */
 "playlistFolders.createNewFolderButtonTitle" = "Utwórz";
@@ -1747,11 +1756,17 @@
 /* The title of the screen where the user edits folder names */
 "playlistFolders.editFolderScreenTitle" = "Edytuj folder";
 
+/* The title of the menu option that allows the user to edit the name of a folder */
+"playlistFolders.editMenuTitle" = "Edytuj listę odtwarzania";
+
 /* The error shown to the user when we cannot save their changes made on a folder */
 "playlistFolders.errorSavingMessage" = "Nie udało się zapisać zmian w tym folderze";
 
 /* The title of the button where the user will move an item from one folder to another folder. */
 "playlistFolders.moveFolderButtonTitle" = "Przenieś";
+
+/* The title of the section indicating the currently selected folder */
+"playlistFolders.moveFolderCurrentSectionTitle" = "Bieżąca lista odtwarzania";
 
 /* The title of the screen where the user will move an item from one folder to another folder. */
 "playlistFolders.moveFolderScreenTitle" = "Przenieś";
@@ -1768,14 +1783,35 @@
 /* %@ and %lld Should NOT be localized. They are placeholders. Example: Brave Folder and 3 more items. Music and 2 more items. */
 "playlistFolders.moveMultipleItemDescription" = "%1$@ i %2$lld więcej rzeczy";
 
+/* The title of the button to create a new folder */
+"playlistFolders.newFolderButtonTitle" = "Nowa lista odtwarzania";
+
+/* The title of the screen to create a new folder */
+"playlistFolders.newFolderScreenTitle" = "Nowa lista odtwarzania";
+
 /* The sub-title of the section where the user can select videos to add to the new folder being created */
 "playlistFolders.newFolderSectionSubtitle" = "Dotknij aby wybrać materiały";
+
+/* The title of the section where the user can select videos to add to the new folder being created */
+"playlistFolders.newFolderSectionTitle" = "Dodaj nagrania wideo do tej listy odtwarzania";
+
+/* The title of the default playlist folder */
+"playlistFolders.savedFolderTitle" = "Odtwórz później";
+
+/* The title of the section indicating that the user should select a folder to move `%zu` items to. %lld should not be translated. It will be replaced by a number so the sentence becomes: 'Select a folder to move 10 items to.' */
+"playlistFolders.selectAFolderTitle" = "Wybierz listę odtwarzania, do której zostaną przeniesione elementy w liczbie %lld";
+
+/* The title of the section indicating that the user should select a folder to move 1 item to. */
+"playlistFolders.selectASingleFolderTitle" = "Wybierz listę odtwarzania, do której zostanie przeniesiony 1 element";
 
 /* The sub-title of the folder. Example: This folder contains 10 Items. This folder contains 3 Items. */
 "playlistFolders.subtitleItemCount" = "%lld rzeczy";
 
 /* The sub-title of the folder. Example: This folder contains ONE item. This folder contains 1 Item. */
 "playlistFolders.subtitleItemSingleCount" = "1 rzecz";
+
+/* The title of a folder when the user enters no name (untitled) */
+"playlistFolders.untitledFolderTitle" = "Lista odtwarzania bez tytułu";
 
 /* Accessibility Title for the button that adds the playlist to the database. */
 "playlistFolderSharing.addButtonAccessibilityTitle" = "Dodaj do przycisku listy odtwarzania Brave";
@@ -2307,9 +2343,6 @@
 
 /* No comment provided by engineer. */
 "RewardsInternalsLegacyPromotion" = "Promocja w starszej wersji";
-
-/* No comment provided by engineer. */
-"RewardsInternalsLegacyWalletInfoHeader" = "Informacje o starszym portfelu";
 
 /* %d will be the number of logs currently being shown, i.e. '10 logs shown' */
 "RewardsInternalsLogsCount" = "Wyświetlanie %d logów";
@@ -2854,6 +2887,9 @@
 /* Part 2 Description for Alert used action Delete Sync Account. */
 "sync.syncDeleteAccountAlertDescriptionPart2" = "To usunięcie jest trwałe i nie ma możliwości odzyskania danych. Jeśli zdecydujesz się ponownie zacząć używać aplikacji Sync, będzie trzeba utworzyć nowe konto i ponownie dodać każde urządzenie po kolei.";
 
+/* The title displayed in alert when a user needs to set passcode */
+"sync.syncSetPasscodeAlertTitle" = "Ustaw kod dostępu";
+
 /* Title for Sync Settings Toggle Header */
 "sync.syncSettingsTitle" = "Ustawienia synchronizacji";
 
@@ -3049,7 +3085,8 @@
 /* Accessibility Label for the browser toolbar Menu button */
 "TabToolbarMenuButtonAccessibilityLabel" = "Menu";
 
-/* Accessibility Label for the tab toolbar Playlist button */
+/* Accessibility Label for the tab toolbar Add to Playlist button
+   Accessibility Label for the tab toolbar Playlist button */
 "TabToolbarPlaylistButtonAccessibilityLabel" = "Lista odtwarzania";
 
 /* Accessibility label for the Reader View button */

--- a/Sources/BraveStrings/Resources/pt-BR.lproj/BraveShared.strings
+++ b/Sources/BraveStrings/Resources/pt-BR.lproj/BraveShared.strings
@@ -100,12 +100,6 @@
 /* cookie settings option */
 "Block3rdPartyCookies" = "Bloquear cookies de terceiros";
 
-/* No comment provided by engineer. */
-"BlockAdsAndTracking" = "Bloquear rastreadores entre sites";
-
-/* No comment provided by engineer. */
-"BlockAdsAndTrackingDescription" = "Impede o carregamento de anúncios, pop-ups e rastreadores.";
-
 /* Title for setting to block all website cookies. */
 "BlockAllCookies" = "Bloquear todos os cookies";
 
@@ -138,9 +132,6 @@
 
 /* A title for setting which blocks 'switch to app' popups */
 "blockMobileAnnoyances" = "Bloquear avisos \"Mudar para o app\"";
-
-/* Brave panel individual toggle title */
-"BlockPhishing" = "Bloquear phishing";
 
 /* Setting to enable popup blocking */
 "BlockPopups" = "Bloquear pop-ups";
@@ -318,15 +309,6 @@
 
 /* Title for toggle for enabling p3a (Privacy Preserving Analytics) Full Screen Callout */
 "callout.p3aCalloutToggleTitle" = "Partilhe informações detalhadas de produtos completamte privadas e anónimas";
-
-/* Button title for Playlist Onboarding View */
-"callout.playlistOnboardingViewButtonTitle" = "Assistir ao vídeo";
-
-/* Description for Playlist Onboarding View */
-"callout.playlistOnboardingViewDescription" = "…reproduza a qualquer hora e em qualquer lugar. Em segundo plano, picture-in-picture ou até mesmo off-line. E, é claro, sem anúncios.";
-
-/* Title for Playlist Onboarding View */
-"callout.playlistOnboardingViewTitle" = "Adicionar vídeo à Playlist…";
 
 /* Subtitle - Description for Privacy Everywhere Full Screen Callout */
 "callout.privacyEverywhereCalloutDescription" = "Tenha a privacidade do Brave no seu computador ou tablet e sincronize favoritos e extensões entre dispositivos.";
@@ -899,7 +881,7 @@
 "GoogleSafeBrowsing" = "Bloquear sites perigosos";
 
 /* No comment provided by engineer. */
-"GoogleSafeBrowsingUsingWebKitDescription" = "Envia URLs ofuscados de algumas páginas que você visita ao serviço Navegação segura do Google quando sua segurança está em risco.";
+"GoogleSafeBrowsingUsingWebKitDescription" = "A Navegação segura protege contra sites considerados perigosos. [Saber mais](%@)";
 
 /* Grand camera access */
 "GrantCameraAccess" = "Ativar câmera";
@@ -986,7 +968,7 @@
 "login.loginInfoDetailsWebsiteFieldTitle" = "Site";
 
 /* The message displayed in alert when a user needs to set a passcode */
-"login.loginInfoSetPasscodeAlertDescription" = "Para ver senhas, antes você precisa definir um código de acesso no seu dispositivo.";
+"login.loginInfoSetPasscodeAlertDescription" = "Para configurar a cadeia de sincronização ou ver as definições, é necessário definir um código de acesso no dispositivo.";
 
 /* The title displayed in alert when a user needs to set passcode */
 "login.loginInfoSetPasscodeAlertTitle" = "Definir um código de acesso";
@@ -1504,6 +1486,9 @@
 /* Label that says who took a photograph that will be displayed to the user. '%@' is a placeholder and will include be a specific person's name, example 'Bill Gates'. */
 "PhotoBy" = "Foto de %@";
 
+/* A message shown when the user adds media to the playlist. '%@' will be replaced by the folder it was added to. Example: 'Added to Play Later' */
+"playList.addedToPlaylistMessage" = "Adicionado a %@";
+
 /* Alert Description for adding videos to playlist */
 "playList.addToPlayListAlertDescription" = "Você deseja adicionar este vídeo à sua playlist?";
 
@@ -1530,6 +1515,9 @@
 
 /* The title of the playlist when in Carplay mode */
 "playlist.carplayTitle" = "Playlist do Brave";
+
+/* Title for changing the folder of the current media playlist item */
+"playList.changeFoldersButtonTitle" = "Alterar lista de reprodução";
 
 /* The title of the button indicating that the user delete the offline data. (deletes the data that allows them to play offline) */
 "playlist.deleteForOfflineButtonTitle" = "Excluir cache off-line";
@@ -1566,6 +1554,9 @@
 
 /* Okay Alert button title */
 "playList.okayButtonTitle" = "OK";
+
+/* Title for opening the playlist */
+"playList.openInPlaylistButtonTitle" = "Abrir na lista de reprodução";
 
 /* The title for the alert that shows up when an item is expired */
 "playList.pictureInPictureErrorTitle" = "Ocorreu um erro ao tentar exibir o picture-in-picture.";
@@ -1614,6 +1605,9 @@
 
 /* Text for Playlist Offline Data Toggle while clearing the offline data storage in settings */
 "playlist.playlistOfflineDataToggleOption" = "Dados off-line da playlist";
+
+/* Title of a button displayed when first adding some media to Playlist. Its shown next to the name of a folder that the item is recently added to to imply that you are changing the folder it was saved to */
+"playlist.playlistPopoverChangeFoldersButtonTitle" = "Alterar";
 
 /* The title for the alert that shows up when removing all videos and their offline mode storage. */
 "playList.playlistResetAlertTitle" = "Redefinir";
@@ -1672,6 +1666,9 @@
 /* Title for removing offline mode storage */
 "playList.removeActionButtonTitle" = "Remover";
 
+/* A message shown when the user removes media from the playlist. '%@' will be replaced by the folder it was added to. Example: 'Removed from Play Later' */
+"playList.removedFromPlaylistMessage" = "Removido de %@";
+
 /* Message for the alert shown when the user tries to remove offline data of an item from playlist */
 "playlist.removePlaylistOfflineDataAlertMessage" = "Essa ação excluirá a mídia do armazenamento off-line. Tem certeza de que deseja continuar?";
 
@@ -1688,7 +1685,7 @@
 "playList.reopenButtonTitle" = "Reabrir";
 
 /* Text indicator on the table cell while saving a video for offline with percentage eg: %25 Saved for Offline */
-"playList.savedForOfflineLabelTitle" = "salvo para uso off-line";
+"playList.savedForOfflineLabelTitle" = "Adicionado para uso offline";
 
 /* The title of the button indicating that the user can save a video for offline playback. (playing without internet) */
 "playlist.saveForOfflineButtonTitle" = "Salvar para uso off-line";
@@ -1732,11 +1729,23 @@
 /* The title for the toast that shows up on a page when an item that has already been added, was updated. */
 "playList.toastExitingItemPlaylistTitle" = "Ver na Brave Playlist";
 
+/* A button title that when tapped will re-add the media item (undo the removal) that the user recently removed. */
+"playList.undoRemoveButtonTitle" = "Desfazer";
+
 /* Footer for option to disable URL-Bar button */
 "playlist.urlBarButtonOptionFooter" = "Adiciona um botão de playlist (semelhante a 4 linhas com um símbolo \"+\") ao lado da barra de endereço no navegador Brave. Esse botão oferece acesso rápido para abrir a playlist ou para adicionar ou remover mídia.";
 
 /* Title for option to disable URL-Bar button */
 "playlist.urlBarButtonOptionTitle" = "Ativar botão de acesso rápido";
+
+/* The title of the screen that allows you to change the folder where a playlist item was saved to */
+"playlistFolders.changeFoldersTitle" = "Mover para";
+
+/* A label shown above the text field that allows the user to type a name of the playlist they are going to create */
+"playlistFolders.createFolderTextFieldLabel" = "Nome da lista de reprodução";
+
+/* A label shown above the text field that allows the user to type a name of the playlist they are going to create */
+"playlistFolders.createFolderTextFieldPlaceholder" = "Introduza o nome da lista de reprodução";
 
 /* The title of the button to create a new folder */
 "playlistFolders.createNewFolderButtonTitle" = "Criar";
@@ -1747,11 +1756,17 @@
 /* The title of the screen where the user edits folder names */
 "playlistFolders.editFolderScreenTitle" = "Editar pasta";
 
+/* The title of the menu option that allows the user to edit the name of a folder */
+"playlistFolders.editMenuTitle" = "Editar lista de reprodução";
+
 /* The error shown to the user when we cannot save their changes made on a folder */
 "playlistFolders.errorSavingMessage" = "Infelizmente, não possível salvar as alterações que você fez nesta pasta";
 
 /* The title of the button where the user will move an item from one folder to another folder. */
 "playlistFolders.moveFolderButtonTitle" = "Mover";
+
+/* The title of the section indicating the currently selected folder */
+"playlistFolders.moveFolderCurrentSectionTitle" = "Lista de reprodução atual";
 
 /* The title of the screen where the user will move an item from one folder to another folder. */
 "playlistFolders.moveFolderScreenTitle" = "Mover";
@@ -1768,14 +1783,35 @@
 /* %@ and %lld Should NOT be localized. They are placeholders. Example: Brave Folder and 3 more items. Music and 2 more items. */
 "playlistFolders.moveMultipleItemDescription" = "%1$@ e mais %2$lld itens";
 
+/* The title of the button to create a new folder */
+"playlistFolders.newFolderButtonTitle" = "Nova lista de reprodução";
+
+/* The title of the screen to create a new folder */
+"playlistFolders.newFolderScreenTitle" = "Nova lista de reprodução";
+
 /* The sub-title of the section where the user can select videos to add to the new folder being created */
 "playlistFolders.newFolderSectionSubtitle" = "Toque para selecionar vídeos";
+
+/* The title of the section where the user can select videos to add to the new folder being created */
+"playlistFolders.newFolderSectionTitle" = "Adicione vídeos a esta lista de reprodução";
+
+/* The title of the default playlist folder */
+"playlistFolders.savedFolderTitle" = "Reproduzir mais tarde";
+
+/* The title of the section indicating that the user should select a folder to move `%zu` items to. %lld should not be translated. It will be replaced by a number so the sentence becomes: 'Select a folder to move 10 items to.' */
+"playlistFolders.selectAFolderTitle" = "Selecione uma lista de reprodução para a qual %lld elementos serão movidos";
+
+/* The title of the section indicating that the user should select a folder to move 1 item to. */
+"playlistFolders.selectASingleFolderTitle" = "Selecione uma lista de reprodução para a qual 1 elemento será movido";
 
 /* The sub-title of the folder. Example: This folder contains 10 Items. This folder contains 3 Items. */
 "playlistFolders.subtitleItemCount" = "%lld itens";
 
 /* The sub-title of the folder. Example: This folder contains ONE item. This folder contains 1 Item. */
 "playlistFolders.subtitleItemSingleCount" = "1 item";
+
+/* The title of a folder when the user enters no name (untitled) */
+"playlistFolders.untitledFolderTitle" = "Lista de reprodução sem título";
 
 /* Accessibility Title for the button that adds the playlist to the database. */
 "playlistFolderSharing.addButtonAccessibilityTitle" = "Botão \"Adicionar à Playlist do Brave\"";
@@ -2307,9 +2343,6 @@
 
 /* No comment provided by engineer. */
 "RewardsInternalsLegacyPromotion" = "Promoção legada";
-
-/* No comment provided by engineer. */
-"RewardsInternalsLegacyWalletInfoHeader" = "Informações de carteira legada";
 
 /* %d will be the number of logs currently being shown, i.e. '10 logs shown' */
 "RewardsInternalsLogsCount" = "%d logs exibidos";
@@ -2854,6 +2887,9 @@
 /* Part 2 Description for Alert used action Delete Sync Account. */
 "sync.syncDeleteAccountAlertDescriptionPart2" = "Esta eliminação é permanente e não será possível recuperar os dados. Se optar por iniciar utilizando a Sincronização novamente, terá de criar uma nova conta e terá de voltar a adicionar individualmente cada dispositivo.";
 
+/* The title displayed in alert when a user needs to set passcode */
+"sync.syncSetPasscodeAlertTitle" = "Definir um código de acesso";
+
 /* Title for Sync Settings Toggle Header */
 "sync.syncSettingsTitle" = "Sincronizar configurações";
 
@@ -3049,7 +3085,8 @@
 /* Accessibility Label for the browser toolbar Menu button */
 "TabToolbarMenuButtonAccessibilityLabel" = "Menu";
 
-/* Accessibility Label for the tab toolbar Playlist button */
+/* Accessibility Label for the tab toolbar Add to Playlist button
+   Accessibility Label for the tab toolbar Playlist button */
 "TabToolbarPlaylistButtonAccessibilityLabel" = "Playlist";
 
 /* Accessibility label for the Reader View button */

--- a/Sources/BraveStrings/Resources/ru.lproj/BraveShared.strings
+++ b/Sources/BraveStrings/Resources/ru.lproj/BraveShared.strings
@@ -100,12 +100,6 @@
 /* cookie settings option */
 "Block3rdPartyCookies" = "Блокировать сторонние файлы cookie";
 
-/* No comment provided by engineer. */
-"BlockAdsAndTracking" = "Блокировка межсайтовых трекеров";
-
-/* No comment provided by engineer. */
-"BlockAdsAndTrackingDescription" = "Блокирует загрузку рекламы, всплывающих окон и трекеров.";
-
 /* Title for setting to block all website cookies. */
 "BlockAllCookies" = "Блокировать все файлы cookie";
 
@@ -138,9 +132,6 @@
 
 /* A title for setting which blocks 'switch to app' popups */
 "blockMobileAnnoyances" = "Блокировать всплывающие окна и не переходить в приложения";
-
-/* Brave panel individual toggle title */
-"BlockPhishing" = "Блокировать фишинг";
 
 /* Setting to enable popup blocking */
 "BlockPopups" = "Блокировать всплывающие окна";
@@ -318,15 +309,6 @@
 
 /* Title for toggle for enabling p3a (Privacy Preserving Analytics) Full Screen Callout */
 "callout.p3aCalloutToggleTitle" = "Делиться полностью конфиденциальными и анонимными сведениями о продукте";
-
-/* Button title for Playlist Onboarding View */
-"callout.playlistOnboardingViewButtonTitle" = "Смотреть видео";
-
-/* Description for Playlist Onboarding View */
-"callout.playlistOnboardingViewDescription" = "Смотрите видео без рекламы где угодно и когда угодно. Доступно фоновое воспроизведение, офлайн-режим и функция «Картинка в картинке».";
-
-/* Title for Playlist Onboarding View */
-"callout.playlistOnboardingViewTitle" = "Добавьте видео в плейлист";
 
 /* Subtitle - Description for Privacy Everywhere Full Screen Callout */
 "callout.privacyEverywhereCalloutDescription" = "Установите Brave на компьютере или планшете и синхронизируйте закладки и расширения на всех устройствах.";
@@ -899,7 +881,7 @@
 "GoogleSafeBrowsing" = "Блокировать опасные сайты";
 
 /* No comment provided by engineer. */
-"GoogleSafeBrowsingUsingWebKitDescription" = "Отправляет обфусцированные URL-адреса некоторых страниц, которые вы посещали, в сервис \"Google Безопасный просмотр\", если есть угроза вашей безопасности.";
+"GoogleSafeBrowsingUsingWebKitDescription" = "Безопасный просмотр защищает от сайтов, представляющих угрозу. [Подробнее](%@)";
 
 /* Grand camera access */
 "GrantCameraAccess" = "Включить камеру";
@@ -986,7 +968,7 @@
 "login.loginInfoDetailsWebsiteFieldTitle" = "Сайт";
 
 /* The message displayed in alert when a user needs to set a passcode */
-"login.loginInfoSetPasscodeAlertDescription" = "Для просмотра паролей необходимо установить код доступа на устройстве.";
+"login.loginInfoSetPasscodeAlertDescription" = "Чтобы создать цепь синхронизации или посмотреть настройки, установите код доступа на устройстве.";
 
 /* The title displayed in alert when a user needs to set passcode */
 "login.loginInfoSetPasscodeAlertTitle" = "Установите код доступа";
@@ -1504,6 +1486,9 @@
 /* Label that says who took a photograph that will be displayed to the user. '%@' is a placeholder and will include be a specific person's name, example 'Bill Gates'. */
 "PhotoBy" = "Автор фото: %@";
 
+/* A message shown when the user adds media to the playlist. '%@' will be replaced by the folder it was added to. Example: 'Added to Play Later' */
+"playList.addedToPlaylistMessage" = "Добавлено в плейлист «%@»";
+
 /* Alert Description for adding videos to playlist */
 "playList.addToPlayListAlertDescription" = "Добавить это видео в плейлист?";
 
@@ -1530,6 +1515,9 @@
 
 /* The title of the playlist when in Carplay mode */
 "playlist.carplayTitle" = "Плейлист Brave";
+
+/* Title for changing the folder of the current media playlist item */
+"playList.changeFoldersButtonTitle" = "Перенести в другой плейлист";
 
 /* The title of the button indicating that the user delete the offline data. (deletes the data that allows them to play offline) */
 "playlist.deleteForOfflineButtonTitle" = "Удалить офлайн-данные";
@@ -1566,6 +1554,9 @@
 
 /* Okay Alert button title */
 "playList.okayButtonTitle" = "ОК";
+
+/* Title for opening the playlist */
+"playList.openInPlaylistButtonTitle" = "Открыть в плейлисте";
 
 /* The title for the alert that shows up when an item is expired */
 "playList.pictureInPictureErrorTitle" = "При переходе в режим «Картинка в картинке» произошла ошибка";
@@ -1614,6 +1605,9 @@
 
 /* Text for Playlist Offline Data Toggle while clearing the offline data storage in settings */
 "playlist.playlistOfflineDataToggleOption" = "Офлайн-данные плейлиста";
+
+/* Title of a button displayed when first adding some media to Playlist. Its shown next to the name of a folder that the item is recently added to to imply that you are changing the folder it was saved to */
+"playlist.playlistPopoverChangeFoldersButtonTitle" = "Изменить";
 
 /* The title for the alert that shows up when removing all videos and their offline mode storage. */
 "playList.playlistResetAlertTitle" = "Сбросить";
@@ -1672,6 +1666,9 @@
 /* Title for removing offline mode storage */
 "playList.removeActionButtonTitle" = "Удалить";
 
+/* A message shown when the user removes media from the playlist. '%@' will be replaced by the folder it was added to. Example: 'Removed from Play Later' */
+"playList.removedFromPlaylistMessage" = "Удалено из плейлиста «%@»";
+
 /* Message for the alert shown when the user tries to remove offline data of an item from playlist */
 "playlist.removePlaylistOfflineDataAlertMessage" = "Все файлы в офлайн-хранилище будут удалены. Продолжить?";
 
@@ -1688,7 +1685,7 @@
 "playList.reopenButtonTitle" = "Открыть повторно";
 
 /* Text indicator on the table cell while saving a video for offline with percentage eg: %25 Saved for Offline */
-"playList.savedForOfflineLabelTitle" = "— сохранено для офлайн-доступа";
+"playList.savedForOfflineLabelTitle" = "Сохранено для офлайн-доступа";
 
 /* The title of the button indicating that the user can save a video for offline playback. (playing without internet) */
 "playlist.saveForOfflineButtonTitle" = "Сохранить для офлайн-доступа";
@@ -1732,11 +1729,23 @@
 /* The title for the toast that shows up on a page when an item that has already been added, was updated. */
 "playList.toastExitingItemPlaylistTitle" = "Посмотреть в плейлисте Brave";
 
+/* A button title that when tapped will re-add the media item (undo the removal) that the user recently removed. */
+"playList.undoRemoveButtonTitle" = "Отменить";
+
 /* Footer for option to disable URL-Bar button */
 "playlist.urlBarButtonOptionFooter" = "Добавляет кнопку плейлиста (четыре полоски с символом плюса) рядом с адресной строкой в браузере Brave. Она позволяет быстро перейти к плейлисту, добавить или удалить контент.";
 
 /* Title for option to disable URL-Bar button */
 "playlist.urlBarButtonOptionTitle" = "Включить кнопку быстрого доступа";
+
+/* The title of the screen that allows you to change the folder where a playlist item was saved to */
+"playlistFolders.changeFoldersTitle" = "Перемещение";
+
+/* A label shown above the text field that allows the user to type a name of the playlist they are going to create */
+"playlistFolders.createFolderTextFieldLabel" = "Название плейлиста";
+
+/* A label shown above the text field that allows the user to type a name of the playlist they are going to create */
+"playlistFolders.createFolderTextFieldPlaceholder" = "Введите название плейлиста";
 
 /* The title of the button to create a new folder */
 "playlistFolders.createNewFolderButtonTitle" = "Создать";
@@ -1747,11 +1756,17 @@
 /* The title of the screen where the user edits folder names */
 "playlistFolders.editFolderScreenTitle" = "Изменение папки";
 
+/* The title of the menu option that allows the user to edit the name of a folder */
+"playlistFolders.editMenuTitle" = "Переименовать";
+
 /* The error shown to the user when we cannot save their changes made on a folder */
 "playlistFolders.errorSavingMessage" = "При сохранении изменений произошла ошибка.";
 
 /* The title of the button where the user will move an item from one folder to another folder. */
 "playlistFolders.moveFolderButtonTitle" = "Перемещение";
+
+/* The title of the section indicating the currently selected folder */
+"playlistFolders.moveFolderCurrentSectionTitle" = "Текущий плейлист";
 
 /* The title of the screen where the user will move an item from one folder to another folder. */
 "playlistFolders.moveFolderScreenTitle" = "Перемещение";
@@ -1768,14 +1783,35 @@
 /* %@ and %lld Should NOT be localized. They are placeholders. Example: Brave Folder and 3 more items. Music and 2 more items. */
 "playlistFolders.moveMultipleItemDescription" = "%1$@ и другие объекты (%2$lld)";
 
+/* The title of the button to create a new folder */
+"playlistFolders.newFolderButtonTitle" = "Новый плейлист";
+
+/* The title of the screen to create a new folder */
+"playlistFolders.newFolderScreenTitle" = "Новый плейлист";
+
 /* The sub-title of the section where the user can select videos to add to the new folder being created */
 "playlistFolders.newFolderSectionSubtitle" = "Нажмите, чтобы выбрать видео.";
+
+/* The title of the section where the user can select videos to add to the new folder being created */
+"playlistFolders.newFolderSectionTitle" = "Добавление видео в плейлист";
+
+/* The title of the default playlist folder */
+"playlistFolders.savedFolderTitle" = "Воспроизвести позже";
+
+/* The title of the section indicating that the user should select a folder to move `%zu` items to. %lld should not be translated. It will be replaced by a number so the sentence becomes: 'Select a folder to move 10 items to.' */
+"playlistFolders.selectAFolderTitle" = "Выберите новый плейлист для %lld объектов";
+
+/* The title of the section indicating that the user should select a folder to move 1 item to. */
+"playlistFolders.selectASingleFolderTitle" = "Выберите новый плейлист для 1 объекта";
 
 /* The sub-title of the folder. Example: This folder contains 10 Items. This folder contains 3 Items. */
 "playlistFolders.subtitleItemCount" = "Объектов: %lld.";
 
 /* The sub-title of the folder. Example: This folder contains ONE item. This folder contains 1 Item. */
 "playlistFolders.subtitleItemSingleCount" = "1 объект.";
+
+/* The title of a folder when the user enters no name (untitled) */
+"playlistFolders.untitledFolderTitle" = "Плейлист без названия";
 
 /* Accessibility Title for the button that adds the playlist to the database. */
 "playlistFolderSharing.addButtonAccessibilityTitle" = "Кнопка «Добавить в плейлист Brave»";
@@ -2307,9 +2343,6 @@
 
 /* No comment provided by engineer. */
 "RewardsInternalsLegacyPromotion" = "Устаревшие бонусы";
-
-/* No comment provided by engineer. */
-"RewardsInternalsLegacyWalletInfoHeader" = "Сведения об устаревшем кошельке";
 
 /* %d will be the number of logs currently being shown, i.e. '10 logs shown' */
 "RewardsInternalsLogsCount" = "Показано журналов: %d";
@@ -2854,6 +2887,9 @@
 /* Part 2 Description for Alert used action Delete Sync Account. */
 "sync.syncDeleteAccountAlertDescriptionPart2" = "Удаление необратимо — вы не сможете восстановить данные. Если вы захотите опять использовать Brave Синхронизацию, создайте новый аккаунт и повторно добавьте устройства.";
 
+/* The title displayed in alert when a user needs to set passcode */
+"sync.syncSetPasscodeAlertTitle" = "Установите код доступа";
+
 /* Title for Sync Settings Toggle Header */
 "sync.syncSettingsTitle" = "Настройки синхронизации";
 
@@ -3049,7 +3085,8 @@
 /* Accessibility Label for the browser toolbar Menu button */
 "TabToolbarMenuButtonAccessibilityLabel" = "Меню";
 
-/* Accessibility Label for the tab toolbar Playlist button */
+/* Accessibility Label for the tab toolbar Add to Playlist button
+   Accessibility Label for the tab toolbar Playlist button */
 "TabToolbarPlaylistButtonAccessibilityLabel" = "Плейлист";
 
 /* Accessibility label for the Reader View button */

--- a/Sources/BraveStrings/Resources/sv.lproj/BraveShared.strings
+++ b/Sources/BraveStrings/Resources/sv.lproj/BraveShared.strings
@@ -100,12 +100,6 @@
 /* cookie settings option */
 "Block3rdPartyCookies" = "Blockera cookies från 3:e part";
 
-/* No comment provided by engineer. */
-"BlockAdsAndTracking" = "Blockera webbplatsspårare";
-
-/* No comment provided by engineer. */
-"BlockAdsAndTrackingDescription" = "Förhindrar att annonser, popups och spårare läses in.";
-
 /* Title for setting to block all website cookies. */
 "BlockAllCookies" = "Blockera alla kakor";
 
@@ -138,9 +132,6 @@
 
 /* A title for setting which blocks 'switch to app' popups */
 "blockMobileAnnoyances" = "Blockera \"Växla till appen\"-aviseringar";
-
-/* Brave panel individual toggle title */
-"BlockPhishing" = "Blockera phishing";
 
 /* Setting to enable popup blocking */
 "BlockPopups" = "Blockera popup-fönster";
@@ -318,15 +309,6 @@
 
 /* Title for toggle for enabling p3a (Privacy Preserving Analytics) Full Screen Callout */
 "callout.p3aCalloutToggleTitle" = "Dela statistik om produkter privat och anonymt.";
-
-/* Button title for Playlist Onboarding View */
-"callout.playlistOnboardingViewButtonTitle" = "Se videon";
-
-/* Description for Playlist Onboarding View */
-"callout.playlistOnboardingViewDescription" = "…spela var som helst, när som helst. I bakgrunden, som bild-i-bild eller offline. Reklamfritt, så klart.";
-
-/* Title for Playlist Onboarding View */
-"callout.playlistOnboardingViewTitle" = "Lägg till video i spellista…";
 
 /* Subtitle - Description for Privacy Everywhere Full Screen Callout */
 "callout.privacyEverywhereCalloutDescription" = "Få Braves integritetsskydd på din dator eller surfplatta och synkronisera bokmärken och tillägg mellan enheter.";
@@ -896,10 +878,10 @@
 "genericErrorTitle" = "Fel";
 
 /* No comment provided by engineer. */
-"GoogleSafeBrowsing" = "Blockera skadliga webbplatser";
+"GoogleSafeBrowsing" = "Blockera farliga webbplatser";
 
 /* No comment provided by engineer. */
-"GoogleSafeBrowsingUsingWebKitDescription" = "Skickar skadliga webbadresser för vissa sidor som du besöker till Googles tjänst för säker webbsökning, när din säkerhet är i fara.";
+"GoogleSafeBrowsingUsingWebKitDescription" = "Säker webbsökning skyddar mot webbplatser som är kända för att vara farliga. [Learn More](%@)";
 
 /* Grand camera access */
 "GrantCameraAccess" = "Aktivera kamera";
@@ -986,7 +968,7 @@
 "login.loginInfoDetailsWebsiteFieldTitle" = "Webbplats";
 
 /* The message displayed in alert when a user needs to set a passcode */
-"login.loginInfoSetPasscodeAlertDescription" = "För att se lösenorden måste du först ställa in en lösenkod på din enhet.";
+"login.loginInfoSetPasscodeAlertDescription" = "Om du vill konfigurera synkroniseringskedjan eller visa inställningarna måste du först ange en lösenkod på enheten.";
 
 /* The title displayed in alert when a user needs to set passcode */
 "login.loginInfoSetPasscodeAlertTitle" = "Ställ in lösenkod";
@@ -1504,6 +1486,9 @@
 /* Label that says who took a photograph that will be displayed to the user. '%@' is a placeholder and will include be a specific person's name, example 'Bill Gates'. */
 "PhotoBy" = "Foto av %@";
 
+/* A message shown when the user adds media to the playlist. '%@' will be replaced by the folder it was added to. Example: 'Added to Play Later' */
+"playList.addedToPlaylistMessage" = "Tillagd i % @";
+
 /* Alert Description for adding videos to playlist */
 "playList.addToPlayListAlertDescription" = "Vill du lägga till den här videon i din spellista?";
 
@@ -1530,6 +1515,9 @@
 
 /* The title of the playlist when in Carplay mode */
 "playlist.carplayTitle" = "Brave-spellista";
+
+/* Title for changing the folder of the current media playlist item */
+"playList.changeFoldersButtonTitle" = "Ändra spellista";
 
 /* The title of the button indicating that the user delete the offline data. (deletes the data that allows them to play offline) */
 "playlist.deleteForOfflineButtonTitle" = "Ta bort offline-cache";
@@ -1566,6 +1554,9 @@
 
 /* Okay Alert button title */
 "playList.okayButtonTitle" = "Okej";
+
+/* Title for opening the playlist */
+"playList.openInPlaylistButtonTitle" = "Öppna i spellista";
 
 /* The title for the alert that shows up when an item is expired */
 "playList.pictureInPictureErrorTitle" = "Tyvärr uppstod ett fel när bild i bild skulle visas.";
@@ -1614,6 +1605,9 @@
 
 /* Text for Playlist Offline Data Toggle while clearing the offline data storage in settings */
 "playlist.playlistOfflineDataToggleOption" = "Offline-data för spellista";
+
+/* Title of a button displayed when first adding some media to Playlist. Its shown next to the name of a folder that the item is recently added to to imply that you are changing the folder it was saved to */
+"playlist.playlistPopoverChangeFoldersButtonTitle" = "Ändra";
 
 /* The title for the alert that shows up when removing all videos and their offline mode storage. */
 "playList.playlistResetAlertTitle" = "Återställ";
@@ -1672,6 +1666,9 @@
 /* Title for removing offline mode storage */
 "playList.removeActionButtonTitle" = "Ta bort";
 
+/* A message shown when the user removes media from the playlist. '%@' will be replaced by the folder it was added to. Example: 'Removed from Play Later' */
+"playList.removedFromPlaylistMessage" = "Borttagen från %@";
+
 /* Message for the alert shown when the user tries to remove offline data of an item from playlist */
 "playlist.removePlaylistOfflineDataAlertMessage" = "Detta tar bort mediet från offlinelagringen. Är du säker på att du vill fortsätta?";
 
@@ -1688,7 +1685,7 @@
 "playList.reopenButtonTitle" = "Öppna igen";
 
 /* Text indicator on the table cell while saving a video for offline with percentage eg: %25 Saved for Offline */
-"playList.savedForOfflineLabelTitle" = "Sparad för offline";
+"playList.savedForOfflineLabelTitle" = "Tillagd till offline";
 
 /* The title of the button indicating that the user can save a video for offline playback. (playing without internet) */
 "playlist.saveForOfflineButtonTitle" = "Spara för offline";
@@ -1732,11 +1729,23 @@
 /* The title for the toast that shows up on a page when an item that has already been added, was updated. */
 "playList.toastExitingItemPlaylistTitle" = "Visa i Brave Playlist";
 
+/* A button title that when tapped will re-add the media item (undo the removal) that the user recently removed. */
+"playList.undoRemoveButtonTitle" = "Ångra";
+
 /* Footer for option to disable URL-Bar button */
 "playlist.urlBarButtonOptionFooter" = "Lägger till en spellistknapp (den ser ut som 4 linjer med en + symbol) bredvid adressfältet i Brave-webbläsaren. Med den här knappen får du snabb åtkomst till att öppna Playlist eller lägga till eller ta bort media.";
 
 /* Title for option to disable URL-Bar button */
 "playlist.urlBarButtonOptionTitle" = "Aktivera snabbåtkomstknapp";
+
+/* The title of the screen that allows you to change the folder where a playlist item was saved to */
+"playlistFolders.changeFoldersTitle" = "Flytta till";
+
+/* A label shown above the text field that allows the user to type a name of the playlist they are going to create */
+"playlistFolders.createFolderTextFieldLabel" = "Spellistans namn";
+
+/* A label shown above the text field that allows the user to type a name of the playlist they are going to create */
+"playlistFolders.createFolderTextFieldPlaceholder" = "Ange namnet på din spellista";
 
 /* The title of the button to create a new folder */
 "playlistFolders.createNewFolderButtonTitle" = "Skapa";
@@ -1747,11 +1756,17 @@
 /* The title of the screen where the user edits folder names */
 "playlistFolders.editFolderScreenTitle" = "Redigera mapp";
 
+/* The title of the menu option that allows the user to edit the name of a folder */
+"playlistFolders.editMenuTitle" = "Redigera spellista";
+
 /* The error shown to the user when we cannot save their changes made on a folder */
 "playlistFolders.errorSavingMessage" = "Tyvärr kunde vi inte spara ändringarna du har gjort i den här mappen";
 
 /* The title of the button where the user will move an item from one folder to another folder. */
 "playlistFolders.moveFolderButtonTitle" = "Flytta";
+
+/* The title of the section indicating the currently selected folder */
+"playlistFolders.moveFolderCurrentSectionTitle" = "Aktuell spellista";
 
 /* The title of the screen where the user will move an item from one folder to another folder. */
 "playlistFolders.moveFolderScreenTitle" = "Flytta";
@@ -1768,14 +1783,35 @@
 /* %@ and %lld Should NOT be localized. They are placeholders. Example: Brave Folder and 3 more items. Music and 2 more items. */
 "playlistFolders.moveMultipleItemDescription" = "%1$@ och %2$lld objekt till";
 
+/* The title of the button to create a new folder */
+"playlistFolders.newFolderButtonTitle" = "Ny spellista";
+
+/* The title of the screen to create a new folder */
+"playlistFolders.newFolderScreenTitle" = "Ny spellista";
+
 /* The sub-title of the section where the user can select videos to add to the new folder being created */
 "playlistFolders.newFolderSectionSubtitle" = "Tryck för att välja videor";
+
+/* The title of the section where the user can select videos to add to the new folder being created */
+"playlistFolders.newFolderSectionTitle" = "Lägg till videor i den här spellistan";
+
+/* The title of the default playlist folder */
+"playlistFolders.savedFolderTitle" = "Spela upp senare";
+
+/* The title of the section indicating that the user should select a folder to move `%zu` items to. %lld should not be translated. It will be replaced by a number so the sentence becomes: 'Select a folder to move 10 items to.' */
+"playlistFolders.selectAFolderTitle" = "Välj en spellista för att flytta %lld objekt till";
+
+/* The title of the section indicating that the user should select a folder to move 1 item to. */
+"playlistFolders.selectASingleFolderTitle" = "Välj en spellista för att flytta 1 objekt till";
 
 /* The sub-title of the folder. Example: This folder contains 10 Items. This folder contains 3 Items. */
 "playlistFolders.subtitleItemCount" = "%lld objekt";
 
 /* The sub-title of the folder. Example: This folder contains ONE item. This folder contains 1 Item. */
 "playlistFolders.subtitleItemSingleCount" = "1 objekt";
+
+/* The title of a folder when the user enters no name (untitled) */
+"playlistFolders.untitledFolderTitle" = "Namnlös spellista";
 
 /* Accessibility Title for the button that adds the playlist to the database. */
 "playlistFolderSharing.addButtonAccessibilityTitle" = "Knappen Lägg till i Brave-spellista";
@@ -2307,9 +2343,6 @@
 
 /* No comment provided by engineer. */
 "RewardsInternalsLegacyPromotion" = "Äldre marknadsföring";
-
-/* No comment provided by engineer. */
-"RewardsInternalsLegacyWalletInfoHeader" = "Legacy Wallet Info";
 
 /* %d will be the number of logs currently being shown, i.e. '10 logs shown' */
 "RewardsInternalsLogsCount" = "%d loggar visas";
@@ -2854,6 +2887,9 @@
 /* Part 2 Description for Alert used action Delete Sync Account. */
 "sync.syncDeleteAccountAlertDescriptionPart2" = "Denna borttagning är permanent och det finns inget sätt att återställa data. Om du bestämmer dig för att börja använda Sync igen måste du skapa ett nytt konto och lägga till varje enhet på nytt.";
 
+/* The title displayed in alert when a user needs to set passcode */
+"sync.syncSetPasscodeAlertTitle" = "Ställ in lösenkod";
+
 /* Title for Sync Settings Toggle Header */
 "sync.syncSettingsTitle" = "Synkronisera inställningar";
 
@@ -3049,7 +3085,8 @@
 /* Accessibility Label for the browser toolbar Menu button */
 "TabToolbarMenuButtonAccessibilityLabel" = "Meny";
 
-/* Accessibility Label for the tab toolbar Playlist button */
+/* Accessibility Label for the tab toolbar Add to Playlist button
+   Accessibility Label for the tab toolbar Playlist button */
 "TabToolbarPlaylistButtonAccessibilityLabel" = "Spellista";
 
 /* Accessibility label for the Reader View button */

--- a/Sources/BraveStrings/Resources/tr.lproj/BraveShared.strings
+++ b/Sources/BraveStrings/Resources/tr.lproj/BraveShared.strings
@@ -100,12 +100,6 @@
 /* cookie settings option */
 "Block3rdPartyCookies" = "Üçüncü taraf çerezlerini engelle";
 
-/* No comment provided by engineer. */
-"BlockAdsAndTracking" = "Siteler Arası İzleyicileri Engelle";
-
-/* No comment provided by engineer. */
-"BlockAdsAndTrackingDescription" = "Reklamların, açılır pencerelerin ve izleyicilerin yüklenmesini engeller.";
-
 /* Title for setting to block all website cookies. */
 "BlockAllCookies" = "Tüm Çerezleri Engelle";
 
@@ -138,9 +132,6 @@
 
 /* A title for setting which blocks 'switch to app' popups */
 "blockMobileAnnoyances" = "\"Uygulamaya Git\" Bildirimlerini engelle";
-
-/* Brave panel individual toggle title */
-"BlockPhishing" = "Kimlik Avını Engelle";
 
 /* Setting to enable popup blocking */
 "BlockPopups" = "Açılır Pencereleri Engelle";
@@ -318,15 +309,6 @@
 
 /* Title for toggle for enabling p3a (Privacy Preserving Analytics) Full Screen Callout */
 "callout.p3aCalloutToggleTitle" = "Tamamen Gizli ve Anonim Ürün İçgörülerini Paylaşın";
-
-/* Button title for Playlist Onboarding View */
-"callout.playlistOnboardingViewButtonTitle" = "Videoyu izleyin";
-
-/* Description for Playlist Onboarding View */
-"callout.playlistOnboardingViewDescription" = "...istediğiniz yerde, istediğiniz zaman oynatım. Arka planda, görüntü içinde görüntüde, hatta çevrimdışıyken bile. Ve tabii ki reklamsız.";
-
-/* Title for Playlist Onboarding View */
-"callout.playlistOnboardingViewTitle" = "Videoyu Oynatma Listesine ekle...";
 
 /* Subtitle - Description for Privacy Everywhere Full Screen Callout */
 "callout.privacyEverywhereCalloutDescription" = "Bilgisayarınızda veya tabletinizde Brave'in gizliliğinin keyfini çıkarın, cihazlarınız arasında yer işaretlerinizi ve eklentilerinizi senkronize edin.";
@@ -896,10 +878,10 @@
 "genericErrorTitle" = "Hata";
 
 /* No comment provided by engineer. */
-"GoogleSafeBrowsing" = "Tehlikeli Siteleri Engelleyin";
+"GoogleSafeBrowsing" = "Tehlikeli Web Siteleri Engelle";
 
 /* No comment provided by engineer. */
-"GoogleSafeBrowsingUsingWebKitDescription" = "Güvenliğiniz risk altındayken, Google güvenli tarama hizmetine ziyaret ettiğiniz bazı sayfaların karartılmış URL'lerini gönderir.";
+"GoogleSafeBrowsingUsingWebKitDescription" = "Güvenli Gezinme, tehlikeli oldukları bilinen web sitelerine karşı koruma sağlar. [Daha Fazla Bilgi](%@)";
 
 /* Grand camera access */
 "GrantCameraAccess" = "Kamerayı Etkinleştir";
@@ -986,7 +968,7 @@
 "login.loginInfoDetailsWebsiteFieldTitle" = "Web sitesi";
 
 /* The message displayed in alert when a user needs to set a passcode */
-"login.loginInfoSetPasscodeAlertDescription" = "Şifreleri görmek için, öncelikle cihazınızda bir parola belirlemeniz gerekiyor.";
+"login.loginInfoSetPasscodeAlertDescription" = "Senkronizasyon zinciri ayarlamak veya ayarları görmek için, öncelikle cihazınızda bir parola belirlemeniz gerekiyor.";
 
 /* The title displayed in alert when a user needs to set passcode */
 "login.loginInfoSetPasscodeAlertTitle" = "Bir Parola Belirleyin";
@@ -1504,6 +1486,9 @@
 /* Label that says who took a photograph that will be displayed to the user. '%@' is a placeholder and will include be a specific person's name, example 'Bill Gates'. */
 "PhotoBy" = "Fotoğraf : %@";
 
+/* A message shown when the user adds media to the playlist. '%@' will be replaced by the folder it was added to. Example: 'Added to Play Later' */
+"playList.addedToPlaylistMessage" = "%@ Klasörüne Eklendi";
+
 /* Alert Description for adding videos to playlist */
 "playList.addToPlayListAlertDescription" = "Bu videoyu oynatma listenize eklemek ister misiniz?";
 
@@ -1530,6 +1515,9 @@
 
 /* The title of the playlist when in Carplay mode */
 "playlist.carplayTitle" = "Brave Oynatma Listesi";
+
+/* Title for changing the folder of the current media playlist item */
+"playList.changeFoldersButtonTitle" = "Oynatma Listesini Değiştir";
 
 /* The title of the button indicating that the user delete the offline data. (deletes the data that allows them to play offline) */
 "playlist.deleteForOfflineButtonTitle" = "Çevrimdışı Önbelleği Sil";
@@ -1566,6 +1554,9 @@
 
 /* Okay Alert button title */
 "playList.okayButtonTitle" = "Tamam";
+
+/* Title for opening the playlist */
+"playList.openInPlaylistButtonTitle" = "Oynatma Listesinde Aç";
 
 /* The title for the alert that shows up when an item is expired */
 "playList.pictureInPictureErrorTitle" = "Üzgünüz, resimde resim görüntülenmeye çalışılırken bir hata oluştu.";
@@ -1614,6 +1605,9 @@
 
 /* Text for Playlist Offline Data Toggle while clearing the offline data storage in settings */
 "playlist.playlistOfflineDataToggleOption" = "Oynatma Listesi Çevrimdışı Verileri";
+
+/* Title of a button displayed when first adding some media to Playlist. Its shown next to the name of a folder that the item is recently added to to imply that you are changing the folder it was saved to */
+"playlist.playlistPopoverChangeFoldersButtonTitle" = "Değiştir";
 
 /* The title for the alert that shows up when removing all videos and their offline mode storage. */
 "playList.playlistResetAlertTitle" = "Sıfırla";
@@ -1672,6 +1666,9 @@
 /* Title for removing offline mode storage */
 "playList.removeActionButtonTitle" = "Kaldır";
 
+/* A message shown when the user removes media from the playlist. '%@' will be replaced by the folder it was added to. Example: 'Removed from Play Later' */
+"playList.removedFromPlaylistMessage" = "%@ Klasöründen Kaldırıldı";
+
 /* Message for the alert shown when the user tries to remove offline data of an item from playlist */
 "playlist.removePlaylistOfflineDataAlertMessage" = "Bu, ortamı çevrimdışı depolama alanından siler. Devam etmek istediğinizden emin misiniz?";
 
@@ -1688,7 +1685,7 @@
 "playList.reopenButtonTitle" = "Yeniden aç";
 
 /* Text indicator on the table cell while saving a video for offline with percentage eg: %25 Saved for Offline */
-"playList.savedForOfflineLabelTitle" = "Çevrimdışı kullanım için kaydedildi";
+"playList.savedForOfflineLabelTitle" = "Çevrimdışı kullanıma eklendi";
 
 /* The title of the button indicating that the user can save a video for offline playback. (playing without internet) */
 "playlist.saveForOfflineButtonTitle" = "Çevrimdışı için Kaydet";
@@ -1732,11 +1729,23 @@
 /* The title for the toast that shows up on a page when an item that has already been added, was updated. */
 "playList.toastExitingItemPlaylistTitle" = "Brave Oynatma Listesinde Görüntüle";
 
+/* A button title that when tapped will re-add the media item (undo the removal) that the user recently removed. */
+"playList.undoRemoveButtonTitle" = "geri almak";
+
 /* Footer for option to disable URL-Bar button */
 "playlist.urlBarButtonOptionFooter" = "Brave tarayıcıda adres çubuğunun yanına bir oynatma listesi düğmesi ekler (+ sembolüyle 4 çizgi olarak görünür). Bu düğme, Oynatma Listesini açmak, medya eklemek ya da kaldırmak için hızlı erişim sağlar.";
 
 /* Title for option to disable URL-Bar button */
 "playlist.urlBarButtonOptionTitle" = "Hızlı erişim düğmesini etkinleştir";
+
+/* The title of the screen that allows you to change the folder where a playlist item was saved to */
+"playlistFolders.changeFoldersTitle" = "Taşı";
+
+/* A label shown above the text field that allows the user to type a name of the playlist they are going to create */
+"playlistFolders.createFolderTextFieldLabel" = "Oynatma Listesi Adı";
+
+/* A label shown above the text field that allows the user to type a name of the playlist they are going to create */
+"playlistFolders.createFolderTextFieldPlaceholder" = "Oynatma listenizin adını girin";
 
 /* The title of the button to create a new folder */
 "playlistFolders.createNewFolderButtonTitle" = "Yarat";
@@ -1747,11 +1756,17 @@
 /* The title of the screen where the user edits folder names */
 "playlistFolders.editFolderScreenTitle" = "Klasörü Düzenle";
 
+/* The title of the menu option that allows the user to edit the name of a folder */
+"playlistFolders.editMenuTitle" = "Oynatma Listesini Düzenle";
+
 /* The error shown to the user when we cannot save their changes made on a folder */
 "playlistFolders.errorSavingMessage" = "Maalesef bu klasörde yaptığınız değişiklikleri kaydedemedik";
 
 /* The title of the button where the user will move an item from one folder to another folder. */
 "playlistFolders.moveFolderButtonTitle" = "Taşı";
+
+/* The title of the section indicating the currently selected folder */
+"playlistFolders.moveFolderCurrentSectionTitle" = "Mevcut Oynatma Listesi";
 
 /* The title of the screen where the user will move an item from one folder to another folder. */
 "playlistFolders.moveFolderScreenTitle" = "Taşı";
@@ -1768,14 +1783,35 @@
 /* %@ and %lld Should NOT be localized. They are placeholders. Example: Brave Folder and 3 more items. Music and 2 more items. */
 "playlistFolders.moveMultipleItemDescription" = "%1$@ ve %2$lld öğe daha";
 
+/* The title of the button to create a new folder */
+"playlistFolders.newFolderButtonTitle" = "Yeni Oynatma Listesi";
+
+/* The title of the screen to create a new folder */
+"playlistFolders.newFolderScreenTitle" = "Yeni Oynatma Listesi";
+
 /* The sub-title of the section where the user can select videos to add to the new folder being created */
 "playlistFolders.newFolderSectionSubtitle" = "Videoları seçmek için dokunun";
+
+/* The title of the section where the user can select videos to add to the new folder being created */
+"playlistFolders.newFolderSectionTitle" = "Bu oynatma listesine videolar ekleyin";
+
+/* The title of the default playlist folder */
+"playlistFolders.savedFolderTitle" = "Daha Sonra Oynat";
+
+/* The title of the section indicating that the user should select a folder to move `%zu` items to. %lld should not be translated. It will be replaced by a number so the sentence becomes: 'Select a folder to move 10 items to.' */
+"playlistFolders.selectAFolderTitle" = "%lld öğeyi taşımak için bir oynatma listesi seçin";
+
+/* The title of the section indicating that the user should select a folder to move 1 item to. */
+"playlistFolders.selectASingleFolderTitle" = "1 öğeyi taşımak için bir oynatma listesi seçin";
 
 /* The sub-title of the folder. Example: This folder contains 10 Items. This folder contains 3 Items. */
 "playlistFolders.subtitleItemCount" = "%lld öğe";
 
 /* The sub-title of the folder. Example: This folder contains ONE item. This folder contains 1 Item. */
 "playlistFolders.subtitleItemSingleCount" = "1 öğe";
+
+/* The title of a folder when the user enters no name (untitled) */
+"playlistFolders.untitledFolderTitle" = "Adsız Oynatma Listesi";
 
 /* Accessibility Title for the button that adds the playlist to the database. */
 "playlistFolderSharing.addButtonAccessibilityTitle" = "Brave Oynatma Listesi Düğmesine Ekle";
@@ -2307,9 +2343,6 @@
 
 /* No comment provided by engineer. */
 "RewardsInternalsLegacyPromotion" = "Eski Promosyon";
-
-/* No comment provided by engineer. */
-"RewardsInternalsLegacyWalletInfoHeader" = "Eski Cüzdan Bilgisi";
 
 /* %d will be the number of logs currently being shown, i.e. '10 logs shown' */
 "RewardsInternalsLogsCount" = "%d günlük gösterildi";
@@ -2854,6 +2887,9 @@
 /* Part 2 Description for Alert used action Delete Sync Account. */
 "sync.syncDeleteAccountAlertDescriptionPart2" = "Silme işlemi kalıcıdır ve verileri kurtarmanın hiçbir yolu yoktur. Senkronizasyonu tekrar kullanmaya karar verirseniz, yeni bir hesap oluşturmanız ve tüm cihazları tek tek yeniden eklemeniz gerekecektir.";
 
+/* The title displayed in alert when a user needs to set passcode */
+"sync.syncSetPasscodeAlertTitle" = "Bir Parola Belirleyin";
+
 /* Title for Sync Settings Toggle Header */
 "sync.syncSettingsTitle" = "Senkronizasyon Ayarları";
 
@@ -3049,7 +3085,8 @@
 /* Accessibility Label for the browser toolbar Menu button */
 "TabToolbarMenuButtonAccessibilityLabel" = "Menü";
 
-/* Accessibility Label for the tab toolbar Playlist button */
+/* Accessibility Label for the tab toolbar Add to Playlist button
+   Accessibility Label for the tab toolbar Playlist button */
 "TabToolbarPlaylistButtonAccessibilityLabel" = "Oynatma listesi";
 
 /* Accessibility label for the Reader View button */

--- a/Sources/BraveStrings/Resources/tr.lproj/BraveShared.strings
+++ b/Sources/BraveStrings/Resources/tr.lproj/BraveShared.strings
@@ -968,7 +968,7 @@
 "login.loginInfoDetailsWebsiteFieldTitle" = "Web sitesi";
 
 /* The message displayed in alert when a user needs to set a passcode */
-"login.loginInfoSetPasscodeAlertDescription" = "Senkronizasyon zinciri ayarlamak veya ayarları görmek için, öncelikle cihazınızda bir parola belirlemeniz gerekiyor.";
+"login.loginInfoSetPasscodeAlertDescription" = "Senkronizasyon zincirini ayarlamak veya ayarları görmek için, öncelikle cihazınızda bir parola belirlemeniz gerekiyor.";
 
 /* The title displayed in alert when a user needs to set passcode */
 "login.loginInfoSetPasscodeAlertTitle" = "Bir Parola Belirleyin";

--- a/Sources/BraveStrings/Resources/uk.lproj/BraveShared.strings
+++ b/Sources/BraveStrings/Resources/uk.lproj/BraveShared.strings
@@ -100,12 +100,6 @@
 /* cookie settings option */
 "Block3rdPartyCookies" = "Блокування додаткових файлів cookie";
 
-/* No comment provided by engineer. */
-"BlockAdsAndTracking" = "Заблокувати міжсайтові трекери";
-
-/* No comment provided by engineer. */
-"BlockAdsAndTrackingDescription" = "Блокує завантаження реклами, спливаючих вікон і трекерів.";
-
 /* Title for setting to block all website cookies. */
 "BlockAllCookies" = "Блокувати всі файли cookie";
 
@@ -138,9 +132,6 @@
 
 /* A title for setting which blocks 'switch to app' popups */
 "blockMobileAnnoyances" = "Блокувати сповіщення «Перемкнути програму»";
-
-/* Brave panel individual toggle title */
-"BlockPhishing" = "Блокування фішингу";
 
 /* Setting to enable popup blocking */
 "BlockPopups" = "Блокування спливаючих вікон";
@@ -318,15 +309,6 @@
 
 /* Title for toggle for enabling p3a (Privacy Preserving Analytics) Full Screen Callout */
 "callout.p3aCalloutToggleTitle" = "Ділитися повністю конфіденційною й анонімною статистикою продукта.";
-
-/* Button title for Playlist Onboarding View */
-"callout.playlistOnboardingViewButtonTitle" = "Переглянути відео";
-
-/* Description for Playlist Onboarding View */
-"callout.playlistOnboardingViewDescription" = "…грайте будь-де й будь-коли. У фоновому режимі, у режимі «картинка в картинці» й навіть в автономному режимі. І, звичайно ж, без реклами.";
-
-/* Title for Playlist Onboarding View */
-"callout.playlistOnboardingViewTitle" = "Додавайте відео в список відтворення…";
 
 /* Subtitle - Description for Privacy Everywhere Full Screen Callout */
 "callout.privacyEverywhereCalloutDescription" = "Отримуйте конфіденційність Brave на своєму комп’ютері або планшеті й синхронізуйте закладки й розширення на різних пристроях.";
@@ -896,10 +878,10 @@
 "genericErrorTitle" = "Помилка";
 
 /* No comment provided by engineer. */
-"GoogleSafeBrowsing" = "Заблокувати небезпечні вебсайти";
+"GoogleSafeBrowsing" = "Блокуйте небезпечні вебсайти";
 
 /* No comment provided by engineer. */
-"GoogleSafeBrowsingUsingWebKitDescription" = "Надсилає приховані URL-адреси деяких сторінок, що ви відвідуєте, до сервісу Google Safe Browsing, коли ваша безпека під загрозою.";
+"GoogleSafeBrowsingUsingWebKitDescription" = "Safe Browsing захищає від вебсайтів, які можуть бути небезпечними. [Докладніше](%@)";
 
 /* Grand camera access */
 "GrantCameraAccess" = "Увімкнути камеру";
@@ -986,7 +968,7 @@
 "login.loginInfoDetailsWebsiteFieldTitle" = "Вебсайт";
 
 /* The message displayed in alert when a user needs to set a passcode */
-"login.loginInfoSetPasscodeAlertDescription" = "Щоб переглядати паролі, вам спершу слід установити код доступу на пристрої.";
+"login.loginInfoSetPasscodeAlertDescription" = "Щоб налаштувати ланцюжок синхронізації або переглядати налаштування, вам спершу слід установити код доступу на пристрої.";
 
 /* The title displayed in alert when a user needs to set passcode */
 "login.loginInfoSetPasscodeAlertTitle" = "Установити код доступу";
@@ -1504,6 +1486,9 @@
 /* Label that says who took a photograph that will be displayed to the user. '%@' is a placeholder and will include be a specific person's name, example 'Bill Gates'. */
 "PhotoBy" = "Фото від %@";
 
+/* A message shown when the user adds media to the playlist. '%@' will be replaced by the folder it was added to. Example: 'Added to Play Later' */
+"playList.addedToPlaylistMessage" = "Додано до %@";
+
 /* Alert Description for adding videos to playlist */
 "playList.addToPlayListAlertDescription" = "Хочете додати це відео до списку відтворення?";
 
@@ -1530,6 +1515,9 @@
 
 /* The title of the playlist when in Carplay mode */
 "playlist.carplayTitle" = "Список відтворення Brave";
+
+/* Title for changing the folder of the current media playlist item */
+"playList.changeFoldersButtonTitle" = "Змінити список відтворення";
 
 /* The title of the button indicating that the user delete the offline data. (deletes the data that allows them to play offline) */
 "playlist.deleteForOfflineButtonTitle" = "Видалити офлайн-кеш";
@@ -1566,6 +1554,9 @@
 
 /* Okay Alert button title */
 "playList.okayButtonTitle" = "Добре";
+
+/* Title for opening the playlist */
+"playList.openInPlaylistButtonTitle" = "Відкрити в списку відтворення";
 
 /* The title for the alert that shows up when an item is expired */
 "playList.pictureInPictureErrorTitle" = "На жаль, під час спроби відобразити картинку в картинці сталася помилка.";
@@ -1614,6 +1605,9 @@
 
 /* Text for Playlist Offline Data Toggle while clearing the offline data storage in settings */
 "playlist.playlistOfflineDataToggleOption" = "Дані списків відтворення офлайн";
+
+/* Title of a button displayed when first adding some media to Playlist. Its shown next to the name of a folder that the item is recently added to to imply that you are changing the folder it was saved to */
+"playlist.playlistPopoverChangeFoldersButtonTitle" = "Змінити";
 
 /* The title for the alert that shows up when removing all videos and their offline mode storage. */
 "playList.playlistResetAlertTitle" = "Скинути";
@@ -1672,6 +1666,9 @@
 /* Title for removing offline mode storage */
 "playList.removeActionButtonTitle" = "Видалити";
 
+/* A message shown when the user removes media from the playlist. '%@' will be replaced by the folder it was added to. Example: 'Removed from Play Later' */
+"playList.removedFromPlaylistMessage" = "Видалено з %@";
+
 /* Message for the alert shown when the user tries to remove offline data of an item from playlist */
 "playlist.removePlaylistOfflineDataAlertMessage" = "Це призведе до видалення медіафайлу з офлайн-сховища. Ви впевнені, що хочете продовжити?";
 
@@ -1688,7 +1685,7 @@
 "playList.reopenButtonTitle" = "Відкрити заново";
 
 /* Text indicator on the table cell while saving a video for offline with percentage eg: %25 Saved for Offline */
-"playList.savedForOfflineLabelTitle" = "збережено для доступу офлайн";
+"playList.savedForOfflineLabelTitle" = "Додано для доступу офлайн";
 
 /* The title of the button indicating that the user can save a video for offline playback. (playing without internet) */
 "playlist.saveForOfflineButtonTitle" = "Зберегти для доступу офлайн";
@@ -1732,11 +1729,23 @@
 /* The title for the toast that shows up on a page when an item that has already been added, was updated. */
 "playList.toastExitingItemPlaylistTitle" = "Подивитися у Brave Playlist";
 
+/* A button title that when tapped will re-add the media item (undo the removal) that the user recently removed. */
+"playList.undoRemoveButtonTitle" = "Скасувати";
+
 /* Footer for option to disable URL-Bar button */
 "playlist.urlBarButtonOptionFooter" = "Поруч із панеллю адреси в браузері Brave з’явиться кнопка списку відтворення. Кнопка має вигляд 4 ліній із символом +. За допомогою неї ви зможете отримати швидкий доступ до списку відтворення, а також видалити/додати медіафайли.";
 
 /* Title for option to disable URL-Bar button */
 "playlist.urlBarButtonOptionTitle" = "Додати кнопку швидкого доступу";
+
+/* The title of the screen that allows you to change the folder where a playlist item was saved to */
+"playlistFolders.changeFoldersTitle" = "Перенести до";
+
+/* A label shown above the text field that allows the user to type a name of the playlist they are going to create */
+"playlistFolders.createFolderTextFieldLabel" = "Назва списку відтворення";
+
+/* A label shown above the text field that allows the user to type a name of the playlist they are going to create */
+"playlistFolders.createFolderTextFieldPlaceholder" = "Уведіть назву списку відтворення";
 
 /* The title of the button to create a new folder */
 "playlistFolders.createNewFolderButtonTitle" = "Створити";
@@ -1747,11 +1756,17 @@
 /* The title of the screen where the user edits folder names */
 "playlistFolders.editFolderScreenTitle" = "Редагування папки";
 
+/* The title of the menu option that allows the user to edit the name of a folder */
+"playlistFolders.editMenuTitle" = "Редагувати список відтворення";
+
 /* The error shown to the user when we cannot save their changes made on a folder */
 "playlistFolders.errorSavingMessage" = "На жаль, не вдалося зберегти зміни, зроблені в цій папці";
 
 /* The title of the button where the user will move an item from one folder to another folder. */
 "playlistFolders.moveFolderButtonTitle" = "Перемістити";
+
+/* The title of the section indicating the currently selected folder */
+"playlistFolders.moveFolderCurrentSectionTitle" = "Поточний список відтворення";
 
 /* The title of the screen where the user will move an item from one folder to another folder. */
 "playlistFolders.moveFolderScreenTitle" = "Перемістити";
@@ -1768,14 +1783,35 @@
 /* %@ and %lld Should NOT be localized. They are placeholders. Example: Brave Folder and 3 more items. Music and 2 more items. */
 "playlistFolders.moveMultipleItemDescription" = "%1$@ та ще кілька об’єктів (%2$lld)";
 
+/* The title of the button to create a new folder */
+"playlistFolders.newFolderButtonTitle" = "Новий список відтворення";
+
+/* The title of the screen to create a new folder */
+"playlistFolders.newFolderScreenTitle" = "Новий список відтворення";
+
 /* The sub-title of the section where the user can select videos to add to the new folder being created */
 "playlistFolders.newFolderSectionSubtitle" = "Торкніться, щоб вибрати відео";
+
+/* The title of the section where the user can select videos to add to the new folder being created */
+"playlistFolders.newFolderSectionTitle" = "Додати відео до цього списку відторення";
+
+/* The title of the default playlist folder */
+"playlistFolders.savedFolderTitle" = "Відтворити пізніше";
+
+/* The title of the section indicating that the user should select a folder to move `%zu` items to. %lld should not be translated. It will be replaced by a number so the sentence becomes: 'Select a folder to move 10 items to.' */
+"playlistFolders.selectAFolderTitle" = "Виберіть список відтворення, щоб перемістити ці об’єкти (%lld)";
+
+/* The title of the section indicating that the user should select a folder to move 1 item to. */
+"playlistFolders.selectASingleFolderTitle" = "Виберіть список відтворення, щоб перемістити 1 об’єкт";
 
 /* The sub-title of the folder. Example: This folder contains 10 Items. This folder contains 3 Items. */
 "playlistFolders.subtitleItemCount" = "Об’єкти: %lld";
 
 /* The sub-title of the folder. Example: This folder contains ONE item. This folder contains 1 Item. */
 "playlistFolders.subtitleItemSingleCount" = "1 об’єкт";
+
+/* The title of a folder when the user enters no name (untitled) */
+"playlistFolders.untitledFolderTitle" = "Список відтворення без назви";
 
 /* Accessibility Title for the button that adds the playlist to the database. */
 "playlistFolderSharing.addButtonAccessibilityTitle" = "Кнопка «Додати до списку відтворення Brave»";
@@ -2307,9 +2343,6 @@
 
 /* No comment provided by engineer. */
 "RewardsInternalsLegacyPromotion" = "Застаріла промоакція";
-
-/* No comment provided by engineer. */
-"RewardsInternalsLegacyWalletInfoHeader" = "Інформація про застарілий гаманець";
 
 /* %d will be the number of logs currently being shown, i.e. '10 logs shown' */
 "RewardsInternalsLogsCount" = "Показано журналів: %d";
@@ -2854,6 +2887,9 @@
 /* Part 2 Description for Alert used action Delete Sync Account. */
 "sync.syncDeleteAccountAlertDescriptionPart2" = "Дані буде видалено остаточно. Їх неможливо буде відновити. Якщо ви вирішите знову користуватися синхронізацією, вам потрібно буде створити новий обліковий запис і ще раз додати свої пристрої.";
 
+/* The title displayed in alert when a user needs to set passcode */
+"sync.syncSetPasscodeAlertTitle" = "Установити код доступу";
+
 /* Title for Sync Settings Toggle Header */
 "sync.syncSettingsTitle" = "Налаштування синхронізації";
 
@@ -3049,7 +3085,8 @@
 /* Accessibility Label for the browser toolbar Menu button */
 "TabToolbarMenuButtonAccessibilityLabel" = "Меню";
 
-/* Accessibility Label for the tab toolbar Playlist button */
+/* Accessibility Label for the tab toolbar Add to Playlist button
+   Accessibility Label for the tab toolbar Playlist button */
 "TabToolbarPlaylistButtonAccessibilityLabel" = "Список відтворення";
 
 /* Accessibility label for the Reader View button */

--- a/Sources/BraveStrings/Resources/zh-TW.lproj/BraveShared.strings
+++ b/Sources/BraveStrings/Resources/zh-TW.lproj/BraveShared.strings
@@ -100,12 +100,6 @@
 /* cookie settings option */
 "Block3rdPartyCookies" = "拦截第三方 cookies";
 
-/* No comment provided by engineer. */
-"BlockAdsAndTracking" = "封鎖跨網站追蹤器";
-
-/* No comment provided by engineer. */
-"BlockAdsAndTrackingDescription" = "禁止載入廣告、彈出式視窗和追蹤器。";
-
 /* Title for setting to block all website cookies. */
 "BlockAllCookies" = "封鎖所有 Cookie";
 
@@ -138,9 +132,6 @@
 
 /* A title for setting which blocks 'switch to app' popups */
 "blockMobileAnnoyances" = "封鎖「切換至應用程式」通知";
-
-/* Brave panel individual toggle title */
-"BlockPhishing" = "封鎖網路釣魚";
 
 /* Setting to enable popup blocking */
 "BlockPopups" = "封鎖彈出式視窗";
@@ -318,15 +309,6 @@
 
 /* Title for toggle for enabling p3a (Privacy Preserving Analytics) Full Screen Callout */
 "callout.p3aCalloutToggleTitle" = "分享完全不公開的匿名產品深入分析。";
-
-/* Button title for Playlist Onboarding View */
-"callout.playlistOnboardingViewButtonTitle" = "觀看影片";
-
-/* Description for Playlist Onboarding View */
-"callout.playlistOnboardingViewDescription" = "…隨時隨地播放。在背景播放、以子母畫面播放，甚至離線播放。當然，完全沒有廣告干擾。";
-
-/* Title for Playlist Onboarding View */
-"callout.playlistOnboardingViewTitle" = "將影片新增至播放清單…";
 
 /* Subtitle - Description for Privacy Everywhere Full Screen Callout */
 "callout.privacyEverywhereCalloutDescription" = "在您的電腦或平板電腦上享有 Brave 隱私保護，並且讓各裝置上的書籤和擴充功能保持同步。";
@@ -899,7 +881,7 @@
 "GoogleSafeBrowsing" = "封鎖不安全的網站";
 
 /* No comment provided by engineer. */
-"GoogleSafeBrowsingUsingWebKitDescription" = "當您有安全風險時，將您所造訪部分網頁的網址經模糊處理後傳送給 Google 安全瀏覽服務。";
+"GoogleSafeBrowsingUsingWebKitDescription" = "安全瀏覽可防止造訪已知不安全的網站。[深入瞭解](%@)";
 
 /* Grand camera access */
 "GrantCameraAccess" = "啟用相機";
@@ -986,7 +968,7 @@
 "login.loginInfoDetailsWebsiteFieldTitle" = "網站";
 
 /* The message displayed in alert when a user needs to set a passcode */
-"login.loginInfoSetPasscodeAlertDescription" = "若要查看密碼，您必須先在裝置上設定密碼。";
+"login.loginInfoSetPasscodeAlertDescription" = "若要設定同步鏈或查看密碼，您必須先在裝置上設定密碼。";
 
 /* The title displayed in alert when a user needs to set passcode */
 "login.loginInfoSetPasscodeAlertTitle" = "設定密碼";
@@ -1504,6 +1486,9 @@
 /* Label that says who took a photograph that will be displayed to the user. '%@' is a placeholder and will include be a specific person's name, example 'Bill Gates'. */
 "PhotoBy" = "圖片由 %@ 提供";
 
+/* A message shown when the user adds media to the playlist. '%@' will be replaced by the folder it was added to. Example: 'Added to Play Later' */
+"playList.addedToPlaylistMessage" = "已新增至「%@」";
+
 /* Alert Description for adding videos to playlist */
 "playList.addToPlayListAlertDescription" = "你想新增此影片至播放清單嗎？";
 
@@ -1530,6 +1515,9 @@
 
 /* The title of the playlist when in Carplay mode */
 "playlist.carplayTitle" = "Brave 播放清單";
+
+/* Title for changing the folder of the current media playlist item */
+"playList.changeFoldersButtonTitle" = "變更播放清單";
 
 /* The title of the button indicating that the user delete the offline data. (deletes the data that allows them to play offline) */
 "playlist.deleteForOfflineButtonTitle" = "刪除離線快取";
@@ -1566,6 +1554,9 @@
 
 /* Okay Alert button title */
 "playList.okayButtonTitle" = "確定";
+
+/* Title for opening the playlist */
+"playList.openInPlaylistButtonTitle" = "在播放清單中開啟";
 
 /* The title for the alert that shows up when an item is expired */
 "playList.pictureInPictureErrorTitle" = "抱歉，嘗試顯示子母畫面時發生錯誤。";
@@ -1614,6 +1605,9 @@
 
 /* Text for Playlist Offline Data Toggle while clearing the offline data storage in settings */
 "playlist.playlistOfflineDataToggleOption" = "播放清單離線數據";
+
+/* Title of a button displayed when first adding some media to Playlist. Its shown next to the name of a folder that the item is recently added to to imply that you are changing the folder it was saved to */
+"playlist.playlistPopoverChangeFoldersButtonTitle" = "變更";
 
 /* The title for the alert that shows up when removing all videos and their offline mode storage. */
 "playList.playlistResetAlertTitle" = "重設";
@@ -1672,6 +1666,9 @@
 /* Title for removing offline mode storage */
 "playList.removeActionButtonTitle" = "移除";
 
+/* A message shown when the user removes media from the playlist. '%@' will be replaced by the folder it was added to. Example: 'Removed from Play Later' */
+"playList.removedFromPlaylistMessage" = "已從「%@」中移除";
+
 /* Message for the alert shown when the user tries to remove offline data of an item from playlist */
 "playlist.removePlaylistOfflineDataAlertMessage" = "這將刪除離線儲存的媒體。你確定要繼續嗎？";
 
@@ -1688,7 +1685,7 @@
 "playList.reopenButtonTitle" = "重新開啟";
 
 /* Text indicator on the table cell while saving a video for offline with percentage eg: %25 Saved for Offline */
-"playList.savedForOfflineLabelTitle" = "已離線儲存";
+"playList.savedForOfflineLabelTitle" = "已新增至「離線」";
 
 /* The title of the button indicating that the user can save a video for offline playback. (playing without internet) */
 "playlist.saveForOfflineButtonTitle" = "儲存以供離線播放";
@@ -1732,11 +1729,23 @@
 /* The title for the toast that shows up on a page when an item that has already been added, was updated. */
 "playList.toastExitingItemPlaylistTitle" = "檢視 Brave Playlist";
 
+/* A button title that when tapped will re-add the media item (undo the removal) that the user recently removed. */
+"playList.undoRemoveButtonTitle" = "復原";
+
 /* Footer for option to disable URL-Bar button */
 "playlist.urlBarButtonOptionFooter" = "在 Brave 瀏覽器的網址列旁邊新增一個播放清單按鈕 (看起來像 4 行附 + 符號)。此按鈕可讓您快速存取，以開啟播放清單，或者新增或移除媒體。";
 
 /* Title for option to disable URL-Bar button */
 "playlist.urlBarButtonOptionTitle" = "啟用快速存取按鈕";
+
+/* The title of the screen that allows you to change the folder where a playlist item was saved to */
+"playlistFolders.changeFoldersTitle" = "移至";
+
+/* A label shown above the text field that allows the user to type a name of the playlist they are going to create */
+"playlistFolders.createFolderTextFieldLabel" = "播放清單名稱";
+
+/* A label shown above the text field that allows the user to type a name of the playlist they are going to create */
+"playlistFolders.createFolderTextFieldPlaceholder" = "輸入您的播放清單名稱";
 
 /* The title of the button to create a new folder */
 "playlistFolders.createNewFolderButtonTitle" = "建立";
@@ -1747,11 +1756,17 @@
 /* The title of the screen where the user edits folder names */
 "playlistFolders.editFolderScreenTitle" = "編輯資料夾";
 
+/* The title of the menu option that allows the user to edit the name of a folder */
+"playlistFolders.editMenuTitle" = "編輯播放清單";
+
 /* The error shown to the user when we cannot save their changes made on a folder */
 "playlistFolders.errorSavingMessage" = "抱歉，無法儲存您對此資料夾所做的變更";
 
 /* The title of the button where the user will move an item from one folder to another folder. */
 "playlistFolders.moveFolderButtonTitle" = "移動";
+
+/* The title of the section indicating the currently selected folder */
+"playlistFolders.moveFolderCurrentSectionTitle" = "目前的播放清單";
 
 /* The title of the screen where the user will move an item from one folder to another folder. */
 "playlistFolders.moveFolderScreenTitle" = "移動";
@@ -1768,14 +1783,35 @@
 /* %@ and %lld Should NOT be localized. They are placeholders. Example: Brave Folder and 3 more items. Music and 2 more items. */
 "playlistFolders.moveMultipleItemDescription" = "%1$@ 和另外 %2$lld 個項目";
 
+/* The title of the button to create a new folder */
+"playlistFolders.newFolderButtonTitle" = "新增播放清單";
+
+/* The title of the screen to create a new folder */
+"playlistFolders.newFolderScreenTitle" = "新增播放清單";
+
 /* The sub-title of the section where the user can select videos to add to the new folder being created */
 "playlistFolders.newFolderSectionSubtitle" = "輕觸以選取影片";
+
+/* The title of the section where the user can select videos to add to the new folder being created */
+"playlistFolders.newFolderSectionTitle" = "將影片新增至此播放清單";
+
+/* The title of the default playlist folder */
+"playlistFolders.savedFolderTitle" = "稍後播放";
+
+/* The title of the section indicating that the user should select a folder to move `%zu` items to. %lld should not be translated. It will be replaced by a number so the sentence becomes: 'Select a folder to move 10 items to.' */
+"playlistFolders.selectAFolderTitle" = "選取要將 %lld 個項目移至其中的播放清單";
+
+/* The title of the section indicating that the user should select a folder to move 1 item to. */
+"playlistFolders.selectASingleFolderTitle" = "選取要將 1 個項目移至其中的播放清單";
 
 /* The sub-title of the folder. Example: This folder contains 10 Items. This folder contains 3 Items. */
 "playlistFolders.subtitleItemCount" = "%lld 個項目";
 
 /* The sub-title of the folder. Example: This folder contains ONE item. This folder contains 1 Item. */
 "playlistFolders.subtitleItemSingleCount" = "1 個項目";
+
+/* The title of a folder when the user enters no name (untitled) */
+"playlistFolders.untitledFolderTitle" = "未命名的播放清單";
 
 /* Accessibility Title for the button that adds the playlist to the database. */
 "playlistFolderSharing.addButtonAccessibilityTitle" = "新增至 Brave 播放清單按鈕";
@@ -2307,9 +2343,6 @@
 
 /* No comment provided by engineer. */
 "RewardsInternalsLegacyPromotion" = "舊行銷活動";
-
-/* No comment provided by engineer. */
-"RewardsInternalsLegacyWalletInfoHeader" = "舊版錢包資訊";
 
 /* %d will be the number of logs currently being shown, i.e. '10 logs shown' */
 "RewardsInternalsLogsCount" = "顯示 %d 筆記錄";
@@ -2854,6 +2887,9 @@
 /* Part 2 Description for Alert used action Delete Sync Account. */
 "sync.syncDeleteAccountAlertDescriptionPart2" = "一旦刪除即永久刪除，資料將無法復原。如果您決定再次使用 Sync，您將需要建立新帳戶，並逐一重新新增每部裝置。";
 
+/* The title displayed in alert when a user needs to set passcode */
+"sync.syncSetPasscodeAlertTitle" = "設定密碼";
+
 /* Title for Sync Settings Toggle Header */
 "sync.syncSettingsTitle" = "同步設定";
 
@@ -3049,7 +3085,8 @@
 /* Accessibility Label for the browser toolbar Menu button */
 "TabToolbarMenuButtonAccessibilityLabel" = "選單";
 
-/* Accessibility Label for the tab toolbar Playlist button */
+/* Accessibility Label for the tab toolbar Add to Playlist button
+   Accessibility Label for the tab toolbar Playlist button */
 "TabToolbarPlaylistButtonAccessibilityLabel" = "播放清單";
 
 /* Accessibility label for the Reader View button */

--- a/Sources/BraveStrings/Resources/zh.lproj/BraveShared.strings
+++ b/Sources/BraveStrings/Resources/zh.lproj/BraveShared.strings
@@ -100,12 +100,6 @@
 /* cookie settings option */
 "Block3rdPartyCookies" = "拦截第三方 cookies";
 
-/* No comment provided by engineer. */
-"BlockAdsAndTracking" = "阻止跨站点跟踪器";
-
-/* No comment provided by engineer. */
-"BlockAdsAndTrackingDescription" = "防止加载广告、弹出窗口和跟踪器。";
-
 /* Title for setting to block all website cookies. */
 "BlockAllCookies" = "拦截所有 Cookie";
 
@@ -138,9 +132,6 @@
 
 /* A title for setting which blocks 'switch to app' popups */
 "blockMobileAnnoyances" = "屏蔽“切换到应用程序”通知";
-
-/* Brave panel individual toggle title */
-"BlockPhishing" = "拦截钓鱼网站";
 
 /* Setting to enable popup blocking */
 "BlockPopups" = "拦截弹出窗口";
@@ -318,15 +309,6 @@
 
 /* Title for toggle for enabling p3a (Privacy Preserving Analytics) Full Screen Callout */
 "callout.p3aCalloutToggleTitle" = "分享完全私密和匿名的产品见解。";
-
-/* Button title for Playlist Onboarding View */
-"callout.playlistOnboardingViewButtonTitle" = "观看视频";
-
-/* Description for Playlist Onboarding View */
-"callout.playlistOnboardingViewDescription" = "...随时随地播放。后台播放、画中画甚至离线播放。当然，完全无广告。";
-
-/* Title for Playlist Onboarding View */
-"callout.playlistOnboardingViewTitle" = "将视频添加至播放列表...";
 
 /* Subtitle - Description for Privacy Everywhere Full Screen Callout */
 "callout.privacyEverywhereCalloutDescription" = "在您的计算机或平板电脑上体验 Brave 隐私保护，在设备间同步书签和扩展部件。";
@@ -899,7 +881,7 @@
 "GoogleSafeBrowsing" = "屏蔽危险网站";
 
 /* No comment provided by engineer. */
-"GoogleSafeBrowsingUsingWebKitDescription" = "当您的安全受到威胁时，系统会将您访问过的某些页面的容易混淆的 URL 发送到 Google 安全浏览服务。";
+"GoogleSafeBrowsingUsingWebKitDescription" = "安全浏览可以防范已知危险的网站。[了解更多](%@)";
 
 /* Grand camera access */
 "GrantCameraAccess" = "启用摄像头";
@@ -986,7 +968,7 @@
 "login.loginInfoDetailsWebsiteFieldTitle" = "网站";
 
 /* The message displayed in alert when a user needs to set a passcode */
-"login.loginInfoSetPasscodeAlertDescription" = "如需查看密码，您必须首先在设备上设置一个密码。";
+"login.loginInfoSetPasscodeAlertDescription" = "如需设置同步链或查看设置，您必须先在您的设备上设置一个密码。";
 
 /* The title displayed in alert when a user needs to set passcode */
 "login.loginInfoSetPasscodeAlertTitle" = "设置密码";
@@ -1504,6 +1486,9 @@
 /* Label that says who took a photograph that will be displayed to the user. '%@' is a placeholder and will include be a specific person's name, example 'Bill Gates'. */
 "PhotoBy" = "摄影者：%@";
 
+/* A message shown when the user adds media to the playlist. '%@' will be replaced by the folder it was added to. Example: 'Added to Play Later' */
+"playList.addedToPlaylistMessage" = "已新增至 %@";
+
 /* Alert Description for adding videos to playlist */
 "playList.addToPlayListAlertDescription" = "是否要将此视频添加至播放列表？";
 
@@ -1530,6 +1515,9 @@
 
 /* The title of the playlist when in Carplay mode */
 "playlist.carplayTitle" = "Brave 播放列表";
+
+/* Title for changing the folder of the current media playlist item */
+"playList.changeFoldersButtonTitle" = "变更播放列表";
 
 /* The title of the button indicating that the user delete the offline data. (deletes the data that allows them to play offline) */
 "playlist.deleteForOfflineButtonTitle" = "删除离线缓存";
@@ -1566,6 +1554,9 @@
 
 /* Okay Alert button title */
 "playList.okayButtonTitle" = "确认";
+
+/* Title for opening the playlist */
+"playList.openInPlaylistButtonTitle" = "在播放列表中开启";
 
 /* The title for the alert that shows up when an item is expired */
 "playList.pictureInPictureErrorTitle" = "抱歉，尝试显示画中画时出错。";
@@ -1614,6 +1605,9 @@
 
 /* Text for Playlist Offline Data Toggle while clearing the offline data storage in settings */
 "playlist.playlistOfflineDataToggleOption" = "播放列表离线数据";
+
+/* Title of a button displayed when first adding some media to Playlist. Its shown next to the name of a folder that the item is recently added to to imply that you are changing the folder it was saved to */
+"playlist.playlistPopoverChangeFoldersButtonTitle" = "變更";
 
 /* The title for the alert that shows up when removing all videos and their offline mode storage. */
 "playList.playlistResetAlertTitle" = "重置";
@@ -1672,6 +1666,9 @@
 /* Title for removing offline mode storage */
 "playList.removeActionButtonTitle" = "移除";
 
+/* A message shown when the user removes media from the playlist. '%@' will be replaced by the folder it was added to. Example: 'Removed from Play Later' */
+"playList.removedFromPlaylistMessage" = "已从 %@ 移除";
+
 /* Message for the alert shown when the user tries to remove offline data of an item from playlist */
 "playlist.removePlaylistOfflineDataAlertMessage" = "这会将所有媒体文件从离线存储中删除。您确定要继续吗？";
 
@@ -1688,7 +1685,7 @@
 "playList.reopenButtonTitle" = "重新打开";
 
 /* Text indicator on the table cell while saving a video for offline with percentage eg: %25 Saved for Offline */
-"playList.savedForOfflineLabelTitle" = "已离线保存";
+"playList.savedForOfflineLabelTitle" = "已新增至离线";
 
 /* The title of the button indicating that the user can save a video for offline playback. (playing without internet) */
 "playlist.saveForOfflineButtonTitle" = "保存以供离线播放";
@@ -1732,11 +1729,23 @@
 /* The title for the toast that shows up on a page when an item that has already been added, was updated. */
 "playList.toastExitingItemPlaylistTitle" = "在 Brave Playlist 中查看";
 
+/* A button title that when tapped will re-add the media item (undo the removal) that the user recently removed. */
+"playList.undoRemoveButtonTitle" = "取消";
+
 /* Footer for option to disable URL-Bar button */
 "playlist.urlBarButtonOptionFooter" = "在 Brave 浏览器的地址栏旁边添加一个播放列表按钮（它看起来就象是 4 行带有一个 + 符号）。此按钮可让您能够快速访问、打开播放列表，或者添加或删除媒体。";
 
 /* Title for option to disable URL-Bar button */
 "playlist.urlBarButtonOptionTitle" = "启用快速访问按钮";
+
+/* The title of the screen that allows you to change the folder where a playlist item was saved to */
+"playlistFolders.changeFoldersTitle" = "移至";
+
+/* A label shown above the text field that allows the user to type a name of the playlist they are going to create */
+"playlistFolders.createFolderTextFieldLabel" = "播放列表名称";
+
+/* A label shown above the text field that allows the user to type a name of the playlist they are going to create */
+"playlistFolders.createFolderTextFieldPlaceholder" = "输入您的播放列表名称";
 
 /* The title of the button to create a new folder */
 "playlistFolders.createNewFolderButtonTitle" = "创建";
@@ -1747,11 +1756,17 @@
 /* The title of the screen where the user edits folder names */
 "playlistFolders.editFolderScreenTitle" = "编辑文件夹";
 
+/* The title of the menu option that allows the user to edit the name of a folder */
+"playlistFolders.editMenuTitle" = "编辑播放列表";
+
 /* The error shown to the user when we cannot save their changes made on a folder */
 "playlistFolders.errorSavingMessage" = "抱歉，无法保存您对此文件夹所做的更改";
 
 /* The title of the button where the user will move an item from one folder to another folder. */
 "playlistFolders.moveFolderButtonTitle" = "移动";
+
+/* The title of the section indicating the currently selected folder */
+"playlistFolders.moveFolderCurrentSectionTitle" = "当前播放列表";
 
 /* The title of the screen where the user will move an item from one folder to another folder. */
 "playlistFolders.moveFolderScreenTitle" = "移动";
@@ -1768,14 +1783,35 @@
 /* %@ and %lld Should NOT be localized. They are placeholders. Example: Brave Folder and 3 more items. Music and 2 more items. */
 "playlistFolders.moveMultipleItemDescription" = "%1$@ 和另外 %2$lld 个项目";
 
+/* The title of the button to create a new folder */
+"playlistFolders.newFolderButtonTitle" = "新增播放列表";
+
+/* The title of the screen to create a new folder */
+"playlistFolders.newFolderScreenTitle" = "新增播放列表";
+
 /* The sub-title of the section where the user can select videos to add to the new folder being created */
 "playlistFolders.newFolderSectionSubtitle" = "轻击以选择视频";
+
+/* The title of the section where the user can select videos to add to the new folder being created */
+"playlistFolders.newFolderSectionTitle" = "添加视频到此播放列表";
+
+/* The title of the default playlist folder */
+"playlistFolders.savedFolderTitle" = "稍后播放";
+
+/* The title of the section indicating that the user should select a folder to move `%zu` items to. %lld should not be translated. It will be replaced by a number so the sentence becomes: 'Select a folder to move 10 items to.' */
+"playlistFolders.selectAFolderTitle" = "选择要将 %lld 项目移至其中的播放列表";
+
+/* The title of the section indicating that the user should select a folder to move 1 item to. */
+"playlistFolders.selectASingleFolderTitle" = "选择要将 1 个项目移至其中的播放列表";
 
 /* The sub-title of the folder. Example: This folder contains 10 Items. This folder contains 3 Items. */
 "playlistFolders.subtitleItemCount" = "%lld 个项目";
 
 /* The sub-title of the folder. Example: This folder contains ONE item. This folder contains 1 Item. */
 "playlistFolders.subtitleItemSingleCount" = "1 个项目";
+
+/* The title of a folder when the user enters no name (untitled) */
+"playlistFolders.untitledFolderTitle" = "未命名播放列表";
 
 /* Accessibility Title for the button that adds the playlist to the database. */
 "playlistFolderSharing.addButtonAccessibilityTitle" = "添加到 Brave 播放列表按钮";
@@ -2307,9 +2343,6 @@
 
 /* No comment provided by engineer. */
 "RewardsInternalsLegacyPromotion" = "旧的促销活动";
-
-/* No comment provided by engineer. */
-"RewardsInternalsLegacyWalletInfoHeader" = "旧版钱包信息";
 
 /* %d will be the number of logs currently being shown, i.e. '10 logs shown' */
 "RewardsInternalsLogsCount" = "显示了 %d 个日志";
@@ -2854,6 +2887,9 @@
 /* Part 2 Description for Alert used action Delete Sync Account. */
 "sync.syncDeleteAccountAlertDescriptionPart2" = "一旦删除即永久删除，资料将无法复原。如果您决定再次使用 Sync，您将需要建立新帐户，并逐一重新新增每台设备。";
 
+/* The title displayed in alert when a user needs to set passcode */
+"sync.syncSetPasscodeAlertTitle" = "设置密码";
+
 /* Title for Sync Settings Toggle Header */
 "sync.syncSettingsTitle" = "同步设置";
 
@@ -3049,7 +3085,8 @@
 /* Accessibility Label for the browser toolbar Menu button */
 "TabToolbarMenuButtonAccessibilityLabel" = "菜单";
 
-/* Accessibility Label for the tab toolbar Playlist button */
+/* Accessibility Label for the tab toolbar Add to Playlist button
+   Accessibility Label for the tab toolbar Playlist button */
 "TabToolbarPlaylistButtonAccessibilityLabel" = "播放列表";
 
 /* Accessibility label for the Reader View button */

--- a/Sources/BraveWallet/Resources/de.lproj/BraveWallet.strings
+++ b/Sources/BraveWallet/Resources/de.lproj/BraveWallet.strings
@@ -32,10 +32,10 @@
 "wallet.activateToken" = "Token %@ aktivieren";
 
 /* The description when showing no transactions inside Activity tab. */
-"wallet.activityPageEmptyDescription" = "Nach Ihrer ersten Transaktion können Sie sie hier einsehen.";
+"wallet.activityPageEmptyDescription" = "Sobald Sie eine Transaktion durchgeführt haben, können Sie sie hier einsehen.";
 
 /* The title when showing no transactions inside Activity tab. */
-"wallet.activityPageEmptyTitle" = "Noch keine Transaktionen";
+"wallet.activityPageEmptyTitle" = "Noch keine Transaktionen zum Anzeigen";
 
 /* The title of the tab that will display user's transaction activity for all accounts. */
 "wallet.activityPageTitle" = "Aktivität";
@@ -401,7 +401,7 @@
 "wallet.customTokenNetworkHeader" = "Netzwerk auswählen";
 
 /* The title displayed on the add custom token screen */
-"wallet.customTokenTitle" = "Benutzerdefiniert";
+"wallet.customTokenTitle" = "Benutzerdefiniertes Asset hinzufügen";
 
 /* The title of the notification which will prompt at the top of the browser when users are visiting web3 site that is not yet connected with Brave Wallet. The '%@' will be the site attempting to connect. For example: \"app.uniswap.org wants to interact with Brave Wallet\" */
 "wallet.dappsConnectionNotificationOriginTitle" = "%@ möchte mit der Brave-Wallet interagieren";
@@ -891,6 +891,24 @@
 
 /* The title an entry that will be displayed in NFT detail. This entry to display this NFT's token standard */
 "wallet.nftDetailTokenStandard" = "Token-Standard";
+
+/* The title of the alert that asks users either to enable NFT discovery or import manually. `SimpleHash` is the third-party service name, so it does not need to be translated. */
+"wallet.nftDiscoveryCalloutDescription" = "Die Brave-Wallet kann mithilfe eines Drittanbieters automatisch Ihre NFTs anzeigen. Um diesen Dienst zu erbringen, wird Brave Ihre Wallet-Adressen mit SimpleHash teilen. Erfahren Sie mehr.";
+
+/* This is the same `Learn more` at the end of `nftDiscoveryCalloutDescription`, but we need a separat translation to detect the range of it in order to build some attributed strings. */
+"wallet.nftDiscoveryCalloutDescriptionLearnMore" = "Mehr erfahren";
+
+/* The title of the button that user clicks to disable NFT discovery. */
+"wallet.nftDiscoveryCalloutDisable" = "Nein, danke, ich mache das manuell";
+
+/* The title of the button that user clicks to enable NFT discovery. */
+"wallet.nftDiscoveryCalloutEnable" = "Ja, fortfahren";
+
+/* The title of the alert that asks users either to enable NFT discovery or import manually. */
+"wallet.nftDiscoveryCalloutTitle" = "Sie möchten, dass Ihre NFTs automatisch angezeigt werden?";
+
+/* The title of the button that user clicks to add his/her first NFT */
+"wallet.nftEmptyImportNFT" = "NFT importieren";
 
 /* Description of the NFT Gateway setting */
 "wallet.nftGatewayLongDescription" = "Ein gültiges IPFS-Gateway sollte bereitgestellt werden. Das bereitgestellte Gateway wird auf die Fähigkeit zum Laden von IPFS-Ressourcen überprüft.";
@@ -1707,6 +1725,12 @@
 
 /* The section title for users to set up preferences for interation with web3 sites. */
 "wallet.web3PreferencesSectionTitle" = "Web3-Einstellungen";
+
+/* The title of the toggle for user to enable/disable NFT discovery inside Web3 settings. */
+"wallet.web3SettingsEnableNFTDiscovery" = "NFT Discovery aktivieren";
+
+/* The footer of the toggle for user to enable/disable NFT discovery inside Web3 settings. */
+"wallet.web3SettingsEnableNFTDiscoveryFooter" = "Fügen Sie NFTs, die Sie besitzen, mithilfe von Drittanbieter-APS automatisch zu Ihrer Wallet hinzu. [Mehr erfahren](%@)";
 
 /* Description of the wrong IPFS gateway alert */
 "wallet.wrongGatewayAlertDescription" = "Es wurde eine ungültige URL angegeben. Gateway sollte in der Lage sein, IPFS-Ressourcen aufzulösen.";

--- a/Sources/BraveWallet/Resources/es.lproj/BraveWallet.strings
+++ b/Sources/BraveWallet/Resources/es.lproj/BraveWallet.strings
@@ -32,10 +32,10 @@
 "wallet.activateToken" = "Activar el token %@";
 
 /* The description when showing no transactions inside Activity tab. */
-"wallet.activityPageEmptyDescription" = "Una vez que hayas hecho tu primera transacción, podrás verla aquí.";
+"wallet.activityPageEmptyDescription" = "Cuando hagas una transacción, podrás verla aquí.";
 
 /* The title when showing no transactions inside Activity tab. */
-"wallet.activityPageEmptyTitle" = "Aún no hay transacciones";
+"wallet.activityPageEmptyTitle" = "Aún no se puede ver ninguna transacción";
 
 /* The title of the tab that will display user's transaction activity for all accounts. */
 "wallet.activityPageTitle" = "Actividad\n";
@@ -401,7 +401,7 @@
 "wallet.customTokenNetworkHeader" = "Seleccionar red";
 
 /* The title displayed on the add custom token screen */
-"wallet.customTokenTitle" = "Personalizado";
+"wallet.customTokenTitle" = "Añadir activo personalizado";
 
 /* The title of the notification which will prompt at the top of the browser when users are visiting web3 site that is not yet connected with Brave Wallet. The '%@' will be the site attempting to connect. For example: \"app.uniswap.org wants to interact with Brave Wallet\" */
 "wallet.dappsConnectionNotificationOriginTitle" = "%@ quiere interactuar con Cartera de Brave";
@@ -891,6 +891,24 @@
 
 /* The title an entry that will be displayed in NFT detail. This entry to display this NFT's token standard */
 "wallet.nftDetailTokenStandard" = "Estándar de token";
+
+/* The title of the alert that asks users either to enable NFT discovery or import manually. `SimpleHash` is the third-party service name, so it does not need to be translated. */
+"wallet.nftDiscoveryCalloutDescription" = "Cartera de Brave puede usar un servicio externo para mostrar automáticamente tus NFT. Brave compartirá las direcciones de tu cartera con SimpleHash para prestar este servicio. Más información.";
+
+/* This is the same `Learn more` at the end of `nftDiscoveryCalloutDescription`, but we need a separat translation to detect the range of it in order to build some attributed strings. */
+"wallet.nftDiscoveryCalloutDescriptionLearnMore" = "Más información";
+
+/* The title of the button that user clicks to disable NFT discovery. */
+"wallet.nftDiscoveryCalloutDisable" = "No, gracias. Lo haré de forma manual";
+
+/* The title of the button that user clicks to enable NFT discovery. */
+"wallet.nftDiscoveryCalloutEnable" = "Sí, continuar";
+
+/* The title of the alert that asks users either to enable NFT discovery or import manually. */
+"wallet.nftDiscoveryCalloutTitle" = "¿Quieres que tus NFT se muestren automáticamente?";
+
+/* The title of the button that user clicks to add his/her first NFT */
+"wallet.nftEmptyImportNFT" = "Importar NFT";
 
 /* Description of the NFT Gateway setting */
 "wallet.nftGatewayLongDescription" = "Debería proporcionarse una puerta de enlace IPFS válida. Se comprobará si la puerta de enlace proporcionada puede cargar recursos IPFS.";
@@ -1707,6 +1725,12 @@
 
 /* The section title for users to set up preferences for interation with web3 sites. */
 "wallet.web3PreferencesSectionTitle" = "Preferencias de Web3";
+
+/* The title of the toggle for user to enable/disable NFT discovery inside Web3 settings. */
+"wallet.web3SettingsEnableNFTDiscovery" = "Activar la detección de NFT";
+
+/* The footer of the toggle for user to enable/disable NFT discovery inside Web3 settings. */
+"wallet.web3SettingsEnableNFTDiscoveryFooter" = "Añade automáticamente NFT de tu propiedad a la cartera utilizando API de terceros. [Más información](%@)";
 
 /* Description of the wrong IPFS gateway alert */
 "wallet.wrongGatewayAlertDescription" = "Se ha proporcionado una URL no válida. La puerta de enlace debería poder resolver recursos IPFS.";

--- a/Sources/BraveWallet/Resources/fr.lproj/BraveWallet.strings
+++ b/Sources/BraveWallet/Resources/fr.lproj/BraveWallet.strings
@@ -32,10 +32,10 @@
 "wallet.activateToken" = "Activer le jeton %@";
 
 /* The description when showing no transactions inside Activity tab. */
-"wallet.activityPageEmptyDescription" = "Une fois votre première transaction effectuée, vous pourrez la consulter ici.";
+"wallet.activityPageEmptyDescription" = "Une fois que vous aurez effectué une transaction, vous pourrez la consulter ici.";
 
 /* The title when showing no transactions inside Activity tab. */
-"wallet.activityPageEmptyTitle" = "Aucune transaction pour le moment";
+"wallet.activityPageEmptyTitle" = "Aucune transaction à consulter pour le moment";
 
 /* The title of the tab that will display user's transaction activity for all accounts. */
 "wallet.activityPageTitle" = "Activité";
@@ -401,7 +401,7 @@
 "wallet.customTokenNetworkHeader" = "Sélectionner le réseau";
 
 /* The title displayed on the add custom token screen */
-"wallet.customTokenTitle" = "Personnalisé";
+"wallet.customTokenTitle" = "Ajouter un actif personnalisé";
 
 /* The title of the notification which will prompt at the top of the browser when users are visiting web3 site that is not yet connected with Brave Wallet. The '%@' will be the site attempting to connect. For example: \"app.uniswap.org wants to interact with Brave Wallet\" */
 "wallet.dappsConnectionNotificationOriginTitle" = "%@ souhaite interagir avec le portefeuille Brave";
@@ -891,6 +891,24 @@
 
 /* The title an entry that will be displayed in NFT detail. This entry to display this NFT's token standard */
 "wallet.nftDetailTokenStandard" = "Norme de jeton";
+
+/* The title of the alert that asks users either to enable NFT discovery or import manually. `SimpleHash` is the third-party service name, so it does not need to be translated. */
+"wallet.nftDiscoveryCalloutDescription" = "Le portefeuille Brave peut utiliser un service tiers pour afficher automatiquement vos NFT. Pour fournir ce service, Brave partagera les adresses de votre portefeuille avec SimpleHash. En savoir plus.";
+
+/* This is the same `Learn more` at the end of `nftDiscoveryCalloutDescription`, but we need a separat translation to detect the range of it in order to build some attributed strings. */
+"wallet.nftDiscoveryCalloutDescriptionLearnMore" = "En savoir plus";
+
+/* The title of the button that user clicks to disable NFT discovery. */
+"wallet.nftDiscoveryCalloutDisable" = "Non merci, je le ferai manuellement";
+
+/* The title of the button that user clicks to enable NFT discovery. */
+"wallet.nftDiscoveryCalloutEnable" = "Oui, poursuivre";
+
+/* The title of the alert that asks users either to enable NFT discovery or import manually. */
+"wallet.nftDiscoveryCalloutTitle" = "Envie que vos NFT s'affichent automatiquement ?";
+
+/* The title of the button that user clicks to add his/her first NFT */
+"wallet.nftEmptyImportNFT" = "Importer des NFT";
 
 /* Description of the NFT Gateway setting */
 "wallet.nftGatewayLongDescription" = "Vous devez fournir une passerelle IPFS valide. Une vérification sera effectuée sur la passerelle fournie pour s'assurer de la possibilité de charger des ressources IPFS.";
@@ -1707,6 +1725,12 @@
 
 /* The section title for users to set up preferences for interation with web3 sites. */
 "wallet.web3PreferencesSectionTitle" = "Préférences Web3";
+
+/* The title of the toggle for user to enable/disable NFT discovery inside Web3 settings. */
+"wallet.web3SettingsEnableNFTDiscovery" = "Activer la détection des NFT";
+
+/* The footer of the toggle for user to enable/disable NFT discovery inside Web3 settings. */
+"wallet.web3SettingsEnableNFTDiscoveryFooter" = "Ajoutez automatiquement les NFT que vous possédez au portefeuille à l'aide d'API tierces. [En savoir plus](%@)";
 
 /* Description of the wrong IPFS gateway alert */
 "wallet.wrongGatewayAlertDescription" = "URL non valide fournie. La passerelle doit pouvoir résoudre les ressources IPFS.";

--- a/Sources/BraveWallet/Resources/id-ID.lproj/BraveWallet.strings
+++ b/Sources/BraveWallet/Resources/id-ID.lproj/BraveWallet.strings
@@ -32,10 +32,10 @@
 "wallet.activateToken" = "Aktifkan Token %@";
 
 /* The description when showing no transactions inside Activity tab. */
-"wallet.activityPageEmptyDescription" = "Setelah transaksi pertama, Anda akan dapat melihatnya di sini.";
+"wallet.activityPageEmptyDescription" = "Setelah Anda melakukan transaksi, Anda akan dapat melihatnya di sini.";
 
 /* The title when showing no transactions inside Activity tab. */
-"wallet.activityPageEmptyTitle" = "Belum ada transaksi";
+"wallet.activityPageEmptyTitle" = "Belum ada transaksi yang dapat dilihat";
 
 /* The title of the tab that will display user's transaction activity for all accounts. */
 "wallet.activityPageTitle" = "Kegiatan";
@@ -401,7 +401,7 @@
 "wallet.customTokenNetworkHeader" = "Pilih jaringan";
 
 /* The title displayed on the add custom token screen */
-"wallet.customTokenTitle" = "Khusus";
+"wallet.customTokenTitle" = "Tambahkan Aset Khusus";
 
 /* The title of the notification which will prompt at the top of the browser when users are visiting web3 site that is not yet connected with Brave Wallet. The '%@' will be the site attempting to connect. For example: \"app.uniswap.org wants to interact with Brave Wallet\" */
 "wallet.dappsConnectionNotificationOriginTitle" = "%@ ingin berinteraksi dengan Dompet Brave";
@@ -891,6 +891,24 @@
 
 /* The title an entry that will be displayed in NFT detail. This entry to display this NFT's token standard */
 "wallet.nftDetailTokenStandard" = "Standar Token";
+
+/* The title of the alert that asks users either to enable NFT discovery or import manually. `SimpleHash` is the third-party service name, so it does not need to be translated. */
+"wallet.nftDiscoveryCalloutDescription" = "Dompet Brave dapat menggunakan jasa pihak ketiga untuk secara otomatis menampilkan NFT Anda. Brave akan membagikan alamat dompet kepada SimpleHash untuk menyediakan layanan ini. Pelajari lebih lanjut.";
+
+/* This is the same `Learn more` at the end of `nftDiscoveryCalloutDescription`, but we need a separat translation to detect the range of it in order to build some attributed strings. */
+"wallet.nftDiscoveryCalloutDescriptionLearnMore" = "Pelajari lebih lanjut";
+
+/* The title of the button that user clicks to disable NFT discovery. */
+"wallet.nftDiscoveryCalloutDisable" = "Tidak, terima kasih. Saya akan melakukannya secara manual";
+
+/* The title of the button that user clicks to enable NFT discovery. */
+"wallet.nftDiscoveryCalloutEnable" = "Ya, lanjutkan";
+
+/* The title of the alert that asks users either to enable NFT discovery or import manually. */
+"wallet.nftDiscoveryCalloutTitle" = "Ingin NFT Anda ditampilkan secara otomatis?";
+
+/* The title of the button that user clicks to add his/her first NFT */
+"wallet.nftEmptyImportNFT" = "Impor NFT";
 
 /* Description of the NFT Gateway setting */
 "wallet.nftGatewayLongDescription" = "Gateway IPFS sah harus disediakan. Gateway tersebut akan diperiksa kemampuannya untuk memuat sumber IPFS.";
@@ -1707,6 +1725,12 @@
 
 /* The section title for users to set up preferences for interation with web3 sites. */
 "wallet.web3PreferencesSectionTitle" = "Preferensi Web3";
+
+/* The title of the toggle for user to enable/disable NFT discovery inside Web3 settings. */
+"wallet.web3SettingsEnableNFTDiscovery" = "Aktifkan Penemuan NFT";
+
+/* The footer of the toggle for user to enable/disable NFT discovery inside Web3 settings. */
+"wallet.web3SettingsEnableNFTDiscoveryFooter" = "Secara otomatis menambahkan NFT yang Anda miliki ke Dompet dengan menggunakan API pihak ketiga. [Pelajari lebih lanjut](%@)";
 
 /* Description of the wrong IPFS gateway alert */
 "wallet.wrongGatewayAlertDescription" = "Diberikan url nonvalid. Gateway harus bisa menyelesaikan sumber IPFS.";

--- a/Sources/BraveWallet/Resources/it.lproj/BraveWallet.strings
+++ b/Sources/BraveWallet/Resources/it.lproj/BraveWallet.strings
@@ -32,10 +32,10 @@
 "wallet.activateToken" = "Attiva il token %@";
 
 /* The description when showing no transactions inside Activity tab. */
-"wallet.activityPageEmptyDescription" = "Una volta completata la tua prima transazione, la vedrai comparire qui.";
+"wallet.activityPageEmptyDescription" = "Quando avrai effettuato una transazione, la troverai qui.";
 
 /* The title when showing no transactions inside Activity tab. */
-"wallet.activityPageEmptyTitle" = "Ancora nessuna transazione";
+"wallet.activityPageEmptyTitle" = "Non c’è ancora nessuna transazione da visualizzare";
 
 /* The title of the tab that will display user's transaction activity for all accounts. */
 "wallet.activityPageTitle" = "Attività";
@@ -401,7 +401,7 @@
 "wallet.customTokenNetworkHeader" = "Seleziona la rete";
 
 /* The title displayed on the add custom token screen */
-"wallet.customTokenTitle" = "Personalizzata";
+"wallet.customTokenTitle" = "Aggiungi asset personalizzato";
 
 /* The title of the notification which will prompt at the top of the browser when users are visiting web3 site that is not yet connected with Brave Wallet. The '%@' will be the site attempting to connect. For example: \"app.uniswap.org wants to interact with Brave Wallet\" */
 "wallet.dappsConnectionNotificationOriginTitle" = "%@ vuole interagire con Brave Wallet";
@@ -891,6 +891,24 @@
 
 /* The title an entry that will be displayed in NFT detail. This entry to display this NFT's token standard */
 "wallet.nftDetailTokenStandard" = "Standard del token";
+
+/* The title of the alert that asks users either to enable NFT discovery or import manually. `SimpleHash` is the third-party service name, so it does not need to be translated. */
+"wallet.nftDiscoveryCalloutDescription" = "Portafoglio Brave può usare un servizio di terze parti per mostrare automaticamente i tuoi NFT. Per fornire questo servizio, Brave condividerà con SimpleHash gli indirizzi del tuo portafoglio. Scopri di più.";
+
+/* This is the same `Learn more` at the end of `nftDiscoveryCalloutDescription`, but we need a separat translation to detect the range of it in order to build some attributed strings. */
+"wallet.nftDiscoveryCalloutDescriptionLearnMore" = "Scopri di più";
+
+/* The title of the button that user clicks to disable NFT discovery. */
+"wallet.nftDiscoveryCalloutDisable" = "No grazie, lo farò a mano";
+
+/* The title of the button that user clicks to enable NFT discovery. */
+"wallet.nftDiscoveryCalloutEnable" = "Sì, procedi";
+
+/* The title of the alert that asks users either to enable NFT discovery or import manually. */
+"wallet.nftDiscoveryCalloutTitle" = "Vuoi che i tuoi NFT compaiano automaticamente?";
+
+/* The title of the button that user clicks to add his/her first NFT */
+"wallet.nftEmptyImportNFT" = "Importa NFT";
 
 /* Description of the NFT Gateway setting */
 "wallet.nftGatewayLongDescription" = "Va indicato un gateway IPFS valido. Il gateway indicato sarà sottoposto a verifica per controllare che possa caricare le risorse IPFS.";
@@ -1707,6 +1725,12 @@
 
 /* The section title for users to set up preferences for interation with web3 sites. */
 "wallet.web3PreferencesSectionTitle" = "Preferenze Web3";
+
+/* The title of the toggle for user to enable/disable NFT discovery inside Web3 settings. */
+"wallet.web3SettingsEnableNFTDiscovery" = "Attiva la scoperta degli NFT";
+
+/* The footer of the toggle for user to enable/disable NFT discovery inside Web3 settings. */
+"wallet.web3SettingsEnableNFTDiscoveryFooter" = "Aggiungi automaticamente al portafoglio gli NFT in tuo possesso usando le API di terze parti.";
 
 /* Description of the wrong IPFS gateway alert */
 "wallet.wrongGatewayAlertDescription" = "È stato indicato un URL non valido. Il gateway deve essere in grado di risolvere le risorse IPFS. ";

--- a/Sources/BraveWallet/Resources/ja.lproj/BraveWallet.strings
+++ b/Sources/BraveWallet/Resources/ja.lproj/BraveWallet.strings
@@ -32,10 +32,10 @@
 "wallet.activateToken" = "トークン %@ をアクティベートする";
 
 /* The description when showing no transactions inside Activity tab. */
-"wallet.activityPageEmptyDescription" = "初回のトランザクション後は、こちらで確認することができます。";
+"wallet.activityPageEmptyDescription" = "実行したトランザクションはこちらで確認できます。";
 
 /* The title when showing no transactions inside Activity tab. */
-"wallet.activityPageEmptyTitle" = "まだトランザクションがありません";
+"wallet.activityPageEmptyTitle" = "表示可能なトランザクションがまだありません";
 
 /* The title of the tab that will display user's transaction activity for all accounts. */
 "wallet.activityPageTitle" = "アクティビティ";
@@ -401,7 +401,7 @@
 "wallet.customTokenNetworkHeader" = "ネットワークを選択";
 
 /* The title displayed on the add custom token screen */
-"wallet.customTokenTitle" = "カスタム";
+"wallet.customTokenTitle" = "カスタムアセットを追加";
 
 /* The title of the notification which will prompt at the top of the browser when users are visiting web3 site that is not yet connected with Brave Wallet. The '%@' will be the site attempting to connect. For example: \"app.uniswap.org wants to interact with Brave Wallet\" */
 "wallet.dappsConnectionNotificationOriginTitle" = "%@がBraveウォレットとの接続を求めています";
@@ -515,7 +515,7 @@
 "wallet.editfCustomNetworkTitle" = "ネットワークを編集";
 
 /* A button title displayed under a Gas Fee title that allows the user to adjust the gas fee/transactions priority */
-"wallet.editGasFeeButtonTitle" = "動画の管理";
+"wallet.editGasFeeButtonTitle" = "編集";
 
 /* A title of the edit gas screen for standard transactions */
 "wallet.editGasTitle" = "Gasを編集する";
@@ -891,6 +891,24 @@
 
 /* The title an entry that will be displayed in NFT detail. This entry to display this NFT's token standard */
 "wallet.nftDetailTokenStandard" = "トークン規格";
+
+/* The title of the alert that asks users either to enable NFT discovery or import manually. `SimpleHash` is the third-party service name, so it does not need to be translated. */
+"wallet.nftDiscoveryCalloutDescription" = "Braveウォレットは、サードパーティーのサービスを利用してお客様のNFTを自動的に表示します。Braveはこのサービスを提供するために、お客様のウォレットアドレスをSimpleHashと共有します。詳細はこちらをご覧ください。";
+
+/* This is the same `Learn more` at the end of `nftDiscoveryCalloutDescription`, but we need a separat translation to detect the range of it in order to build some attributed strings. */
+"wallet.nftDiscoveryCalloutDescriptionLearnMore" = "詳細はこちら";
+
+/* The title of the button that user clicks to disable NFT discovery. */
+"wallet.nftDiscoveryCalloutDisable" = "いいえ、手動で設定します";
+
+/* The title of the button that user clicks to enable NFT discovery. */
+"wallet.nftDiscoveryCalloutEnable" = "はい、続行します";
+
+/* The title of the alert that asks users either to enable NFT discovery or import manually. */
+"wallet.nftDiscoveryCalloutTitle" = "NFTを自動で表示しますか？";
+
+/* The title of the button that user clicks to add his/her first NFT */
+"wallet.nftEmptyImportNFT" = "NFTをインポート";
 
 /* Description of the NFT Gateway setting */
 "wallet.nftGatewayLongDescription" = "有効なIPFSゲートウェイを提供してください。提供されたゲートウェイについては、IPFSリソースの読み込みが可能かどうかの確認が行われます。";
@@ -1707,6 +1725,12 @@
 
 /* The section title for users to set up preferences for interation with web3 sites. */
 "wallet.web3PreferencesSectionTitle" = "Web3環境設定";
+
+/* The title of the toggle for user to enable/disable NFT discovery inside Web3 settings. */
+"wallet.web3SettingsEnableNFTDiscovery" = "NFTディスカバリーを有効にする";
+
+/* The footer of the toggle for user to enable/disable NFT discovery inside Web3 settings. */
+"wallet.web3SettingsEnableNFTDiscoveryFooter" = "サードパーティーのAPIを使用して、所有するNFTを自動的にウォレットに追加します。[詳細はこちら](%@)";
 
 /* Description of the wrong IPFS gateway alert */
 "wallet.wrongGatewayAlertDescription" = "無効なURLが渡されました。ゲートウェイはIPFSリソースを解決できるものでなければいけません。";

--- a/Sources/BraveWallet/Resources/ko-KR.lproj/BraveWallet.strings
+++ b/Sources/BraveWallet/Resources/ko-KR.lproj/BraveWallet.strings
@@ -32,10 +32,10 @@
 "wallet.activateToken" = "토큰 %@ 활성화";
 
 /* The description when showing no transactions inside Activity tab. */
-"wallet.activityPageEmptyDescription" = "첫 트랜잭션 이후 여기서 볼 수 있습니다.";
+"wallet.activityPageEmptyDescription" = "트랜잭션이 완료되면 여기서 볼 수 있습니다.";
 
 /* The title when showing no transactions inside Activity tab. */
-"wallet.activityPageEmptyTitle" = "아직 트랜잭션 없음";
+"wallet.activityPageEmptyTitle" = "아직 볼 수 있는 트랜잭션 없음";
 
 /* The title of the tab that will display user's transaction activity for all accounts. */
 "wallet.activityPageTitle" = "활동";
@@ -401,7 +401,7 @@
 "wallet.customTokenNetworkHeader" = "네트워크 선택";
 
 /* The title displayed on the add custom token screen */
-"wallet.customTokenTitle" = "맞춤";
+"wallet.customTokenTitle" = "맞춤 자산 추가";
 
 /* The title of the notification which will prompt at the top of the browser when users are visiting web3 site that is not yet connected with Brave Wallet. The '%@' will be the site attempting to connect. For example: \"app.uniswap.org wants to interact with Brave Wallet\" */
 "wallet.dappsConnectionNotificationOriginTitle" = "%@이(가) Brave 월렛과 상호작용하려고 함";
@@ -891,6 +891,24 @@
 
 /* The title an entry that will be displayed in NFT detail. This entry to display this NFT's token standard */
 "wallet.nftDetailTokenStandard" = "토큰 표준";
+
+/* The title of the alert that asks users either to enable NFT discovery or import manually. `SimpleHash` is the third-party service name, so it does not need to be translated. */
+"wallet.nftDiscoveryCalloutDescription" = "Brave 월렛은 귀하의 NFT를 자동으로 표시하기 위해 제3자 서비스를 사용할 수 있습니다. Brave는 이 서비스를 제공하기 위한 목적으로 SimpleHash에 귀하의 월렛 주소를 공유합니다. 자세히 알아보세요.";
+
+/* This is the same `Learn more` at the end of `nftDiscoveryCalloutDescription`, but we need a separat translation to detect the range of it in order to build some attributed strings. */
+"wallet.nftDiscoveryCalloutDescriptionLearnMore" = "자세히 알아보기";
+
+/* The title of the button that user clicks to disable NFT discovery. */
+"wallet.nftDiscoveryCalloutDisable" = "아니요, 직접 하겠습니다";
+
+/* The title of the button that user clicks to enable NFT discovery. */
+"wallet.nftDiscoveryCalloutEnable" = "예, 진행합니다";
+
+/* The title of the alert that asks users either to enable NFT discovery or import manually. */
+"wallet.nftDiscoveryCalloutTitle" = "NFT를 자동으로 표시하고 싶으십니까?";
+
+/* The title of the button that user clicks to add his/her first NFT */
+"wallet.nftEmptyImportNFT" = "NFT 가져오기";
 
 /* Description of the NFT Gateway setting */
 "wallet.nftGatewayLongDescription" = "유효한 IPFS 게이트웨이를 제공해야 합니다. 제공된 게이트웨이에 IPFS 리소스 로드 권한이 있는지 확인합니다.";
@@ -1707,6 +1725,12 @@
 
 /* The section title for users to set up preferences for interation with web3 sites. */
 "wallet.web3PreferencesSectionTitle" = "Web3 선호설정";
+
+/* The title of the toggle for user to enable/disable NFT discovery inside Web3 settings. */
+"wallet.web3SettingsEnableNFTDiscovery" = "NFT 디스커버리 활성화";
+
+/* The footer of the toggle for user to enable/disable NFT discovery inside Web3 settings. */
+"wallet.web3SettingsEnableNFTDiscoveryFooter" = "보유한 NFT를 제3자 API를 사용하여 자동으로 월렛에 추가합니다. [자세히 알아보기](%@)";
 
 /* Description of the wrong IPFS gateway alert */
 "wallet.wrongGatewayAlertDescription" = "유효하지 않은 URL이 제공되었습니다. 게이트웨이가 IPFS 리소스를 해석할 수 있어야 합니다.";

--- a/Sources/BraveWallet/Resources/ms.lproj/BraveWallet.strings
+++ b/Sources/BraveWallet/Resources/ms.lproj/BraveWallet.strings
@@ -32,10 +32,10 @@
 "wallet.activateToken" = "Aktifkan Token %@";
 
 /* The description when showing no transactions inside Activity tab. */
-"wallet.activityPageEmptyDescription" = "Selepas transaksi pertama, anda akan boleh memaparkan transaksi di sini.";
+"wallet.activityPageEmptyDescription" = "Setelah anda membuat transaksi, anda akan dapat melihat transaksi ini di sini.";
 
 /* The title when showing no transactions inside Activity tab. */
-"wallet.activityPageEmptyTitle" = "Belum ada transaksi";
+"wallet.activityPageEmptyTitle" = "Tiada transaksi untuk dilihat lagi";
 
 /* The title of the tab that will display user's transaction activity for all accounts. */
 "wallet.activityPageTitle" = "Aktiviti";
@@ -401,7 +401,7 @@
 "wallet.customTokenNetworkHeader" = "Pilih rangkaian";
 
 /* The title displayed on the add custom token screen */
-"wallet.customTokenTitle" = "Tersuai";
+"wallet.customTokenTitle" = "Tambah Aset Tersuai";
 
 /* The title of the notification which will prompt at the top of the browser when users are visiting web3 site that is not yet connected with Brave Wallet. The '%@' will be the site attempting to connect. For example: \"app.uniswap.org wants to interact with Brave Wallet\" */
 "wallet.dappsConnectionNotificationOriginTitle" = "%@ mahu berinteraksi dengan Dompet Brave";
@@ -891,6 +891,24 @@
 
 /* The title an entry that will be displayed in NFT detail. This entry to display this NFT's token standard */
 "wallet.nftDetailTokenStandard" = "Standard token";
+
+/* The title of the alert that asks users either to enable NFT discovery or import manually. `SimpleHash` is the third-party service name, so it does not need to be translated. */
+"wallet.nftDiscoveryCalloutDescription" = "Brave Wallet boleh menggunakan perkhidmatan pihak ketiga untuk memaparkan NFT anda secara automatik. Brave akan berkongsi alamat dompet anda dengan SimpleHash untuk menyediakan perkhidmatan ini. Ketahui lebih lanjut.";
+
+/* This is the same `Learn more` at the end of `nftDiscoveryCalloutDescription`, but we need a separat translation to detect the range of it in order to build some attributed strings. */
+"wallet.nftDiscoveryCalloutDescriptionLearnMore" = "Ketahui lebih lanjut";
+
+/* The title of the button that user clicks to disable NFT discovery. */
+"wallet.nftDiscoveryCalloutDisable" = "Tidak, terima kasih, saya akan membuat secara manual";
+
+/* The title of the button that user clicks to enable NFT discovery. */
+"wallet.nftDiscoveryCalloutEnable" = "Ya, teruskan";
+
+/* The title of the alert that asks users either to enable NFT discovery or import manually. */
+"wallet.nftDiscoveryCalloutTitle" = "Mahu NFT anda dipaparkan secara automatik?";
+
+/* The title of the button that user clicks to add his/her first NFT */
+"wallet.nftEmptyImportNFT" = "Import NFT";
 
 /* Description of the NFT Gateway setting */
 "wallet.nftGatewayLongDescription" = "Get laluan IPFS sah patut disediakan. Get laluan yang disediakan akan diperiksa dari segi keupayaan untuk memuatkan sumber IPFS.";
@@ -1707,6 +1725,12 @@
 
 /* The section title for users to set up preferences for interation with web3 sites. */
 "wallet.web3PreferencesSectionTitle" = "Keutamaan Web3";
+
+/* The title of the toggle for user to enable/disable NFT discovery inside Web3 settings. */
+"wallet.web3SettingsEnableNFTDiscovery" = "Dayakan Penemuan NFT";
+
+/* The footer of the toggle for user to enable/disable NFT discovery inside Web3 settings. */
+"wallet.web3SettingsEnableNFTDiscoveryFooter" = "Tambah NFT yang anda miliki secara automatik kepada Wallet dengan menggunakan API pihak ketiga. [Ketahui lebih lanjut](%@)";
 
 /* Description of the wrong IPFS gateway alert */
 "wallet.wrongGatewayAlertDescription" = "Url tidak sah telah diberikan. Get laluan sepatutnya boleh menyelesaikan sumber IPFS.";

--- a/Sources/BraveWallet/Resources/nb.lproj/BraveWallet.strings
+++ b/Sources/BraveWallet/Resources/nb.lproj/BraveWallet.strings
@@ -32,10 +32,10 @@
 "wallet.activateToken" = "Aktiver token: %@";
 
 /* The description when showing no transactions inside Activity tab. */
-"wallet.activityPageEmptyDescription" = "Etter din første transaksjon vil du kunne se den her.";
+"wallet.activityPageEmptyDescription" = "Etter at du har gjennomført en transaksjon, vil du kunne se den her.";
 
 /* The title when showing no transactions inside Activity tab. */
-"wallet.activityPageEmptyTitle" = "Ingen transaksjoner ennå";
+"wallet.activityPageEmptyTitle" = "Ingen transaksjoner kan vises ennå";
 
 /* The title of the tab that will display user's transaction activity for all accounts. */
 "wallet.activityPageTitle" = "Aktivitet";
@@ -401,7 +401,7 @@
 "wallet.customTokenNetworkHeader" = "Velg nettverk";
 
 /* The title displayed on the add custom token screen */
-"wallet.customTokenTitle" = "Egendefinert";
+"wallet.customTokenTitle" = "Legg til egendefinert eiendel";
 
 /* The title of the notification which will prompt at the top of the browser when users are visiting web3 site that is not yet connected with Brave Wallet. The '%@' will be the site attempting to connect. For example: \"app.uniswap.org wants to interact with Brave Wallet\" */
 "wallet.dappsConnectionNotificationOriginTitle" = "%@ ønsker tilgang til Brave-lommeboken";
@@ -891,6 +891,24 @@
 
 /* The title an entry that will be displayed in NFT detail. This entry to display this NFT's token standard */
 "wallet.nftDetailTokenStandard" = "Token-standard";
+
+/* The title of the alert that asks users either to enable NFT discovery or import manually. `SimpleHash` is the third-party service name, so it does not need to be translated. */
+"wallet.nftDiscoveryCalloutDescription" = "Brave Wallet kan bruke en tredjeparts tjeneste for å vise NFT-ene dine automatisk. Brave deler lommebokadressene dine med SimpleHash for å tilby denne tjenesten. Finn ut mer.";
+
+/* This is the same `Learn more` at the end of `nftDiscoveryCalloutDescription`, but we need a separat translation to detect the range of it in order to build some attributed strings. */
+"wallet.nftDiscoveryCalloutDescriptionLearnMore" = "Finn ut mer";
+
+/* The title of the button that user clicks to disable NFT discovery. */
+"wallet.nftDiscoveryCalloutDisable" = "Nei takk, jeg gjør det manuelt";
+
+/* The title of the button that user clicks to enable NFT discovery. */
+"wallet.nftDiscoveryCalloutEnable" = "Ja, fortsett";
+
+/* The title of the alert that asks users either to enable NFT discovery or import manually. */
+"wallet.nftDiscoveryCalloutTitle" = "Vil du at NFT-ene dine skal vises automatisk?";
+
+/* The title of the button that user clicks to add his/her first NFT */
+"wallet.nftEmptyImportNFT" = "Importer NFT";
 
 /* Description of the NFT Gateway setting */
 "wallet.nftGatewayLongDescription" = "Kunne ikke levere en gyldig IPFS-gateway. Den leverte gatewayen blir sjekket for evnen til å laste IPFS-ressurser.";
@@ -1707,6 +1725,12 @@
 
 /* The section title for users to set up preferences for interation with web3 sites. */
 "wallet.web3PreferencesSectionTitle" = "Web3-preferanser";
+
+/* The title of the toggle for user to enable/disable NFT discovery inside Web3 settings. */
+"wallet.web3SettingsEnableNFTDiscovery" = "Aktiver NFT-oppdagelse";
+
+/* The footer of the toggle for user to enable/disable NFT discovery inside Web3 settings. */
+"wallet.web3SettingsEnableNFTDiscoveryFooter" = "Legg til NFT-er du eier i lommeboken automatisk ved hjelp av tredjeparts API-er. [Finn ut mer](%@)";
 
 /* Description of the wrong IPFS gateway alert */
 "wallet.wrongGatewayAlertDescription" = "Ugyldig URL. Gatewayen må kunne behandle IPFS-ressurser.";

--- a/Sources/BraveWallet/Resources/pl.lproj/BraveWallet.strings
+++ b/Sources/BraveWallet/Resources/pl.lproj/BraveWallet.strings
@@ -32,10 +32,10 @@
 "wallet.activateToken" = "Aktywuj token %@";
 
 /* The description when showing no transactions inside Activity tab. */
-"wallet.activityPageEmptyDescription" = "Po ukończeniu pierwszej transakcji zostanie ona wyświetlona tutaj.";
+"wallet.activityPageEmptyDescription" = "Po wykonaniu transakcji będzie ona widoczna tutaj.";
 
 /* The title when showing no transactions inside Activity tab. */
-"wallet.activityPageEmptyTitle" = "Brak transakcji";
+"wallet.activityPageEmptyTitle" = "Brak transakcji do wyświetlenia";
 
 /* The title of the tab that will display user's transaction activity for all accounts. */
 "wallet.activityPageTitle" = "Aktywność";
@@ -401,7 +401,7 @@
 "wallet.customTokenNetworkHeader" = "Wybierz sieć";
 
 /* The title displayed on the add custom token screen */
-"wallet.customTokenTitle" = "Niestandardowe";
+"wallet.customTokenTitle" = "Dodaj zasób niestandardowy";
 
 /* The title of the notification which will prompt at the top of the browser when users are visiting web3 site that is not yet connected with Brave Wallet. The '%@' will be the site attempting to connect. For example: \"app.uniswap.org wants to interact with Brave Wallet\" */
 "wallet.dappsConnectionNotificationOriginTitle" = "%@ chce wejść w interakcję z portfelem Brave Wallet";
@@ -891,6 +891,24 @@
 
 /* The title an entry that will be displayed in NFT detail. This entry to display this NFT's token standard */
 "wallet.nftDetailTokenStandard" = "Standard tokena";
+
+/* The title of the alert that asks users either to enable NFT discovery or import manually. `SimpleHash` is the third-party service name, so it does not need to be translated. */
+"wallet.nftDiscoveryCalloutDescription" = "Portfel Brave Wallet może korzystać z usługi strony trzeciej, aby automatycznie wyświetlać Twoje NFT. Brave udostępni Twoje adresy portfela  SimpleHash, aby zapewnić tę usługę. Dowiedz się więcej.";
+
+/* This is the same `Learn more` at the end of `nftDiscoveryCalloutDescription`, but we need a separat translation to detect the range of it in order to build some attributed strings. */
+"wallet.nftDiscoveryCalloutDescriptionLearnMore" = "Dowiedz się więcej";
+
+/* The title of the button that user clicks to disable NFT discovery. */
+"wallet.nftDiscoveryCalloutDisable" = "Nie, zrobię to ręcznie";
+
+/* The title of the button that user clicks to enable NFT discovery. */
+"wallet.nftDiscoveryCalloutEnable" = "Tak, kontynuuj";
+
+/* The title of the alert that asks users either to enable NFT discovery or import manually. */
+"wallet.nftDiscoveryCalloutTitle" = "Chcesz, żeby Twoje NFT były wyświetlane automatycznie?";
+
+/* The title of the button that user clicks to add his/her first NFT */
+"wallet.nftEmptyImportNFT" = "Importowanie NFT";
 
 /* Description of the NFT Gateway setting */
 "wallet.nftGatewayLongDescription" = "Należy podać aktualną bramkę IPFS. Podana bramka zostanie sprawdzona po względem możliwości wczytywania zasobów IPFS.";
@@ -1707,6 +1725,12 @@
 
 /* The section title for users to set up preferences for interation with web3 sites. */
 "wallet.web3PreferencesSectionTitle" = "Preferencje Web3";
+
+/* The title of the toggle for user to enable/disable NFT discovery inside Web3 settings. */
+"wallet.web3SettingsEnableNFTDiscovery" = "Włącz odkrywanie NFT";
+
+/* The footer of the toggle for user to enable/disable NFT discovery inside Web3 settings. */
+"wallet.web3SettingsEnableNFTDiscoveryFooter" = "Automatycznie dodawaj posiadane przez siebie NFT do portfela za pomocą API innych firm. [Learn more](%@)";
 
 /* Description of the wrong IPFS gateway alert */
 "wallet.wrongGatewayAlertDescription" = "Podano nieprawidłowy adres URL. Bramka powinna być w stanie obsługiwać zasoby IPFS.";

--- a/Sources/BraveWallet/Resources/pt-BR.lproj/BraveWallet.strings
+++ b/Sources/BraveWallet/Resources/pt-BR.lproj/BraveWallet.strings
@@ -32,10 +32,10 @@
 "wallet.activateToken" = "Ativar token %@";
 
 /* The description when showing no transactions inside Activity tab. */
-"wallet.activityPageEmptyDescription" = "Depois da sua primeira transação, você poderá vê-la aqui.";
+"wallet.activityPageEmptyDescription" = "As transações que fizer serão apresentadas aqui.";
 
 /* The title when showing no transactions inside Activity tab. */
-"wallet.activityPageEmptyTitle" = "Ainda não há transações";
+"wallet.activityPageEmptyTitle" = "Ainda sem transações";
 
 /* The title of the tab that will display user's transaction activity for all accounts. */
 "wallet.activityPageTitle" = "Atividade";
@@ -401,7 +401,7 @@
 "wallet.customTokenNetworkHeader" = "Selecionar rede";
 
 /* The title displayed on the add custom token screen */
-"wallet.customTokenTitle" = "Personalizado";
+"wallet.customTokenTitle" = "Adicionar ativo personalizado";
 
 /* The title of the notification which will prompt at the top of the browser when users are visiting web3 site that is not yet connected with Brave Wallet. The '%@' will be the site attempting to connect. For example: \"app.uniswap.org wants to interact with Brave Wallet\" */
 "wallet.dappsConnectionNotificationOriginTitle" = "%@ deseja interagir com a Carteira Brave";
@@ -891,6 +891,24 @@
 
 /* The title an entry that will be displayed in NFT detail. This entry to display this NFT's token standard */
 "wallet.nftDetailTokenStandard" = "Padrão de token";
+
+/* The title of the alert that asks users either to enable NFT discovery or import manually. `SimpleHash` is the third-party service name, so it does not need to be translated. */
+"wallet.nftDiscoveryCalloutDescription" = "A Brave Wallet pode utilizar um serviço externo para apresentar automaticamente os seus NFT. A Brave compartilha os endereços da sua carteira com a SimpleHash para fornecer este serviço. Saiba mais.";
+
+/* This is the same `Learn more` at the end of `nftDiscoveryCalloutDescription`, but we need a separat translation to detect the range of it in order to build some attributed strings. */
+"wallet.nftDiscoveryCalloutDescriptionLearnMore" = "Saiba mais";
+
+/* The title of the button that user clicks to disable NFT discovery. */
+"wallet.nftDiscoveryCalloutDisable" = "Não, prefiro fazê-lo manualmente";
+
+/* The title of the button that user clicks to enable NFT discovery. */
+"wallet.nftDiscoveryCalloutEnable" = "Sim, continuar";
+
+/* The title of the alert that asks users either to enable NFT discovery or import manually. */
+"wallet.nftDiscoveryCalloutTitle" = "Quer que seus NFTs sejam exibidos automaticamente?";
+
+/* The title of the button that user clicks to add his/her first NFT */
+"wallet.nftEmptyImportNFT" = "Importar NFT";
 
 /* Description of the NFT Gateway setting */
 "wallet.nftGatewayLongDescription" = "Um gateway IPFS válido deve ser informado. O gateway fornecido será verificado quanto à capacidade de carregamento de recursos IPFS.";
@@ -1707,6 +1725,12 @@
 
 /* The section title for users to set up preferences for interation with web3 sites. */
 "wallet.web3PreferencesSectionTitle" = "Preferências de web3";
+
+/* The title of the toggle for user to enable/disable NFT discovery inside Web3 settings. */
+"wallet.web3SettingsEnableNFTDiscovery" = "Ativar a Detecção de NFT";
+
+/* The footer of the toggle for user to enable/disable NFT discovery inside Web3 settings. */
+"wallet.web3SettingsEnableNFTDiscoveryFooter" = "Adicione automaticamente os seus NFT à Wallet usando API externas. [Saiba mais](%@)";
 
 /* Description of the wrong IPFS gateway alert */
 "wallet.wrongGatewayAlertDescription" = "Foi informado um URL inválido. O gateway deve ser capaz de resolver recursos IPFS.";

--- a/Sources/BraveWallet/Resources/ru.lproj/BraveWallet.strings
+++ b/Sources/BraveWallet/Resources/ru.lproj/BraveWallet.strings
@@ -32,10 +32,10 @@
 "wallet.activateToken" = "Активировать токен %@";
 
 /* The description when showing no transactions inside Activity tab. */
-"wallet.activityPageEmptyDescription" = "Как только вы совершите первую транзакцию, она появится здесь.";
+"wallet.activityPageEmptyDescription" = "Когда вы совершите транзакцию, она появится здесь.";
 
 /* The title when showing no transactions inside Activity tab. */
-"wallet.activityPageEmptyTitle" = "Транзакций нет";
+"wallet.activityPageEmptyTitle" = "Пока транзакций нет";
 
 /* The title of the tab that will display user's transaction activity for all accounts. */
 "wallet.activityPageTitle" = "Действия";
@@ -401,7 +401,7 @@
 "wallet.customTokenNetworkHeader" = "Выбор сети";
 
 /* The title displayed on the add custom token screen */
-"wallet.customTokenTitle" = "Пользовательский";
+"wallet.customTokenTitle" = "Добавление пользовательского актива";
 
 /* The title of the notification which will prompt at the top of the browser when users are visiting web3 site that is not yet connected with Brave Wallet. The '%@' will be the site attempting to connect. For example: \"app.uniswap.org wants to interact with Brave Wallet\" */
 "wallet.dappsConnectionNotificationOriginTitle" = "%@ запрашивает доступ к Brave Кошельку";
@@ -891,6 +891,24 @@
 
 /* The title an entry that will be displayed in NFT detail. This entry to display this NFT's token standard */
 "wallet.nftDetailTokenStandard" = "Стандарт токена";
+
+/* The title of the alert that asks users either to enable NFT discovery or import manually. `SimpleHash` is the third-party service name, so it does not need to be translated. */
+"wallet.nftDiscoveryCalloutDescription" = "Brave Кошелек может использовать сторонний сервис и автоматически показывать NFT. Для этого Brave будет делиться адресами ваших кошельков с SimpleHash. Подробнее";
+
+/* This is the same `Learn more` at the end of `nftDiscoveryCalloutDescription`, but we need a separat translation to detect the range of it in order to build some attributed strings. */
+"wallet.nftDiscoveryCalloutDescriptionLearnMore" = "Подробнее";
+
+/* The title of the button that user clicks to disable NFT discovery. */
+"wallet.nftDiscoveryCalloutDisable" = "Нет";
+
+/* The title of the button that user clicks to enable NFT discovery. */
+"wallet.nftDiscoveryCalloutEnable" = "Да";
+
+/* The title of the alert that asks users either to enable NFT discovery or import manually. */
+"wallet.nftDiscoveryCalloutTitle" = "Хотите, чтобы NFT-токены отображались автоматически?";
+
+/* The title of the button that user clicks to add his/her first NFT */
+"wallet.nftEmptyImportNFT" = "Импортировать NFT";
 
 /* Description of the NFT Gateway setting */
 "wallet.nftGatewayLongDescription" = "Укажите действительный шлюз IPFS. Мы проверим, можно ли через него загружать IPFS-ресурсы.";
@@ -1707,6 +1725,12 @@
 
 /* The section title for users to set up preferences for interation with web3 sites. */
 "wallet.web3PreferencesSectionTitle" = "Настройки Web3";
+
+/* The title of the toggle for user to enable/disable NFT discovery inside Web3 settings. */
+"wallet.web3SettingsEnableNFTDiscovery" = "Включить обнаружение NFT";
+
+/* The footer of the toggle for user to enable/disable NFT discovery inside Web3 settings. */
+"wallet.web3SettingsEnableNFTDiscoveryFooter" = "Автоматически добавляет NFT, которыми вы владеете, в кошелек, используя сторонние API. [Подробнее](%@)";
 
 /* Description of the wrong IPFS gateway alert */
 "wallet.wrongGatewayAlertDescription" = "Предоставлен некорректный URL-адрес. Шлюз должен быть совместимым с протоколом IPFS.";

--- a/Sources/BraveWallet/Resources/sv.lproj/BraveWallet.strings
+++ b/Sources/BraveWallet/Resources/sv.lproj/BraveWallet.strings
@@ -32,10 +32,10 @@
 "wallet.activateToken" = "Aktivera %@-token";
 
 /* The description when showing no transactions inside Activity tab. */
-"wallet.activityPageEmptyDescription" = "Efter din första transaktion kommer du att kunna se den här.";
+"wallet.activityPageEmptyDescription" = "Efter en transaktion kan du se den här.";
 
 /* The title when showing no transactions inside Activity tab. */
-"wallet.activityPageEmptyTitle" = "Inga transaktioner ännu";
+"wallet.activityPageEmptyTitle" = "Inga transaktioner att visa ännu";
 
 /* The title of the tab that will display user's transaction activity for all accounts. */
 "wallet.activityPageTitle" = "Aktivitet";
@@ -401,7 +401,7 @@
 "wallet.customTokenNetworkHeader" = "Välj nätverk";
 
 /* The title displayed on the add custom token screen */
-"wallet.customTokenTitle" = "Anpassad";
+"wallet.customTokenTitle" = "Lägg till anpassad tillgång";
 
 /* The title of the notification which will prompt at the top of the browser when users are visiting web3 site that is not yet connected with Brave Wallet. The '%@' will be the site attempting to connect. For example: \"app.uniswap.org wants to interact with Brave Wallet\" */
 "wallet.dappsConnectionNotificationOriginTitle" = "%@ vill interagera med Brave Wallet";
@@ -891,6 +891,24 @@
 
 /* The title an entry that will be displayed in NFT detail. This entry to display this NFT's token standard */
 "wallet.nftDetailTokenStandard" = "Tokenstandard";
+
+/* The title of the alert that asks users either to enable NFT discovery or import manually. `SimpleHash` is the third-party service name, so it does not need to be translated. */
+"wallet.nftDiscoveryCalloutDescription" = "Brave Wallet kan använda en tredjepartstjänst för att automatiskt visa dina NFT:er. Brave kommer att dela dina plånboksadresser med SimpleHash för att tillhandahålla denna tjänst. Läs mer.";
+
+/* This is the same `Learn more` at the end of `nftDiscoveryCalloutDescription`, but we need a separat translation to detect the range of it in order to build some attributed strings. */
+"wallet.nftDiscoveryCalloutDescriptionLearnMore" = "Läs mer";
+
+/* The title of the button that user clicks to disable NFT discovery. */
+"wallet.nftDiscoveryCalloutDisable" = "Nej tack, jag gör det manuellt";
+
+/* The title of the button that user clicks to enable NFT discovery. */
+"wallet.nftDiscoveryCalloutEnable" = "Ja, fortsätt";
+
+/* The title of the alert that asks users either to enable NFT discovery or import manually. */
+"wallet.nftDiscoveryCalloutTitle" = "Vill du att NFT:er ska visas automatiskt?";
+
+/* The title of the button that user clicks to add his/her first NFT */
+"wallet.nftEmptyImportNFT" = "Importera NFT";
 
 /* Description of the NFT Gateway setting */
 "wallet.nftGatewayLongDescription" = "En giltig IPFS-gateway ska anges. Tillhandahållen gateway kommer att kontrolleras för möjligheten att läsa in IPFS-resurser.";
@@ -1707,6 +1725,12 @@
 
 /* The section title for users to set up preferences for interation with web3 sites. */
 "wallet.web3PreferencesSectionTitle" = "Web3-inställningar";
+
+/* The title of the toggle for user to enable/disable NFT discovery inside Web3 settings. */
+"wallet.web3SettingsEnableNFTDiscovery" = "Aktivera NFT-upptäckt";
+
+/* The footer of the toggle for user to enable/disable NFT discovery inside Web3 settings. */
+"wallet.web3SettingsEnableNFTDiscoveryFooter" = "Lägg automatiskt till NFT:er som du äger i plånboken med hjälp av tredjeparts-API:er.  [Läs mer](%@)";
 
 /* Description of the wrong IPFS gateway alert */
 "wallet.wrongGatewayAlertDescription" = "Ogiltig url angavs. Gateway ska kunna lösa IPFS-resurser.";

--- a/Sources/BraveWallet/Resources/tr.lproj/BraveWallet.strings
+++ b/Sources/BraveWallet/Resources/tr.lproj/BraveWallet.strings
@@ -32,10 +32,10 @@
 "wallet.activateToken" = "%@ Token'ını Etkinleştir";
 
 /* The description when showing no transactions inside Activity tab. */
-"wallet.activityPageEmptyDescription" = "İlk işleminizden sonra buradan görebilirsiniz.";
+"wallet.activityPageEmptyDescription" = "Bir işlem yaptıktan sonra, buradan görebilirsiniz.";
 
 /* The title when showing no transactions inside Activity tab. */
-"wallet.activityPageEmptyTitle" = "Henüz işlem yok";
+"wallet.activityPageEmptyTitle" = "Henüz görüntülenecek işlem yok";
 
 /* The title of the tab that will display user's transaction activity for all accounts. */
 "wallet.activityPageTitle" = "Eylem";
@@ -401,7 +401,7 @@
 "wallet.customTokenNetworkHeader" = "Ağ seç";
 
 /* The title displayed on the add custom token screen */
-"wallet.customTokenTitle" = "Özel";
+"wallet.customTokenTitle" = "Özel Varlık Ekle";
 
 /* The title of the notification which will prompt at the top of the browser when users are visiting web3 site that is not yet connected with Brave Wallet. The '%@' will be the site attempting to connect. For example: \"app.uniswap.org wants to interact with Brave Wallet\" */
 "wallet.dappsConnectionNotificationOriginTitle" = "%@, Brave Cüzdanı ile etkileşime girmek istiyor";
@@ -891,6 +891,24 @@
 
 /* The title an entry that will be displayed in NFT detail. This entry to display this NFT's token standard */
 "wallet.nftDetailTokenStandard" = "Token standardı";
+
+/* The title of the alert that asks users either to enable NFT discovery or import manually. `SimpleHash` is the third-party service name, so it does not need to be translated. */
+"wallet.nftDiscoveryCalloutDescription" = "Brave Cüzdan, NFT'lerinizi otomatik olarak görüntülemek için üçüncü taraf bir hizmet kullanabilir. Brave, bu hizmeti sağlamak için cüzdan adreslerinizi SimpleHash ile paylaşacaktır. Daha fazla bilgi alın.";
+
+/* This is the same `Learn more` at the end of `nftDiscoveryCalloutDescription`, but we need a separat translation to detect the range of it in order to build some attributed strings. */
+"wallet.nftDiscoveryCalloutDescriptionLearnMore" = "Daha fazla bilgi edinin";
+
+/* The title of the button that user clicks to disable NFT discovery. */
+"wallet.nftDiscoveryCalloutDisable" = "Hayır teşekkürler, manuel olarak yaparım";
+
+/* The title of the button that user clicks to enable NFT discovery. */
+"wallet.nftDiscoveryCalloutEnable" = "Evet, devam et";
+
+/* The title of the alert that asks users either to enable NFT discovery or import manually. */
+"wallet.nftDiscoveryCalloutTitle" = "NFT'leriniz otomatik olarak görüntülensin mi?";
+
+/* The title of the button that user clicks to add his/her first NFT */
+"wallet.nftEmptyImportNFT" = "NFT'yi içe aktar";
 
 /* Description of the NFT Gateway setting */
 "wallet.nftGatewayLongDescription" = "Geçerli IPFS ağ geçidi sağlanmalıdır. Sağlanan ağ geçidinin IPFS kaynaklarını yükleme özelliği kontrol edilecektir.";
@@ -1707,6 +1725,12 @@
 
 /* The section title for users to set up preferences for interation with web3 sites. */
 "wallet.web3PreferencesSectionTitle" = "Web3 tercihleri";
+
+/* The title of the toggle for user to enable/disable NFT discovery inside Web3 settings. */
+"wallet.web3SettingsEnableNFTDiscovery" = "NFT Keşfini Etkinleştir";
+
+/* The footer of the toggle for user to enable/disable NFT discovery inside Web3 settings. */
+"wallet.web3SettingsEnableNFTDiscoveryFooter" = "Üçüncü taraf API'leri kullanarak otomatik olarak sahip olduğunuz NFT'leri Cüzdanınıza ekleyin. [Daha fazla bilgi](%@)";
 
 /* Description of the wrong IPFS gateway alert */
 "wallet.wrongGatewayAlertDescription" = "Geçersiz url sağlandı. Ağ geçidinin, IPFS kaynaklarını çözebilmesi gerekir.";

--- a/Sources/BraveWallet/Resources/uk.lproj/BraveWallet.strings
+++ b/Sources/BraveWallet/Resources/uk.lproj/BraveWallet.strings
@@ -32,7 +32,7 @@
 "wallet.activateToken" = "Активувати токен %@";
 
 /* The description when showing no transactions inside Activity tab. */
-"wallet.activityPageEmptyDescription" = "Коли ви виконаєте першу транзакцію, її можна буде переглянути тут.";
+"wallet.activityPageEmptyDescription" = "Коли ви виконаєте транзакцію, її можна буде переглянути тут.";
 
 /* The title when showing no transactions inside Activity tab. */
 "wallet.activityPageEmptyTitle" = "Транзакцій наразі немає";
@@ -401,7 +401,7 @@
 "wallet.customTokenNetworkHeader" = "Вибрати мережу";
 
 /* The title displayed on the add custom token screen */
-"wallet.customTokenTitle" = "Користувацькі";
+"wallet.customTokenTitle" = "Додати користувацький актив";
 
 /* The title of the notification which will prompt at the top of the browser when users are visiting web3 site that is not yet connected with Brave Wallet. The '%@' will be the site attempting to connect. For example: \"app.uniswap.org wants to interact with Brave Wallet\" */
 "wallet.dappsConnectionNotificationOriginTitle" = "Користувач %@ хоче взаємодіяти з гаманцем Brave";
@@ -891,6 +891,24 @@
 
 /* The title an entry that will be displayed in NFT detail. This entry to display this NFT's token standard */
 "wallet.nftDetailTokenStandard" = "Стандарт токена";
+
+/* The title of the alert that asks users either to enable NFT discovery or import manually. `SimpleHash` is the third-party service name, so it does not need to be translated. */
+"wallet.nftDiscoveryCalloutDescription" = "Brave Wallet може використовувати сторонні сервіси для автоматичного відображення ваших NFT. Brave розкриє адреси ваших гаманців сервісу SimpleHash, щоб він працював. Детальніше.";
+
+/* This is the same `Learn more` at the end of `nftDiscoveryCalloutDescription`, but we need a separat translation to detect the range of it in order to build some attributed strings. */
+"wallet.nftDiscoveryCalloutDescriptionLearnMore" = "Докладніше";
+
+/* The title of the button that user clicks to disable NFT discovery. */
+"wallet.nftDiscoveryCalloutDisable" = "Ні, дякую. Я зроблю це вручну.";
+
+/* The title of the button that user clicks to enable NFT discovery. */
+"wallet.nftDiscoveryCalloutEnable" = "Так, продовжити";
+
+/* The title of the alert that asks users either to enable NFT discovery or import manually. */
+"wallet.nftDiscoveryCalloutTitle" = "Хочете, щоб ваші NFT відображалися автоматично?";
+
+/* The title of the button that user clicks to add his/her first NFT */
+"wallet.nftEmptyImportNFT" = "Імпортувати NFT";
 
 /* Description of the NFT Gateway setting */
 "wallet.nftGatewayLongDescription" = "Потрібно надати дійсний IPFS-шлюз. Наданий шлюз буде перевірено на можливість завантаження ресурсів IPFS.";
@@ -1707,6 +1725,12 @@
 
 /* The section title for users to set up preferences for interation with web3 sites. */
 "wallet.web3PreferencesSectionTitle" = "Параметри Web3";
+
+/* The title of the toggle for user to enable/disable NFT discovery inside Web3 settings. */
+"wallet.web3SettingsEnableNFTDiscovery" = "Увімкнути знаходження NFT";
+
+/* The footer of the toggle for user to enable/disable NFT discovery inside Web3 settings. */
+"wallet.web3SettingsEnableNFTDiscoveryFooter" = "Автоматично додавайте NFT, якими ви володієте, у гаманець, використовуючи сторонні API. [Докладніше](%@)";
 
 /* Description of the wrong IPFS gateway alert */
 "wallet.wrongGatewayAlertDescription" = "Надано недійсну URL-адресу. Шлюз повинен вирішувати ресурси IPFS.";

--- a/Sources/BraveWallet/Resources/zh-TW.lproj/BraveWallet.strings
+++ b/Sources/BraveWallet/Resources/zh-TW.lproj/BraveWallet.strings
@@ -32,10 +32,10 @@
 "wallet.activateToken" = "啟用代幣 %@";
 
 /* The description when showing no transactions inside Activity tab. */
-"wallet.activityPageEmptyDescription" = "第一筆交易完成後，您就可在此檢視交易。";
+"wallet.activityPageEmptyDescription" = "進行交易後，即可在此檢視交易。";
 
 /* The title when showing no transactions inside Activity tab. */
-"wallet.activityPageEmptyTitle" = "尚無交易";
+"wallet.activityPageEmptyTitle" = "尚無可供檢視的交易";
 
 /* The title of the tab that will display user's transaction activity for all accounts. */
 "wallet.activityPageTitle" = "活動";
@@ -401,7 +401,7 @@
 "wallet.customTokenNetworkHeader" = "選擇網路";
 
 /* The title displayed on the add custom token screen */
-"wallet.customTokenTitle" = "自訂";
+"wallet.customTokenTitle" = "新增自訂資產";
 
 /* The title of the notification which will prompt at the top of the browser when users are visiting web3 site that is not yet connected with Brave Wallet. The '%@' will be the site attempting to connect. For example: \"app.uniswap.org wants to interact with Brave Wallet\" */
 "wallet.dappsConnectionNotificationOriginTitle" = "%@ 想與 Brave 錢包互動";
@@ -891,6 +891,24 @@
 
 /* The title an entry that will be displayed in NFT detail. This entry to display this NFT's token standard */
 "wallet.nftDetailTokenStandard" = "代幣標準";
+
+/* The title of the alert that asks users either to enable NFT discovery or import manually. `SimpleHash` is the third-party service name, so it does not need to be translated. */
+"wallet.nftDiscoveryCalloutDescription" = "Brave 錢包可使用第三方服務來自動顯示您的 NFT。Brave 將與 SimpleHash 分享您的錢包位址，以提供此服務。深入瞭解。";
+
+/* This is the same `Learn more` at the end of `nftDiscoveryCalloutDescription`, but we need a separat translation to detect the range of it in order to build some attributed strings. */
+"wallet.nftDiscoveryCalloutDescriptionLearnMore" = "深入了解";
+
+/* The title of the button that user clicks to disable NFT discovery. */
+"wallet.nftDiscoveryCalloutDisable" = "不用了，謝謝，我會手動執行";
+
+/* The title of the button that user clicks to enable NFT discovery. */
+"wallet.nftDiscoveryCalloutEnable" = "是，請繼續";
+
+/* The title of the alert that asks users either to enable NFT discovery or import manually. */
+"wallet.nftDiscoveryCalloutTitle" = "想自動顯示您的 NFT 嗎？";
+
+/* The title of the button that user clicks to add his/her first NFT */
+"wallet.nftEmptyImportNFT" = "匯入 NFT";
 
 /* Description of the NFT Gateway setting */
 "wallet.nftGatewayLongDescription" = "應提供有效的 IPFS 閘道。系統會檢查提供的閘道是否可載入 IPFS 資源。";
@@ -1707,6 +1725,12 @@
 
 /* The section title for users to set up preferences for interation with web3 sites. */
 "wallet.web3PreferencesSectionTitle" = "Web3 偏好設定";
+
+/* The title of the toggle for user to enable/disable NFT discovery inside Web3 settings. */
+"wallet.web3SettingsEnableNFTDiscovery" = "啟用 NFT 探索";
+
+/* The footer of the toggle for user to enable/disable NFT discovery inside Web3 settings. */
+"wallet.web3SettingsEnableNFTDiscoveryFooter" = "使用第三方 API 將您擁有的 NFT 自動新增至「錢包」。[深入瞭解](%@)";
 
 /* Description of the wrong IPFS gateway alert */
 "wallet.wrongGatewayAlertDescription" = "提供的 URL 無效。閘道應可解析 IPFS 資源。";

--- a/Sources/BraveWallet/Resources/zh.lproj/BraveWallet.strings
+++ b/Sources/BraveWallet/Resources/zh.lproj/BraveWallet.strings
@@ -32,10 +32,10 @@
 "wallet.activateToken" = "激活令牌 %@";
 
 /* The description when showing no transactions inside Activity tab. */
-"wallet.activityPageEmptyDescription" = "在您的首次交易后，您将能够在这里查看它。";
+"wallet.activityPageEmptyDescription" = "交易完成后即可在此查看交易。";
 
 /* The title when showing no transactions inside Activity tab. */
-"wallet.activityPageEmptyTitle" = "暂无交易";
+"wallet.activityPageEmptyTitle" = "尚无可供查看的交易";
 
 /* The title of the tab that will display user's transaction activity for all accounts. */
 "wallet.activityPageTitle" = "活动";
@@ -401,7 +401,7 @@
 "wallet.customTokenNetworkHeader" = "选择网络";
 
 /* The title displayed on the add custom token screen */
-"wallet.customTokenTitle" = "自定义";
+"wallet.customTokenTitle" = "新增自定义资产";
 
 /* The title of the notification which will prompt at the top of the browser when users are visiting web3 site that is not yet connected with Brave Wallet. The '%@' will be the site attempting to connect. For example: \"app.uniswap.org wants to interact with Brave Wallet\" */
 "wallet.dappsConnectionNotificationOriginTitle" = "%@ 想与 Brave Wallet 互动";
@@ -891,6 +891,24 @@
 
 /* The title an entry that will be displayed in NFT detail. This entry to display this NFT's token standard */
 "wallet.nftDetailTokenStandard" = "代幣標準";
+
+/* The title of the alert that asks users either to enable NFT discovery or import manually. `SimpleHash` is the third-party service name, so it does not need to be translated. */
+"wallet.nftDiscoveryCalloutDescription" = "Brave 钱包可使用第三方服务自动显示您的 NFT。Brave 将与 SimpleHash 共享您的钱包地址，以提供此服务。了解更多。";
+
+/* This is the same `Learn more` at the end of `nftDiscoveryCalloutDescription`, but we need a separat translation to detect the range of it in order to build some attributed strings. */
+"wallet.nftDiscoveryCalloutDescriptionLearnMore" = "了解更多";
+
+/* The title of the button that user clicks to disable NFT discovery. */
+"wallet.nftDiscoveryCalloutDisable" = "不用了，谢谢，我会手动执行";
+
+/* The title of the button that user clicks to enable NFT discovery. */
+"wallet.nftDiscoveryCalloutEnable" = "是，請繼續";
+
+/* The title of the alert that asks users either to enable NFT discovery or import manually. */
+"wallet.nftDiscoveryCalloutTitle" = "想自動顯示您的 NFT 嗎？";
+
+/* The title of the button that user clicks to add his/her first NFT */
+"wallet.nftEmptyImportNFT" = "导入 NFT";
 
 /* Description of the NFT Gateway setting */
 "wallet.nftGatewayLongDescription" = "应该提供有效的 IPFS 网关。所提供的网关将检查是否有能力加载 IPFS 资源。";
@@ -1707,6 +1725,12 @@
 
 /* The section title for users to set up preferences for interation with web3 sites. */
 "wallet.web3PreferencesSectionTitle" = "Web3 首选项";
+
+/* The title of the toggle for user to enable/disable NFT discovery inside Web3 settings. */
+"wallet.web3SettingsEnableNFTDiscovery" = "启用 NFT 发现";
+
+/* The footer of the toggle for user to enable/disable NFT discovery inside Web3 settings. */
+"wallet.web3SettingsEnableNFTDiscoveryFooter" = "使用第三方 API 将您拥有的 NFT 自动新增至钱包。[了解更多](%@)";
 
 /* Description of the wrong IPFS gateway alert */
 "wallet.wrongGatewayAlertDescription" = "提供了无效的链接。网关应能够解析 IPFS 资源。";


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7544 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Go to Brave Shields and Privacy settings
Verify that 'standard/aggressive' shields toggle is translated

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
