### PR TITLE
Fix #7596: User can open "Sync" settings screen when device screen lock is disabled

### DIFF
--- a/Sources/Brave/Frontend/Browser/Tabs/TabTray/TabTrayController.swift
+++ b/Sources/Brave/Frontend/Browser/Tabs/TabTray/TabTrayController.swift
@@ -643,7 +643,8 @@ class TabTrayController: LoadingViewController {
             syncAPI: braveCore.syncAPI,
             syncProfileServices: braveCore.syncProfileService,
             tabManager: tabManager,
-            windowProtection: windowProtection))
+            windowProtection: windowProtection,
+            isModallyPresented: true))
       case .openTabsDisabled, .noSyncedSessions:
         if !DeviceInfo.hasConnectivity() {
           present(SyncAlerts.noConnection, animated: true)

--- a/Sources/Brave/Frontend/Login/LoginAuthViewController.swift
+++ b/Sources/Brave/Frontend/Login/LoginAuthViewController.swift
@@ -25,15 +25,15 @@ class LoginAuthViewController: UITableViewController {
     fatalError("init(coder:) has not been implemented")
   }
 
-  override func viewDidLoad() {
-    if requiresAuthentication, Preferences.Privacy.lockWithPasscode.value {
-      askForAuthentication()
-    }
-  }
-
   override func viewWillAppear(_ animated: Bool) {
     super.viewWillAppear(animated)
 
+    if requiresAuthentication, Preferences.Privacy.lockWithPasscode.value {
+      askForAuthentication() { [weak self] status in
+        self?.navigationController?.popViewController(animated: true)
+      }
+    }
+    
     NotificationCenter.default.do {
       $0.addObserver(
         self, selector: #selector(removeBackgroundedBlur),

--- a/Sources/Brave/Frontend/Sync/SyncSettingsTableViewController.swift
+++ b/Sources/Brave/Frontend/Sync/SyncSettingsTableViewController.swift
@@ -91,7 +91,7 @@ class SyncSettingsTableViewController: SyncViewController, UITableViewDelegate, 
     self.syncProfileService = syncProfileService
     self.tabManager = tabManager
     
-    super.init(windowProtection: windowProtection, requiresAuthentication: requiresAuthentication)
+    super.init(windowProtection: windowProtection, requiresAuthentication: requiresAuthentication, isModallyPresented: isModallyPresented)
   }
 
   required init?(coder: NSCoder) {

--- a/Sources/Brave/Frontend/Sync/SyncViewController.swift
+++ b/Sources/Brave/Frontend/Sync/SyncViewController.swift
@@ -9,13 +9,15 @@ class SyncViewController: UIViewController {
 
   let windowProtection: WindowProtection?
   private let requiresAuthentication: Bool
+  private let isModallyPresented: Bool
 
   // MARK: Lifecycle
 
-  init(windowProtection: WindowProtection? = nil, requiresAuthentication: Bool = false) {
+  init(windowProtection: WindowProtection? = nil, requiresAuthentication: Bool = false, isModallyPresented: Bool = false) {
     self.windowProtection = windowProtection
     self.requiresAuthentication = requiresAuthentication
-    
+    self.isModallyPresented = isModallyPresented
+
     super.init(nibName: nil, bundle: nil)
   }
 
@@ -25,9 +27,21 @@ class SyncViewController: UIViewController {
   
   override func viewDidLoad() {
     view.backgroundColor = .secondaryBraveBackground
-
+  }
+  
+  override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
+    
     if requiresAuthentication {
-      askForAuthentication()
+      askForAuthentication() { [weak self] status in
+        guard let self else { return }
+        
+        if isModallyPresented {
+          self.dismiss(animated: true)
+        } else {
+          self.navigationController?.popViewController(animated: true)
+        }
+      }
     }
   }
 

--- a/Sources/Brave/Frontend/Sync/SyncWelcomeViewController.swift
+++ b/Sources/Brave/Frontend/Sync/SyncWelcomeViewController.swift
@@ -142,12 +142,13 @@ class SyncWelcomeViewController: SyncViewController {
   init(syncAPI: BraveSyncAPI,
        syncProfileServices: BraveSyncProfileServiceIOS,
        tabManager: TabManager,
-       windowProtection: WindowProtection?) {
+       windowProtection: WindowProtection?,
+       isModallyPresented: Bool = false) {
     self.syncAPI = syncAPI
     self.syncProfileServices = syncProfileServices
     self.tabManager = tabManager
     
-    super.init(windowProtection: windowProtection)
+    super.init(windowProtection: windowProtection, isModallyPresented: isModallyPresented)
   }
 
   @available(*, unavailable)


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7596 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

- Launch Brave > Enable Sync from the Settings or Tab Tray
- Go to device settings and disable the screen lock
- Return to Brave > Go to settings > Sync > Observe Set a Passcode message
- Tap OK > Observe that the user can change any setting
- Tab Tray > Tabs from Other Devices > Enable tab syncing (Open Tabs must be OFF)
- Observe Set a Passcode message > Tap OK > Observe that the user can change any setting

## Screenshots:


https://github.com/brave/brave-ios/assets/6643505/d21b72ed-b3e7-49e7-ac0c-562268252adf


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
