### PR TITLE
Fix #7606: VPN toggle switch is blinking twice when enabling it 

### DIFF
--- a/Sources/BraveVPN/BraveVPNProtocolPickerViewController.swift
+++ b/Sources/BraveVPN/BraveVPNProtocolPickerViewController.swift
@@ -92,15 +92,17 @@ extension BraveVPNProtocolPickerViewController: UITableViewDelegate, UITableView
     BraveVPN.changePreferredTransportProtocol(with: tunnelProtocol) { [weak self] success in
       guard let self else { return }
 
-      self.isLoading = false
-
-      if success {
-        self.dismiss(animated: true) {
-          self.showSuccessAlert(text: Strings.VPN.protocolSwitchSuccessPopupText)
+      DispatchQueue.main.async {
+        self.isLoading = false
+        
+        if success {
+          self.dismiss(animated: true) {
+            self.showSuccessAlert(text: Strings.VPN.protocolSwitchSuccessPopupText)
+          }
+        } else {
+          self.showErrorAlert(title: Strings.VPN.protocolPickerErrorTitle,
+                              message: Strings.VPN.protocolPickerErrorMessage)
         }
-      } else {
-        self.showErrorAlert(title: Strings.VPN.protocolPickerErrorTitle,
-                            message: Strings.VPN.protocolPickerErrorMessage)
       }
     }
 

--- a/Sources/BraveVPN/BraveVPNSettingsViewController.swift
+++ b/Sources/BraveVPN/BraveVPNSettingsViewController.swift
@@ -97,7 +97,7 @@ public class BraveVPNSettingsViewController: TableViewController {
     super.viewDidLoad()
 
     title = Strings.VPN.vpnName
-    NotificationCenter.default.addObserver(self, selector: #selector(vpnConfigChanged),
+    NotificationCenter.default.addObserver(self, selector: #selector(vpnConfigChanged(_:)),
                                            name: .NEVPNStatusDidChange, object: nil)
     
     let switchView = SwitchAccessoryView(initialValue: BraveVPN.isConnected, valueChange: { vpnOn in
@@ -304,7 +304,23 @@ public class BraveVPNSettingsViewController: TableViewController {
     present(alert, animated: true)
   }
 
-  @objc func vpnConfigChanged() {
-    vpnConnectionStatusSwitch?.isOn = BraveVPN.isConnected
+  @objc func vpnConfigChanged(_ notification: NSNotification) {
+    guard let vpnConnection = notification.object as? NEVPNConnection else {
+      return
+    }
+        
+    switch vpnConnection.status {
+    case.connecting, .disconnecting, .reasserting:
+      isLoading = true
+    case .invalid:
+      vpnConnectionStatusSwitch?.isOn = false
+    case .connected, .disconnected:
+      vpnConnectionStatusSwitch?.isOn = BraveVPN.isConnected
+    @unknown default:
+      assertionFailure()
+      break
+    }
+    
+    isLoading = false
   }
 }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

Adding VPN status edit to toggle action inside VPN detail settings.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7606 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

1. Launch Brave > Three-dot Menu > Brave VPN
2. Purchase TF subscription > Install certificate
3. Settings > Brave Firewall + VPN
4. Enable the toggle switch > Observe

## Screenshots:


https://github.com/brave/brave-ios/assets/6643505/5c4b079b-1586-432a-9396-f657d9f54710




## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
