### PR TITLE
Fix #7690: Crash in BraveRewards when killing the app

### DIFF
--- a/App/iOS/Delegates/AppDelegate.swift
+++ b/App/iOS/Delegates/AppDelegate.swift
@@ -38,6 +38,7 @@ extension AppDelegate {
     let profile: Profile
     let diskImageStore: DiskImageStore?
     let migration: Migration?
+    let rewards: Brave.BraveRewards
   }
 }
 
@@ -200,12 +201,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
       }
       return nil
     }()
+    
+    // Setup ads
+    let rewardsConfiguration = BraveRewards.Configuration.current()
+    Migration.migrateAdsConfirmations(for: rewardsConfiguration)
 
     // Setup Scene Info
     sceneInfo = SceneInfoModel(
       profile: profile,
       diskImageStore: diskImageStore,
-      migration: migration)
+      migration: migration,
+      rewards: BraveRewards(configuration: rewardsConfiguration))
 
     // Perform migrations
     let profilePrefix = profile.prefs.getBranchPrefix()

--- a/App/iOS/Delegates/SceneDelegate.swift
+++ b/App/iOS/Delegates/SceneDelegate.swift
@@ -88,7 +88,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
       braveCore: appDelegate.braveCore,
       profile: sceneInfo.profile,
       diskImageStore: sceneInfo.diskImageStore,
-      migration: sceneInfo.migration)
+      migration: sceneInfo.migration,
+      rewards: sceneInfo.rewards
+    )
 
     if SceneDelegate.shouldHandleUrpLookup {
       // TODO: Find a better way to do this when multiple windows are involved.
@@ -395,7 +397,7 @@ extension SceneDelegate {
 }
 
 extension SceneDelegate {
-  private func createBrowserWindow(scene: UIWindowScene, braveCore: BraveCoreMain, profile: Profile, diskImageStore: DiskImageStore?, migration: Migration?) -> BrowserViewController {
+  private func createBrowserWindow(scene: UIWindowScene, braveCore: BraveCoreMain, profile: Profile, diskImageStore: DiskImageStore?, migration: Migration?, rewards: Brave.BraveRewards) -> BrowserViewController {
     // Make sure current private browsing flag respects the private browsing only user preference
     PrivateBrowsingManager.shared.isPrivateBrowsing = Preferences.Privacy.privateBrowsingOnly.value
 
@@ -408,6 +410,7 @@ extension SceneDelegate {
       profile: profile,
       diskImageStore: diskImageStore,
       braveCore: braveCore,
+      rewards: rewards,
       migration: migration,
       crashedLastSession: crashedLastSession)
 

--- a/Sources/Brave/Frontend/Browser/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController.swift
@@ -274,23 +274,18 @@ public class BrowserViewController: UIViewController {
     profile: Profile,
     diskImageStore: DiskImageStore?,
     braveCore: BraveCoreMain,
+    rewards: BraveRewards,
     migration: Migration?,
     crashedLastSession: Bool
   ) {
     self.profile = profile
     self.braveCore = braveCore
     self.bookmarkManager = BookmarkManager(bookmarksAPI: braveCore.bookmarksAPI)
+    self.rewards = rewards
     self.migration = migration
     self.crashedLastSession = crashedLastSession
     feedDataSource.historyAPI = braveCore.historyAPI
     backgroundDataSource = .init(service: braveCore.backgroundImagesService)
-    
-    let configuration: BraveRewards.Configuration = .current()
-
-    Self.migrateAdsConfirmations(for: configuration)
-
-    // Initialize Rewards
-    self.rewards = BraveRewards(configuration: configuration)
 
     // Initialize TabManager
     self.tabManager = TabManager(
@@ -319,7 +314,7 @@ public class BrowserViewController: UIViewController {
       }
     }
 
-    self.deviceCheckClient = DeviceCheckClient(environment: configuration.environment)
+    self.deviceCheckClient = DeviceCheckClient(environment: BraveRewards.Configuration.current().environment)
 
     if Locale.current.regionCode == "JP" {
       benchmarkBlockingDataSource = BlockingSummaryDataSource()

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
@@ -16,7 +16,7 @@ import os.log
 import Favicon
 
 // TODO: Move this log to the Rewards/Ads target once we move Rewards/Ads files.
-let adsRewardsLog = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "ads-rewards")
+public let adsRewardsLog = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "ads-rewards")
 
 extension BrowserViewController {
   func updateRewardsButtonState() {
@@ -110,35 +110,6 @@ extension BrowserViewController {
   @objc func resetNTPNotification() {
     Preferences.NewTabPage.brandedImageShowed.value = false
     Preferences.NewTabPage.atleastOneNTPNotificationWasShowed.value = false
-  }
-
-  static func migrateAdsConfirmations(for configruation: BraveRewards.Configuration) {
-    // To ensure after a user launches 1.21 that their ads confirmations, viewed count and
-    // estimated payout remain correct.
-    //
-    // This hack is unfortunately neccessary due to a missed migration path when moving
-    // confirmations from ledger to ads, we must extract `confirmations.json` out of ledger's
-    // state file and save it as a new file under the ads directory.
-    let base = configruation.storageURL
-    let ledgerStateContainer = base.appendingPathComponent("ledger/random_state.plist")
-    let adsConfirmations = base.appendingPathComponent("ads/confirmations.json")
-    let fm = FileManager.default
-
-    if !fm.fileExists(atPath: ledgerStateContainer.path) || fm.fileExists(atPath: adsConfirmations.path) {
-      // Nothing to migrate or already migrated
-      return
-    }
-
-    do {
-      let contents = NSDictionary(contentsOfFile: ledgerStateContainer.path)
-      guard let confirmations = contents?["confirmations.json"] as? String else {
-        adsRewardsLog.debug("No confirmations found to migrate in ledger's state container")
-        return
-      }
-      try confirmations.write(toFile: adsConfirmations.path, atomically: true, encoding: .utf8)
-    } catch {
-      adsRewardsLog.error("Failed to migrate confirmations.json to ads folder: \(error.localizedDescription)")
-    }
   }
 
   private func loadNewTabWithRewardsURL(_ url: URL) {

--- a/Sources/Brave/Frontend/Rewards/BraveRewards.swift
+++ b/Sources/Brave/Frontend/Rewards/BraveRewards.swift
@@ -28,7 +28,7 @@ public class BraveRewards: NSObject {
 
   private let configuration: Configuration
 
-  init(configuration: Configuration) {
+  public init(configuration: Configuration) {
     self.configuration = configuration
 
     ads = BraveAds(stateStoragePath: configuration.storageURL.appendingPathComponent("ads").path)


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Fix crash when swiping Brave application closed. The reason is because Brave-Rewards gets allocated twice because Apple calls willConnect on SceneDelegate when terminating.
- BraveRewards is a singleton in Brave-Core, but is allocated twice on the iOS side which is bad.
- This is just a quick fix because Multi-Window ALSO fixes the same issue, but better.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7690

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
