### PR TITLE
Fix #7609: Add reader mode bar on top of webview instead of below header

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+ReaderMode.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+ReaderMode.swift
@@ -113,7 +113,7 @@ extension BrowserViewController {
     if self.readerModeBar == nil {
       let readerModeBar = ReaderModeBarView(frame: CGRect.zero)
       readerModeBar.delegate = self
-      view.insertSubview(readerModeBar, belowSubview: header)
+      view.insertSubview(readerModeBar, aboveSubview: webViewContainer)
       self.readerModeBar = readerModeBar
     }
 


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #7609 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
