### PR TITLE
Fix #7676: Changing compression priority search button item

### DIFF
--- a/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
+++ b/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
@@ -205,7 +205,7 @@ class TopToolbarView: UIView, ToolbarProtocol {
     $0.setImage(UIImage(braveSystemNamed: "leo.qr.code", compatibleWith: nil), for: .normal)
     $0.tintColor = .braveLabel
     $0.contentEdgeInsets = UIEdgeInsets(top: 0, left: 5, bottom: 0, right: 5)
-    $0.setContentCompressionResistancePriority(UILayoutPriority(rawValue: 1000), for: .horizontal)
+    $0.setContentCompressionResistancePriority(.required, for: .horizontal)
     $0.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
     $0.setContentHuggingPriority(.defaultHigh, for: .horizontal)
     $0.setContentHuggingPriority(.defaultHigh, for: .vertical)
@@ -218,7 +218,7 @@ class TopToolbarView: UIView, ToolbarProtocol {
     $0.setImage(UIImage(braveSystemNamed: "leo.microphone", compatibleWith: nil), for: .normal)
     $0.tintColor = .braveLabel
     $0.contentEdgeInsets = UIEdgeInsets(top: 0, left: 5, bottom: 0, right: 5)
-    $0.setContentCompressionResistancePriority(UILayoutPriority(rawValue: 1000), for: .horizontal)
+    $0.setContentCompressionResistancePriority(.required, for: .horizontal)
     $0.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
     $0.setContentHuggingPriority(.defaultHigh, for: .horizontal)
     $0.setContentHuggingPriority(.defaultHigh, for: .vertical)

--- a/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
+++ b/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
@@ -198,22 +198,30 @@ class TopToolbarView: UIView, ToolbarProtocol {
   
   private var locationTextContentView: UIStackView?
   
-  private lazy var qrCodeButton = ToolbarButton().then {
+  private var qrCodeButton = ToolbarButton().then {
     $0.accessibilityIdentifier = "TabToolbar.qrCodeButton"
     $0.isAccessibilityElement = true
     $0.accessibilityLabel = Strings.quickActionScanQRCode
     $0.setImage(UIImage(braveSystemNamed: "leo.qr.code", compatibleWith: nil), for: .normal)
     $0.tintColor = .braveLabel
-    $0.addTarget(self, action: #selector(topToolbarDidPressQrCodeButton), for: .touchUpInside)
+    $0.contentEdgeInsets = UIEdgeInsets(top: 0, left: 5, bottom: 0, right: 5)
+    $0.setContentCompressionResistancePriority(UILayoutPriority(rawValue: 1000), for: .horizontal)
+    $0.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
+    $0.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+    $0.setContentHuggingPriority(.defaultHigh, for: .vertical)
   }
   
-  private lazy var voiceSearchButton = ToolbarButton().then {
+  private var voiceSearchButton = ToolbarButton().then {
     $0.accessibilityIdentifier = "TabToolbar.voiceSearchButton"
     $0.isAccessibilityElement = true
     $0.accessibilityLabel = Strings.tabToolbarVoiceSearchButtonAccessibilityLabel
     $0.setImage(UIImage(braveSystemNamed: "leo.microphone", compatibleWith: nil), for: .normal)
     $0.tintColor = .braveLabel
-    $0.addTarget(self, action: #selector(topToolbarDidPressVoiceSearchButton), for: .touchUpInside)
+    $0.contentEdgeInsets = UIEdgeInsets(top: 0, left: 5, bottom: 0, right: 5)
+    $0.setContentCompressionResistancePriority(UILayoutPriority(rawValue: 1000), for: .horizontal)
+    $0.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
+    $0.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+    $0.setContentHuggingPriority(.defaultHigh, for: .vertical)
   }
   
   private lazy var locationBarOptionsStackView = UIStackView().then {
@@ -303,6 +311,9 @@ class TopToolbarView: UIView, ToolbarProtocol {
     locationView.addGestureRecognizer(swipeGestureRecognizer)
     
     self.displayTabTraySwipeGestureRecognizer = swipeGestureRecognizer
+    
+    qrCodeButton.addTarget(self, action: #selector(topToolbarDidPressQrCodeButton), for: .touchUpInside)
+    voiceSearchButton.addTarget(self, action: #selector(topToolbarDidPressVoiceSearchButton), for: .touchUpInside)
   }
 
   @available(*, unavailable)
@@ -406,14 +417,9 @@ class TopToolbarView: UIView, ToolbarProtocol {
     let dragInteraction = UIDragInteraction(delegate: self)
     locationTextField.addInteraction(dragInteraction)
 
-    let optionSubviews = [qrCodeButton, voiceSearchButton]
-    optionSubviews.forEach {
-      ($0 as? UIButton)?.contentEdgeInsets = UIEdgeInsets(top: 0, left: 5, bottom: 0, right: 5)
-      $0.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
-      $0.setContentHuggingPriority(.defaultHigh, for: .horizontal)
-      locationBarOptionsStackView.addArrangedSubview($0)
-    }
-      
+    locationBarOptionsStackView.addArrangedSubview(qrCodeButton)
+    locationBarOptionsStackView.addArrangedSubview(voiceSearchButton)
+   
     let subviews = [locationTextField, locationBarOptionsStackView]
     locationTextContentView = UIStackView(arrangedSubviews: subviews).then {
       $0.layoutMargins = UIEdgeInsets(top: 2, left: 8, bottom: 2, right: 0)


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

Changing content compression  and priority search button items

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7676

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

1. Install 1.53.x
2. Navigate to webpage, tap on url and clear
3. Observe icon size, search again
4. Repeat a few times

## Screenshots:

https://github.com/brave/brave-ios/assets/6643505/55c4ca44-23d9-4c50-bd03-fd901a4efd3a



https://github.com/brave/brave-ios/assets/6643505/f11c4d47-0926-40a1-bc0a-6ff0c60924b1



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
