### PR TITLE
Fix # 7605: Camera view is rotated to 90 degrees in "Scan QR Code" UI when a device in Landscape Mode

### DIFF
--- a/Sources/Brave/Frontend/Browser/Search/Recent Search/RecentSearchQRCodeScannerController.swift
+++ b/Sources/Brave/Frontend/Browser/Search/Recent Search/RecentSearchQRCodeScannerController.swift
@@ -64,6 +64,19 @@ class RecentSearchQRCodeScannerController: UIViewController {
 
     scannerView.cameraView.startRunning()
   }
+  
+  override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+    scannerView.cameraView.stopRunning()
+    
+    coordinator.animate(alongsideTransition: nil) { [weak self] _ in
+      guard let self else { return }
+      
+      if let orientation = self.view.window?.windowScene?.interfaceOrientation {
+          self.scannerView.cameraView.videoPreviewLayer?.connection?.videoOrientation = AVCaptureVideoOrientation(ui: orientation)
+      }
+      self.scannerView.cameraView.startRunning()
+    }
+  }
 
   // MARK: - Actions
 


### PR DESCRIPTION
Adding viewWillTransition change for orientation in preview video layer orientation change

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7605 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

1. Launch Brave
2. URL search bar > Remove URL
3. Tap QR code thumbnail
4. When Scan QR Code UI is opened rotate the device to Landscape Mode > Observe

## Screenshots:


https://github.com/brave/brave-ios/assets/6643505/fd041beb-ef4a-4fd7-be68-e3584f852668


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
