### PR TITLE
No Bug: Add followed locales & decoding errors to News debug settings

### DIFF
--- a/Sources/BraveNews/Settings/BraveNewsDebugSettingsView.swift
+++ b/Sources/BraveNews/Settings/BraveNewsDebugSettingsView.swift
@@ -85,6 +85,13 @@ public struct BraveNewsDebugSettingsView: View {
           Text(feedDataSource.description(of: feedDataSource.state))
             .foregroundColor(.secondary)
         }
+        HStack {
+          Text("Following Locales")
+          Spacer()
+          Text(feedDataSource.followedLocales.joined(separator: ", "))
+            .foregroundColor(.secondary)
+            .multilineTextAlignment(.trailing)
+        }
         switch feedDataSource.state {
         case .initial:
           EmptyView()
@@ -116,6 +123,27 @@ public struct BraveNewsDebugSettingsView: View {
         case .failure(let error):
           Text(error.localizedDescription)
             .foregroundColor(.secondary)
+        }
+        if !feedDataSource.decodingErrors.isEmpty {
+          NavigationLink {
+            List(feedDataSource.decodingErrors) { error in
+              VStack(alignment: .leading) {
+                Text(error.resourceName)
+                  .font(.headline)
+                Text(error.error)
+                  .font(.subheadline)
+                  .multilineTextAlignment(.leading)
+              }
+              .frame(maxWidth: .infinity)
+            }
+          } label: {
+            HStack {
+              Text("Decoding Errors")
+              Spacer()
+              Text(feedDataSource.decodingErrors.count, format: .number)
+                .foregroundColor(.secondary)
+            }
+          }
         }
       }
       .listRowBackground(Color(.secondaryBraveGroupedBackground))

--- a/Sources/CodableHelpers/FailableDecodable.swift
+++ b/Sources/CodableHelpers/FailableDecodable.swift
@@ -35,19 +35,19 @@ import Foundation
 /// where `Bar` is some complex type
 @propertyWrapper public struct FailableDecodable<T: Decodable>: Decodable {
   public var wrappedValue: T?
+  public var decodingError: Error?
   public init(from decoder: Decoder) throws {
     let container = try decoder.singleValueContainer()
-    #if DEBUG
-    // In debug builds we print out failed decodes to console so we can fix the issue or notify the
-    // appropriate team about some malformed JSON
     do {
       wrappedValue = try container.decode(T.self)
     } catch {
-      print("FailableDecodable failed to decode to type \(T.self): \(error.localizedDescription)")
       wrappedValue = nil
+#if DEBUG
+      // In debug builds we print out failed decodes to console so we can fix the issue or notify the
+      // appropriate team about some malformed JSON
+      print("FailableDecodable failed to decode to type \(T.self): \(error.localizedDescription)")
+#endif
+      decodingError = error
     }
-    #else
-    wrappedValue = try? container.decode(T.self)
-    #endif
   }
 }


### PR DESCRIPTION
## Summary of Changes

Adds some more stuff to News debug settings to try and help debug #7601

No changes to release/public beta builds

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
