### PR TITLE
Fix #7514 - #7280: Search buttons are behind safe area when using hardware keyboard - Omnibar missing after trying to change search settings 

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController.swift
@@ -1180,9 +1180,25 @@ public class BrowserViewController: UIViewController {
     header.snp.remakeConstraints { make in
       if self.isUsingBottomBar {
         // Need to check Find In Page Bar is enabled in order to aligh it properly when bottom-bar is enabled
-        if let keyboardHeight = keyboardState?.intersectionHeightForView(self.view), keyboardHeight > 0,
-           (presentedViewController == nil || findInPageBar != nil) {
-          var offset = -keyboardHeight
+        var shouldEvaluateKeyboardConstraints = false
+        var activeKeyboardHeight: CGFloat = 0
+        var searchEngineSettingsDismissed = false
+
+        if let keyboardHeight = keyboardState?.intersectionHeightForView(self.view) {
+          activeKeyboardHeight = keyboardHeight
+        }
+        
+        if let presentedNavigationController = presentedViewController as? ModalSettingsNavigationController ,
+           let presentedRootController = presentedNavigationController.viewControllers.first,
+           presentedRootController is SearchSettingsTableViewController {
+          searchEngineSettingsDismissed = true
+        }
+        
+        shouldEvaluateKeyboardConstraints = (activeKeyboardHeight > 0)
+          && (presentedViewController == nil || searchEngineSettingsDismissed || findInPageBar != nil)
+                
+        if shouldEvaluateKeyboardConstraints {
+          var offset = -activeKeyboardHeight
           if !topToolbar.inOverlayMode {
             // Showing collapsed URL bar while the keyboard is up
             offset += toolbarVisibilityViewModel.transitionDistance

--- a/Sources/Brave/Frontend/Browser/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController.swift
@@ -1188,7 +1188,7 @@ public class BrowserViewController: UIViewController {
           activeKeyboardHeight = keyboardHeight
         }
         
-        if let presentedNavigationController = presentedViewController as? ModalSettingsNavigationController ,
+        if let presentedNavigationController = presentedViewController as? ModalSettingsNavigationController,
            let presentedRootController = presentedNavigationController.viewControllers.first,
            presentedRootController is SearchSettingsTableViewController {
           searchEngineSettingsDismissed = true

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
@@ -651,10 +651,8 @@ extension BrowserViewController: TopToolbarDelegate {
     } else {
       view.insertSubview(searchController.view, belowSubview: header)
     }
-    searchController.view.snp.makeConstraints { make in
-      make.top.bottom.equalTo(self.view)
-      make.left.right.equalTo(self.view)
-      return
+    searchController.view.snp.makeConstraints {
+      $0.edges.equalTo(view.safeAreaLayoutGuide)
     }
     searchController.didMove(toParent: self)
     searchController.view.setNeedsLayout()


### PR DESCRIPTION
Fixing omnibar is missing after search settings and search engines button safe area placement

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7280
This pull request fixes #7514

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
Test Plans indicated in tickets are great

Omnibar 7280

Open a new tab
Enter a search term
Tap magnifying glass icon in the keyboard toolbar
Tap done
Observe search / omni bar is missing

Keyboard 7514

Enable top toolbar (required) in settings
Connect a hardware keyboard
Tap URL bar
Enter any character
Observe search quick actions are in the safe area

## Screenshots:

https://github.com/brave/brave-ios/assets/6643505/eea345ee-38e6-4cf6-8237-45d2e3ce2446


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
