### PR TITLE
Fix #7636: Fix Tab's Title not restoring properly

### DIFF
--- a/Sources/Brave/Frontend/Browser/Tab.swift
+++ b/Sources/Brave/Frontend/Browser/Tab.swift
@@ -507,7 +507,7 @@ class Tab: NSObject {
       return Strings.Hotkey.newTabTitle
     }
 
-    if let url = self.url, !InternalURL.isValid(url: url), let shownUrl = url.displayURL?.absoluteString {
+    if let url = self.url, !InternalURL.isValid(url: url), let shownUrl = url.displayURL?.absoluteString, webView != nil {
       syncTab?.setTitle(shownUrl)
       return shownUrl
     }


### PR DESCRIPTION
## Summary of Changes
- `WebView.title` is nil when a tab is lazily restored. The old tab logic did not support this, so the titles were always loaded as every webView immediately loaded
- To fix it, we just check if the webView is nil, and if it is, we show the restoring title instead of a URL.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7636

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
- Open 3 tabs
- Kill the app
- Restore the app
- Notice: Tab Title should now be correct instead of a URL.


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
