### PR TITLE
Fix #6260: Reverse order of URL bar context menu items when using bottom bar

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
@@ -7,6 +7,7 @@ import BraveShared
 import BraveUI
 import Shared
 import BraveCore
+import BraveStrings
 import Storage
 import Data
 import SwiftUI
@@ -914,11 +915,10 @@ extension BrowserViewController: ToolbarDelegate {
 extension BrowserViewController: UIContextMenuInteractionDelegate {
   public func contextMenuInteraction(_ interaction: UIContextMenuInteraction, configurationForMenuAtLocation location: CGPoint) -> UIContextMenuConfiguration? {
     return UIContextMenuConfiguration(identifier: nil, previewProvider: nil) { [unowned self] _ in
-      var actionMenuChildren: [UIAction] = []
+      var actionMenu: [UIMenu] = []
+      var pasteMenuChildren: [UIAction] = []
 
       let pasteGoAction = UIAction(
-        title: Strings.pasteAndGoTitle,
-        image: UIImage(systemName: "doc.on.clipboard.fill"),
         identifier: .pasteAndGo,
         handler: UIAction.deferredActionHandler { _ in
           if let pasteboardContents = UIPasteboard.general.string {
@@ -927,8 +927,6 @@ extension BrowserViewController: UIContextMenuInteractionDelegate {
         })
 
       let pasteAction = UIAction(
-        title: Strings.pasteTitle,
-        image: UIImage(systemName: "doc.on.clipboard"),
         identifier: .paste,
         handler: UIAction.deferredActionHandler { _ in
           if let pasteboardContents = UIPasteboard.general.string {
@@ -936,6 +934,12 @@ extension BrowserViewController: UIContextMenuInteractionDelegate {
             self.topToolbar.enterOverlayMode(pasteboardContents, pasted: true, search: true)
           }
         })
+      
+      pasteMenuChildren = [pasteGoAction, pasteAction]
+      
+      if isUsingBottomBar {
+        pasteMenuChildren.reverse()
+      }
 
       let copyAction = UIAction(
         title: Strings.copyAddressTitle,
@@ -945,14 +949,22 @@ extension BrowserViewController: UIContextMenuInteractionDelegate {
             UIPasteboard.general.url = url as URL
           }
         })
+      
+      let copyMenu = UIMenu(title: "", options: .displayInline, children: [copyAction])
 
       if UIPasteboard.general.hasStrings || UIPasteboard.general.hasURLs {
-        actionMenuChildren = [pasteGoAction, pasteAction, copyAction]
+        let pasteMenu = UIMenu(title: "", options: .displayInline, children: pasteMenuChildren)
+
+        actionMenu = [pasteMenu, copyMenu]
+        
+        if isUsingBottomBar {
+          actionMenu.reverse()
+        }
       } else {
-        actionMenuChildren = [copyAction]
+        actionMenu = [copyMenu]
       }
 
-      return UIMenu(title: "", identifier: nil, children: actionMenuChildren)
+      return UIMenu(title: "", identifier: nil, children: actionMenu)
     }
   }
 }

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
@@ -914,71 +914,63 @@ extension BrowserViewController: ToolbarDelegate {
 
 extension BrowserViewController: UIContextMenuInteractionDelegate {
   public func contextMenuInteraction(_ interaction: UIContextMenuInteraction, configurationForMenuAtLocation location: CGPoint) -> UIContextMenuConfiguration? {
-    
-    func createURLBarContextMenuConfiguration(priorityEnabled: Bool) -> UIContextMenuConfiguration {
-      let configuration =  UIContextMenuConfiguration(identifier: nil, previewProvider: nil) { [unowned self] _ in
-        var actionMenu: [UIMenu] = []
-        var pasteMenuChildren: [UIAction] = []
-        
-        let pasteGoAction = UIAction(
-          identifier: .pasteAndGo,
-          handler: UIAction.deferredActionHandler { _ in
-            if let pasteboardContents = UIPasteboard.general.string {
-              self.topToolbar(self.topToolbar, didSubmitText: pasteboardContents)
-            }
-          })
-        
-        let pasteAction = UIAction(
-          identifier: .paste,
-          handler: UIAction.deferredActionHandler { _ in
-            if let pasteboardContents = UIPasteboard.general.string {
-              // Enter overlay mode and make the search controller appear.
-              self.topToolbar.enterOverlayMode(pasteboardContents, pasted: true, search: true)
-            }
-          })
-        
-        pasteMenuChildren = [pasteGoAction, pasteAction]
-        
-        if isUsingBottomBar, !priorityEnabled {
-          pasteMenuChildren.reverse()
-        }
-        
-        let copyAction = UIAction(
-          title: Strings.copyAddressTitle,
-          image: UIImage(systemName: "doc.on.doc"),
-          handler: UIAction.deferredActionHandler { _ in
-            if let url = self.topToolbar.currentURL {
-              UIPasteboard.general.url = url as URL
-            }
-          })
-        
-        let copyMenu = UIMenu(title: "", options: .displayInline, children: [copyAction])
-        
-        if UIPasteboard.general.hasStrings || UIPasteboard.general.hasURLs {
-          let pasteMenu = UIMenu(title: "", options: .displayInline, children: pasteMenuChildren)
-          
-          actionMenu = [pasteMenu, copyMenu]
-          
-          if isUsingBottomBar, !priorityEnabled {
-            actionMenu.reverse()
+    let configuration =  UIContextMenuConfiguration(identifier: nil, previewProvider: nil) { [unowned self] _ in
+      var actionMenu: [UIMenu] = []
+      var pasteMenuChildren: [UIAction] = []
+      
+      let pasteGoAction = UIAction(
+        identifier: .pasteAndGo,
+        handler: UIAction.deferredActionHandler { _ in
+          if let pasteboardContents = UIPasteboard.general.string {
+            self.topToolbar(self.topToolbar, didSubmitText: pasteboardContents)
           }
-        } else {
-          actionMenu = [copyMenu]
-        }
-        
-        return UIMenu(title: "", identifier: nil, children: actionMenu)
+        })
+
+      let pasteAction = UIAction(
+        identifier: .paste,
+        handler: UIAction.deferredActionHandler { _ in
+          if let pasteboardContents = UIPasteboard.general.string {
+            // Enter overlay mode and make the search controller appear.
+            self.topToolbar.enterOverlayMode(pasteboardContents, pasted: true, search: true)
+          }
+        })
+
+      pasteMenuChildren = [pasteGoAction, pasteAction]
+      
+      if #unavailable(iOS 16.0), isUsingBottomBar {
+        pasteMenuChildren.reverse()
       }
       
-      return configuration
-    }
-    
-    if #available(iOS 16.0, *) {
-      let configuration = createURLBarContextMenuConfiguration(priorityEnabled: true)
-      configuration.preferredMenuElementOrder = .priority
+      let copyAction = UIAction(
+        title: Strings.copyAddressTitle,
+        image: UIImage(systemName: "doc.on.doc"),
+        handler: UIAction.deferredActionHandler { _ in
+          if let url = self.topToolbar.currentURL {
+            UIPasteboard.general.url = url as URL
+          }
+        })
+
+      let copyMenu = UIMenu(title: "", options: .displayInline, children: [copyAction])
       
-      return configuration
+      if UIPasteboard.general.hasStrings || UIPasteboard.general.hasURLs {
+        let pasteMenu = UIMenu(title: "", options: .displayInline, children: pasteMenuChildren)
+        
+        actionMenu = [pasteMenu, copyMenu]
+        
+        if #unavailable(iOS 16.0), isUsingBottomBar {
+          actionMenu.reverse()
+        }
+      } else {
+        actionMenu = [copyMenu]
+      }
+
+      return UIMenu(title: "", identifier: nil, children: actionMenu)
+    }
+      
+    if #available(iOS 16.0, *) {
+      configuration.preferredMenuElementOrder = .priority
     }
     
-    return createURLBarContextMenuConfiguration(priorityEnabled: false)
+    return configuration
   }
 }

--- a/Sources/BraveStrings/BraveStrings.swift
+++ b/Sources/BraveStrings/BraveStrings.swift
@@ -32,6 +32,7 @@ extension Strings {
   public static let download = NSLocalizedString("CommonDownload", tableName: "BraveShared", bundle: .module, value: "Download", comment: "Text to choose for downloading a file (example: saving an image to phone)")
   public static let showLinkPreviewsActionTitle = NSLocalizedString("ShowLinkPreviewsActionTitle", tableName: "BraveShared", bundle: .module, value: "Show Link Previews", comment: "Context menu item for showing link previews")
   public static let hideLinkPreviewsActionTitle = NSLocalizedString("HideLinkPreviewsActionTitle", tableName: "BraveShared", bundle: .module, value: "Hide Link Previews", comment: "Context menu item for hiding link previews")
+  public static let copyAddressTitle = NSLocalizedString("CopyAddressTitle", bundle: .module, value: "Copy Address", comment: "The title for the button that lets you copy the url from the location bar.")
   public static let learnMore = NSLocalizedString(
     "learnMore", tableName: "BraveShared",
     bundle: .module, value: "Learn More", comment: "")

--- a/Sources/Shared/SharedStrings.swift
+++ b/Sources/Shared/SharedStrings.swift
@@ -99,10 +99,3 @@ extension Strings {
 extension Strings {
   public static let externalLinkAppStoreConfirmationTitle = NSLocalizedString("ExternalLinkAppStoreConfirmationTitle", bundle: .module, value: "Open this link in the App Store app?", comment: "Question shown to user when tapping a link that opens the App Store app")
 }
-
-// Location bar long press menu
-extension Strings {
-  public static let pasteAndGoTitle = NSLocalizedString("PasteAndGoTitle", bundle: .module, value: "Paste & Go", comment: "The title for the button that lets you paste and go to a URL")
-  public static let pasteTitle = NSLocalizedString("PasteTitle", bundle: .module, value: "Paste", comment: "The title for the button that lets you paste into the location bar")
-  public static let copyAddressTitle = NSLocalizedString("CopyAddressTitle", bundle: .module, value: "Copy Address", comment: "The title for the button that lets you copy the url from the location bar.")
-}


### PR DESCRIPTION
Changing Context Menu order and add additional menu section for better usability copy address

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #6260

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:

Test context menu order and spacing for both bottom and top toolbar order change

## Screenshots:

![1](https://github.com/brave/brave-ios/assets/6643505/094a919f-a7c2-4d05-a9fa-58061b3a1a86)


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
