### PR TITLE
Fix #5902: Let user select active rpc endpoint 

### DIFF
--- a/Sources/BraveWallet/Settings/CustomNetworkDetailsView.swift
+++ b/Sources/BraveWallet/Settings/CustomNetworkDetailsView.swift
@@ -11,6 +11,7 @@ import BraveUI
 
 struct NetworkInputItem: Identifiable {
   var input: String
+  var isSelected: Bool = false
   var error: String?
   var id = UUID()
 }
@@ -213,7 +214,11 @@ class CustomNetworkModel: ObservableObject, Identifiable {
     self.networkSymbol.input = network.symbol
     self.networkDecimals.input = String(network.decimals)
     if !network.rpcEndpoints.isEmpty {
-      self.rpcUrls = network.rpcEndpoints.compactMap { NetworkInputItem(input: $0.absoluteString) }
+      var result: [NetworkInputItem] = []
+      for (index, endpoint) in network.rpcEndpoints.enumerated() {
+        result.append(NetworkInputItem(input: endpoint.absoluteString, isSelected: index == network.activeRpcEndpointIndex))
+      }
+      self.rpcUrls = result
     } else if mode.isViewMode {
       self.rpcUrls = []
     }
@@ -338,7 +343,8 @@ struct CustomNetworkDetailsView: View {
           ForEach($model.rpcUrls) { $url in
             networkTextField(
               placeholder: Strings.Wallet.customNetworkUrlsPlaceholder,
-              item: $url
+              item: $url,
+              showRadioButton: true
             )
           }
           .listRowBackground(Color(.secondaryBraveGroupedBackground))
@@ -412,19 +418,31 @@ struct CustomNetworkDetailsView: View {
     )
   }
   
-  @ViewBuilder private func networkTextField(placeholder: String, item: Binding<NetworkInputItem>) -> some View {
-    if model.mode.isViewMode {
-      Text(item.wrappedValue.input)
-        .contextMenu {
-          Button(action: { UIPasteboard.general.string = item.wrappedValue.input }) {
-            Label(Strings.Wallet.copyToPasteboard, braveSystemImage: "leo.copy.plain-text")
+  @ViewBuilder private func networkTextField(placeholder: String, item: Binding<NetworkInputItem>, showRadioButton: Bool = false) -> some View {
+    HStack {
+      if showRadioButton {
+        NetworkRadioButton(
+          checked: item.isSelected,
+          isDisabled: Binding(get: { item.input.wrappedValue.isEmpty }, set: { _, _ in }),
+          onTapped: {
+            for index in model.rpcUrls.indices where model.rpcUrls[index].id != item.id {
+              model.rpcUrls[index].isSelected = !item.isSelected.wrappedValue
+            }
+          })
+      }
+      if model.mode.isViewMode {
+        Text(item.wrappedValue.input)
+          .contextMenu {
+            Button(action: { UIPasteboard.general.string = item.wrappedValue.input }) {
+              Label(Strings.Wallet.copyToPasteboard, braveSystemImage: "leo.copy.plain-text")
+            }
           }
-        }
-    } else {
-      NetworkTextField(
-        placeholder: placeholder,
-        item: item
-      )
+      } else {
+        NetworkTextField(
+          placeholder: placeholder,
+          item: item
+        )
+      }
     }
   }
 
@@ -491,12 +509,13 @@ struct CustomNetworkDetailsView: View {
         return nil
       }
     })
+    let activeRpcEndpointIndex = model.rpcUrls.firstIndex(where: { $0.isSelected }) ?? 0
     let network: BraveWallet.NetworkInfo = .init(
       chainId: chainIdInHex,
       chainName: model.networkName.input,
       blockExplorerUrls: blockExplorerUrls,
       iconUrls: iconUrls,
-      activeRpcEndpointIndex: 0,
+      activeRpcEndpointIndex: Int32(activeRpcEndpointIndex),
       rpcEndpoints: rpcEndpoints,
       symbol: model.networkSymbol.input,
       symbolName: model.networkSymbol.input,
@@ -511,6 +530,36 @@ struct CustomNetworkDetailsView: View {
       }
 
       presentationMode.dismiss()
+    }
+  }
+}
+
+struct NetworkRadioButton: View {
+  @Binding var checked: Bool
+  @Binding var isDisabled: Bool
+  var onTapped: () -> Void
+  
+  var body: some View {
+    if checked {
+      ZStack {
+        Circle()
+          .fill(Color(.braveBlurpleTint))
+          .frame(width: 20, height: 20)
+        Circle()
+          .fill(Color.white)
+          .frame(width: 8, height: 8)
+      }
+    } else {
+      Circle()
+        .fill(Color.white)
+        .frame(width: 20, height: 20)
+        .overlay(Circle().stroke(.gray, lineWidth: 1))
+        .onTapGesture {
+          if !self.isDisabled {
+            self.checked = true
+            self.onTapped()
+          }
+        }
     }
   }
 }

