### PR TITLE
No Bug: Wallet V2 Design Colors & Symbols

### DIFF
--- a/Sources/BraveWallet/Crypto/Accounts/MultipleAccountBlockiesView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/MultipleAccountBlockiesView.swift
@@ -1,0 +1,27 @@
+// Copyright 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import SwiftUI
+import BraveCore
+
+struct MultipleAccountBlockiesView: View {
+  let accountAddresses: [String]
+  let maxBlockies = 3
+  @ScaledMetric var blockieSize = 16.0
+  var maxBlockieSize: CGFloat = 32
+  @ScaledMetric var blockieDotSize = 2.0
+
+  var body: some View {
+    MultipleCircleIconView(
+      models: accountAddresses,
+      iconSize: blockieSize,
+      maxIconSize: maxBlockieSize,
+      iconDotSize: blockieDotSize,
+      iconView: { address in
+        Blockie(address: address)
+      }
+    )
+  }
+}

--- a/Sources/BraveWallet/Extensions/ViewExtensions.swift
+++ b/Sources/BraveWallet/Extensions/ViewExtensions.swift
@@ -1,0 +1,17 @@
+// Copyright 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import SwiftUI
+
+extension View {
+  /// Helper for `hidden()` modifier that accepts a boolean determining if we should hide the view or not.
+  @ViewBuilder public func hidden(isHidden: Bool) -> some View {
+    if isHidden {
+      self.hidden()
+    } else {
+      self
+    }
+  }
+}

