### PR TITLE
Fix #7607: Select Multiple Networks in Network Filter Views

### DIFF
--- a/Sources/BraveWallet/Crypto/CryptoPagesView.swift
+++ b/Sources/BraveWallet/Crypto/CryptoPagesView.swift
@@ -83,7 +83,6 @@ struct CryptoPagesView: View {
         .sheet(isPresented: $cryptoStore.isPresentingAssetSearch) {
           AssetSearchView(
             keyringStore: keyringStore,
-            networkStore: cryptoStore.networkStore,
             cryptoStore: cryptoStore,
             userAssetsStore: cryptoStore.portfolioStore.userAssetsStore
           )

--- a/Sources/BraveWallet/Crypto/CryptoPagesView.swift
+++ b/Sources/BraveWallet/Crypto/CryptoPagesView.swift
@@ -83,6 +83,7 @@ struct CryptoPagesView: View {
         .sheet(isPresented: $cryptoStore.isPresentingAssetSearch) {
           AssetSearchView(
             keyringStore: keyringStore,
+            networkStore: cryptoStore.networkStore,
             cryptoStore: cryptoStore,
             userAssetsStore: cryptoStore.portfolioStore.userAssetsStore
           )

--- a/Sources/BraveWallet/Crypto/NFT/NFTView.swift
+++ b/Sources/BraveWallet/Crypto/NFT/NFTView.swift
@@ -103,18 +103,19 @@ struct NFTView: View {
     Button(action: {
       self.isPresentingNetworkFilter = true
     }) {
-      HStack {
-        Image(braveSystemName: "leo.list")
-        Text(nftStore.networkFilter.title)
-      }
-      .font(.footnote.weight(.medium))
-      .foregroundColor(Color(.braveBlurpleTint))
+      Image(braveSystemName: "leo.tune")
+        .font(.footnote.weight(.medium))
+        .foregroundColor(Color(.braveBlurpleTint))
+        .clipShape(Rectangle())
     }
     .sheet(isPresented: $isPresentingNetworkFilter) {
       NavigationView {
         NetworkFilterView(
-          networkFilter: $nftStore.networkFilter,
-          networkStore: networkStore
+          networks: nftStore.networkFilters,
+          networkStore: networkStore,
+          saveAction: { selectedNetworks in
+            nftStore.networkFilters = selectedNetworks
+          }
         )
       }
       .onDisappear {

--- a/Sources/BraveWallet/Crypto/NetworkFilterView.swift
+++ b/Sources/BraveWallet/Crypto/NetworkFilterView.swift
@@ -20,8 +20,6 @@ struct NetworkFilterView: View {
   @ObservedObject var networkStore: NetworkStore
   let saveAction: ([Selectable<BraveWallet.NetworkInfo>]) -> Void
   
-  @State private(set) var primaryNetworks: [NetworkPresentation] = []
-  @State private(set) var secondaryNetworks: [NetworkPresentation] = []
   @Environment(\.presentationMode) @Binding private var presentationMode
   
   init(
@@ -38,13 +36,9 @@ struct NetworkFilterView: View {
     NetworkSelectionRootView(
       navigationTitle: Strings.Wallet.networkFilterTitle,
       selectedNetworks: networks.filter(\.isSelected).map(\.model),
-      primaryNetworks: primaryNetworks,
-      secondaryNetworks: secondaryNetworks,
+      allNetworks: networks.map(\.model),
       selectNetwork: selectNetwork
     )
-    .onAppear {
-      fetchNetworks()
-    }
     .toolbar {
       ToolbarItem(placement: .confirmationAction) {
         Button(action: {
@@ -56,27 +50,6 @@ struct NetworkFilterView: View {
         }
       }
     }
-  }
-  
-  private func fetchNetworks() {
-    self.primaryNetworks = networkStore.primaryNetworks
-      .map { network in
-        let subNetworks = networkStore.subNetworks(for: network)
-        return NetworkPresentation(
-          network: network,
-          subNetworks: subNetworks.count > 1 ? subNetworks : [],
-          isPrimaryNetwork: true
-        )
-      }
-
-    self.secondaryNetworks = networkStore.secondaryNetworks
-      .map { network in
-        NetworkPresentation(
-          network: network,
-          subNetworks: [],
-          isPrimaryNetwork: false
-        )
-      }
   }
   
   private func selectNetwork(_ network: BraveWallet.NetworkInfo) {

--- a/Sources/BraveWallet/Crypto/NetworkFilterView.swift
+++ b/Sources/BraveWallet/Crypto/NetworkFilterView.swift
@@ -7,28 +7,37 @@ import BraveCore
 import SwiftUI
 import BraveShared
 
+struct Selectable<T: Identifiable & Equatable>: Equatable, Identifiable {
+  let isSelected: Bool
+  let model: T
+  
+  var id: T.ID { model.id }
+}
+
 struct NetworkFilterView: View {
   
-  @Binding var networkFilter: NetworkFilter
+  @State var networks: [Selectable<BraveWallet.NetworkInfo>]
   @ObservedObject var networkStore: NetworkStore
+  let saveAction: ([Selectable<BraveWallet.NetworkInfo>]) -> Void
   
   @State private(set) var primaryNetworks: [NetworkPresentation] = []
   @State private(set) var secondaryNetworks: [NetworkPresentation] = []
   @Environment(\.presentationMode) @Binding private var presentationMode
   
-  private var selectedNetwork: NetworkPresentation.Network {
-    switch networkFilter {
-    case .allNetworks:
-      return .allNetworks
-    case let .network(network):
-      return .network(network)
-    }
+  init(
+    networks: [Selectable<BraveWallet.NetworkInfo>],
+    networkStore: NetworkStore,
+    saveAction: @escaping ([Selectable<BraveWallet.NetworkInfo>]) -> Void
+  ) {
+    self._networks = .init(initialValue: networks)
+    self.networkStore = networkStore
+    self.saveAction = saveAction
   }
   
   var body: some View {
     NetworkSelectionRootView(
       navigationTitle: Strings.Wallet.networkFilterTitle,
-      selectedNetwork: selectedNetwork,
+      selectedNetworks: networks.filter(\.isSelected).map(\.model),
       primaryNetworks: primaryNetworks,
       secondaryNetworks: secondaryNetworks,
       selectNetwork: selectNetwork
@@ -36,39 +45,47 @@ struct NetworkFilterView: View {
     .onAppear {
       fetchNetworks()
     }
+    .toolbar {
+      ToolbarItem(placement: .confirmationAction) {
+        Button(action: {
+          saveAction(networks)
+          presentationMode.dismiss()
+        }) {
+          Text("Save")
+            .foregroundColor(Color(.braveBlurpleTint))
+        }
+      }
+    }
   }
   
   private func fetchNetworks() {
-    let primaryNetworks = networkStore.primaryNetworks
+    self.primaryNetworks = networkStore.primaryNetworks
       .map { network in
         let subNetworks = networkStore.subNetworks(for: network)
         return NetworkPresentation(
-          network: .network(network),
+          network: network,
           subNetworks: subNetworks.count > 1 ? subNetworks : [],
           isPrimaryNetwork: true
         )
       }
-    self.primaryNetworks = [.allNetworks] + primaryNetworks
 
     self.secondaryNetworks = networkStore.secondaryNetworks
       .map { network in
         NetworkPresentation(
-          network: .network(network),
+          network: network,
           subNetworks: [],
           isPrimaryNetwork: false
         )
       }
   }
   
-  private func selectNetwork(_ network: NetworkPresentation.Network) {
+  private func selectNetwork(_ network: BraveWallet.NetworkInfo) {
     DispatchQueue.main.async {
-      switch network {
-      case .allNetworks:
-        networkFilter = .allNetworks
-      case let .network(network):
-        networkFilter = .network(network)
+      if let index = networks.firstIndex(
+        where: { $0.model.chainId == network.chainId && $0.model.coin == network.coin }
+      ) {
+        networks[index] = .init(isSelected: !networks[index].isSelected, model: networks[index].model)
       }
-      presentationMode.dismiss()
     }
   }
 }

--- a/Sources/BraveWallet/Crypto/NetworkSelectionView.swift
+++ b/Sources/BraveWallet/Crypto/NetworkSelectionView.swift
@@ -48,15 +48,11 @@ struct NetworkSelectionView: View {
     NetworkSelectionRootView(
       navigationTitle: navigationTitle,
       selectedNetworks: [selectedNetwork],
-      primaryNetworks: store.primaryNetworks,
-      secondaryNetworks: store.secondaryNetworks,
+      allNetworks: networkStore.allChains,
       selectNetwork: { network in
         selectNetwork(network)
       }
     )
-    .onAppear {
-      store.update()
-    }
     .background(
       Color.clear
         .alert(

--- a/Sources/BraveWallet/Crypto/NetworkSelectionView.swift
+++ b/Sources/BraveWallet/Crypto/NetworkSelectionView.swift
@@ -25,15 +25,15 @@ struct NetworkSelectionView: View {
     self.store = networkSelectionStore
   }
   
-  private var selectedNetwork: NetworkPresentation.Network {
+  private var selectedNetwork: BraveWallet.NetworkInfo {
     switch store.mode {
     case let .select(isForOrigin):
       if isForOrigin {
-        return .network(networkStore.selectedChainForOrigin)
+        return networkStore.selectedChainForOrigin
       }
-      return .network(networkStore.defaultSelectedChain)
+      return networkStore.defaultSelectedChain
     case .formSelection:
-      return .network(store.networkSelectionInForm ?? .init())
+      return store.networkSelectionInForm ?? .init()
     }
   }
   
@@ -47,7 +47,7 @@ struct NetworkSelectionView: View {
   var body: some View {
     NetworkSelectionRootView(
       navigationTitle: navigationTitle,
-      selectedNetwork: selectedNetwork,
+      selectedNetworks: [selectedNetwork],
       primaryNetworks: store.primaryNetworks,
       secondaryNetworks: store.secondaryNetworks,
       selectNetwork: { network in
@@ -94,9 +94,9 @@ struct NetworkSelectionView: View {
     )
   }
   
-  private func selectNetwork(_ presentation: NetworkPresentation.Network) {
+  private func selectNetwork(_ network: BraveWallet.NetworkInfo) {
     Task { @MainActor in
-      if await store.selectNetwork(presentation) {
+      if await store.selectNetwork(network) {
         presentationMode.dismiss()
       }
     }

--- a/Sources/BraveWallet/Crypto/Portfolio/EditUserAssetsView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/EditUserAssetsView.swift
@@ -99,12 +99,10 @@ struct EditUserAssetsView: View {
     Button(action: {
       self.isPresentingNetworkFilter = true
     }) {
-      HStack {
-        Image(braveSystemName: "leo.list")
-        Text(userAssetsStore.networkFilter.title)
-      }
-      .font(.footnote.weight(.medium))
-      .foregroundColor(Color(.braveBlurpleTint))
+      Image(braveSystemName: "leo.tune")
+        .font(.footnote.weight(.medium))
+        .foregroundColor(Color(.braveBlurpleTint))
+        .clipShape(Rectangle())
     }
   }
   
@@ -212,8 +210,11 @@ struct EditUserAssetsView: View {
     .background(Color.clear.sheet(isPresented: $isPresentingNetworkFilter) {
       NavigationView {
         NetworkFilterView(
-          networkFilter: $userAssetsStore.networkFilter,
-          networkStore: networkStore
+          networks: userAssetsStore.networkFilters,
+          networkStore: networkStore,
+          saveAction: { selectedNetworks in
+            userAssetsStore.networkFilters = selectedNetworks
+          }
         )
       }
       .onDisappear {

--- a/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
@@ -97,18 +97,19 @@ struct PortfolioView: View {
     Button(action: {
       self.isPresentingNetworkFilter = true
     }) {
-      HStack {
-        Text(portfolioStore.networkFilter.title)
-        Image(braveSystemName: "leo.list")
-      }
-      .font(.footnote.weight(.medium))
-      .foregroundColor(Color(.braveBlurpleTint))
+      Image(braveSystemName: "leo.tune")
+        .font(.footnote.weight(.medium))
+        .foregroundColor(Color(.braveBlurpleTint))
+        .clipShape(Rectangle())
     }
     .sheet(isPresented: $isPresentingNetworkFilter) {
       NavigationView {
         NetworkFilterView(
-          networkFilter: $portfolioStore.networkFilter,
-          networkStore: networkStore
+          networks: portfolioStore.networkFilters,
+          networkStore: networkStore,
+          saveAction: { selectedNetworks in
+            portfolioStore.networkFilters = selectedNetworks
+          }
         )
       }
       .onDisappear {

--- a/Sources/BraveWallet/Crypto/Search/AssetSearchView.swift
+++ b/Sources/BraveWallet/Crypto/Search/AssetSearchView.swift
@@ -181,6 +181,12 @@ struct AssetSearchView: View {
         }
       }
     }
+    .onChange(of: networkStore.allChains) { allChains in
+      self.networkFilters = allChains.map { network in
+        let existingSelectionValue = self.networkFilters.first(where: { $0.model.chainId == network.chainId})?.isSelected
+        return .init(isSelected: existingSelectionValue ?? true, model: network)
+      }
+    }
   }
   
   private func title(for token: BraveWallet.BlockchainToken) -> String {

--- a/Sources/BraveWallet/Crypto/SelectAccountTokenView.swift
+++ b/Sources/BraveWallet/Crypto/SelectAccountTokenView.swift
@@ -83,18 +83,19 @@ struct SelectAccountTokenView: View {
     Button(action: {
       self.isPresentingNetworkFilter = true
     }) {
-      HStack {
-        Image(braveSystemName: "leo.list")
-        Text(store.networkFilter.title)
-      }
-      .font(.footnote.weight(.medium))
-      .foregroundColor(Color(.braveBlurpleTint))
+      Image(braveSystemName: "leo.tune")
+        .font(.footnote.weight(.medium))
+        .foregroundColor(Color(.braveBlurpleTint))
+        .clipShape(Rectangle())
     }
     .sheet(isPresented: $isPresentingNetworkFilter) {
       NavigationView {
         NetworkFilterView(
-          networkFilter: $store.networkFilter,
-          networkStore: networkStore
+          networks: store.networkFilters,
+          networkStore: networkStore,
+          saveAction: { selectedNetworks in
+            store.networkFilters = selectedNetworks
+          }
         )
       }
       .onDisappear {

--- a/Sources/BraveWallet/Crypto/Stores/NFTStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/NFTStore.swift
@@ -25,8 +25,9 @@ public class NFTStore: ObservableObject {
   /// The users visible NFTs
   @Published private(set) var userVisibleNFTs: [NFTAssetViewModel] = []
   /// The network filter in NFT tab
-  @Published var networkFilter: NetworkFilter = .allNetworks {
+  @Published var networkFilters: [Selectable<BraveWallet.NetworkInfo>] = [] {
     didSet {
+      guard !oldValue.isEmpty else { return } // initial assignment to `networkFilters`
       update()
     }
   }
@@ -85,14 +86,13 @@ public class NFTStore: ObservableObject {
   func update() {
     self.updateTask?.cancel()
     self.updateTask = Task { @MainActor in
-      let networks: [BraveWallet.NetworkInfo]
-      switch networkFilter {
-      case .allNetworks:
-        networks = await self.rpcService.allNetworksForSupportedCoins()
-          .filter { !WalletConstants.supportedTestNetworkChainIds.contains($0.chainId) }
-      case let .network(network):
-        networks = [network]
+      // setup network filters if not currently setup
+      if self.networkFilters.isEmpty {
+        self.networkFilters = await self.rpcService.allNetworksForSupportedCoins().map {
+          .init(isSelected: !WalletConstants.supportedTestNetworkChainIds.contains($0.chainId), model: $0)
+        }
       }
+      let networks: [BraveWallet.NetworkInfo] = self.networkFilters.filter(\.isSelected).map(\.model)
       let allVisibleUserAssets = assetManager.getAllVisibleAssetsInNetworkAssets(networks: networks)
       var updatedUserVisibleNFTs: [NFTAssetViewModel] = []
       for networkAssets in allVisibleUserAssets {

--- a/Sources/BraveWallet/Crypto/Stores/NFTStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/NFTStore.swift
@@ -223,6 +223,14 @@ extension NFTStore: BraveWalletBraveWalletServiceObserver {
   }
   
   public func onNetworkListChanged() {
+    Task { @MainActor in
+      // A network was added or removed, update our network filters for the change.
+      self.networkFilters = await self.rpcService.allNetworksForSupportedCoins().map { network in
+        let defaultValue = !WalletConstants.supportedTestNetworkChainIds.contains(network.chainId)
+        let existingSelectionValue = self.networkFilters.first(where: { $0.model.chainId == network.chainId})?.isSelected
+        return .init(isSelected: existingSelectionValue ?? defaultValue, model: network)
+      }
+    }
   }
   
   public func onDiscoverAssetsStarted() {

--- a/Sources/BraveWallet/Crypto/Stores/NetworkSelectionStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/NetworkSelectionStore.swift
@@ -17,9 +17,6 @@ class NetworkSelectionStore: ObservableObject {
   let mode: Mode
   var networkStore: NetworkStore
   
-  @Published private(set) var primaryNetworks: [NetworkPresentation] = []
-  @Published private(set) var secondaryNetworks: [NetworkPresentation] = []
-  
   /// If we are prompting the user to add an account for the `nextNetwork.coin` type
   @Published var isPresentingNextNetworkAlert = false
   /// The network the user wishes to switch to, but does not (yet) have an account for `nextNetwork.coin` type
@@ -35,27 +32,6 @@ class NetworkSelectionStore: ObservableObject {
   ) {
     self.mode = mode
     self.networkStore = networkStore
-  }
-  
-  func update() {
-    self.primaryNetworks = networkStore.primaryNetworks
-      .map { network in
-        let subNetworks = networkStore.subNetworks(for: network)
-        return NetworkPresentation(
-          network: network,
-          subNetworks: subNetworks.count > 1 ? subNetworks : [],
-          isPrimaryNetwork: true
-        )
-      }
-
-    self.secondaryNetworks = networkStore.secondaryNetworks
-      .map { network in
-        NetworkPresentation(
-          network: network,
-          subNetworks: [],
-          isPrimaryNetwork: false
-        )
-      }
   }
   
   @MainActor func selectNetwork(_ network: BraveWallet.NetworkInfo) async -> Bool {

--- a/Sources/BraveWallet/Crypto/Stores/NetworkSelectionStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/NetworkSelectionStore.swift
@@ -42,7 +42,7 @@ class NetworkSelectionStore: ObservableObject {
       .map { network in
         let subNetworks = networkStore.subNetworks(for: network)
         return NetworkPresentation(
-          network: .network(network),
+          network: network,
           subNetworks: subNetworks.count > 1 ? subNetworks : [],
           isPrimaryNetwork: true
         )
@@ -51,18 +51,16 @@ class NetworkSelectionStore: ObservableObject {
     self.secondaryNetworks = networkStore.secondaryNetworks
       .map { network in
         NetworkPresentation(
-          network: .network(network),
+          network: network,
           subNetworks: [],
           isPrimaryNetwork: false
         )
       }
   }
   
-  @MainActor func selectNetwork(_ network: NetworkPresentation.Network) async -> Bool {
+  @MainActor func selectNetwork(_ network: BraveWallet.NetworkInfo) async -> Bool {
     switch mode {
     case let .select(isForOrigin):
-      guard case let .network(network) = network else { return false }
-
       let error = await networkStore.setSelectedChain(network, isForOrigin: isForOrigin)
       switch error {
       case .selectedChainHasNoAccounts:
@@ -73,13 +71,8 @@ class NetworkSelectionStore: ObservableObject {
         return true
       }
     case .formSelection:
-      switch network {
-      case let .network(network):
-        networkSelectionInForm = network
-        return true
-      default:
-        return false
-      }
+      networkSelectionInForm = network
+      return true
     }
   }
   

--- a/Sources/BraveWallet/Crypto/Stores/NetworkStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/NetworkStore.swift
@@ -23,21 +23,6 @@ public class NetworkStore: ObservableObject {
   
   @Published private(set) var allChains: [BraveWallet.NetworkInfo] = []
   @Published private(set) var customChains: [BraveWallet.NetworkInfo] = []
-  
-  /// The primary networks from `allChains`
-  var primaryNetworks: [BraveWallet.NetworkInfo] {
-    allChains
-      .filter { WalletConstants.primaryNetworkChainIds.contains($0.chainId) }
-  }
-  
-  // The secondary networks from `allChains`
-  var secondaryNetworks: [BraveWallet.NetworkInfo] {
-    allChains
-      .filter {
-        !WalletConstants.primaryNetworkChainIds.contains($0.chainId)
-        && !WalletConstants.supportedTestNetworkChainIds.contains($0.chainId)
-      }
-  }
 
   @Published private(set) var defaultSelectedChainId: String = BraveWallet.MainnetChainId
   var defaultSelectedChain: BraveWallet.NetworkInfo {
@@ -357,5 +342,27 @@ extension NetworkStore: BraveWalletKeyringServiceObserver {
   }
   
   public func accountsAdded(_ addedAccounts: [BraveWallet.AccountInfo]) {
+  }
+}
+
+extension Array where Element == BraveWallet.NetworkInfo {
+  /// Returns the primary networks in Self.
+  var primaryNetworks: [BraveWallet.NetworkInfo] {
+    filter { WalletConstants.primaryNetworkChainIds.contains($0.chainId) }
+  }
+  
+  /// Returns the secondary networks in Self.
+  var secondaryNetworks: [BraveWallet.NetworkInfo] {
+    filter {
+      !WalletConstants.primaryNetworkChainIds.contains($0.chainId)
+      && !WalletConstants.supportedTestNetworkChainIds.contains($0.chainId)
+    }
+  }
+  
+  /// Returns the known test networks in Self.
+  var testNetworks: [BraveWallet.NetworkInfo] {
+    filter {
+      WalletConstants.supportedTestNetworkChainIds.contains($0.chainId)
+    }
   }
 }

--- a/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
@@ -353,6 +353,14 @@ extension PortfolioStore: BraveWalletBraveWalletServiceObserver {
   }
 
   public func onNetworkListChanged() {
+    Task { @MainActor in
+      // A network was added or removed, update our network filters for the change.
+      self.networkFilters = await self.rpcService.allNetworksForSupportedCoins().map { network in
+        let defaultValue = !WalletConstants.supportedTestNetworkChainIds.contains(network.chainId)
+        let existingSelectionValue = self.networkFilters.first(where: { $0.model.chainId == network.chainId})?.isSelected
+        return .init(isSelected: existingSelectionValue ?? defaultValue, model: network)
+      }
+    }
   }
   
   public func onDefaultEthereumWalletChanged(_ wallet: BraveWallet.DefaultWallet) {

--- a/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
@@ -47,20 +47,6 @@ struct BalanceTimePrice: DataPoint, Equatable {
   }
 }
 
-public enum NetworkFilter: Equatable {
-  case allNetworks
-  case network(BraveWallet.NetworkInfo)
-  
-  var title: String {
-    switch self {
-    case .allNetworks:
-      return Strings.Wallet.allNetworksTitle
-    case let .network(network):
-      return network.chainName
-    }
-  }
-}
-
 /// A store containing data around the users assets
 public class PortfolioStore: ObservableObject {
   /// The dollar amount of your portfolio
@@ -88,8 +74,9 @@ public class PortfolioStore: ObservableObject {
     }
   }
   
-  @Published var networkFilter: NetworkFilter = .allNetworks {
+  @Published var networkFilters: [Selectable<BraveWallet.NetworkInfo>] = [] {
     didSet {
+      guard !oldValue.isEmpty else { return } // initial assignment to `networkFilters`
       update()
     }
   }
@@ -158,14 +145,13 @@ public class PortfolioStore: ObservableObject {
     self.updateTask?.cancel()
     self.updateTask = Task { @MainActor in
       self.isLoadingBalances = true
-      let networks: [BraveWallet.NetworkInfo]
-      switch networkFilter {
-      case .allNetworks:
-        networks = await self.rpcService.allNetworksForSupportedCoins()
-          .filter { !WalletConstants.supportedTestNetworkChainIds.contains($0.chainId) }
-      case let .network(network):
-        networks = [network]
+      // setup network filters if not currently setup
+      if self.networkFilters.isEmpty {
+        self.networkFilters = await self.rpcService.allNetworksForSupportedCoins().map {
+          .init(isSelected: !WalletConstants.supportedTestNetworkChainIds.contains($0.chainId), model: $0)
+        }
       }
+      let networks: [BraveWallet.NetworkInfo] = self.networkFilters.filter(\.isSelected).map(\.model)
       struct NetworkAssets: Equatable {
         let network: BraveWallet.NetworkInfo
         let tokens: [BraveWallet.BlockchainToken]

--- a/Sources/BraveWallet/Crypto/Stores/SelectAccountTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SelectAccountTokenStore.swift
@@ -308,7 +308,15 @@ extension SelectAccountTokenStore: BraveWalletBraveWalletServiceObserver {
   
   func onDefaultBaseCryptocurrencyChanged(_ cryptocurrency: String) { }
   
-  func onNetworkListChanged() { }
+  func onNetworkListChanged() {
+    Task { @MainActor in
+      // A network was added or removed, update our network filters for the change.
+      self.networkFilters = await self.rpcService.allNetworksForSupportedCoins().map { network in
+        let existingSelectionValue = self.networkFilters.first(where: { $0.model.chainId == network.chainId})?.isSelected
+        return .init(isSelected: existingSelectionValue ?? true, model: network)
+      }
+    }
+  }
   
   func onDiscoverAssetsStarted() { }
   

--- a/Sources/BraveWallet/Crypto/Stores/SelectAccountTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SelectAccountTokenStore.swift
@@ -65,7 +65,7 @@ class SelectAccountTokenStore: ObservableObject {
             return true
           }
       )
-      if shouldShowSection(accountSection) {
+      if shouldShowSection(updatedAccountSection) {
         filteredAccountSections.append(updatedAccountSection)
       }
     }
@@ -129,7 +129,7 @@ class SelectAccountTokenStore: ObservableObject {
   func resetFilters() {
     isHidingZeroBalances = true
     networkFilters = allNetworks.map {
-      .init(isSelected: !WalletConstants.supportedTestNetworkChainIds.contains($0.chainId), model: $0)
+      .init(isSelected: true, model: $0)
     }
   }
   

--- a/Sources/BraveWallet/Crypto/Stores/TransactionsActivityStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/TransactionsActivityStore.swift
@@ -16,8 +16,9 @@ class TransactionsActivityStore: ObservableObject {
       update()
     }
   }
-  @Published var networkFilter: NetworkFilter = .allNetworks {
+  @Published var networkFilters: [Selectable<BraveWallet.NetworkInfo>] = [] {
     didSet {
+      guard !oldValue.isEmpty else { return } // initial assignment to `networkFilters`
       update()
     }
   }
@@ -71,16 +72,14 @@ class TransactionsActivityStore: ObservableObject {
         for: WalletConstants.supportedCoinTypes
       )
       let allAccountInfos = allKeyrings.flatMap(\.accountInfos)
-      var networksForCoin: [BraveWallet.CoinType: [BraveWallet.NetworkInfo]] = [:]
-      
-      switch networkFilter {
-      case .allNetworks:
-        for coin in WalletConstants.supportedCoinTypes {
-          networksForCoin[coin] = await rpcService.allNetworks(coin)
+      // setup network filters if not currently setup
+      if self.networkFilters.isEmpty {
+        self.networkFilters = await self.rpcService.allNetworksForSupportedCoins().map {
+          .init(isSelected: true, model: $0)
         }
-      case .network(let networkInfo):
-        networksForCoin = [networkInfo.coin: [networkInfo]]
       }
+      let networks = networkFilters.filter(\.isSelected).map(\.model)
+      let networksForCoin: [BraveWallet.CoinType: [BraveWallet.NetworkInfo]] = Dictionary(grouping: networks, by: \.coin)
       
       let chainIdsForCoin = networksForCoin.mapValues { networks in
         networks.map(\.chainId)

--- a/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
@@ -52,6 +52,12 @@ public class AssetStore: ObservableObject, Equatable {
 public class UserAssetsStore: ObservableObject {
   @Published private(set) var assetStores: [AssetStore] = []
   @Published var isSearchingToken: Bool = false
+  @Published var networkFilters: [Selectable<BraveWallet.NetworkInfo>] = [] {
+    didSet {
+      guard !oldValue.isEmpty else { return } // initial assignment to `networkFilters`
+      update()
+    }
+  }
 
   private let blockchainRegistry: BraveWalletBlockchainRegistry
   private let rpcService: BraveWalletJsonRpcService
@@ -79,21 +85,15 @@ public class UserAssetsStore: ObservableObject {
     self.keyringService.add(self)
   }
   
-  @Published var networkFilter: NetworkFilter = .allNetworks {
-    didSet {
-      update()
-    }
-  }
-  
   func update() {
     Task { @MainActor in
-      let networks: [BraveWallet.NetworkInfo]
-      switch networkFilter {
-      case .allNetworks:
-        networks = await self.rpcService.allNetworksForSupportedCoins()
-      case let .network(network):
-        networks = [network]
+      // setup network filters if not currently setup
+      if self.networkFilters.isEmpty {
+        self.networkFilters = await self.rpcService.allNetworksForSupportedCoins().map {
+          .init(isSelected: true, model: $0)
+        }
       }
+      let networks: [BraveWallet.NetworkInfo] = self.networkFilters.filter(\.isSelected).map(\.model)
       let allUserAssets = assetManager.getAllUserAssetsInNetworkAssets(networks: networks)
       var allTokens = await self.blockchainRegistry.allTokens(in: networks)
       // Filter `allTokens` to remove any tokens existing in `allUserAssets`. This is possible for ERC721 tokens in the registry without a `tokenId`, which requires the user to add as a custom token

--- a/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
@@ -262,3 +262,31 @@ extension UserAssetsStore: BraveWalletKeyringServiceObserver {
   public func accountsAdded(_ addedAccounts: [BraveWallet.AccountInfo]) {
   }
 }
+
+extension UserAssetsStore: BraveWalletBraveWalletServiceObserver {
+  public func onActiveOriginChanged(_ originInfo: BraveWallet.OriginInfo) { }
+  
+  public func onDefaultEthereumWalletChanged(_ wallet: BraveWallet.DefaultWallet) { }
+  
+  public func onDefaultSolanaWalletChanged(_ wallet: BraveWallet.DefaultWallet) { }
+  
+  public func onDefaultBaseCurrencyChanged(_ currency: String) { }
+  
+  public func onDefaultBaseCryptocurrencyChanged(_ cryptocurrency: String) { }
+  
+  public func onNetworkListChanged() {
+    Task { @MainActor in
+      // A network was added or removed, update our network filters for the change.
+      self.networkFilters = await self.rpcService.allNetworksForSupportedCoins().map { network in
+        let existingSelectionValue = self.networkFilters.first(where: { $0.model.chainId == network.chainId})?.isSelected
+        return .init(isSelected: existingSelectionValue ?? true, model: network)
+      }
+    }
+  }
+  
+  public func onDiscoverAssetsStarted() { }
+  
+  public func onDiscoverAssetsCompleted(_ discoveredAssets: [BraveWallet.BlockchainToken]) { }
+  
+  public func onResetWallet() { }
+}

--- a/Sources/BraveWallet/Crypto/TransactionsActivityView.swift
+++ b/Sources/BraveWallet/Crypto/TransactionsActivityView.swift
@@ -18,18 +18,19 @@ struct TransactionsActivityView: View {
     Button(action: {
       self.isPresentingNetworkFilter = true
     }) {
-      HStack {
-        Text(store.networkFilter.title)
-        Image(braveSystemName: "leo.list")
-      }
-      .font(.footnote.weight(.medium))
-      .foregroundColor(Color(.braveBlurpleTint))
+      Image(braveSystemName: "leo.tune")
+        .font(.footnote.weight(.medium))
+        .foregroundColor(Color(.braveBlurpleTint))
+        .clipShape(Rectangle())
     }
     .sheet(isPresented: $isPresentingNetworkFilter) {
       NavigationView {
         NetworkFilterView(
-          networkFilter: $store.networkFilter,
-          networkStore: networkStore
+          networks: store.networkFilters,
+          networkStore: networkStore,
+          saveAction: { selectedNetworks in
+            store.networkFilters = selectedNetworks
+          }
         )
       }
       .onDisappear {

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -3407,7 +3407,7 @@ extension Strings {
       "wallet.networkFilterTitle",
       tableName: "BraveWallet",
       bundle: .module,
-      value: "Select Network Filter",
+      value: "Select Networks",
       comment: "The title displayed on the view to filter by a network / all networks."
     )
     public static let userAssetSymbolNetworkDesc = NSLocalizedString(
@@ -4092,6 +4092,20 @@ extension Strings {
       bundle: .module,
       value: "Hide Zero Balances",
       comment: "The title of a button that updates the filter to hide tokens with zero balances."
+    )
+    public static let selectAllButtonTitle = NSLocalizedString(
+      "wallet.selectAllButtonTitle",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Select All",
+      comment: "The title of a button that Selects all visible options."
+    )
+    public static let deselectAllButtonTitle = NSLocalizedString(
+      "wallet.deselectAllButtonTitle",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Deselect All",
+      comment: "The title of a button that Deselects all visible options."
     )
   }
 }

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -3403,13 +3403,6 @@ extension Strings {
       value: "View original message",
       comment: "The title of the button that users can click to display the sign request message as its original content."
     )
-    public static let allNetworksTitle = NSLocalizedString(
-      "wallet.allNetworksTitle",
-      tableName: "BraveWallet",
-      bundle: .module,
-      value: "All Networks",
-      comment: "The title of the option to filter by all networks, displayed in a view to filter assets between 'All Networks' or a specific Crypto network."
-    )
     public static let networkFilterTitle = NSLocalizedString(
       "wallet.networkFilterTitle",
       tableName: "BraveWallet",

--- a/Tests/BraveWalletTests/NetworkSelectionStoreTests.swift
+++ b/Tests/BraveWalletTests/NetworkSelectionStoreTests.swift
@@ -80,11 +80,11 @@ import Preferences
     store.update()
     
     let expectedPrimaryNetworks: [NetworkPresentation] = [
-      .init(network: .network(.mockSolana), subNetworks: [], isPrimaryNetwork: true),
-      .init(network: .network(.mockMainnet), subNetworks: [], isPrimaryNetwork: true)
+      .init(network: .mockSolana, subNetworks: [], isPrimaryNetwork: true),
+      .init(network: .mockMainnet, subNetworks: [], isPrimaryNetwork: true)
     ]
     let expectedSecondaryNetworks: [NetworkPresentation] = [
-      .init(network: .network(.mockPolygon), subNetworks: [], isPrimaryNetwork: false)
+      .init(network: .mockPolygon, subNetworks: [], isPrimaryNetwork: false)
     ]
     XCTAssertEqual(store.primaryNetworks, expectedPrimaryNetworks, "Unexpected primary networks set")
     XCTAssertEqual(store.secondaryNetworks, expectedSecondaryNetworks, "Unexpected secondary networks set")
@@ -110,11 +110,11 @@ import Preferences
     store.update()
     
     let expectedPrimaryNetworks: [NetworkPresentation] = [
-      .init(network: .network(.mockSolana), subNetworks: [.mockSolana, .mockSolanaTestnet], isPrimaryNetwork: true),
-      .init(network: .network(.mockMainnet), subNetworks: [.mockMainnet, .mockGoerli, .mockSepolia], isPrimaryNetwork: true)
+      .init(network: .mockSolana, subNetworks: [.mockSolana, .mockSolanaTestnet], isPrimaryNetwork: true),
+      .init(network: .mockMainnet, subNetworks: [.mockMainnet, .mockGoerli, .mockSepolia], isPrimaryNetwork: true)
     ]
     let expectedSecondaryNetworks: [NetworkPresentation] = [
-      .init(network: .network(.mockPolygon), subNetworks: [], isPrimaryNetwork: false)
+      .init(network: .mockPolygon, subNetworks: [], isPrimaryNetwork: false)
     ]
     XCTAssertEqual(store.primaryNetworks, expectedPrimaryNetworks, "Unexpected primary networks set")
     XCTAssertEqual(store.secondaryNetworks, expectedSecondaryNetworks, "Unexpected secondary networks set")
@@ -132,7 +132,7 @@ import Preferences
     await networkStore.setup()
     
     let store = NetworkSelectionStore(networkStore: networkStore)
-    let success = await store.selectNetwork(.network(.mockGoerli))
+    let success = await store.selectNetwork(.mockGoerli)
     XCTAssertTrue(success, "Expected success for selecting Goerli because we have ethereum accounts.")
   }
   
@@ -158,7 +158,7 @@ import Preferences
       mode: .select(isForOrigin: true),
       networkStore: networkStore
     )
-    let success = await store.selectNetwork(.network(.mockGoerli))
+    let success = await store.selectNetwork(.mockGoerli)
     XCTAssertTrue(success, "Expected success for selecting Goerli because we have ethereum accounts.")
   }
   
@@ -174,7 +174,7 @@ import Preferences
     await networkStore.setup()
     
     let store = NetworkSelectionStore(networkStore: networkStore)
-    let success = await store.selectNetwork(.network(.mockSolana))
+    let success = await store.selectNetwork(.mockSolana)
     XCTAssertFalse(success, "Expected failure for selecting Solana because we have no Solana accounts.")
     XCTAssertTrue(store.isPresentingNextNetworkAlert, "Expected to set isPresentingNextNetworkAlert to true to show alert asking user to create Solana account")
   }
@@ -191,7 +191,7 @@ import Preferences
     await networkStore.setup()
     
     let store = NetworkSelectionStore(mode: .formSelection, networkStore: networkStore)
-    let success = await store.selectNetwork(.network(.mockGoerli))
+    let success = await store.selectNetwork(.mockGoerli)
     XCTAssertTrue(success, "Expected success for selecting Goerli")
     XCTAssertEqual(store.networkSelectionInForm, .mockGoerli)
   }
@@ -294,7 +294,7 @@ import Preferences
     
     let store = NetworkSelectionStore(networkStore: networkStore)
     
-    let success = await store.selectNetwork(.network(.mockSolana))
+    let success = await store.selectNetwork(.mockSolana)
     XCTAssertFalse(success, "Expected failure to select network due to no accounts")
     XCTAssertTrue(store.isPresentingNextNetworkAlert, "Expected to present next network alert")
     

--- a/Tests/BraveWalletTests/NetworkSelectionStoreTests.swift
+++ b/Tests/BraveWalletTests/NetworkSelectionStoreTests.swift
@@ -60,66 +60,6 @@ import Preferences
     return (keyringService, rpcService, walletService, swapService)
   }
   
-  func testUpdateSelectMode() async {
-    Preferences.Wallet.showTestNetworks.value = false
-
-    let (keyringService, rpcService, walletService, swapService) = setupServices()
-    
-    let networkStore = NetworkStore(
-      keyringService: keyringService,
-      rpcService: rpcService,
-      walletService: walletService,
-      swapService: swapService
-    )
-    await networkStore.setup()
-    
-    let store = NetworkSelectionStore(networkStore: networkStore)
-    XCTAssertTrue(store.primaryNetworks.isEmpty, "Test setup failed, expected empty primary networks")
-    XCTAssertTrue(store.secondaryNetworks.isEmpty, "Test setup failed, expected empty secondary networks")
-    
-    store.update()
-    
-    let expectedPrimaryNetworks: [NetworkPresentation] = [
-      .init(network: .mockSolana, subNetworks: [], isPrimaryNetwork: true),
-      .init(network: .mockMainnet, subNetworks: [], isPrimaryNetwork: true)
-    ]
-    let expectedSecondaryNetworks: [NetworkPresentation] = [
-      .init(network: .mockPolygon, subNetworks: [], isPrimaryNetwork: false)
-    ]
-    XCTAssertEqual(store.primaryNetworks, expectedPrimaryNetworks, "Unexpected primary networks set")
-    XCTAssertEqual(store.secondaryNetworks, expectedSecondaryNetworks, "Unexpected secondary networks set")
-  }
-  
-  func testUpdateTestNetworksEnabledSelectMode() async {
-    Preferences.Wallet.showTestNetworks.value = true
-    
-    let (keyringService, rpcService, walletService, swapService) = setupServices()
-    
-    let networkStore = NetworkStore(
-      keyringService: keyringService,
-      rpcService: rpcService,
-      walletService: walletService,
-      swapService: swapService
-    )
-    await networkStore.setup()
-    
-    let store = NetworkSelectionStore(networkStore: networkStore)
-    XCTAssertTrue(store.primaryNetworks.isEmpty, "Test setup failed, expected empty primary networks")
-    XCTAssertTrue(store.secondaryNetworks.isEmpty, "Test setup failed, expected empty secondary networks")
-    
-    store.update()
-    
-    let expectedPrimaryNetworks: [NetworkPresentation] = [
-      .init(network: .mockSolana, subNetworks: [.mockSolana, .mockSolanaTestnet], isPrimaryNetwork: true),
-      .init(network: .mockMainnet, subNetworks: [.mockMainnet, .mockGoerli, .mockSepolia], isPrimaryNetwork: true)
-    ]
-    let expectedSecondaryNetworks: [NetworkPresentation] = [
-      .init(network: .mockPolygon, subNetworks: [], isPrimaryNetwork: false)
-    ]
-    XCTAssertEqual(store.primaryNetworks, expectedPrimaryNetworks, "Unexpected primary networks set")
-    XCTAssertEqual(store.secondaryNetworks, expectedSecondaryNetworks, "Unexpected secondary networks set")
-  }
-  
   func testSetSelectedNetwork() async {
     let (keyringService, rpcService, walletService, swapService) = setupServices()
     

--- a/Tests/BraveWalletTests/SelectAccountTokenStoreTests.swift
+++ b/Tests/BraveWalletTests/SelectAccountTokenStoreTests.swift
@@ -314,10 +314,15 @@ import BraveCore
       )
     ]
     // all networks
-    store.networkFilter = .allNetworks
+    store.networkFilters = [
+      .init(isSelected: true, model: .mockMainnet),
+      .init(isSelected: true, model: .mockGoerli),
+      .init(isSelected: true, model: .mockSolana),
+      .init(isSelected: true, model: .mockSolanaTestnet)
+    ]
     XCTAssertEqual(store.filteredAccountSections, store.accountSections)
     // Ethereum mainnet
-    store.networkFilter = .network(.mockMainnet)
+    store.networkFilters = [.init(isSelected: true, model: .mockMainnet)]
     XCTAssertEqual(store.filteredAccountSections.count, 1)
     XCTAssertEqual(store.filteredAccountSections, [
       .init(
@@ -332,7 +337,7 @@ import BraveCore
       )
     ])
     // Solana mainnet
-    store.networkFilter = .network(.mockSolana)
+    store.networkFilters = [.init(isSelected: true, model: .mockSolana)]
     XCTAssertEqual(store.filteredAccountSections.count, 1)
     XCTAssertEqual(store.filteredAccountSections, [
       .init(

--- a/Tests/BraveWalletTests/TransactionsActivityStoreTests.swift
+++ b/Tests/BraveWalletTests/TransactionsActivityStoreTests.swift
@@ -55,6 +55,7 @@ class TransactionsActivityStoreTests: XCTestCase {
     }
     
     let walletService = BraveWallet.TestBraveWalletService()
+    walletService._addObserver = { _ in }
     walletService._defaultBaseCurrency = { $0(CurrencyCode.usd.code) }
     
     let assetRatioService = BraveWallet.TestAssetRatioService()


### PR DESCRIPTION
## Summary of Changes
- Update to allow selecting multiple networks in the Network Filter Views for Portfolio tab, NFT tab, Activity tab, Edit User Assets, Search Assets, Select Token to Send (in Send view)
- Move test networks to their own section instead of a detail push.
    - This removed a good chunk of UI code. The detail view (test networks), detail rows, view models, etc. no longer needed. 
- Most stores already supported multiple networks in the default flow where 'all networks' was selected. This update piggybacks on that logic.

This pull request fixes #7607

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
Test the network filter with All Networks (default) and only a few networks selected in the following views:
1. Portfolio tab
    - Test networks are NOT selected by default (matching existing logic)
5. NFT tab
    - Test networks are NOT selected by default (matching existing logic)
6. Activity tab
    - Test networks selected by default.
7. Edit User Assets
    - Test networks are selected by default.
8. Asset Search (from Portfolio tab)
    - Test networks are selected by default.
9. Select Token to Send (from Send view)
    - Test networks are selected by default.

Show/Hide test networks:
1. Disable 'Show test networks' in Web3 Settings -> Networks
2. Verify test networks are not shown in Network Selection (in Wallet Panel or in Buy/Swap)
3. Verify test networks are not shown in filters (Portfolio / NFT / Activity tab / etc)
4. Enable 'Show test networks' in Web3 Settings -> Networks
5. Verify test networks are shown in Network Selection (in Wallet Panel or in Buy/Swap)
6. Verify test networks are now shown in filters (Portfolio / NFT / Activity tab / etc)

## Screenshots:

Network Filter (Multi-Select) | Network Selection (Single)
--|--
![Network Filter](https://github.com/brave/brave-ios/assets/5314553/42c1d335-463b-495c-9c69-2d521ed61bd0) | ![Network Selection](https://github.com/brave/brave-ios/assets/5314553/8b15d048-4dd1-4452-969a-5fbbf87adf21)


Portfolio tab, NFT tab, Activity tab:

https://github.com/brave/brave-ios/assets/5314553/9985b0a0-cbe0-45d7-9c28-06db6f0649e6

Search Assets, Edit User Assets, Select Token to Send:

https://github.com/brave/brave-ios/assets/5314553/a09bed18-3a2a-4d3c-af21-82a48f8c86c3


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
