### PR TITLE
Fix #7615: Don't leak status bar color while in overlay mode.

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController.swift
@@ -104,7 +104,7 @@ public class BrowserViewController: UIViewController {
   var readerModeBar: ReaderModeBarView?
   var readerModeCache: ReaderModeCache
   
-  private let statusBarOverlay: UIView = {
+  let statusBarOverlay: UIView = {
     // Temporary work around for covering the non-clipped web view content
     let statusBarOverlay = UIView()
     statusBarOverlay.backgroundColor = Preferences.General.nightModeEnabled.value ? .nightModeBackground : .urlBarBackground
@@ -784,8 +784,8 @@ public class BrowserViewController: UIViewController {
     view.addSubview(topTouchArea)
     view.addSubview(bottomBarKeyboardBackground)
     view.addSubview(footer)
-    view.addSubview(header)
     view.addSubview(statusBarOverlay)
+    view.addSubview(header)
     
     // For now we hide some elements so they are not visible
     header.isHidden = true

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
@@ -731,7 +731,11 @@ extension BrowserViewController: TopToolbarDelegate {
       if let ntpController = self.activeNewTabPageViewController, ntpController.parent != nil {
         view.insertSubview(favoritesController.view, aboveSubview: ntpController.view)
       } else {
-        view.insertSubview(favoritesController.view, aboveSubview: footer)
+        // Two different behaviors here:
+        // 1. For bottom bar we do not want to show the status bar color
+        // 2. For top bar we do so it matches the address bar background
+        let subview = isUsingBottomBar ? statusBarOverlay : footer
+        view.insertSubview(favoritesController.view, aboveSubview: subview)
       }
       favoritesController.didMove(toParent: self)
 


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7615 

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
