### PR TITLE
Ref #3939: Add support to Apple Screen Time Limits

### DIFF
--- a/Sources/Brave/Frontend/Browser/Tab.swift
+++ b/Sources/Brave/Frontend/Browser/Tab.swift
@@ -177,7 +177,7 @@ class Tab: NSObject {
     willSet {
       url = newValue
       previousComittedURL = committedURL
-      screenTimeViewController.url = isPrivate ? nil : url
+      screenTimeViewController.url = url
     }
   }
 


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #3939. It adds support for:

<details>
  <summary>tracking time spent on individual websites (unless you're in incognito mode)</summary>
  <img src="https://github.com/brave/brave-ios/assets/61356846/4c07b189-607f-421d-bc80-cab7bf09ae39" width="512">
</details> 

<details>
  <summary>enforcing usage limits per single web page</summary>
  <img src="https://github.com/brave/brave-ios/assets/61356846/f4b0f0dc-2d97-442d-a1c9-a95a1f6e6b3c" width="256">
</details>

The Screen Time API is not well documented. I benefitted from reading https://github.com/mozilla-mobile/firefox-ios/pull/15111.

There is no way to test this feature using the Simulator&mdash;I've tried but Screen Time does not work. You need a real device.

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->

### Background

1. Build the app on your real device
3. Go to Settings > Screen Time > turn it on if you didn't already
4. Go to Settings > Screen Time > App limits > Add Limit and add a one minute limit on a website of your choice

### Test 1

1. Given you visit the website in a non-private tab
2. Given you browse the website for one minute
3. Then you should see the Screen Time limit over view

### Test 2

1. Given you visit the website in a private tab
2. Given you browse the website for one minute
3. Then you won't see the Screen Time limit over view nor the page usage will appear in the Screen Time activity log

### Test 3

1. Given you visit the website in a non-private tab
2. Given you switch to an empty tab
3. Given you wait for one minute
4. Then you won't see a dedicated entry for the internal URL in the Screen Time activity log 

### Test 4

1. Given you visit the website in a non-private tab
2. Given you switch to an empty tab
3. Given you wait for one minute to show the Screen Time block view
4. Then the ST block view should go away when you change the current tab URL

#### Test 5

1. Given you visit the website in a non-private tab
2. Given you browse the website for one minute
3. Given you switch to a private tab and visit the same website
4. Then you should see the Screen Time limit over view

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
