### PR TITLE
No Bug: Use the top toolbar to color the bottom bar keyboard background

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController.swift
@@ -875,7 +875,7 @@ public class BrowserViewController: UIViewController {
       .removeDuplicates()
       .sink(receiveValue: { [weak self] isPrivateBrowsing in
         self?.updateStatusBarOverlayColor()
-        self?.bottomBarKeyboardBackground.backgroundColor = self?.statusBarOverlay.backgroundColor
+        self?.bottomBarKeyboardBackground.backgroundColor = self?.topToolbar.backgroundColor
       })
     
     appReviewCancelable = AppReviewManager.shared
@@ -896,7 +896,7 @@ public class BrowserViewController: UIViewController {
       .receive(on: RunLoop.main)
       .sink { [weak self] _ in
         self?.updateStatusBarOverlayColor()
-        self?.bottomBarKeyboardBackground.backgroundColor = self?.statusBarOverlay.backgroundColor
+        self?.bottomBarKeyboardBackground.backgroundColor = self?.topToolbar.backgroundColor
       }
       .store(in: &cancellables)
     


### PR DESCRIPTION
The status bar overlay is sometimes colored to match the website, which we don't want behind the keyboard

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
