### PR TITLE
Fix #7610: Remove stale hitTest function in Tab.

### DIFF
--- a/Sources/Brave/Frontend/Browser/Tab.swift
+++ b/Sources/Brave/Frontend/Browser/Tab.swift
@@ -945,13 +945,6 @@ class TabWebView: BraveWebView, MenuHelperInterface {
     }
   }
 
-  override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
-    // The find-in-page selection menu only appears if the webview is the first responder.
-    becomeFirstResponder()
-
-    return super.hitTest(point, with: event)
-  }
-
   // rdar://33283179 Apple bug where `serverTrust` is not defined as KVO when it should be
   override func value(forUndefinedKey key: String) -> Any? {
     if key == #keyPath(WKWebView.serverTrust) {


### PR DESCRIPTION
This caused the iOS Find in Page(UIFindInteraction) bar to dismiss on scroll. Removing this for iOS 15 and lower too as it seems to work fine without.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7610 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Go to wikipedia.
type some letters in url bar and go to 'find in page' option.
Scroll down a bit.

Verify that the find in page bar does not disappear.
Please verify it on both iOS 16 and 15.

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