--- a/Sources/BraveWallet/Extensions/WalletColors.swift
+++ b/Sources/BraveWallet/Extensions/WalletColors.swift
@@ -145,12 +145,7 @@ enum WalletV2Design {
   // Dark/Container/Background rgba(25, 27, 34, 1)
   static let containerBackground = UIColor(dynamicProvider: { traits in
     if traits.userInterfaceStyle == .light {
-      return UIColor(
-        red: 255 / 255,
-        green: 255 / 255,
-        blue: 255 / 255,
-        alpha: 1
-      )
+      return UIColor.white
     } else {
       return UIColor(
         red: 25 / 255,

--- a/Sources/BraveWallet/Extensions/WalletColors.swift
+++ b/Sources/BraveWallet/Extensions/WalletColors.swift
@@ -17,3 +17,236 @@ extension UIColor {
     UIColor(rgb: 0xee6374)
   }
 }
+
+/// Tempoarily store Leo Design Colours used in Wallet v2 until we pull in all colours to DesignSystem.
+enum WalletV2Design {
+  // Light/Text/Primary rgba(28, 30, 38, 1)
+  // Dark/Text/Primary rgba(237, 238, 241, 1)
+  static let textPrimary = UIColor(dynamicProvider: { traits in
+    if traits.userInterfaceStyle == .light {
+      return UIColor(
+        red: 28 / 255,
+        green: 30 / 255,
+        blue: 38 / 255,
+        alpha: 1
+      )
+    } else {
+      return UIColor(
+        red: 237 / 255,
+        green: 238 / 255,
+        blue: 241 / 255,
+        alpha: 1
+      )
+    }
+  })
+
+  // Light/Text/Secondary rgba(102, 109, 137, 1)
+  // Dark/Text/Secondary rgba(135, 141, 166, 1)
+  static let textSecondary = UIColor(dynamicProvider: { traits in
+    if traits.userInterfaceStyle == .light {
+      return UIColor(
+        red: 102 / 255,
+        green: 109 / 255,
+        blue: 137 / 255,
+        alpha: 1
+      )
+    } else {
+      return UIColor(
+        red: 135 / 255,
+        green: 141 / 255,
+        blue: 166 / 255,
+        alpha: 1
+      )
+    }
+  })
+
+  // Light/Text/Tertiary rgba(126, 133, 160, 1)
+  // Dark/Text/Tertiary rgba(97, 104, 132, 1)
+  static let textTertiary = UIColor(dynamicProvider: { traits in
+    if traits.userInterfaceStyle == .light {
+      return UIColor(
+        red: 126 / 255,
+        green: 133 / 255,
+        blue: 160 / 255,
+        alpha: 1
+      )
+    } else {
+      return UIColor(
+        red: 97 / 255,
+        green: 104 / 255,
+        blue: 132 / 255,
+        alpha: 1
+      )
+    }
+  })
+
+  // Light/Text/Interactive rgba(66, 62, 238, 1)
+  // Dark/Text/Interactive rgba(170, 168, 247, 1)
+  static let textInteractive = UIColor(dynamicProvider: { traits in
+    if traits.userInterfaceStyle == .light {
+      return UIColor(
+        red: 66 / 255,
+        green: 62 / 255,
+        blue: 238 / 255,
+        alpha: 1
+      )
+    } else {
+      return UIColor(
+        red: 170 / 255,
+        green: 168 / 255,
+        blue: 247 / 255,
+        alpha: 1
+      )
+    }
+  })
+
+  // Light Theme/Text/text01 rgba(33, 37, 41, 1)
+  static let text01: UIColor = .bravePrimary
+  
+  // Extended/Gray/20 rgba(225, 226, 232, 1) / rgba(38, 42, 51, 1)
+  static let extendedGray20 = UIColor(dynamicProvider: { traits in
+    if traits.userInterfaceStyle == .light {
+      return UIColor(
+        red: 225 / 255,
+        green: 226 / 255,
+        blue: 232 / 255,
+        alpha: 1
+      )
+    } else {
+      return UIColor(
+        red: 38 / 255,
+        green: 42 / 255,
+        blue: 51 / 255,
+        alpha: 1
+      )
+    }
+  })
+  
+  // Extended/Gray/50 rgba(84, 90, 113, 1) / rgba(168, 173, 191, 1)
+  static let extendedGray50 = UIColor(dynamicProvider: { traits in
+    if traits.userInterfaceStyle == .light {
+      return UIColor(
+        red: 84 / 255,
+        green: 90 / 255,
+        blue: 113 / 255,
+        alpha: 1
+      )
+    } else {
+      return UIColor(
+        red: 168 / 255,
+        green: 173 / 255,
+        blue: 191 / 255,
+        alpha: 1
+      )
+    }
+  })
+
+  // Light/Container/Background rgba(255, 255, 255, 1)
+  // Dark/Container/Background rgba(25, 27, 34, 1)
+  static let containerBackground = UIColor(dynamicProvider: { traits in
+    if traits.userInterfaceStyle == .light {
+      return UIColor(
+        red: 255 / 255,
+        green: 255 / 255,
+        blue: 255 / 255,
+        alpha: 1
+      )
+    } else {
+      return UIColor(
+        red: 25 / 255,
+        green: 27 / 255,
+        blue: 34 / 255,
+        alpha: 1
+      )
+    }
+  })
+
+  // Light/Container/Highlight rgba(240, 241, 244, 1)
+  // Dark/Container/Highlight rgba(13, 14, 18, 1)
+  static let containerHighlight = UIColor(dynamicProvider: { traits in
+    if traits.userInterfaceStyle == .light {
+      return UIColor(
+        red: 240 / 255,
+        green: 241 / 255,
+        blue: 244 / 255,
+        alpha: 1
+      )
+    } else {
+      return UIColor(
+        red: 13 / 255,
+        green: 14 / 255,
+        blue: 18 / 255,
+        alpha: 1
+      )
+    }
+  })
+
+  // Light/Interaction/Button-primary-background rgba(66, 62, 238, 1)
+  // Dark/Interaction/Button-primary-background rgba(66, 62, 238, 1)
+  static let interactionButtonPrimaryBackground = UIColor(
+    red: 66 / 255,
+    green: 62 / 255,
+    blue: 238 / 255,
+    alpha: 1
+  )
+
+  // Light/Icon/Interactive rgba(95, 92, 241, 1)
+  // Dark/Icon/Interactive rgba(135, 132, 244, 1)
+  static let iconInteractive = UIColor(dynamicProvider: { traits in
+    if traits.userInterfaceStyle == .light {
+      return UIColor(
+        red: 95 / 255,
+        green: 92 / 255,
+        blue: 241 / 255,
+        alpha: 1
+      )
+    } else {
+      return UIColor(
+        red: 135 / 255,
+        green: 132 / 255,
+        blue: 244 / 255,
+        alpha: 1
+      )
+    }
+  })
+
+  // Light/Icon/Default rgba(102, 109, 137, 1)
+  // Dark/Icon/Default rgba(135, 141, 166, 1)
+  static let iconDefault = UIColor(dynamicProvider: { traits in
+    if traits.userInterfaceStyle == .light {
+      return UIColor(
+        red: 102 / 255,
+        green: 109 / 255,
+        blue: 137 / 255,
+        alpha: 1
+      )
+    } else {
+      return UIColor(
+        red: 135 / 255,
+        green: 141 / 255,
+        blue: 166 / 255,
+        alpha: 1
+      )
+    }
+  })
+
+  // Light/Divider/Subtle rgba(232, 233, 238, 1)
+  // Dark/Divider/Subtle rgba(43, 46, 59, 1)
+  static let dividerSubtle = UIColor(dynamicProvider: { traits in
+    if traits.userInterfaceStyle == .light {
+      return UIColor(
+        red: 232 / 255,
+        green: 233 / 255,
+        blue: 238 / 255,
+        alpha: 1
+      )
+    } else {
+      return UIColor(
+        red: 43 / 255,
+        green: 46 / 255,
+        blue: 59 / 255,
+        alpha: 1
+      )
+    }
+  })
+}

--- a/Sources/BraveWallet/MultipleCircleIconView.swift
+++ b/Sources/BraveWallet/MultipleCircleIconView.swift
@@ -1,0 +1,45 @@
+// Copyright 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import SwiftUI
+import BraveCore
+
+struct MultipleCircleIconView<IconView: View, Model>: View {
+  let models: [Model]
+  let maxIcons = 3
+  @ScaledMetric var iconSize = 16.0
+  var maxIconSize: CGFloat = 32
+  @ScaledMetric var iconDotSize = 2.0
+
+  @ViewBuilder var iconView: (Model) -> IconView
+
+  var body: some View {
+    HStack(spacing: -(min(iconSize, maxIconSize) / 2)) {
+      let numberOfIcons = min(maxIcons, models.count)
+      ForEach(0..<numberOfIcons, id: \.self) { index in
+        iconView(models[index])
+          .frame(width: min(iconSize, maxIconSize), height: min(iconSize, maxIconSize))
+          .overlay(Circle().stroke(Color(.secondaryBraveGroupedBackground), lineWidth: 1))
+          .zIndex(Double(numberOfIcons - index))
+      }
+      if models.count > maxIcons {
+        Circle()
+          .foregroundColor(Color(.braveBlurpleTint))
+          .frame(width: min(iconSize, maxIconSize), height: min(iconSize, maxIconSize))
+          .overlay(
+            HStack(spacing: 1) {
+              Circle()
+                .frame(width: iconDotSize, height: iconDotSize)
+              Circle()
+                .frame(width: iconDotSize, height: iconDotSize)
+              Circle()
+                .frame(width: iconDotSize, height: iconDotSize)
+            }
+              .foregroundColor(.white)
+          )
+      }
+    }
+  }
+}

--- a/Sources/BraveWallet/Settings/DappsSettings.swift
+++ b/Sources/BraveWallet/Settings/DappsSettings.swift
@@ -185,11 +185,6 @@ private struct SiteRow: View {
   
   let siteConnection: SiteConnection
   
-  private let maxBlockies = 3
-  @ScaledMetric private var blockieSize = 16.0
-  private let maxBlockieSize: CGFloat = 32
-  @ScaledMetric private var blockieDotSize = 2.0
-  
   private var connectedAddresses: String {
     let account = Strings.Wallet.manageSiteConnectionsAccountSingular
     let accounts = Strings.Wallet.manageSiteConnectionsAccountPlural
@@ -220,31 +215,9 @@ private struct SiteRow: View {
     if siteConnection.connectedAddresses.isEmpty {
       EmptyView()
     } else {
-      HStack(spacing: -(min(blockieSize, maxBlockieSize) / 2)) {
-        let numberOfBlockies = min(maxBlockies, siteConnection.connectedAddresses.count)
-        ForEach(0..<numberOfBlockies, id: \.self) { index in
-          Blockie(address: siteConnection.connectedAddresses[index])
-            .frame(width: min(blockieSize, maxBlockieSize), height: min(blockieSize, maxBlockieSize))
-            .overlay(Circle().stroke(Color(.secondaryBraveGroupedBackground), lineWidth: 1))
-            .zIndex(Double(numberOfBlockies - index))
-        }
-        if siteConnection.connectedAddresses.count > maxBlockies {
-          Circle()
-            .foregroundColor(Color(.braveBlurpleTint))
-            .frame(width: min(blockieSize, maxBlockieSize), height: min(blockieSize, maxBlockieSize))
-            .overlay(
-              HStack(spacing: 1) {
-                Circle()
-                  .frame(width: blockieDotSize, height: blockieDotSize)
-                Circle()
-                  .frame(width: blockieDotSize, height: blockieDotSize)
-                Circle()
-                  .frame(width: blockieDotSize, height: blockieDotSize)
-              }
-                .foregroundColor(.white)
-            )
-        }
-      }
+      MultipleAccountBlockiesView(
+        accountAddresses: siteConnection.connectedAddresses
+      )
     }
   }
 }

--- a/Sources/DesignSystem/Icons/Symbols.xcassets/leo.arrow.down.symbolset/Contents.json
+++ b/Sources/DesignSystem/Icons/Symbols.xcassets/leo.arrow.down.symbolset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "symbols" : [
+    {
+      "idiom" : "universal"
+    }
+  ]
+}

--- a/Sources/DesignSystem/Icons/Symbols.xcassets/leo.carat.down.symbolset/Contents.json
+++ b/Sources/DesignSystem/Icons/Symbols.xcassets/leo.carat.down.symbolset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "symbols" : [
+    {
+      "idiom" : "universal"
+    }
+  ]
+}

--- a/Sources/DesignSystem/Icons/Symbols.xcassets/leo.carat.up.symbolset/Contents.json
+++ b/Sources/DesignSystem/Icons/Symbols.xcassets/leo.carat.up.symbolset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "symbols" : [
+    {
+      "idiom" : "universal"
+    }
+  ]
+}

--- a/Sources/DesignSystem/Icons/Symbols.xcassets/leo.internet.symbolset/Contents.json
+++ b/Sources/DesignSystem/Icons/Symbols.xcassets/leo.internet.symbolset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "symbols" : [
+    {
+      "idiom" : "universal"
+    }
+  ]
+}

--- a/Sources/DesignSystem/Icons/Symbols.xcassets/leo.list.bullet-default.symbolset/Contents.json
+++ b/Sources/DesignSystem/Icons/Symbols.xcassets/leo.list.bullet-default.symbolset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "symbols" : [
+    {
+      "idiom" : "universal"
+    }
+  ]
+}

--- a/Sources/DesignSystem/Icons/Symbols.xcassets/leo.user.accounts.symbolset/Contents.json
+++ b/Sources/DesignSystem/Icons/Symbols.xcassets/leo.user.accounts.symbolset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "symbols" : [
+    {
+      "idiom" : "universal"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary of Changes
- Temporarily storing Leo Design colours in Wallet target until we pull in all Leo Design Colours similar to SF Symbols.
- Add new Leo SF Symbols used in parts of Wallet v2.
- Some extensions and UI refactors (account blockies view re-usable) for Wallet v2.

This pull request fixes #<number>

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Quick check DappSettings still displays account blockies as expected after refactor to re-usable view.

## Screenshots:

![Blockies](https://github.com/brave/brave-ios/assets/5314553/c948ca6f-4f47-4847-990e-7cf2ed51f6f6)

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
