### PR TITLE
Fix #7640: Sort test network tokens to end of Select Token to Send

### DIFF
--- a/Sources/BraveWallet/Crypto/Stores/SelectAccountTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SelectAccountTokenStore.swift
@@ -250,6 +250,13 @@ class SelectAccountTokenStore: ObservableObject {
           )
         }
         .sorted { lhs, rhs in
+          if lhs.network.isKnownTestnet && rhs.network.isKnownTestnet {
+            return (lhs.balance ?? 0) > (rhs.balance ?? 0)
+          } else if lhs.network.isKnownTestnet {
+            return false // sort test networks to end of list
+          } else if rhs.network.isKnownTestnet {
+            return true // sort test networks to end of list
+          }
           return (lhs.balance ?? 0) > (rhs.balance ?? 0)
         }
       return AccountSection(

--- a/Sources/BraveWallet/Extensions/BraveWalletSwiftUIExtensions.swift
+++ b/Sources/BraveWallet/Extensions/BraveWalletSwiftUIExtensions.swift
@@ -41,6 +41,10 @@ extension BraveWallet.NetworkInfo: Identifiable {
   var shortChainName: String {
     chainName.split(separator: " ").first?.capitalized ?? chainName
   }
+  
+  var isKnownTestnet: Bool {
+    WalletConstants.supportedTestNetworkChainIds.contains(chainId)
+  }
 
   public var nativeToken: BraveWallet.BlockchainToken {
     .init(


### PR DESCRIPTION
## Summary of Changes
- When sorting Select Token to Send tokens by balance, keep the test networks at the bottom of the list

This pull request fixes #7640

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

prerequisite: Have larger balance for a token on test network than on a non-test network. Ex. Higher ETH balance on Goerli than Mainnet
1. Open Send token view
2. Tap the token to choose a token/account/network
3. Verify test network token(s) are sorted to the bottom of the list of available tokens


## Screenshots:

![Select Token to Send testnet](https://github.com/brave/brave-ios/assets/5314553/dea0fb4e-670e-4341-b1c6-336f78267312) | ![Select Token to Send testnet 2](https://github.com/brave/brave-ios/assets/5314553/d6bc4f85-aeb8-44fe-8391-78377552e50d)
--|--


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
