### PR TITLE
Fix #7532: Support reader mode text direction when Readability detects it

### DIFF
--- a/Sources/Brave/Frontend/Reader/Reader.html
+++ b/Sources/Brave/Frontend/Reader/Reader.html
@@ -12,7 +12,7 @@
   <title id="reader-page-title"></title>
 </head>
 
-<body>
+<body dir="%READER-DIRECTION%">
   <div id="reader-header" class="header">
     <h1 id="reader-title"></h1>
     <div id="reader-credits" class="credits"></div>

--- a/Sources/Brave/Frontend/Reader/ReaderModeUtils.swift
+++ b/Sources/Brave/Frontend/Reader/ReaderModeUtils.swift
@@ -30,6 +30,7 @@ struct ReaderModeUtils {
       .replacingOccurrences(of: "%READER-TITLE%", with: readabilityResult.title.javaScriptEscapedString?.unquotedIfNecessary ?? readabilityResult.title.htmlEntityEncodedString)
       .replacingOccurrences(of: "%READER-CREDITS%", with: readabilityResult.credits.javaScriptEscapedString?.unquotedIfNecessary ?? readabilityResult.credits.htmlEntityEncodedString)
       .replacingOccurrences(of: "%READER-CONTENT%", with: readabilityResult.content)
+      .replacingOccurrences(of: "%READER-DIRECTION%", with: readabilityResult.direction.javaScriptEscapedString?.unquotedIfNecessary ?? readabilityResult.direction.htmlEntityEncodedString)
       .replacingOccurrences(of: "%READER-MESSAGE%", with: "")
   }
 }

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/ReaderModeScriptHandler.swift
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/ReaderModeScriptHandler.swift
@@ -164,6 +164,7 @@ struct ReadabilityResult {
   var content = ""
   var title = ""
   var credits = ""
+  var direction = "auto"
 
   init?(object: AnyObject?) {
     if let dict = object as? NSDictionary {
@@ -188,6 +189,9 @@ struct ReadabilityResult {
       if let credits = dict["byline"] as? String {
         self.credits = credits
       }
+      if let direction = dict["dir"] as? String {
+        self.direction = direction
+      }
     } else {
       return nil
     }
@@ -201,6 +205,7 @@ struct ReadabilityResult {
     let content = object["content"].string
     let title = object["title"].string
     let credits = object["credits"].string
+    let direction = object["dir"].string
 
     if domain == nil || url == nil || content == nil || title == nil || credits == nil {
       return nil
@@ -211,11 +216,12 @@ struct ReadabilityResult {
     self.content = content!
     self.title = title!
     self.credits = credits!
+    self.direction = direction ?? "auto"
   }
 
   /// Encode to a dictionary, which can then for example be json encoded
   func encode() -> [String: Any] {
-    return ["domain": domain, "url": url, "content": content, "title": title, "credits": credits]
+    return ["domain": domain, "url": url, "content": content, "title": title, "credits": credits, "dir": direction]
   }
 
   /// Encode to a JSON encoded string


### PR DESCRIPTION
This adds support for RTL reader mode by grabbing it from the parsed readability result. This unfortunately only works when the page itself annotates using the `dir` attribute in their HTML and not when pages use CSS to specifically mark pieces of their content as RTL

We may want to open a new issue to figure out if its possible to add support on pages that use CSS

## Summary of Changes

This pull request fixes #7532

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

Unfortunately the site in the issue uses CSS so it doesn't render RTL correctly, but you can use https://ar.timesofisrael.com/ instead and it will render RTL

## Screenshots:

![Simulator Screenshot - iPhone 14 Pro - 2023-07-11 at 16 19 32](https://github.com/brave/brave-ios/assets/529104/553b5173-5a05-48bb-8329-1a0b2c5f7ead)

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
