### PR TITLE
Ref #7596: User can open "Sync" settings screen when device screen lock is disabled

### DIFF
--- a/Sources/Brave/Frontend/Login/LoginAuthViewController.swift
+++ b/Sources/Brave/Frontend/Login/LoginAuthViewController.swift
@@ -29,8 +29,10 @@ class LoginAuthViewController: UITableViewController {
     super.viewWillAppear(animated)
 
     if requiresAuthentication, Preferences.Privacy.lockWithPasscode.value {
-      askForAuthentication() { [weak self] status in
-        self?.navigationController?.popViewController(animated: true)
+      askForAuthentication() { [weak self] success in
+        if !success {
+          self?.navigationController?.popViewController(animated: true)
+        }
       }
     }
     

--- a/Sources/Brave/Frontend/Sync/SyncViewController.swift
+++ b/Sources/Brave/Frontend/Sync/SyncViewController.swift
@@ -33,13 +33,15 @@ class SyncViewController: UIViewController {
     super.viewWillAppear(animated)
     
     if requiresAuthentication {
-      askForAuthentication() { [weak self] status in
+      askForAuthentication() { [weak self] success in
         guard let self else { return }
         
-        if isModallyPresented {
-          self.dismiss(animated: true)
-        } else {
-          self.navigationController?.popViewController(animated: true)
+        if !success {
+          if isModallyPresented {
+            self.dismiss(animated: true)
+          } else {
+            self.navigationController?.popViewController(animated: true)
+          }
         }
       }
     }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request references #7596 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
