### PR TITLE
Fix #7663: Dismiss popup in playlist onboarding when tapping Maybe Later

### DIFF
--- a/Sources/Onboarding/Callouts/OnboardingPlaylistView.swift
+++ b/Sources/Onboarding/Callouts/OnboardingPlaylistView.swift
@@ -180,6 +180,8 @@ public struct OnboardingPlaylistView: View {
         case .details:
           DetailsStepView(advance: {
             model.step = .tryItOut
+          }, dismiss: {
+            dismiss()
           })
           .transition(.asymmetric(insertion: .opacity.animation(.default.delay(0.1)), removal: .opacity.animation(.default)))
           .accessibilityFocused($accessibilityFocusStep, equals: .details)
@@ -205,6 +207,8 @@ public struct OnboardingPlaylistView: View {
       if model.step == .details {
         DetailsStepView(advance: {
           model.step = .tryItOut
+        }, dismiss: {
+          dismiss()
         })
         .expandedViewButtons
         .foregroundStyle(.white)
@@ -290,7 +294,7 @@ extension OnboardingPlaylistView {
   
   struct DetailsStepView: View {
     var advance: () -> Void
-    @Environment(\.dismiss) private var dismiss
+    var dismiss: () -> Void
     
     var body: some View {
       VStack(spacing: 24) {


### PR DESCRIPTION
This moves the dismissal environment call to the parent View. This is likely a side-effect of path taken to render the same buttons in one view in another like so:

```
DetailsStepView(advance: {
  model.step = .tryItOut
})
.expandedViewButtons
```

Since the View itself (`DetailsStepView`) is not used, and thus has no `body`, it can't access the environment.

## Summary of Changes

This pull request fixes #7663 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
