### PR TITLE
Fix #7601: Force locale & calendar for news date decoding formatter

### DIFF
--- a/Sources/BraveNews/Composer/FeedDataSource.swift
+++ b/Sources/BraveNews/Composer/FeedDataSource.swift
@@ -144,6 +144,8 @@ public class FeedDataSource: ObservableObject {
       DateFormatter().then {
         $0.dateFormat = "yyyy-MM-dd HH:mm:ss"
         $0.timeZone = TimeZone(secondsFromGMT: 0)
+        $0.locale = Locale(identifier: "en_US_POSIX")
+        $0.calendar = Calendar(identifier: .iso8601)
       })
     return decoder
   }()


### PR DESCRIPTION
It seems somehow on certain devices in the UK, date decoding is failing. I couldn't reproduce locally unfortunately so this solution is untested though hopefully the correct one

## Summary of Changes

This pull request fixes #7601 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
