### PR TITLE
Fix #7603: Fix Certificate Viewer Sizing

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
@@ -110,7 +110,7 @@ extension BrowserViewController: TopToolbarDelegate {
             webView.findInteraction?.dismissFindNavigator()
           }
           let certificateViewController = CertificateViewController(certificate: certificate, evaluationError: errorDescription)
-          let popover = PopoverController(contentController: certificateViewController, contentSizeBehavior: .preferredContentSize)
+          let popover = PopoverController(contentController: certificateViewController, contentSizeBehavior: .autoLayout(.phoneBounds))
           popover.addsConvenientDismissalMargins = true
           popover.present(from: self.topToolbar.locationView.lockImageView.imageView!, on: self)
         }

--- a/Sources/Brave/Frontend/Browser/Certificate Viewer/CertificateViewController.swift
+++ b/Sources/Brave/Frontend/Browser/Certificate Viewer/CertificateViewController.swift
@@ -370,8 +370,6 @@ class CertificateViewController: UIViewController, PopoverContentComponent {
     controller.view.snp.makeConstraints {
       $0.edges.equalToSuperview()
     }
-
-    self.preferredContentSize = CGSize(width: 375.0, height: 667.0)
   }
 
   required init?(coder: NSCoder) {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Fix certificate viewer text being cropped

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7603

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
- Display certificate viewer and make sure the text is fully showing


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
