### PR TITLE
Fix #7707: iPad incorrectly using split view for network filter

### DIFF
--- a/Sources/BraveWallet/Crypto/NFT/NFTView.swift
+++ b/Sources/BraveWallet/Crypto/NFT/NFTView.swift
@@ -118,6 +118,7 @@ struct NFTView: View {
           }
         )
       }
+      .navigationViewStyle(.stack)
       .onDisappear {
         networkStore.closeNetworkSelectionStore()
       }

--- a/Sources/BraveWallet/Crypto/Portfolio/EditUserAssetsView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/EditUserAssetsView.swift
@@ -217,6 +217,7 @@ struct EditUserAssetsView: View {
           }
         )
       }
+      .navigationViewStyle(.stack)
       .onDisappear {
         networkStore.closeNetworkSelectionStore()
       }

--- a/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
@@ -112,6 +112,7 @@ struct PortfolioView: View {
           }
         )
       }
+      .navigationViewStyle(.stack)
       .onDisappear {
         networkStore.closeNetworkSelectionStore()
       }

--- a/Sources/BraveWallet/Crypto/Search/AssetSearchView.swift
+++ b/Sources/BraveWallet/Crypto/Search/AssetSearchView.swift
@@ -72,6 +72,7 @@ struct AssetSearchView: View {
           }
         )
       }
+      .navigationViewStyle(.stack)
       .onDisappear {
         cryptoStore.networkStore.closeNetworkSelectionStore()
       }

--- a/Sources/BraveWallet/Crypto/SelectAccountTokenView.swift
+++ b/Sources/BraveWallet/Crypto/SelectAccountTokenView.swift
@@ -98,6 +98,7 @@ struct SelectAccountTokenView: View {
           }
         )
       }
+      .navigationViewStyle(.stack)
       .onDisappear {
         networkStore.closeNetworkSelectionStore()
       }

--- a/Sources/BraveWallet/Crypto/TransactionsActivityView.swift
+++ b/Sources/BraveWallet/Crypto/TransactionsActivityView.swift
@@ -33,6 +33,7 @@ struct TransactionsActivityView: View {
           }
         )
       }
+      .navigationViewStyle(.stack)
       .onDisappear {
         networkStore.closeNetworkSelectionStore()
       }


### PR DESCRIPTION
## Summary of Changes
- Missing navigation style for network filter modal on iPad, causing it to present in split view. Only a bug on Select Token to Send but added to all modal presentations to be safe until `NavigationView` is replaced with `NavigationStack`.

This pull request fixes #7707

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
  1. Select Send screen
  2. Select the token to bring up token selection screen
  3. Click on the network selection icon, verify layout is shown as expected


## Screenshots:

https://github.com/brave/brave-ios/assets/5314553/a619468e-f20b-4fe1-95b0-c27880082673


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