--- a/Sources/BraveWallet/Settings/CustomNetworkDetailsView.swift
+++ b/Sources/BraveWallet/Settings/CustomNetworkDetailsView.swift
@@ -120,7 +120,7 @@ class CustomNetworkModel: ObservableObject, Identifiable {
     }
   }
 
-  @Published var rpcUrls: [NetworkInputItem] = [NetworkInputItem(input: "")] {
+  @Published var rpcUrls: [NetworkInputItem] = [NetworkInputItem(input: "", isSelected: true)] {
     didSet {
       // we only care the set on each item's `input`
       if rpcUrls.reduce("", { $0 + $1.input }) != oldValue.reduce("", { $0 + $1.input }) {
@@ -216,7 +216,12 @@ class CustomNetworkModel: ObservableObject, Identifiable {
     if !network.rpcEndpoints.isEmpty {
       var result: [NetworkInputItem] = []
       for (index, endpoint) in network.rpcEndpoints.enumerated() {
-        result.append(NetworkInputItem(input: endpoint.absoluteString, isSelected: index == network.activeRpcEndpointIndex))
+        result.append(
+          NetworkInputItem(
+            input: endpoint.absoluteString,
+            isSelected: index == network.activeRpcEndpointIndex
+          )
+        )
       }
       self.rpcUrls = result
     } else if mode.isViewMode {
@@ -423,7 +428,7 @@ struct CustomNetworkDetailsView: View {
       if showRadioButton {
         NetworkRadioButton(
           checked: item.isSelected,
-          isDisabled: Binding(get: { item.input.wrappedValue.isEmpty }, set: { _, _ in }),
+          isDisabled: Binding(get: { item.input.wrappedValue.isEmpty || model.mode.isViewMode }, set: { _, _ in }),
           onTapped: {
             for index in model.rpcUrls.indices where model.rpcUrls[index].id != item.id {
               model.rpcUrls[index].isSelected = !item.isSelected.wrappedValue

--- a/Sources/BraveWallet/Settings/CustomNetworkDetailsView.swift
+++ b/Sources/BraveWallet/Settings/CustomNetworkDetailsView.swift
@@ -540,27 +540,16 @@ struct NetworkRadioButton: View {
   var onTapped: () -> Void
   
   var body: some View {
-    if checked {
-      ZStack {
-        Circle()
-          .fill(Color(.braveBlurpleTint))
-          .frame(width: 20, height: 20)
-        Circle()
-          .fill(Color.white)
-          .frame(width: 8, height: 8)
-      }
-    } else {
-      Circle()
-        .fill(Color.white)
-        .frame(width: 20, height: 20)
-        .overlay(Circle().stroke(.gray, lineWidth: 1))
-        .onTapGesture {
-          if !self.isDisabled {
-            self.checked = true
-            self.onTapped()
-          }
+    Image(uiImage: UIImage(braveSystemNamed: checked ? "leo.check.circle-outline" : "leo.radio.unchecked")!)
+      .renderingMode(.template)
+      .foregroundColor(Color(checked ? .braveBlurpleTint : .braveDisabled))
+      .font(.title3)
+      .onTapGesture {
+        if !self.isDisabled && !checked {
+          self.checked = true
+          self.onTapped()
         }
-    }
+      }
   }
 }
 

--- a/Sources/BraveWallet/Settings/CustomNetworkListView.swift
+++ b/Sources/BraveWallet/Settings/CustomNetworkListView.swift
@@ -46,14 +46,14 @@ struct CustomNetworkListView: View {
               if sizeCategory.isAccessibilityCategory {
                 VStack(alignment: .leading) {
                   Text(network.id)
-                  if let rpcEndpoint = network.rpcEndpoints.first?.absoluteString {
+                  if let rpcEndpoint = network.rpcEndpoints[safe: Int(network.activeRpcEndpointIndex)]?.absoluteString {
                     Text(rpcEndpoint)
                   }
                 }
               } else {
                 HStack {
                   Text(network.id)
-                  if let rpcEndpoint = network.rpcEndpoints.first?.absoluteString {
+                  if let rpcEndpoint = network.rpcEndpoints[safe: Int(network.activeRpcEndpointIndex)]?.absoluteString {
                     Text(rpcEndpoint)
                   }
                 }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
Users can already input multiple rpc endpoints when adding a custom network. But cannot select an active one (default the first input). This PR will let users to choose which endpoint to use. 

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5902

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
1. go to brave wallet and navigate to settings/network 
2. try to add a new custom network
3. input all mandatory filed and make sure input multiple rpc urls
4. observe each input rpc url filed will have a unchecked radio button on the left side
5. add the network without check any active rpc url
6. observe network is saved successfully, and user will be bring back to the network list screen
7. observe the new network is displayed correctly with the first rpc url value. 
8. click the newly saved network 
9. observe now the first rpc url has radio button checked 
10. change to another url and save
11. observe now the network is saved with correct rpc value. (both in network list and network details) 


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->
![Simulator Screenshot - iPhone 14 Pro - 2023-06-22 at 19 31 39](https://github.com/brave/brave-ios/assets/1187676/24656af8-4234-478c-b950-78f1bacb743d)


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
