### PR TITLE
Fix #7657 - #7656: Local Authentication Changes and Bug Fixes

### DIFF
--- a/Sources/Brave/Frontend/Login/LoginAuthViewController.swift
+++ b/Sources/Brave/Frontend/Login/LoginAuthViewController.swift
@@ -23,7 +23,7 @@ class LoginAuthViewController: UITableViewController {
     self.requiresAuthentication = requiresAuthentication
     super.init(nibName: nil, bundle: nil)
     
-    windowProtection?.isCancallable = true
+    windowProtection?.isCancellable = true
   }
 
   required init?(coder: NSCoder) {

--- a/Sources/Brave/Frontend/Login/LoginAuthViewController.swift
+++ b/Sources/Brave/Frontend/Login/LoginAuthViewController.swift
@@ -8,10 +8,13 @@ import Preferences
 import BraveUI
 import Shared
 import UIKit
+import LocalAuthentication
+import Combine
 
 class LoginAuthViewController: UITableViewController {
 
   private let windowProtection: WindowProtection?
+  private var localAuthObservers = Set<AnyCancellable>()
 
   // MARK: Lifecycle
 
@@ -19,6 +22,8 @@ class LoginAuthViewController: UITableViewController {
     self.windowProtection = windowProtection
     self.requiresAuthentication = requiresAuthentication
     super.init(nibName: nil, bundle: nil)
+    
+    windowProtection?.isCancallable = true
   }
 
   required init?(coder: NSCoder) {
@@ -29,8 +34,8 @@ class LoginAuthViewController: UITableViewController {
     super.viewWillAppear(animated)
 
     if requiresAuthentication, Preferences.Privacy.lockWithPasscode.value {
-      askForAuthentication() { [weak self] success in
-        if !success {
+      askForAuthentication() { [weak self] success, error in
+        if !success, error != .userCancel {
           self?.navigationController?.popViewController(animated: true)
         }
       }
@@ -58,19 +63,19 @@ class LoginAuthViewController: UITableViewController {
 
   // MARK: Internal
 
-  func askForAuthentication(completion: ((Bool) -> Void)? = nil) {
+  func askForAuthentication(completion: ((Bool, LAError.Code?) -> Void)? = nil) {
     guard let windowProtection = windowProtection else {
-      completion?(false)
+      completion?(false, nil)
       return
     }
 
     if !windowProtection.isPassCodeAvailable {
       showSetPasscodeError() {
-        completion?(false)
+        completion?(false, .passcodeNotSet)
       }
     } else {
-      windowProtection.presentAuthenticationForViewController(determineLockWithPasscode: false) { status in
-        completion?(status)
+      windowProtection.presentAuthenticationForViewController(determineLockWithPasscode: false) { status, error in
+        completion?(status, error)
       }
     }
   }

--- a/Sources/Brave/Frontend/Login/LoginInfoViewController.swift
+++ b/Sources/Brave/Frontend/Login/LoginInfoViewController.swift
@@ -10,6 +10,7 @@ import SwiftKeychainWrapper
 import BraveCore
 import UIKit
 import BraveUI
+import Combine
 
 class LoginInfoViewController: LoginAuthViewController {
 
@@ -69,6 +70,8 @@ class LoginInfoViewController: LoginAuthViewController {
 
     return dateFormatter.string(from: credentials.dateCreated ?? Date())
   }
+
+  private var localAuthObservers = Set<AnyCancellable>()
 
   // MARK: Lifecycle
 
@@ -287,7 +290,7 @@ extension LoginInfoViewController {
 extension LoginInfoViewController {
 
   @objc private func edit() {
-    askForAuthentication() { [weak self] status in
+    askForAuthentication() { [weak self] status, _ in
       guard let self = self, status else { return }
       
       self.isEditingFieldData = true
@@ -410,7 +413,7 @@ extension LoginInfoViewController: LoginInfoTableViewCellDelegate {
   }
 
   func didSelectReveal(_ cell: LoginInfoTableViewCell, completion: ((Bool) -> Void)?) {
-    askForAuthentication() { status in
+    askForAuthentication() { status, _ in
       completion?(status)
     }
   }
@@ -425,7 +428,7 @@ extension LoginInfoViewController: LoginInfoTableViewCellDelegate {
     }
     
     if authenticationRequired {
-      askForAuthentication() { status in
+      askForAuthentication() { status, _ in
         if status {
           addPasswordToPasteBoardWithExpiry()
         }

--- a/Sources/Brave/Frontend/Login/LoginListViewController.swift
+++ b/Sources/Brave/Frontend/Login/LoginListViewController.swift
@@ -12,6 +12,7 @@ import Storage
 import Data
 import BraveCore
 import Favicon
+import Combine
 
 class LoginListViewController: LoginAuthViewController {
 
@@ -42,6 +43,8 @@ class LoginListViewController: LoginAuthViewController {
   private let emptyStateOverlayView = EmptyStateOverlayView(
     overlayDetails: EmptyOverlayStateDetails(title: Strings.Login.loginListEmptyScreenTitle))
 
+  private var localAuthObservers = Set<AnyCancellable>()
+
   // MARK: Lifecycle
 
   init(passwordAPI: BravePasswordAPI, windowProtection: WindowProtection?) {
@@ -62,6 +65,11 @@ class LoginListViewController: LoginAuthViewController {
           self.fetchLoginInfo()
         }
       })
+    
+    windowProtection?.cancelPressed
+      .sink { [weak self] _ in
+        self?.navigationController?.popViewController(animated: true)
+      }.store(in: &localAuthObservers)
   }
 
   required init?(coder: NSCoder) {

--- a/Sources/Brave/Frontend/Passcode/WindowProtection.swift
+++ b/Sources/Brave/Frontend/Passcode/WindowProtection.swift
@@ -50,7 +50,7 @@ public class WindowProtection {
       }
       unlockButton.snp.makeConstraints {
         $0.leading.greaterThanOrEqualToSuperview().offset(20)
-        $0.trailing.lessThanOrEqualToSuperview().offset(20)
+        $0.trailing.lessThanOrEqualToSuperview().offset(-20)
         $0.centerX.equalToSuperview()
         $0.height.greaterThanOrEqualTo(44)
         $0.width.greaterThanOrEqualTo(230)
@@ -58,7 +58,7 @@ public class WindowProtection {
       }
       cancelButton.snp.makeConstraints {
         $0.leading.greaterThanOrEqualToSuperview().offset(20)
-        $0.trailing.lessThanOrEqualToSuperview().offset(20)
+        $0.trailing.lessThanOrEqualToSuperview().offset(-20)
         $0.centerX.equalToSuperview()
         $0.height.greaterThanOrEqualTo(44)
         $0.width.greaterThanOrEqualTo(230)
@@ -95,10 +95,10 @@ public class WindowProtection {
     return true
   }
 
-  var isCancallable: Bool = false {
+  var isCancellable: Bool = false {
     didSet {
-      if oldValue != isCancallable {
-        lockedViewController.cancelButton.isHidden = !isCancallable
+      if oldValue != isCancellable {
+        lockedViewController.cancelButton.isHidden = !isCancellable
       }
     }
   }

--- a/Sources/Brave/Frontend/Passcode/WindowProtection.swift
+++ b/Sources/Brave/Frontend/Passcode/WindowProtection.swift
@@ -19,10 +19,19 @@ public class WindowProtection {
     let backgroundView = UIVisualEffectView(effect: UIBlurEffect(style: .systemThickMaterial))
     let lockImageView = UIImageView(image: UIImage(named: "browser-lock-icon", in: .module, compatibleWith: nil)!)
     let unlockButton = FilledActionButton(type: .system).then {
-      $0.setTitle("Unlock", for: .normal)
+      $0.setTitle(Strings.unlockButtonTitle, for: .normal)
       $0.titleLabel?.font = .preferredFont(forTextStyle: .headline)
       $0.titleLabel?.adjustsFontForContentSizeCategory = true
       $0.backgroundColor = .braveBlurpleTint
+      $0.isHidden = true
+    }
+    
+    let cancelButton = ActionButton(type: .system).then {
+      $0.setTitle(Strings.cancelButtonTitle, for: .normal)
+      $0.titleLabel?.font = .preferredFont(forTextStyle: .headline)
+      $0.titleLabel?.adjustsFontForContentSizeCategory = true
+      $0.setTitle(Strings.cancelButtonTitle, for: .normal)
+      $0.tintColor = .braveLabel
       $0.isHidden = true
     }
 
@@ -32,6 +41,7 @@ public class WindowProtection {
       view.addSubview(backgroundView)
       view.addSubview(lockImageView)
       view.addSubview(unlockButton)
+      view.addSubview(cancelButton)
       backgroundView.snp.makeConstraints {
         $0.edges.equalTo(view)
       }
@@ -45,6 +55,14 @@ public class WindowProtection {
         $0.height.greaterThanOrEqualTo(44)
         $0.width.greaterThanOrEqualTo(230)
         $0.top.equalTo(lockImageView.snp.bottom).offset(60)
+      }
+      cancelButton.snp.makeConstraints {
+        $0.leading.greaterThanOrEqualToSuperview().offset(20)
+        $0.trailing.lessThanOrEqualToSuperview().offset(20)
+        $0.centerX.equalToSuperview()
+        $0.height.greaterThanOrEqualTo(44)
+        $0.width.greaterThanOrEqualTo(230)
+        $0.top.equalTo(unlockButton.snp.bottom).offset(15)
       }
     }
   }
@@ -77,6 +95,20 @@ public class WindowProtection {
     return true
   }
 
+  var isCancallable: Bool = false {
+    didSet {
+      if oldValue != isCancallable {
+        lockedViewController.cancelButton.isHidden = !isCancallable
+      }
+    }
+  }
+  
+  private let onCancelPressed = PassthroughSubject<Void, Never>()
+  
+  var cancelPressed: AnyPublisher<Void, Never> {
+    onCancelPressed.eraseToAnyPublisher()
+  }
+  
   public init?(window: UIWindow) {
     guard let scene = window.windowScene else { return nil }
     protectedWindow = window
@@ -86,7 +118,8 @@ public class WindowProtection {
     passcodeWindow.rootViewController = lockedViewController
 
     lockedViewController.unlockButton.addTarget(self, action: #selector(tappedUnlock), for: .touchUpInside)
-
+    lockedViewController.cancelButton.addTarget(self, action: #selector(tappedCancel), for: .touchUpInside)
+    
     NotificationCenter.default.publisher(for: UIApplication.didEnterBackgroundNotification)
       .sink(receiveValue: { [weak self] _ in
         guard let self = self else { return }
@@ -113,14 +146,19 @@ public class WindowProtection {
   @objc private func tappedUnlock() {
     presentLocalAuthentication()
   }
+  
+  @objc private func tappedCancel() {
+    onCancelPressed.send(())
+    isVisible = false
+  }
 
-  private func updateVisibleStatusForForeground(_ determineLockWithPasscode: Bool = true, completion: ((Bool) -> Void)? = nil) {
+  private func updateVisibleStatusForForeground(_ determineLockWithPasscode: Bool = true, completion: ((Bool, LAError.Code?) -> Void)? = nil) {
     var error: NSError?
     if !context.canEvaluatePolicy(.deviceOwnerAuthentication, error: &error),
       (error as? LAError)?.code == .passcodeNotSet {
       // User no longer has a passcode set so we can't evaluate the auth policy
       isVisible = false
-      completion?(false)
+      completion?(false, .passcodeNotSet)
       return
     }
 
@@ -128,21 +166,21 @@ public class WindowProtection {
       let isLocked = Preferences.Privacy.lockWithPasscode.value
       isVisible = isLocked
       if isLocked {
-        presentLocalAuthentication() { status in
-          completion?(status)
+        presentLocalAuthentication() { status, error in
+          completion?(status, error)
         }
       }
     } else {
       isVisible = true
-      presentLocalAuthentication() { status in
-        completion?(status)
+      presentLocalAuthentication() { status, error in
+        completion?(status, error)
       }
     }
   }
 
-  private func presentLocalAuthentication(completion: ((Bool) -> Void)? = nil) {
+  private func presentLocalAuthentication(completion: ((Bool, LAError.Code?) -> Void)? = nil) {
     if !context.canEvaluatePolicy(.deviceOwnerAuthentication, error: nil) {
-      completion?(false)
+      completion?(false, .passcodeNotSet)
       return
     }
     
@@ -158,11 +196,13 @@ public class WindowProtection {
             completion: { [self] _ in
               isVisible = false
               lockedViewController.view.alpha = 1.0
-              completion?(true)
+              completion?(true, nil)
             })
         } else {
           lockedViewController.unlockButton.isHidden = false
-          completion?(false)
+          
+          let errorPolicy = error as? LAError
+          completion?(false, errorPolicy?.code)
           
           if let error = error {
             Logger.module.error("Failed to unlock browser using local authentication: \(error.localizedDescription)")
@@ -172,14 +212,14 @@ public class WindowProtection {
     }
   }
 
-  func presentAuthenticationForViewController(determineLockWithPasscode: Bool = true, completion: ((Bool) -> Void)? = nil) {
+  func presentAuthenticationForViewController(determineLockWithPasscode: Bool = true, completion: ((Bool, LAError.Code?) -> Void)? = nil) {
     if isVisible {
       return
     }
 
     context = LAContext()
-    updateVisibleStatusForForeground(determineLockWithPasscode) { status in
-      completion?(status)
+    updateVisibleStatusForForeground(determineLockWithPasscode) { status, error in
+      completion?(status, error)
     }
   }
 }

--- a/Sources/Brave/Frontend/Sync/SyncViewController.swift
+++ b/Sources/Brave/Frontend/Sync/SyncViewController.swift
@@ -4,21 +4,34 @@ import UIKit
 import Shared
 import BraveShared
 import Data
+import LocalAuthentication
+import Combine
 
 class SyncViewController: UIViewController {
 
   let windowProtection: WindowProtection?
   private let requiresAuthentication: Bool
   private let isModallyPresented: Bool
+  private var localAuthObservers = Set<AnyCancellable>()
 
   // MARK: Lifecycle
 
-  init(windowProtection: WindowProtection? = nil, requiresAuthentication: Bool = false, isModallyPresented: Bool = false) {
+  init(windowProtection: WindowProtection? = nil,
+       requiresAuthentication: Bool = false,
+       isAuthenticationCancallable: Bool = true,
+       isModallyPresented: Bool = false) {
     self.windowProtection = windowProtection
     self.requiresAuthentication = requiresAuthentication
     self.isModallyPresented = isModallyPresented
 
     super.init(nibName: nil, bundle: nil)
+    
+    windowProtection?.isCancallable = isAuthenticationCancallable
+    
+    windowProtection?.cancelPressed
+      .sink { [weak self] _ in
+        self?.dismissSyncController()
+      }.store(in: &localAuthObservers)
   }
 
   required init?(coder: NSCoder) {
@@ -33,15 +46,11 @@ class SyncViewController: UIViewController {
     super.viewWillAppear(animated)
     
     if requiresAuthentication {
-      askForAuthentication() { [weak self] success in
+      askForAuthentication() { [weak self] success, error in
         guard let self else { return }
         
-        if !success {
-          if isModallyPresented {
-            self.dismiss(animated: true)
-          } else {
-            self.navigationController?.popViewController(animated: true)
-          }
+        if !success, error != .userCancel {
+          self.dismissSyncController()
         }
       }
     }
@@ -60,21 +69,29 @@ class SyncViewController: UIViewController {
   
   /// A method to ask biometric authentication to user
   /// - Parameter completion: block returning authentication status
-  func askForAuthentication(completion: ((Bool) -> Void)? = nil) {
+  func askForAuthentication(completion: ((Bool, LAError.Code?) -> Void)? = nil) {
     guard let windowProtection = windowProtection else {
-      completion?(false)
+      completion?(false, nil)
       return
     }
 
     if !windowProtection.isPassCodeAvailable {
       showSetPasscodeError() {
-        completion?(false)
+        completion?(false, LAError.passcodeNotSet)
       }
     } else {
       windowProtection.presentAuthenticationForViewController(
-        determineLockWithPasscode: false) { status in
-          completion?(status)
+        determineLockWithPasscode: false) { status, error in
+          completion?(status, error)
       }
+    }
+  }
+  
+  private func dismissSyncController() {
+    if isModallyPresented {
+      self.dismiss(animated: true)
+    } else {
+      self.navigationController?.popViewController(animated: true)
     }
   }
   

--- a/Sources/Brave/Frontend/Sync/SyncViewController.swift
+++ b/Sources/Brave/Frontend/Sync/SyncViewController.swift
@@ -18,7 +18,7 @@ class SyncViewController: UIViewController {
 
   init(windowProtection: WindowProtection? = nil,
        requiresAuthentication: Bool = false,
-       isAuthenticationCancallable: Bool = true,
+       isAuthenticationCancellable: Bool = true,
        isModallyPresented: Bool = false) {
     self.windowProtection = windowProtection
     self.requiresAuthentication = requiresAuthentication
@@ -26,7 +26,7 @@ class SyncViewController: UIViewController {
 
     super.init(nibName: nil, bundle: nil)
     
-    windowProtection?.isCancallable = isAuthenticationCancallable
+    windowProtection?.isCancellable = isAuthenticationCancellable
     
     windowProtection?.cancelPressed
       .sink { [weak self] _ in

--- a/Sources/Brave/Frontend/Sync/SyncWelcomeViewController.swift
+++ b/Sources/Brave/Frontend/Sync/SyncWelcomeViewController.swift
@@ -196,7 +196,7 @@ class SyncWelcomeViewController: SyncViewController {
 
   @objc
   private func newToSyncAction() {
-    askForAuthentication() { [weak self] status in
+    askForAuthentication() { [weak self] status, error in
       guard let self = self, status else { return }
       
       let addDevice = SyncSelectDeviceTypeViewController()
@@ -253,7 +253,7 @@ class SyncWelcomeViewController: SyncViewController {
 
   @objc
   private func existingUserAction() {
-    askForAuthentication() { [weak self] status in
+    askForAuthentication() { [weak self] status, error in
       guard let self = self, status else { return }
       
       let pairCamera = SyncPairCameraViewController(syncAPI: syncAPI)
@@ -264,7 +264,7 @@ class SyncWelcomeViewController: SyncViewController {
   
   @objc
   private func onSyncInternalsAction() {
-    askForAuthentication() { [weak self] status in
+    askForAuthentication() { [weak self] status, error in
       guard let self = self, status else { return }
       
       let syncInternalsController = syncAPI.createSyncInternalsController().then {

--- a/Sources/BraveStrings/BraveStrings.swift
+++ b/Sources/BraveStrings/BraveStrings.swift
@@ -21,6 +21,7 @@ import Foundation
 // MARK: - Common Strings
 extension Strings {
   public static let cancelButtonTitle = NSLocalizedString("CancelButtonTitle", tableName: "BraveShared", bundle: .module, value: "Cancel", comment: "")
+  public static let unlockButtonTitle = NSLocalizedString("UnlockButtonTitle", tableName: "BraveShared", bundle: .module, value: "Unlock", comment: "")
   public static let webContentAccessibilityLabel = NSLocalizedString("WebContentAccessibilityLabel", tableName: "BraveShared", bundle: .module, value: "Web content", comment: "Accessibility label for the main web content view")
   public static let shareLinkActionTitle = NSLocalizedString("ShareLinkActionTitle", tableName: "BraveShared", bundle: .module, value: "Share Link", comment: "Context menu item for sharing a link URL")
   public static let showTabs = NSLocalizedString("ShowTabs", tableName: "BraveShared", bundle: .module, value: "Show Tabs", comment: "Accessibility Label for the tabs button in the browser toolbar")


### PR DESCRIPTION
This PR is adding unlock capability to local authentication and in addition to cancel ability the dismiss logic after unlocking and cancel to unlock is added for variety of screens.


## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7656
This pull request fixes #7657

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

Test1:
1. Launch Brave > Tree-dot menu > Settings
2. Sync > Observe PIN screen to unlock the device
3. Tap Cancel > Tap Unlock again
4. Enter correct PIN > Observe

Test2:
1. Launch Brave > Tree-dot menu > Settings
2. Sync > Observe PIN screen to unlock the device
3. Tap Cancel > Try to go back to a previous Settings screen > Observe that the gesture is not working
4. The other way to repro it > Go to Logins & Passwords in Brave settings
5. Tap on any saved account > Tap edit bar button > Cancel PIN unlock > Observe the dismiss

## Screenshots:

https://github.com/brave/brave-ios/assets/6643505/8265bb32-c507-48bd-bd75-b21dd811e4d6


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
