### PR TITLE
Fix #7702: OpenSearch issues - [hackerone 2057565]

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController/OpenSearch/BrowserViewController+OpenSearch.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/OpenSearch/BrowserViewController+OpenSearch.swift
@@ -183,7 +183,21 @@ extension BrowserViewController {
   }
 
   private func addSearchEngine(_ engine: OpenSearchEngine) {
-    let alert = ThirdPartySearchAlerts.addThirdPartySearchEngine(engine) { alertAction in
+    var customEngineAlert: UIAlertController
+    
+    if let searchTemplateURL = URL(string: engine.searchTemplate), !searchTemplateURL.isSecureWebPage() {
+      customEngineAlert = ThirdPartySearchAlerts.insecureSearchTemplateURL(engine)
+      present(customEngineAlert, animated: true)
+      return
+    }
+    
+    if let suggestTemplate = engine.suggestTemplate, let suggestTemplateURL = URL(string: suggestTemplate), !suggestTemplateURL.isSecureWebPage() {
+      customEngineAlert = ThirdPartySearchAlerts.insecureSearchTemplateURL(engine)
+      present(customEngineAlert, animated: true)
+      return
+    }
+    
+    customEngineAlert = ThirdPartySearchAlerts.addThirdPartySearchEngine(engine) { alertAction in
       if alertAction.style == .cancel {
         return
       }
@@ -203,7 +217,6 @@ extension BrowserViewController {
         }
       }
     }
-
-    self.present(alert, animated: true, completion: {})
+    present(customEngineAlert, animated: true)
   }
 }

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/OpenSearch/BrowserViewController+OpenSearch.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/OpenSearch/BrowserViewController+OpenSearch.swift
@@ -185,18 +185,21 @@ extension BrowserViewController {
   private func addSearchEngine(_ engine: OpenSearchEngine) {
     var customEngineAlert: UIAlertController
 
-    if let existingEngine = profile.searchEngines.orderedEngines.first(where: { $0.shortName == engine.shortName }) {
+    // Checking existance of search engine with same name
+    if let existingEngine = profile.searchEngines.orderedEngines.first(where: { $0.shortName.lowercased() == engine.shortName.lowercased() }) {
       customEngineAlert = ThirdPartySearchAlerts.engineAlreadyExists(existingEngine)
       present(customEngineAlert, animated: true)
       return
     }
     
+    // Checking Search Template is a secure URL
     if let searchTemplateURL = URL(string: engine.searchTemplate), !searchTemplateURL.isSecureWebPage() {
       customEngineAlert = ThirdPartySearchAlerts.insecureSearchTemplateURL(engine)
       present(customEngineAlert, animated: true)
       return
     }
     
+    // Checking Suggest Template is a secure URL
     if let suggestTemplate = engine.suggestTemplate, let suggestTemplateURL = URL(string: suggestTemplate), !suggestTemplateURL.isSecureWebPage() {
       customEngineAlert = ThirdPartySearchAlerts.insecureSearchTemplateURL(engine)
       present(customEngineAlert, animated: true)

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/OpenSearch/BrowserViewController+OpenSearch.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/OpenSearch/BrowserViewController+OpenSearch.swift
@@ -184,6 +184,12 @@ extension BrowserViewController {
 
   private func addSearchEngine(_ engine: OpenSearchEngine) {
     var customEngineAlert: UIAlertController
+
+    if let existingEngine = profile.searchEngines.orderedEngines.first(where: { $0.shortName == engine.shortName }) {
+      customEngineAlert = ThirdPartySearchAlerts.engineAlreadyExists(existingEngine)
+      present(customEngineAlert, animated: true)
+      return
+    }
     
     if let searchTemplateURL = URL(string: engine.searchTemplate), !searchTemplateURL.isSecureWebPage() {
       customEngineAlert = ThirdPartySearchAlerts.insecureSearchTemplateURL(engine)

--- a/Sources/Brave/Frontend/Browser/Search/OpenSearch.swift
+++ b/Sources/Brave/Frontend/Browser/Search/OpenSearch.swift
@@ -55,7 +55,7 @@ class OpenSearchEngine: NSObject, NSSecureCoding {
   let image: UIImage
   let isCustomEngine: Bool
   let searchTemplate: String
-  fileprivate let suggestTemplate: String?
+  let suggestTemplate: String?
 
   fileprivate let SearchTermComponent = "{searchTerms}"
   fileprivate let LocaleTermComponent = "{moz:locale}"

--- a/Sources/Brave/Frontend/Browser/Search/SearchSuggestionDataSource.swift
+++ b/Sources/Brave/Frontend/Browser/Search/SearchSuggestionDataSource.swift
@@ -109,7 +109,7 @@ class SearchSuggestionDataSource {
   
   func querySuggestClient() {
     // Do not query suggestions if user is not opt_ed in
-    guard Preferences.Search.shouldShowSuggestionsOptIn.value else {
+    if !Preferences.Search.shouldShowSuggestionsOptIn.value {
       Logger.module.info("Suggestions are not enabled")
       return
     }

--- a/Sources/Brave/Frontend/Browser/Search/SearchSuggestionDataSource.swift
+++ b/Sources/Brave/Frontend/Browser/Search/SearchSuggestionDataSource.swift
@@ -108,6 +108,12 @@ class SearchSuggestionDataSource {
   }
   
   func querySuggestClient() {
+    // Do not query suggestions if user is not opt_ed in
+    guard Preferences.Search.shouldShowSuggestionsOptIn.value else {
+      Logger.module.info("Suggestions are not enabled")
+      return
+    }
+    
     cancelPendingSuggestionsRequests()
 
     let localSearchQuery = searchQuery.lowercased()

--- a/Sources/Brave/Frontend/Browser/ThirdPartySearchAlerts.swift
+++ b/Sources/Brave/Frontend/Browser/ThirdPartySearchAlerts.swift
@@ -26,9 +26,9 @@ class ThirdPartySearchAlerts: UIAlertController {
   static func addThirdPartySearchEngine(_ engine: OpenSearchEngine, completion: @escaping (UIAlertAction) -> Void) -> UIAlertController {
     let alertMessage = """
       \n\(engine.displayName)
-      \nSearch Template:
+      \n\(Strings.CustomSearchEngine.searchTemplateTitle)
       \(engine.searchTemplate)
-      \nSuggestion Template:
+      \n\(Strings.CustomSearchEngine.suggestionTemplateTitle)
       \(engine.suggestTemplate ?? "N/A")
       \n\(Strings.CustomSearchEngine.thirdPartySearchEngineAddAlertDescription)
       """

--- a/Sources/Brave/Frontend/Browser/ThirdPartySearchAlerts.swift
+++ b/Sources/Brave/Frontend/Browser/ThirdPartySearchAlerts.swift
@@ -58,35 +58,35 @@ class ThirdPartySearchAlerts: UIAlertController {
   
   static func insecureSearchTemplateURL(_ engine: OpenSearchEngine) -> UIAlertController {
     let alertMessage = """
-      \nInsecure Custom Search Template for
+      \n\(Strings.CustomSearchEngine.insecureSearchTemplateURLErrorDescription)"
       \(engine.displayName)
-      \nSearch Template:
+      \n\(Strings.CustomSearchEngine.searchTemplateTitle)
       \(engine.searchTemplate)
       """
     return searchAlertWithOK(
-      title: "Error Adding Custom Search Engine",
+      title: Strings.CustomSearchEngine.customSearchEngineAddErrorTitle,
       message: alertMessage)
   }
   
   static func engineAlreadyExists(_ engine: OpenSearchEngine) -> UIAlertController {
     let alertMessage = """
       \n\(engine.displayName)
-      \nA search engine with the same name already exists.
+      \n\(Strings.CustomSearchEngine.engineExistsAlertDescription)
       """
     return searchAlertWithOK(
-      title: "Error Adding Custom Search Engine",
+      title: Strings.CustomSearchEngine.customSearchEngineAddErrorTitle,
       message: alertMessage)
   }
   
   static func insecureSuggestionTemplateURL(_ engine: OpenSearchEngine) -> UIAlertController {
     let alertMessage = """
-      \nInsecure Custom Suggestion Template for
+      \n\(Strings.CustomSearchEngine.insecureSuggestionTemplateURLErrorDescription)
       \(engine.displayName)
-      \nSuggestion Template:
+      \n\(Strings.CustomSearchEngine.suggestionTemplateTitle)
       \(engine.suggestTemplate ?? "")
       """
     return searchAlertWithOK(
-      title: "Error Adding Custom Search Engine",
+      title: Strings.CustomSearchEngine.customSearchEngineAddErrorTitle,
       message: alertMessage)
   }
 
@@ -124,7 +124,7 @@ class ThirdPartySearchAlerts: UIAlertController {
       title: Strings.CustomSearchEngine.thirdPartySearchEngineAddErrorTitle,
       message: Strings.CustomSearchEngine.thirdPartySearchEngineInsecureURLErrorDescription)
   }
-  
+
   private static func searchAlertWithOK(title: String, message: String) -> UIAlertController {
     let alert = ThirdPartySearchAlerts(
       title: title,

--- a/Sources/Brave/Frontend/Browser/ThirdPartySearchAlerts.swift
+++ b/Sources/Brave/Frontend/Browser/ThirdPartySearchAlerts.swift
@@ -68,6 +68,16 @@ class ThirdPartySearchAlerts: UIAlertController {
       message: alertMessage)
   }
   
+  static func engineAlreadyExists(_ engine: OpenSearchEngine) -> UIAlertController {
+    let alertMessage = """
+      \n\(engine.displayName)
+      \nA search engine with the same name already exists.
+      """
+    return searchAlertWithOK(
+      title: "Error Adding Custom Search Engine",
+      message: alertMessage)
+  }
+  
   static func insecureSuggestionTemplateURL(_ engine: OpenSearchEngine) -> UIAlertController {
     let alertMessage = """
       \nInsecure Custom Suggestion Template for

--- a/Sources/Brave/Frontend/Browser/ThirdPartySearchAlerts.swift
+++ b/Sources/Brave/Frontend/Browser/ThirdPartySearchAlerts.swift
@@ -16,19 +16,20 @@ class ThirdPartySearchAlerts: UIAlertController {
   }
 
   /**
-     Builds the Alert view that asks if the users wants to add a third party search engine.
+   Builds the Alert view that asks if the users wants to add a third party search engine.
 
-     - parameter engine: To add engine details to alert
-
-     - parameter completion: Okay option handler.
-
-     - returns: UIAlertController for asking the user to add a search engine
-     **/
+   - parameter engine: To add engine details to alert
+   - parameter completion: Okay option handler.
+   - returns: UIAlertController for asking the user to add a search engine
+  **/
 
   static func addThirdPartySearchEngine(_ engine: OpenSearchEngine, completion: @escaping (UIAlertAction) -> Void) -> UIAlertController {
     let alertMessage = """
       \n\(engine.displayName)
+      \nSearch Template:
       \(engine.searchTemplate)
+      \nSuggestion Template:
+      \(engine.suggestTemplate ?? "N/A")
       \n\(Strings.CustomSearchEngine.thirdPartySearchEngineAddAlertDescription)
       """
     let alert = ThirdPartySearchAlerts(
@@ -54,12 +55,35 @@ class ThirdPartySearchAlerts: UIAlertController {
 
     return alert
   }
+  
+  static func insecureSearchTemplateURL(_ engine: OpenSearchEngine) -> UIAlertController {
+    let alertMessage = """
+      \nInsecure Custom Search Template for
+      \(engine.displayName)
+      \nSearch Template:
+      \(engine.searchTemplate)
+      """
+    return searchAlertWithOK(
+      title: "Error Adding Custom Search Engine",
+      message: alertMessage)
+  }
+  
+  static func insecureSuggestionTemplateURL(_ engine: OpenSearchEngine) -> UIAlertController {
+    let alertMessage = """
+      \nInsecure Custom Suggestion Template for
+      \(engine.displayName)
+      \nSuggestion Template:
+      \(engine.suggestTemplate ?? "")
+      """
+    return searchAlertWithOK(
+      title: "Error Adding Custom Search Engine",
+      message: alertMessage)
+  }
 
   /**
-     Builds the Alert view that shows the user an error in case a search engine could not be added.
-
-     - returns: UIAlertController with an error dialog
-     **/
+   Builds the Alert view that shows the user an error in case a search engine could not be added.
+   - returns: UIAlertController with an error dialog
+  **/
 
   static func failedToAddThirdPartySearch() -> UIAlertController {
     return searchAlertWithOK(
@@ -90,7 +114,7 @@ class ThirdPartySearchAlerts: UIAlertController {
       title: Strings.CustomSearchEngine.thirdPartySearchEngineAddErrorTitle,
       message: Strings.CustomSearchEngine.thirdPartySearchEngineInsecureURLErrorDescription)
   }
-
+  
   private static func searchAlertWithOK(title: String, message: String) -> UIAlertController {
     let alert = ThirdPartySearchAlerts(
       title: title,

--- a/Sources/BraveStrings/BraveStrings.swift
+++ b/Sources/BraveStrings/BraveStrings.swift
@@ -608,6 +608,30 @@ extension Strings {
     public static let deleteEngineAlertDescription = NSLocalizedString("customSearchEngine.deleteEngineAlertDescription", tableName: "BraveShared", bundle: .module,
       value: "Deleting a custom search engine while it is default will switch default engine automatically.",
       comment: "The warning description shown to user when custom search engine will be deleted while it is default search engine.")
+    
+    public static let customSearchEngineAddErrorTitle = NSLocalizedString("customSearchEngine.customSearchEngineAddErrorTitle", tableName: "BraveShared", bundle: .module,
+      value: "Error Adding Custom Search Engine",
+      comment: "A title explaining that an error shown while adding custom search engine")
+    
+    public static let insecureSearchTemplateURLErrorDescription = NSLocalizedString("customSearchEngine.insecureSearchTemplateURLErrorDescription", tableName: "BraveShared", bundle: .module,
+      value: "Insecure Custom Search Template for",
+      comment: "A description explaining that search template url is insecure, it is used for instance - Insecure Custom Search Template for Brave Search, Brave Search is a search engineand on a new seperate line")
+    
+    public static let insecureSuggestionTemplateURLErrorDescription = NSLocalizedString("customSearchEngine.insecureSuggestionTemplateURLErrorDescription", tableName: "BraveShared", bundle: .module,
+      value: "Insecure Custom Suggestion Template for",
+      comment: "A description explaining that suggestion template url is insecure, it is used for instance - Insecure Custom Suggestion Template for Brave Search, Brave Search is name of search engine on a new seperate line")
+    
+    public static let searchTemplateTitle = NSLocalizedString("customSearchEngine.searchTemplateTitle", tableName: "BraveShared", bundle: .module,
+      value: "Search Template:",
+      comment: "Search Template title - for instance it will be used Search Template: Brave Search - Brave Search is the name of Search Engine on  seperate line")
+    
+    public static let suggestionTemplateTitle = NSLocalizedString("customSearchEngine.suggestionTemplateTitle", tableName: "BraveShared", bundle: .module,
+      value: "Suggestion Template:",
+      comment: "Suggestion Template title - for instance it will be used Suggestion Template: Brave Search - Brave Search is the name of Search Engine on  seperate line")
+    
+    public static let engineExistsAlertDescription = NSLocalizedString("customSearchEngine.engineAlertExistsAlertDescription", tableName: "BraveShared", bundle: .module,
+      value: "A search engine with the same name already exists.",
+      comment: "The warning description shown to user when custom search engine already exists.")
   }
 }
 


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7702

This pull request handles multitude of problems and security concerns 

- Prevent custom search engine be added more than once
- If Show Search Suggestions off, do not send request with Search Suggestions API
- Show both search template and suggestion template URL on the description alert
- Not let custom search engine be added if search template or suggestion template is not having secure URL


## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

- Visit https://en.m.wikipedia.org/wiki/Main_Page
- Click magnifier button and activate search
- Click add custom search engine button over keyboard
- Check both suggestion - search URL template is written on description on alert

## Screenshots:


![eroorcustomengine1](https://github.com/brave/brave-ios/assets/6643505/5a1d2fe7-442a-480c-ac11-084675625a18)



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
