### PR TITLE
Fix #7697: Connecting second Solana account does not show connect request

### DIFF
--- a/Sources/BraveWallet/WalletProviderPermissionRequestsManager.swift
+++ b/Sources/BraveWallet/WalletProviderPermissionRequestsManager.swift
@@ -29,7 +29,9 @@ public struct WebpagePermissionRequest: Equatable {
   public var providerHandler: RequestPermissionsCallback?
   
   public static func == (lhs: Self, rhs: Self) -> Bool {
-    lhs.requestingOrigin == rhs.requestingOrigin && lhs.coinType == rhs.coinType
+    lhs.requestingOrigin == rhs.requestingOrigin
+    && lhs.coinType == rhs.coinType
+    && lhs.requestingAccounts == rhs.requestingAccounts
   }
 }
 


### PR DESCRIPTION
## Summary of Changes
- If you previously connected 1 Solana account to a Dapp, then changed accounts to another account that was never connected, tapping `Connect` / `Connect Wallet` will not create the dapp request.
- The bug was in refactor to `getAllowedAccounts` in v1.53 core bump.
    - `getAllowedAccounts` was not factoring in the `accounts` param when returning permitted accounts.
    - `if !allowedAccounts.isEmpty {` check was incorrectly returning empty array when there were allowed accounts.

This pull request fixes #7697

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Have 2+ Solana accounts, disconnect all from the https://pwgoom.csb.app/ test DApp site.
2. Open https://pwgoom.csb.app/ test DApp and connect the selected Solana account.
3. Verify the selected account address is displayed on the test DApp site.
4. Open the Wallet Panel and change to the a different Solana account
5. Verify connect request is now shown automatically for the new Solana account

## Screenshots:

https://github.com/brave/brave-ios/assets/5314553/833d6a89-ecc7-4105-8dae-e7f434a961ce

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
