### PR TITLE
Fix #7667: Fix Long-press not detecting video elements of zero size

### DIFF
--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Paged/PlaylistScript.js
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Paged/PlaylistScript.js
@@ -194,6 +194,19 @@ window.__firefox__.includeOnce("Playlist", function($) {
               }
             }
             
+            // No elements found nearby
+            // Select the first of each IF found because some websites can have video elements with zero size.
+            // In such cases, the gesture would not be on or inside the element, so this is a fallback.
+            if (!targetVideo && !targetAudio) {
+              if (videoElements.length > 0) {
+                targetVideo = videoElements[0];
+              }
+              
+              if (audioElements.length > 0) {
+                targetAudio = audioElements[0];
+              }
+            }
+            
             // No elements found nearby so do nothing..
             if (!targetVideo && !targetAudio) {
               return;


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Allow Long-Press on video and audio elements that have zero size to be detected by a long-press on the page itself.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7667

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
