### PR TITLE
No bug: Add missing localization for test networks copy

### DIFF
--- a/Sources/BraveWallet/Crypto/NetworkSelectionRootView.swift
+++ b/Sources/BraveWallet/Crypto/NetworkSelectionRootView.swift
@@ -53,7 +53,7 @@ struct NetworkSelectionRootView: View {
             .listRowBackground(Color(.secondaryBraveGroupedBackground))
           }
         }, header: {
-          WalletListHeaderView(title: Text("Test Networks"))
+          WalletListHeaderView(title: Text(Strings.Wallet.networkSelectionTestNetworks))
         })
       }
     }

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -2829,6 +2829,13 @@ extension Strings {
       value: "Secondary Networks",
       comment: "The title of the section for secondary networks in the network selection view."
     )
+    public static let networkSelectionTestNetworks = NSLocalizedString(
+      "wallet.networkSelectionTestNetworks",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Test Networks",
+      comment: "The title of the section for test networks in the network selection view."
+    )
     public static let networkSelectionTestnetAccessibilityLabel = NSLocalizedString(
       "wallet.networkSelectionTestnetAccessibilityLabel",
       tableName: "BraveWallet",


### PR DESCRIPTION
## Summary of Changes
- Missed localization when moving test networks to their own section

This pull request fixes #<number>

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
