### PR TITLE
Fix #7626: Hide the CF selector elements from the dom

### DIFF
--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Sandboxed/SelectorsPollerScript.js
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Sandboxed/SelectorsPollerScript.js
@@ -1000,10 +1000,15 @@ window.__firefox__.execute(function($) {
   }
 
   const deleteHideSelector = (selector) => {
-    const index = CC.ruleIndexes[selector]
+    if (CC.ruleIndexes[selector] === undefined) { return }
+    const ruleList = CC.cosmeticStyleSheet.sheet.cssRules
+    CC.ruleIndexes.delete(selector)
 
-    if (index !== undefined) {
-      CC.cosmeticStyleSheet.sheet.deleteRule(index)
+    for (let i = 0; i < ruleList.length; i++) {
+      if (ruleList[i].selectorText === selector) {
+        CC.cosmeticStyleSheet.sheet.deleteRule(i)
+        return
+      }
     }
   }
 

--- a/Tests/ClientTests/User Scripts/ScriptExecutionTests.swift
+++ b/Tests/ClientTests/User Scripts/ScriptExecutionTests.swift
@@ -345,7 +345,6 @@ final class ScriptExecutionTests: XCTestCase {
     XCTAssertEqual(resultsAfterPump?.unhiddenIds.contains("test-ad-1st-party"), true)
     XCTAssertEqual(resultsAfterPump?.unhiddenIds.contains("test-ad-primary-standard-1st-party"), true)
     XCTAssertEqual(resultsAfterPump?.unhiddenIds.contains("test-ad-primary-standard-3rd-party"), true)
-    XCTAssertEqual(resultsAfterPump?.unhiddenIds.contains("test-ad-1st-party"), true)
     XCTAssertEqual(resultsAfterPump?.hiddenIds.contains("test-ad-aggressive"), true)
     XCTAssertEqual(resultsAfterPump?.hiddenIds.contains("test-ad-3rd-party"), true)
     XCTAssertEqual(resultsAfterPump?.hiddenIds.contains("test-ad-simple"), true)


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7626 

This is not a perfect fix. You will still see the style element but it will be empty.

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
See issue for STR

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
