### PR TITLE
Fix #7674: Update bookmarks cell to show the count of child bookmarks in a folder

### DIFF
--- a/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarksViewController.swift
+++ b/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarksViewController.swift
@@ -443,16 +443,26 @@ class BookmarksViewController: SiteTableViewController, ToolbarUrlActionsProtoco
     let fontSize: CGFloat = 14.0
     cell.textLabel?.text = item.title ?? item.url
     cell.textLabel?.lineBreakMode = .byTruncatingTail
+    cell.detailTextLabel?.lineBreakMode = .byTruncatingTail
 
     if !item.isFolder {
       configCell()
       cell.textLabel?.font = UIFont.systemFont(ofSize: fontSize)
       cell.accessoryType = .none
+      cell.detailTextLabel?.text = nil
     } else {
       configCell(image: UIImage(braveSystemNamed: "leo.folder"))
       cell.textLabel?.font = UIFont.boldSystemFont(ofSize: fontSize)
       cell.accessoryType = .disclosureIndicator
       cell.setRightBadge(nil)
+      
+      // 0 bookmarks
+      // 1 bookmark
+      // 2 bookmarks
+      // ...
+      cell.detailTextLabel?.text = String(format: item.bookmarkNode.childCount == 1 ? Strings.bookmarkSingleCount :
+                                            Strings.bookmarkMultipleCount, item.children?.count ?? 0)
+      cell.detailTextLabel?.font = UIFont.systemFont(ofSize: fontSize)
     }
   }
 

--- a/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarksViewController.swift
+++ b/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarksViewController.swift
@@ -460,8 +460,8 @@ class BookmarksViewController: SiteTableViewController, ToolbarUrlActionsProtoco
       // 1 bookmark
       // 2 bookmarks
       // ...
-      cell.detailTextLabel?.text = String(format: item.bookmarkNode.childCount == 1 ? Strings.bookmarkSingleCount :
-                                            Strings.bookmarkMultipleCount, item.children?.count ?? 0)
+      let bookmarksCount = item.children?.filter({ !$0.isFolder }).count ?? 0
+      cell.detailTextLabel?.text = String(format: bookmarksCount == 1 ? Strings.bookmarkSingleCount : Strings.bookmarkMultipleCount, bookmarksCount)
       cell.detailTextLabel?.font = UIFont.systemFont(ofSize: fontSize)
     }
   }

--- a/Sources/BraveStrings/BraveStrings.swift
+++ b/Sources/BraveStrings/BraveStrings.swift
@@ -1093,6 +1093,8 @@ extension Strings {
   public static let favoritesRootLevelCellTitle = NSLocalizedString("FavoritesRootLevelCellTitle", tableName: "BraveShared", bundle: .module, value: "Favorites", comment: "Title for favorites cell")
   public static let addFolderActionCellTitle = NSLocalizedString("AddFolderActionCellTitle", tableName: "BraveShared", bundle: .module, value: "New folder", comment: "Cell title for add folder action")
   public static let editBookmarkTableLocationHeader = NSLocalizedString("EditBookmarkTableLocationHeader", tableName: "BraveShared", bundle: .module, value: "Location", comment: "Header title for bookmark save location")
+  public static let bookmarkSingleCount = NSLocalizedString("BookmarkSingleCount", tableName: "BraveShared", bundle: .module, value: "%d bookmark", comment: "Title for a single bookmark (Do not localize %d, it is a placeholder for a number. IE: 1 bookmark)")
+  public static let bookmarkMultipleCount = NSLocalizedString("BookmarkMultipleCount", tableName: "BraveShared", bundle: .module, value: "%d bookmarks", comment: "Title for a single bookmark (Do not localize %d, it is a placeholder for a number. IE: 10 bookmarks")
   public static let newBookmarkTitle = NSLocalizedString("NewBookmarkTitle", tableName: "BraveShared", bundle: .module, value: "New bookmark", comment: "Title for adding new bookmark")
   public static let newFolderTitle = NSLocalizedString("NewFolderTitle", tableName: "BraveShared", bundle: .module, value: "New folder", comment: "Title for adding new folder")
   public static let editBookmarkTitle = NSLocalizedString("EditBookmarkTitle", tableName: "BraveShared", bundle: .module, value: "Edit bookmark", comment: "Title for editing a bookmark")


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Add the bookmark child count to the Bookmarks Folder

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7674

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes


## Screenshots:
<img width="286" alt="image" src="https://github.com/brave/brave-ios/assets/1530031/c9fa8690-add6-4868-9a3c-6843fc9bc09c">
<img width="287" alt="image" src="https://github.com/brave/brave-ios/assets/1530031/e57b5d98-4eec-48b9-8390-59bf91cf5dd8">



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
