### PR TITLE
Fix #7692: Improve cosmetic filters script performance

### DIFF
--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Sandboxed/SelectorsPollerScript.js
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Sandboxed/SelectorsPollerScript.js
@@ -27,7 +27,7 @@ window.__firefox__.execute(function($) {
   
   /**
    * Send new urls found on the page and return their partiness
-   * @param {Array} urls The urls found on this page
+   * @param {Array<string>} urls The urls found on this page
    * @returns A Promise resolving to a dictionary base urls and their first party status
    */
   const getPartiness = $((urls) => {
@@ -623,7 +623,7 @@ window.__firefox__.execute(function($) {
    * Unhide the given selectors.
    * (i.e. Remove them from CC.hiddenSelectors and move them to CC.unhiddenSelectors)
    * This will not recreate the stylesheet
-   * @param {Set} selectors The selectors to unhide
+   * @param {Set<string>} selectors The selectors to unhide
    */
   const unhideSelectors = (selectors) => {
     if (selectors.size === 0) { return }
@@ -842,7 +842,7 @@ window.__firefox__.execute(function($) {
   /**
    * This method will unhide the node an all parent nodes if they are needed.
    * This will move up each parent for the each node until it reaches the document body
-   * @param {Array} nodes Array of WeakRef nodes
+   * @param {Array<object>} nodes Array of WeakRef nodes
    * @returns A list of unhidden selectors
    */
   const unhideSelectorsMatchingElementsAndTheirParents = (nodes) => {
@@ -867,7 +867,7 @@ window.__firefox__.execute(function($) {
    * 1. Extract any urls from the mutations and add them to pendingURLs
    * 2. Send them to iOS for 1st party analysis
    * 3. Unhide any elements (or their parents) that are 1st party
-   * @param {*} mutations
+   * @param {[MutationRecord]} mutations
    * @param {MutationObserver} observer
    */
   const onURLMutations = async (mutations, observer) => {
@@ -944,7 +944,7 @@ window.__firefox__.execute(function($) {
 
   /**
    * Adds given selectors to hiddenSelectors unless they are in the unhiddenSelectors set
-   * @param {*} selectors The selectors to add
+   * @param {Array<string>} selectors The selectors to add
    */
   const processHideSelectors = (selectors, canUnhide1PElements) => {
     let hasChanges = false
@@ -969,7 +969,7 @@ window.__firefox__.execute(function($) {
 
   /**
    * Adds given style selectors to allStyleRules
-   * @param {*} styleSelectors The style selectors to add
+   * @param {Array<string>} styleSelectors The style selectors to add
    */
   const processStyleSelectors = (styleSelectors) => {
     styleSelectors.forEach(entry => {

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Sandboxed/SelectorsPollerScript.js
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Sandboxed/SelectorsPollerScript.js
@@ -170,7 +170,7 @@ window.__firefox__.execute(function($) {
     
     if (sendPendingSelectorsTimerId) {
       // Each time this is called cancell the timer and allow a new one to start
-      window.clearInterval(sendPendingSelectorsTimerId)
+      window.clearTimeout(sendPendingSelectorsTimerId)
     }
     
     sendPendingSelectorsTimerId = window.setTimeout(() => {
@@ -997,7 +997,7 @@ window.__firefox__.execute(function($) {
   const moveStyleThrottled = async () => {
     if (moveStyleTimerId) {
       // Each time this is called cancell the timer and allow a new one to start
-      window.clearInterval(moveStyleTimerId)
+      window.clearTimeout(moveStyleTimerId)
     }
     
     moveStyleTimerId = window.setTimeout(() => {
@@ -1036,7 +1036,7 @@ window.__firefox__.execute(function($) {
   const setRulesOnStylesheetThrottled = () => {
     if (setRulesTimerId) {
       // Each time this is called cancell the timer and allow a new one to start
-      window.clearInterval(setRulesTimerId)
+      window.clearTimeout(setRulesTimerId)
     }
     
     setRulesTimerId = window.setTimeout(() => {

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Sandboxed/SelectorsPollerScript.js
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Sandboxed/SelectorsPollerScript.js
@@ -168,8 +168,10 @@ window.__firefox__.execute(function($) {
       return
     }
     
-    // Ensure we are not already waiting on a timer
-    if (sendPendingSelectorsTimerId) { return }
+    if (sendPendingSelectorsTimerId) {
+      // Each time this is called cancell the timer and allow a new one to start
+      window.clearInterval(sendPendingSelectorsTimerId)
+    }
     
     sendPendingSelectorsTimerId = window.setTimeout(() => {
       sendPendingSelectorsIfNeeded()


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7692

In this PR are a number of fixes:
1. Fixed a potential for `usePolling` from being called more than once. This is the main fix here. This is a really bad issue because of the following:
The poller is designed to run for only 10 seconds and then switch back to the mutation observer. Because it sets a global variable `selectorsPollingIntervalId` a second poller would replace that variable, this means that when a second poller starts and sets the variable, the first poller is no longer referenced and can not be canceled. After 10 seconds it starts another mutation observer, the second poller is cancelled but not the first one, it then keeps running starting a new mutation observer every time it runs. Each new mutation observer then may start new pollers. This results in mutation observers and pollers starting with no end killing the web-page and making it completely unusable. The only fix at this point is to refresh the page. Because YouTube is a single page application that almost never reloads, this problem persists when navigating.

This is solved with the following line:
```
if (selectorsPollingIntervalId !== undefined) { return }
```

2. Synced code that was different from desktop. On a mutation observer when a new node is added it will add elements into a queue rather than adding the selectors right away. We extract the selectors only when calling `sendPendingSelectorsIfNeeded`. This is reflecting a change on desktop [here](https://github.com/brave/brave-core/commit/276b8063057911996f22a5de781bdb76a9556f28).

3. Synced changes that happened in desktop that were missing on iOS found [here](https://github.com/brave/brave-core/commit/78bb36e83ce1ec4644a05145aa056aef2fa648c9). This removes an unnecessary call to `queueSelectorsFromMutations` (`queueAttrsFromMutations` on desktop) and clears the  `notYetQueriedElements`.

4. Throttle sending of selectors, moving stylesheet and rewriting css rules so they don't happen often when new elements are frequently added/modified such as in those cases on YouTube when scrolling through comments, these are seen by adding `moveStyleThrottled`, `setRulesOnStylesheetThrottled` and `sendPendingSelectorsThrottled`.

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
See STR in issue

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
