### PR TITLE
Fix #4821: Update order of buttons on 'create sync chain' screen

### DIFF
--- a/Sources/Brave/Frontend/Sync/SyncWelcomeViewController.swift
+++ b/Sources/Brave/Frontend/Sync/SyncWelcomeViewController.swift
@@ -185,8 +185,8 @@ class SyncWelcomeViewController: SyncViewController {
     textStackView.addArrangedSubview(descriptionStackView)
     mainStackView.addArrangedSubview(textStackView)
 
-    buttonsStackView.addArrangedSubview(newToSyncButton)
     buttonsStackView.addArrangedSubview(existingUserButton)
+    buttonsStackView.addArrangedSubview(newToSyncButton)
     mainStackView.addArrangedSubview(buttonsStackView)
 
     navigationItem.rightBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "gearshape"), style: .plain, target: self, action: #selector(onSyncInternalsAction))


### PR DESCRIPTION
Update order of buttons on 'create sync chain' screen

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4821

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
