### PR TITLE
Fix #7723: Selected Account Refactor & Bump BraveCore to v1.58.26

### DIFF
--- a/Sources/Brave/Extensions/Rewards/BraveLedgerExtensions.swift
+++ b/Sources/Brave/Extensions/Rewards/BraveLedgerExtensions.swift
@@ -9,7 +9,7 @@ import Shared
 import BraveShared
 import os.log
 
-extension BraveLedger {
+extension BraveRewardsAPI {
 
   public var isLedgerTransferExpired: Bool {
     if Locale.current.regionCode != "JP" {
@@ -149,7 +149,7 @@ extension BraveLedger {
     }
     return await withCheckedContinuation { c in
       self.claimPromotion(promotion.id, publicKey: attestation.publicKeyHash) { result, nonce in
-        if result != .ledgerOk {
+        if result != .ok {
           c.resume(returning: false)
           return
         }
@@ -161,7 +161,7 @@ extension BraveLedger {
           solution.blob = try verification.attestationBlob.bsonData().base64EncodedString()
           
           self.attestPromotion(promotion.id, solution: solution) { result, promotion in
-            if result == .ledgerOk {
+            if result == .ok {
               self.updatePendingAndFinishedPromotions {
                 c.resume(returning: true)
               }

--- a/Sources/Brave/Frontend/Browser/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController.swift
@@ -215,7 +215,7 @@ public class BrowserViewController: UIViewController {
   private var cancellables: Set<AnyCancellable> = []
 
   let rewards: BraveRewards
-  var ledgerObserver: LedgerObserver?
+  var rewardsObserver: RewardsObserver?
   var promotionFetchTimer: Timer?
   private var notificationsHandler: AdsNotificationHandler?
   let notificationsPresenter = BraveNotificationsPresenter()
@@ -324,16 +324,16 @@ public class BrowserViewController: UIViewController {
     super.init(nibName: nil, bundle: nil)
     didInit()
 
-    rewards.ledgerServiceDidStart = { [weak self] _ in
+    rewards.rewardsServiceDidStart = { [weak self] _ in
       self?.setupLedger()
     }
 
     rewards.ads.captchaHandler = self
     let shouldStartAds = rewards.ads.isEnabled || Preferences.BraveNews.isEnabled.value
     if shouldStartAds {
-      // Only start ledger service automatically if ads is enabled
+      // Only start rewards service automatically if ads is enabled
       if rewards.isEnabled {
-        rewards.startLedgerService(nil)
+        rewards.startRewardsService(nil)
       } else {
         rewards.ads.initialize(walletInfo: .init()) { _ in }
       }
@@ -458,7 +458,7 @@ public class BrowserViewController: UIViewController {
     Preferences.PrivacyReports.captureVPNAlerts.observe(from: self)
     Preferences.Wallet.defaultEthWallet.observe(from: self)
 
-    if rewards.ledger != nil {
+    if rewards.rewardsAPI != nil {
       // Ledger was started immediately due to user having ads enabled
       setupLedger()
     }
@@ -1065,8 +1065,8 @@ public class BrowserViewController: UIViewController {
     super.viewWillAppear(animated)
     updateToolbarUsingTabManager(tabManager)
 
-    if let tabId = tabManager.selectedTab?.rewardsId, rewards.ledger?.selectedTabId == 0 {
-      rewards.ledger?.selectedTabId = tabId
+    if let tabId = tabManager.selectedTab?.rewardsId, rewards.rewardsAPI?.selectedTabId == 0 {
+      rewards.rewardsAPI?.selectedTabId = tabId
     }
   }
 
@@ -1139,7 +1139,7 @@ public class BrowserViewController: UIViewController {
     screenshotHelper.viewIsVisible = false
     super.viewWillDisappear(animated)
 
-    rewards.ledger?.selectedTabId = 0
+    rewards.rewardsAPI?.selectedTabId = 0
   }
 
   /// A layout guide defining where the favorites and NTP overlay are placed

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
@@ -81,27 +81,27 @@ extension BrowserViewController {
     popover.present(from: topToolbar.locationView.rewardsButton, on: self)
     popover.popoverDidDismiss = { [weak self] _ in
       guard let self = self else { return }
-      if let tabId = self.tabManager.selectedTab?.rewardsId, self.rewards.ledger?.selectedTabId == 0 {
+      if let tabId = self.tabManager.selectedTab?.rewardsId, self.rewards.rewardsAPI?.selectedTabId == 0 {
         // Show the tab currently visible
-        self.rewards.ledger?.selectedTabId = tabId
+        self.rewards.rewardsAPI?.selectedTabId = tabId
       }
     }
     // Hide the current tab
-    rewards.ledger?.selectedTabId = 0
+    rewards.rewardsAPI?.selectedTabId = 0
     // Fetch new promotions
-    rewards.ledger?.fetchPromotions(nil)
+    rewards.rewardsAPI?.fetchPromotions(nil)
   }
 
   func claimPendingPromotions() {
     guard
-      let ledger = rewards.ledger,
-      case let promotions = ledger.pendingPromotions.filter({ $0.status == .active }),
+      let rewardsAPI = rewards.rewardsAPI,
+      case let promotions = rewardsAPI.pendingPromotions.filter({ $0.status == .active }),
       !promotions.isEmpty else {
       return
     }
     Task {
       for promo in promotions {
-        let success = await ledger.claimPromotion(promo)
+        let success = await rewardsAPI.claimPromotion(promo)
         adsRewardsLog.info("[BraveRewards] Auto-Claim Promotion - \(success) for \(promo.approximateValue)")
       }
     }
@@ -141,21 +141,21 @@ extension BrowserViewController {
   }
 
   func setupLedger() {
-    guard let ledger = rewards.ledger else { return }
+    guard let rewardsAPI = rewards.rewardsAPI else { return }
     // Update defaults
-    ledger.setMinimumVisitDuration(8)
-    ledger.setMinimumNumberOfVisits(1)
-    ledger.setContributionAmount(Double.greatestFiniteMagnitude)
+    rewardsAPI.setMinimumVisitDuration(8)
+    rewardsAPI.setMinimumNumberOfVisits(1)
+    rewardsAPI.setContributionAmount(Double.greatestFiniteMagnitude)
 
-    // Create ledger observer
-    let rewardsObserver = LedgerObserver(ledger: ledger)
-    ledger.add(rewardsObserver)
-    ledgerObserver = rewardsObserver
+    // Create rewards observer
+    let rewardsObserver = RewardsObserver(rewardsAPI: rewardsAPI)
+    rewardsAPI.add(rewardsObserver)
+    self.rewardsObserver = rewardsObserver
 
     rewardsObserver.walletInitalized = { [weak self] result in
       guard let self = self, let client = self.deviceCheckClient else { return }
-      if result == .ledgerOk, !DeviceCheckClient.isDeviceEnrolled() {
-        ledger.setupDeviceCheckEnrollment(client) {}
+      if result == .ok, !DeviceCheckClient.isDeviceEnrolled() {
+        rewardsAPI.setupDeviceCheckEnrollment(client) {}
         self.updateRewardsButtonState()
       }
     }
@@ -172,10 +172,10 @@ extension BrowserViewController {
     promotionFetchTimer = Timer.scheduledTimer(
       withTimeInterval: 1.hours,
       repeats: true,
-      block: { [weak self, weak ledger] _ in
-        guard let self = self, let ledger = ledger else { return }
+      block: { [weak self, weak rewardsAPI] _ in
+        guard let self = self, let rewardsAPI = rewardsAPI else { return }
         if self.rewards.isEnabled {
-          ledger.fetchPromotions(nil)
+          rewardsAPI.fetchPromotions(nil)
         }
       }
     )
@@ -230,7 +230,7 @@ extension BrowserViewController: BraveAdsCaptchaHandler {
     }
     Task {
       do {
-        try await rewards.ledger?.solveAdaptiveCaptcha(paymentId: paymentId, captchaId: captchaId)
+        try await rewards.rewardsAPI?.solveAdaptiveCaptcha(paymentId: paymentId, captchaId: captchaId)
       } catch {
         // Increase failure count, stop attempting attestation altogether passed a specific count
         Preferences.Rewards.adaptiveCaptchaFailureCount.value += 1

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
@@ -262,7 +262,7 @@ extension Tab: BraveWalletProviderDelegate {
   }
   
   /// Returns the selected account if present in `allowedAccounts`, otherwise returns `allowedAccounts`
-  private func filterAllowedAccounts(
+  func filterAllowedAccounts(
     _ allowedAccounts: [String],
     selectedAccount: String?
   ) -> [String] {
@@ -270,23 +270,6 @@ extension Tab: BraveWalletProviderDelegate {
       return [selectedAccount]
     }
     return allowedAccounts
-  }
-
-  /// Helper to fetch the allowed accounts for the current coin. Unlike `allowedAccounts(_:accounts:)`
-  /// this will filter the selected account to the front of the array if it is an allowed/permitted account
-  @MainActor func allowedAccountsForCurrentCoin() async -> [String] {
-//    guard let keyringService = BraveWallet.KeyringServiceFactory.get(privateMode: false),
-//          let walletService = BraveWallet.ServiceFactory.get(privateMode: false) else {
-//      return []
-//    }
-//    let coin = await walletService.selectedCoin()
-//    let allAccounts = await keyringService.keyringInfo(coin.keyringId).accountInfos.map(\.address)
-//    guard let allowedAccounts = getAllowedAccounts(coin, accounts: allAccounts) else {
-//      return []
-//    }
-//    let selectedAccounts = await keyringService.selectedAccount(coin)
-//    return filterAllowedAccounts(allowedAccounts, selectedAccount: selectedAccounts)
-    return []
   }
   
   /// Fetches all allowed accounts for the current origin.
@@ -480,28 +463,31 @@ extension Tab: BraveWalletEventsListener {
       asFunction: false
     )
     
-//    let coin: BraveWallet.CoinType = .eth
-//    let keyring = await keyringService.keyringInfo(coin.keyringId)
-//    let selectedAccount: String
-//    if keyring.isLocked {
-//      // Check for locked status before assigning account address.
-//      // `getAllowedAccounts` is not async, can't check locked status.
-//      selectedAccount = valueOrUndefined(Optional<String>.none)
-//    } else {
-//      let allAccounts = keyring.accountInfos.map(\.address)
-//      if let allowedAccounts = getAllowedAccounts(coin, accounts: allAccounts) {
-//        let selectedAccountForCoin = await keyringService.selectedAccount(coin)
-//        let filteredAllowedAccounts = filterAllowedAccounts(allowedAccounts, selectedAccount: selectedAccountForCoin)
-//        selectedAccount = valueOrUndefined(filteredAllowedAccounts.first)
-//      } else {
-//        selectedAccount = valueOrUndefined(Optional<String>.none)
-//      }
-//    }
-//    await webView.evaluateSafeJavaScript(
-//      functionName: "window.ethereum.selectedAddress = \(selectedAccount)",
-//      contentWorld: EthereumProviderScriptHandler.scriptSandbox,
-//      asFunction: false
-//    )
+    let isKeyringLocked = await keyringService.isLocked()
+    let selectedAccount: String
+    if isKeyringLocked {
+      // Check for locked status before assigning account address.
+      // `getAllowedAccounts` is not async, can't check locked status.
+      selectedAccount = valueOrUndefined(Optional<String>.none)
+    } else {
+      let allAccounts = await keyringService.allAccounts()
+      let allEthAccounts = allAccounts.accounts.filter { $0.coin == .eth }
+      if let allowedAccounts = getAllowedAccounts(.eth, accounts: allEthAccounts.map(\.address)) {
+        let selectedAccountForCoin = allAccounts.ethDappSelectedAccount
+        let filteredAllowedAccounts = filterAllowedAccounts(
+          allowedAccounts,
+          selectedAccount: selectedAccountForCoin?.address
+        )
+        selectedAccount = valueOrUndefined(filteredAllowedAccounts.first)
+      } else {
+        selectedAccount = valueOrUndefined(Optional<String>.none)
+      }
+    }
+    await webView.evaluateSafeJavaScript(
+      functionName: "window.ethereum.selectedAddress = \(selectedAccount)",
+      contentWorld: EthereumProviderScriptHandler.scriptSandbox,
+      asFunction: false
+    )
   }
   
   func messageEvent(_ subscriptionId: String, result: MojoBase.Value) {
@@ -566,24 +552,24 @@ extension Tab: BraveWalletSolanaEventsListener {
       contentWorld: .page,
       asFunction: false
     )
-//    // publicKey
-//    if let keyringService = walletKeyringService,
-//       let publicKey = await keyringService.selectedAccount(.sol),
-//       self.isSolanaAccountConnected(publicKey) {
-//      await webView.evaluateSafeJavaScript(
-//        functionName: """
-//        if (\(UserScriptManager.walletSolanaNameSpace).solanaWeb3) {
-//          window.__firefox__.execute(function($) {
-//            window.solana.publicKey = $.deepFreeze(
-//              new \(UserScriptManager.walletSolanaNameSpace).solanaWeb3.PublicKey('\(publicKey.htmlEntityEncodedString)')
-//            );
-//          });
-//        }
-//        """,
-//        contentWorld: .page,
-//        asFunction: false
-//      )
-//    }
+    // publicKey
+    if let keyringService = walletKeyringService,
+       let publicKey = await keyringService.allAccounts().solDappSelectedAccount?.address,
+       self.isSolanaAccountConnected(publicKey) {
+      await webView.evaluateSafeJavaScript(
+        functionName: """
+        if (\(UserScriptManager.walletSolanaNameSpace).solanaWeb3) {
+          window.__firefox__.execute(function($) {
+            window.solana.publicKey = $.deepFreeze(
+              new \(UserScriptManager.walletSolanaNameSpace).solanaWeb3.PublicKey('\(publicKey.htmlEntityEncodedString)')
+            );
+          });
+        }
+        """,
+        contentWorld: .page,
+        asFunction: false
+      )
+    }
   }
 }
 
@@ -607,19 +593,24 @@ extension Tab: BraveWalletKeyringServiceObserver {
   }
   
   func unlocked() {
-    guard let origin = url?.origin else { return }
+    guard let origin = url?.origin,
+          let keyringService = walletKeyringService else { return }
     Task { @MainActor in
       // check domain already has some permitted accounts for this Tab's URLOrigin
       let permissionRequestManager = WalletProviderPermissionRequestsManager.shared
-      if permissionRequestManager.hasPendingRequest(for: origin, coinType: .eth) {
-        let pendingRequests = permissionRequestManager.pendingRequests(for: origin, coinType: .eth)
-        let accounts = await allowedAccountsForCurrentCoin()
-        if !accounts.isEmpty {
-          for request in pendingRequests {
-            // cancel the requests if `allowedAccounts` is not empty for this domain
-            permissionRequestManager.cancelRequest(request)
-            // let wallet provider know we have allowed accounts for this domain
-            request.providerHandler?(.none, accounts)
+      let allAccounts = await keyringService.allAccounts().accounts
+      for coin in WalletConstants.supportedCoinTypes {
+        let allAccountsForCoin = allAccounts.filter { $0.coin == coin }
+        if permissionRequestManager.hasPendingRequest(for: origin, coinType: coin) {
+          let pendingRequests = permissionRequestManager.pendingRequests(for: origin, coinType: coin)
+          let accounts = getAllowedAccounts(coin, accounts: allAccountsForCoin.map(\.address)) ?? []
+          if !accounts.isEmpty {
+            for request in pendingRequests {
+              // cancel the requests if `allowedAccounts` is not empty for this domain
+              permissionRequestManager.cancelRequest(request)
+              // let wallet provider know we have allowed accounts for this domain
+              request.providerHandler?(.none, accounts)
+            }
           }
         }
       }
@@ -635,10 +626,9 @@ extension Tab: BraveWalletKeyringServiceObserver {
   func autoLockMinutesChanged() {
   }
   
-//  func selectedAccountChanged(_ coin: BraveWallet.CoinType) {
-//  }
   func selectedWalletAccountChanged(_ account: BraveWallet.AccountInfo) {
   }
+  
   func selectedDappAccountChanged(_ coin: BraveWallet.CoinType, account: BraveWallet.AccountInfo?) {
   }
   

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
@@ -275,17 +275,18 @@ extension Tab: BraveWalletProviderDelegate {
   /// Helper to fetch the allowed accounts for the current coin. Unlike `allowedAccounts(_:accounts:)`
   /// this will filter the selected account to the front of the array if it is an allowed/permitted account
   @MainActor func allowedAccountsForCurrentCoin() async -> [String] {
-    guard let keyringService = BraveWallet.KeyringServiceFactory.get(privateMode: false),
-          let walletService = BraveWallet.ServiceFactory.get(privateMode: false) else {
-      return []
-    }
-    let coin = await walletService.selectedCoin()
-    let allAccounts = await keyringService.keyringInfo(coin.keyringId).accountInfos.map(\.address)
-    guard let allowedAccounts = getAllowedAccounts(coin, accounts: allAccounts) else {
-      return []
-    }
-    let selectedAccounts = await keyringService.selectedAccount(coin)
-    return filterAllowedAccounts(allowedAccounts, selectedAccount: selectedAccounts)
+//    guard let keyringService = BraveWallet.KeyringServiceFactory.get(privateMode: false),
+//          let walletService = BraveWallet.ServiceFactory.get(privateMode: false) else {
+//      return []
+//    }
+//    let coin = await walletService.selectedCoin()
+//    let allAccounts = await keyringService.keyringInfo(coin.keyringId).accountInfos.map(\.address)
+//    guard let allowedAccounts = getAllowedAccounts(coin, accounts: allAccounts) else {
+//      return []
+//    }
+//    let selectedAccounts = await keyringService.selectedAccount(coin)
+//    return filterAllowedAccounts(allowedAccounts, selectedAccount: selectedAccounts)
+    return []
   }
   
   /// Fetches all allowed accounts for the current origin.
@@ -479,28 +480,28 @@ extension Tab: BraveWalletEventsListener {
       asFunction: false
     )
     
-    let coin: BraveWallet.CoinType = .eth
-    let keyring = await keyringService.keyringInfo(coin.keyringId)
-    let selectedAccount: String
-    if keyring.isLocked {
-      // Check for locked status before assigning account address.
-      // `getAllowedAccounts` is not async, can't check locked status.
-      selectedAccount = valueOrUndefined(Optional<String>.none)
-    } else {
-      let allAccounts = keyring.accountInfos.map(\.address)
-      if let allowedAccounts = getAllowedAccounts(coin, accounts: allAccounts) {
-        let selectedAccountForCoin = await keyringService.selectedAccount(coin)
-        let filteredAllowedAccounts = filterAllowedAccounts(allowedAccounts, selectedAccount: selectedAccountForCoin)
-        selectedAccount = valueOrUndefined(filteredAllowedAccounts.first)
-      } else {
-        selectedAccount = valueOrUndefined(Optional<String>.none)
-      }
-    }
-    await webView.evaluateSafeJavaScript(
-      functionName: "window.ethereum.selectedAddress = \(selectedAccount)",
-      contentWorld: EthereumProviderScriptHandler.scriptSandbox,
-      asFunction: false
-    )
+//    let coin: BraveWallet.CoinType = .eth
+//    let keyring = await keyringService.keyringInfo(coin.keyringId)
+//    let selectedAccount: String
+//    if keyring.isLocked {
+//      // Check for locked status before assigning account address.
+//      // `getAllowedAccounts` is not async, can't check locked status.
+//      selectedAccount = valueOrUndefined(Optional<String>.none)
+//    } else {
+//      let allAccounts = keyring.accountInfos.map(\.address)
+//      if let allowedAccounts = getAllowedAccounts(coin, accounts: allAccounts) {
+//        let selectedAccountForCoin = await keyringService.selectedAccount(coin)
+//        let filteredAllowedAccounts = filterAllowedAccounts(allowedAccounts, selectedAccount: selectedAccountForCoin)
+//        selectedAccount = valueOrUndefined(filteredAllowedAccounts.first)
+//      } else {
+//        selectedAccount = valueOrUndefined(Optional<String>.none)
+//      }
+//    }
+//    await webView.evaluateSafeJavaScript(
+//      functionName: "window.ethereum.selectedAddress = \(selectedAccount)",
+//      contentWorld: EthereumProviderScriptHandler.scriptSandbox,
+//      asFunction: false
+//    )
   }
   
   func messageEvent(_ subscriptionId: String, result: MojoBase.Value) {
@@ -565,24 +566,24 @@ extension Tab: BraveWalletSolanaEventsListener {
       contentWorld: .page,
       asFunction: false
     )
-    // publicKey
-    if let keyringService = walletKeyringService,
-       let publicKey = await keyringService.selectedAccount(.sol),
-       self.isSolanaAccountConnected(publicKey) {
-      await webView.evaluateSafeJavaScript(
-        functionName: """
-        if (\(UserScriptManager.walletSolanaNameSpace).solanaWeb3) {
-          window.__firefox__.execute(function($) {
-            window.solana.publicKey = $.deepFreeze(
-              new \(UserScriptManager.walletSolanaNameSpace).solanaWeb3.PublicKey('\(publicKey.htmlEntityEncodedString)')
-            );
-          });
-        }
-        """,
-        contentWorld: .page,
-        asFunction: false
-      )
-    }
+//    // publicKey
+//    if let keyringService = walletKeyringService,
+//       let publicKey = await keyringService.selectedAccount(.sol),
+//       self.isSolanaAccountConnected(publicKey) {
+//      await webView.evaluateSafeJavaScript(
+//        functionName: """
+//        if (\(UserScriptManager.walletSolanaNameSpace).solanaWeb3) {
+//          window.__firefox__.execute(function($) {
+//            window.solana.publicKey = $.deepFreeze(
+//              new \(UserScriptManager.walletSolanaNameSpace).solanaWeb3.PublicKey('\(publicKey.htmlEntityEncodedString)')
+//            );
+//          });
+//        }
+//        """,
+//        contentWorld: .page,
+//        asFunction: false
+//      )
+//    }
   }
 }
 
@@ -634,7 +635,11 @@ extension Tab: BraveWalletKeyringServiceObserver {
   func autoLockMinutesChanged() {
   }
   
-  func selectedAccountChanged(_ coin: BraveWallet.CoinType) {
+//  func selectedAccountChanged(_ coin: BraveWallet.CoinType) {
+//  }
+  func selectedWalletAccountChanged(_ account: BraveWallet.AccountInfo) {
+  }
+  func selectedDappAccountChanged(_ coin: BraveWallet.CoinType, account: BraveWallet.AccountInfo?) {
   }
   
   func accountsAdded(_ addedAccounts: [BraveWallet.AccountInfo]) {

--- a/Sources/Brave/Frontend/Browser/TabManager.swift
+++ b/Sources/Brave/Frontend/Browser/TabManager.swift
@@ -1200,26 +1200,31 @@ extension TabManager: PreferencesObserver {
 
 extension TabManager: NSFetchedResultsControllerDelegate {
   func controller(_ controller: NSFetchedResultsController<NSFetchRequestResult>, didChange anObject: Any, at indexPath: IndexPath?, for type: NSFetchedResultsChangeType, newIndexPath: IndexPath?) {
-//    if let domain = anObject as? Domain, let domainURL = domain.url {
-//      // if `wallet_permittedAccounts` changes on a `Domain` from
-//      // wallet settings / manage web3 site connections, we need to
-//      // fire `accountsChanged` event on open tabs for this `Domain`
-//      let tabsForDomain = self.allTabs.filter { $0.url?.domainURL.absoluteString.caseInsensitiveCompare(domainURL) == .orderedSame }
-//      tabsForDomain.forEach { tab in
-//        Task { @MainActor in
-//          let privateMode = PrivateBrowsingManager.shared.isPrivateBrowsing
-//          // iOS does not have `HostContentSettingsMap`, so we must
-//          // implement `SolanaProviderImpl::OnContentSettingChanged`
-//          if let keyringService = BraveWallet.KeyringServiceFactory.get(privateMode: privateMode),
-//             let selectedSolAccount = await keyringService.selectedAccount(.sol),
-//             tab.isSolanaAccountConnected(selectedSolAccount), // currently connected
-//             !tab.isAccountAllowed(.sol, account: selectedSolAccount) { // user revoked access
-//            tab.walletSolProvider?.disconnect()
-//          }
-//          let accounts = await tab.allowedAccountsForCurrentCoin()
-//          tab.accountsChangedEvent(Array(accounts))
-//        }
-//      }
-//    }
+    if let domain = anObject as? Domain, let domainURL = domain.url {
+      // if `wallet_permittedAccounts` changes on a `Domain` from
+      // wallet settings / manage web3 site connections, we need to
+      // fire `accountsChanged` event on open tabs for this `Domain`
+      let tabsForDomain = self.allTabs.filter { $0.url?.domainURL.absoluteString.caseInsensitiveCompare(domainURL) == .orderedSame }
+      tabsForDomain.forEach { tab in
+        Task { @MainActor in
+          let privateMode = PrivateBrowsingManager.shared.isPrivateBrowsing
+          guard let keyringService = BraveWallet.KeyringServiceFactory.get(privateMode: privateMode) else {
+            return
+          }
+          let allAccounts = await keyringService.allAccounts()
+          // iOS does not have `HostContentSettingsMap`, so we must
+          // implement `SolanaProviderImpl::OnContentSettingChanged`
+          if let selectedSolAccount = allAccounts.solDappSelectedAccount,
+             tab.isSolanaAccountConnected(selectedSolAccount.address), // currently connected
+             !tab.isAccountAllowed(.sol, account: selectedSolAccount.address) { // user revoked access
+            tab.walletSolProvider?.disconnect()
+          }
+          
+          let ethAccountAddressess = allAccounts.accounts.filter { $0.coin == .eth }.map(\.address)
+          let allowedEthAccountAddresses = tab.getAllowedAccounts(.eth, accounts: ethAccountAddressess) ?? []
+          tab.accountsChangedEvent(Array(allowedEthAccountAddresses))
+        }
+      }
+    }
   }
 }

--- a/Sources/Brave/Frontend/Browser/TabManager.swift
+++ b/Sources/Brave/Frontend/Browser/TabManager.swift
@@ -1200,26 +1200,26 @@ extension TabManager: PreferencesObserver {
 
 extension TabManager: NSFetchedResultsControllerDelegate {
   func controller(_ controller: NSFetchedResultsController<NSFetchRequestResult>, didChange anObject: Any, at indexPath: IndexPath?, for type: NSFetchedResultsChangeType, newIndexPath: IndexPath?) {
-    if let domain = anObject as? Domain, let domainURL = domain.url {
-      // if `wallet_permittedAccounts` changes on a `Domain` from
-      // wallet settings / manage web3 site connections, we need to
-      // fire `accountsChanged` event on open tabs for this `Domain`
-      let tabsForDomain = self.allTabs.filter { $0.url?.domainURL.absoluteString.caseInsensitiveCompare(domainURL) == .orderedSame }
-      tabsForDomain.forEach { tab in
-        Task { @MainActor in
-          let privateMode = PrivateBrowsingManager.shared.isPrivateBrowsing
-          // iOS does not have `HostContentSettingsMap`, so we must
-          // implement `SolanaProviderImpl::OnContentSettingChanged`
-          if let keyringService = BraveWallet.KeyringServiceFactory.get(privateMode: privateMode),
-             let selectedSolAccount = await keyringService.selectedAccount(.sol),
-             tab.isSolanaAccountConnected(selectedSolAccount), // currently connected
-             !tab.isAccountAllowed(.sol, account: selectedSolAccount) { // user revoked access
-            tab.walletSolProvider?.disconnect()
-          }
-          let accounts = await tab.allowedAccountsForCurrentCoin()
-          tab.accountsChangedEvent(Array(accounts))
-        }
-      }
-    }
+//    if let domain = anObject as? Domain, let domainURL = domain.url {
+//      // if `wallet_permittedAccounts` changes on a `Domain` from
+//      // wallet settings / manage web3 site connections, we need to
+//      // fire `accountsChanged` event on open tabs for this `Domain`
+//      let tabsForDomain = self.allTabs.filter { $0.url?.domainURL.absoluteString.caseInsensitiveCompare(domainURL) == .orderedSame }
+//      tabsForDomain.forEach { tab in
+//        Task { @MainActor in
+//          let privateMode = PrivateBrowsingManager.shared.isPrivateBrowsing
+//          // iOS does not have `HostContentSettingsMap`, so we must
+//          // implement `SolanaProviderImpl::OnContentSettingChanged`
+//          if let keyringService = BraveWallet.KeyringServiceFactory.get(privateMode: privateMode),
+//             let selectedSolAccount = await keyringService.selectedAccount(.sol),
+//             tab.isSolanaAccountConnected(selectedSolAccount), // currently connected
+//             !tab.isAccountAllowed(.sol, account: selectedSolAccount) { // user revoked access
+//            tab.walletSolProvider?.disconnect()
+//          }
+//          let accounts = await tab.allowedAccountsForCurrentCoin()
+//          tab.accountsChangedEvent(Array(accounts))
+//        }
+//      }
+//    }
   }
 }

--- a/Sources/Brave/Frontend/Rewards/BraveRewards.swift
+++ b/Sources/Brave/Frontend/Rewards/BraveRewards.swift
@@ -23,8 +23,8 @@ public class BraveRewards: NSObject {
   }
 
   private(set) var ads: BraveAds
-  private(set) var ledger: BraveLedger?
-  var ledgerServiceDidStart: ((BraveLedger) -> Void)?
+  private(set) var rewardsAPI: BraveRewardsAPI?
+  var rewardsServiceDidStart: ((BraveRewardsAPI) -> Void)?
 
   private let configuration: Configuration
 
@@ -49,20 +49,20 @@ public class BraveRewards: NSObject {
     reportLastAdsUsageP3A()
   }
 
-  func startLedgerService(_ completion: (() -> Void)?) {
-    if ledger != nil {
+  func startRewardsService(_ completion: (() -> Void)?) {
+    if rewardsAPI != nil {
       // Already started
       completion?()
       return
     }
     let storagePath = configuration.storageURL.appendingPathComponent("ledger").path
-    ledger = BraveLedger(stateStoragePath: storagePath)
-    ledger?.initializeLedgerService { [weak self] in
-      guard let self = self, let ledger = self.ledger else { return }
+    rewardsAPI = BraveRewardsAPI(stateStoragePath: storagePath)
+    rewardsAPI?.initializeRewardsService { [weak self] in
+      guard let self = self, let rewardsAPI = self.rewardsAPI else { return }
       if self.ads.isEnabled {
         self.fetchWalletAndInitializeAds()
       }
-      self.ledgerServiceDidStart?(ledger)
+      self.rewardsServiceDidStart?(rewardsAPI)
       completion?()
     }
   }
@@ -73,8 +73,8 @@ public class BraveRewards: NSObject {
       return
     }
     isAdsInitialized = true
-    guard let ledger = ledger else { return }
-    ledger.currentWalletInfo { wallet in
+    guard let rewardsAPI = rewardsAPI else { return }
+    rewardsAPI.currentWalletInfo { wallet in
       var walletInfo: BraveAds.WalletInfo?
       if let wallet {
         let seed = wallet.recoverySeed.map(\.uint8Value)
@@ -123,7 +123,7 @@ public class BraveRewards: NSObject {
       Preferences.Rewards.rewardsToggledOnce.value = true
       createWalletIfNeeded { [weak self] in
         guard let self = self else { return }
-        self.ledger?.setAutoContributeEnabled(newValue)
+        self.rewardsAPI?.setAutoContributeEnabled(newValue)
         let wasEnabled = self.ads.isEnabled
         if !wasEnabled && newValue {
           Preferences.Rewards.adsEnabledTimestamp.value = Date()
@@ -148,9 +148,9 @@ public class BraveRewards: NSObject {
       return
     }
     isCreatingWallet = true
-    startLedgerService {
-      guard let ledger = self.ledger else { return }
-      ledger.createWalletAndFetchDetails { [weak self] success in
+    startRewardsService {
+      guard let rewardsAPI = self.rewardsAPI else { return }
+      rewardsAPI.createWalletAndFetchDetails { [weak self] success in
         self?.isCreatingWallet = false
         completion?()
       }
@@ -184,7 +184,7 @@ public class BraveRewards: NSObject {
   ) {
     let tabId = Int(tab.rewardsId)
     if isSelected {
-      ledger?.selectedTabId = UInt32(tabId)
+      rewardsAPI?.selectedTabId = UInt32(tabId)
       tabRetrieved(tabId, url: url, html: nil)
     }
     if isAdsInitialized && !isPrivate {
@@ -213,12 +213,12 @@ public class BraveRewards: NSObject {
         tabId: tabId
       )
     }
-    ledger?.reportLoadedPage(url: url, tabId: UInt32(tabId))
+    rewardsAPI?.reportLoadedPage(url: url, tabId: UInt32(tabId))
   }
 
   /// Report any XHR load happening in the page
   func reportXHRLoad(url: URL, tabId: Int, firstPartyURL: URL, referrerURL: URL?) {
-    ledger?.reportXHRLoad(
+    rewardsAPI?.reportXHRLoad(
       url,
       tabId: UInt32(tabId),
       firstPartyURL: firstPartyURL,
@@ -240,7 +240,7 @@ public class BraveRewards: NSObject {
 
   /// Report that a tab with a given id navigated to a new page in the same tab
   func reportTabNavigation(tabId: UInt32) {
-    ledger?.reportTabNavigationOrClosed(tabId: tabId)
+    rewardsAPI?.reportTabNavigationOrClosed(tabId: tabId)
   }
 
   /// Report that a tab with a given id was closed by the user
@@ -248,11 +248,11 @@ public class BraveRewards: NSObject {
     if isAdsInitialized {
       ads.reportTabClosed(tabId: tabId)
     }
-    ledger?.reportTabNavigationOrClosed(tabId: UInt32(tabId))
+    rewardsAPI?.reportTabNavigationOrClosed(tabId: UInt32(tabId))
   }
 
   private func tabRetrieved(_ tabId: Int, url: URL, html: String?) {
-    ledger?.fetchPublisherActivity(from: url, faviconURL: nil, publisherBlob: html, tabId: UInt64(tabId))
+    rewardsAPI?.fetchPublisherActivity(from: url, faviconURL: nil, publisherBlob: html, tabId: UInt64(tabId))
   }
   
   // MARK: - P3A

--- a/Sources/Brave/Frontend/Settings/BraveRewardsSettingsViewController.swift
+++ b/Sources/Brave/Frontend/Settings/BraveRewardsSettingsViewController.swift
@@ -42,8 +42,8 @@ class BraveRewardsSettingsViewController: TableViewController {
       )
     ]
 
-    if let ledger = rewards.ledger {
-      ledger.rewardsInternalInfo { [weak self] info in
+    if let rewardsAPI = rewards.rewardsAPI {
+      rewardsAPI.rewardsInternalInfo { [weak self] info in
         if let info = info, !info.paymentId.isEmpty {
           self?.dataSource.sections += [
             Section(rows: [
@@ -51,7 +51,7 @@ class BraveRewardsSettingsViewController: TableViewController {
                 text: Strings.RewardsInternals.title,
                 selection: {
                   guard let self = self else { return }
-                  let controller = RewardsInternalsViewController(ledger: ledger)
+                  let controller = RewardsInternalsViewController(rewardsAPI: rewardsAPI)
                   self.navigationController?.pushViewController(controller, animated: true)
                 }, accessory: .disclosureIndicator)
             ])
@@ -66,7 +66,7 @@ class BraveRewardsSettingsViewController: TableViewController {
 
     title = Strings.braveRewardsTitle
 
-    rewards.startLedgerService { [weak self] in
+    rewards.startRewardsService { [weak self] in
       guard let self = self else { return }
       self.reloadSections()
     }

--- a/Sources/Brave/Frontend/Settings/Rewards Internals/QA/RewardsDebugSettingsViewController.swift
+++ b/Sources/Brave/Frontend/Settings/Rewards Internals/QA/RewardsDebugSettingsViewController.swift
@@ -94,7 +94,7 @@ class RewardsDebugSettingsViewController: TableViewController {
   }
 
   @objc private func customUserAgentEditingEnded() {
-    rewards.ledger?.customUserAgent = customUserAgentTextField.text
+    rewards.rewardsAPI?.customUserAgent = customUserAgentTextField.text
   }
 
   private var numpadDismissalToolbar: UIToolbar {
@@ -140,7 +140,7 @@ class RewardsDebugSettingsViewController: TableViewController {
     customUserAgentTextField.delegate = self
     customUserAgentTextField.frame = CGRect(x: 0, y: 0, width: 125, height: 32)
     customUserAgentTextField.inputAccessoryView = numpadDismissalToolbar
-    customUserAgentTextField.text = rewards.ledger?.customUserAgent
+    customUserAgentTextField.text = rewards.rewardsAPI?.customUserAgent
 
     KeyboardHelper.defaultHelper.addDelegate(self)
 
@@ -165,13 +165,13 @@ class RewardsDebugSettingsViewController: TableViewController {
           Row(
             text: "Internals",
             selection: { [unowned self] in
-              if let ledger = self.rewards.ledger {
-                let controller = RewardsInternalsDebugViewController(ledger: ledger)
+              if let rewardsAPI = self.rewards.rewardsAPI {
+                let controller = RewardsInternalsDebugViewController(rewardsAPI: rewardsAPI)
                 self.navigationController?.pushViewController(controller, animated: true)
               } else {
-                self.rewards.startLedgerService {
-                  guard let ledger = self.rewards.ledger else { return }
-                  let controller = RewardsInternalsDebugViewController(ledger: ledger)
+                self.rewards.startRewardsService {
+                  guard let rewardsAPI = self.rewards.rewardsAPI else { return }
+                  let controller = RewardsInternalsDebugViewController(rewardsAPI: rewardsAPI)
                   self.navigationController?.pushViewController(controller, animated: true)
                 }
               }
@@ -242,9 +242,9 @@ class RewardsDebugSettingsViewController: TableViewController {
   }
 
   private func fetchAndClaimPromotions() async {
-    guard let ledger = rewards.ledger else { return }
+    guard let rewardsAPI = rewards.rewardsAPI else { return }
     let activePromotions: [BraveCore.BraveRewards.Promotion] = await withCheckedContinuation { c in
-      ledger.fetchPromotions { promotions in
+      rewardsAPI.fetchPromotions { promotions in
         c.resume(returning: promotions.filter { $0.status == .active })
       }
     }
@@ -260,7 +260,7 @@ class RewardsDebugSettingsViewController: TableViewController {
     var failuresCount: Int = 0
     
     for promo in activePromotions {
-      let success = await ledger.claimPromotion(promo)
+      let success = await rewardsAPI.claimPromotion(promo)
       if success {
         successCount += 1
         claimedAmount += promo.approximateValue

--- a/Sources/Brave/Frontend/Settings/Rewards Internals/QA/RewardsInternalsAutoContributeController.swift
+++ b/Sources/Brave/Frontend/Settings/Rewards Internals/QA/RewardsInternalsAutoContributeController.swift
@@ -9,7 +9,7 @@ import BraveUI
 
 class RewardsInternalsAutoContributeController: UITableViewController {
 
-  let ledger: BraveLedger
+  let rewardsAPI: BraveRewardsAPI
   private var publishers: [BraveCore.BraveRewards.PublisherInfo] = []
   private var autocontributeProperties: BraveCore.BraveRewards.AutoContributeProperties?
   private let percentFormatter = NumberFormatter().then {
@@ -21,8 +21,8 @@ class RewardsInternalsAutoContributeController: UITableViewController {
     $0.timeStyle = .none
   }
 
-  init(ledger: BraveLedger) {
-    self.ledger = ledger
+  init(rewardsAPI: BraveRewardsAPI) {
+    self.rewardsAPI = rewardsAPI
     super.init(style: .grouped)
   }
 
@@ -37,12 +37,12 @@ class RewardsInternalsAutoContributeController: UITableViewController {
     tableView.register(AutoContributePublisherCell.self)
     title = "Auto-Contribute"
 
-    ledger.listAutoContributePublishers { [weak self] list in
+    rewardsAPI.listAutoContributePublishers { [weak self] list in
       guard let self = self else { return }
       self.publishers = list
       self.tableView.reloadData()
     }
-    ledger.fetchAutoContributeProperties { [weak self] properties in
+    rewardsAPI.fetchAutoContributeProperties { [weak self] properties in
       self?.autocontributeProperties = properties
       self?.tableView.reloadData()
     }

--- a/Sources/Brave/Frontend/Settings/Rewards Internals/QA/RewardsInternalsDebugViewController.swift
+++ b/Sources/Brave/Frontend/Settings/Rewards Internals/QA/RewardsInternalsDebugViewController.swift
@@ -14,12 +14,12 @@ import DeviceCheck
 /// A place where all rewards debugging information will live.
 class RewardsInternalsDebugViewController: TableViewController {
 
-  private let ledger: BraveLedger
+  private let rewardsAPI: BraveRewardsAPI
   private var internalsInfo: BraveCore.BraveRewards.RewardsInternalsInfo?
   private var transferrableTokens: Double = 0.0
 
-  init(ledger: BraveLedger) {
-    self.ledger = ledger
+  init(rewardsAPI: BraveRewardsAPI) {
+    self.rewardsAPI = rewardsAPI
     super.init(style: .insetGrouped)
   }
 
@@ -37,7 +37,7 @@ class RewardsInternalsDebugViewController: TableViewController {
       $0.accessibilityLabel = Strings.RewardsInternals.shareInternalsTitle
     }
 
-    ledger.rewardsInternalInfo { info in
+    rewardsAPI.rewardsInternalInfo { info in
       self.internalsInfo = info
       self.reloadSections()
     }
@@ -73,7 +73,7 @@ class RewardsInternalsDebugViewController: TableViewController {
       ),
     ]
     
-    if let balance = ledger.balance {
+    if let balance = rewardsAPI.balance {
       let keyMaps = [
         "anonymous": Strings.RewardsInternals.anonymous,
         "uphold": "Uphold",
@@ -98,19 +98,19 @@ class RewardsInternalsDebugViewController: TableViewController {
           Row(
             text: Strings.RewardsInternals.promotionsTitle,
             selection: { [unowned self] in
-              let controller = RewardsInternalsPromotionListController(ledger: self.ledger)
+              let controller = RewardsInternalsPromotionListController(rewardsAPI: self.rewardsAPI)
               self.navigationController?.pushViewController(controller, animated: true)
             }, accessory: .disclosureIndicator),
           Row(
             text: Strings.RewardsInternals.contributionsTitle,
             selection: { [unowned self] in
-              let controller = RewardsInternalsContributionListController(ledger: self.ledger)
+              let controller = RewardsInternalsContributionListController(rewardsAPI: self.rewardsAPI)
               self.navigationController?.pushViewController(controller, animated: true)
             }, accessory: .disclosureIndicator),
           Row(
             text: "Auto-Contribute",
             selection: { [unowned self] in
-              let controller = RewardsInternalsAutoContributeController(ledger: self.ledger)
+              let controller = RewardsInternalsAutoContributeController(rewardsAPI: self.rewardsAPI)
               self.navigationController?.pushViewController(controller, animated: true)
             }, accessory: .disclosureIndicator),
         ]
@@ -121,7 +121,7 @@ class RewardsInternalsDebugViewController: TableViewController {
   }
 
   @objc private func tappedShare() {
-    let controller = RewardsInternalsShareController(ledger: self.ledger, initiallySelectedSharables: RewardsInternalsSharable.qa, sharables: RewardsInternalsSharable.qa)
+    let controller = RewardsInternalsShareController(rewardsAPI: self.rewardsAPI, initiallySelectedSharables: RewardsInternalsSharable.qa, sharables: RewardsInternalsSharable.qa)
     let container = UINavigationController(rootViewController: controller)
     present(container, animated: true)
   }

--- a/Sources/Brave/Frontend/Settings/Rewards Internals/RewardsInternalsContributionListController.swift
+++ b/Sources/Brave/Frontend/Settings/Rewards Internals/RewardsInternalsContributionListController.swift
@@ -70,11 +70,11 @@ extension BraveCore.BraveRewards.ContributionProcessor {
 }
 
 class RewardsInternalsContributionListController: TableViewController {
-  private let ledger: BraveLedger
+  private let rewardsAPI: BraveRewardsAPI
   private var contributions: [BraveCore.BraveRewards.ContributionInfo] = []
 
-  init(ledger: BraveLedger) {
-    self.ledger = ledger
+  init(rewardsAPI: BraveRewardsAPI) {
+    self.rewardsAPI = rewardsAPI
     super.init(style: .grouped)
   }
 
@@ -90,7 +90,7 @@ class RewardsInternalsContributionListController: TableViewController {
       $0.accessibilityLabel = Strings.RewardsInternals.shareInternalsTitle
     }
 
-    ledger.allContributions { contributions in
+    rewardsAPI.allContributions { contributions in
       self.contributions = contributions
       self.reloadData()
     }
@@ -131,7 +131,7 @@ class RewardsInternalsContributionListController: TableViewController {
   }
 
   @objc private func tappedShare() {
-    let controller = RewardsInternalsShareController(ledger: self.ledger, initiallySelectedSharables: [.contributions])
+    let controller = RewardsInternalsShareController(rewardsAPI: self.rewardsAPI, initiallySelectedSharables: [.contributions])
     let container = UINavigationController(rootViewController: controller)
     present(container, animated: true)
   }
@@ -141,8 +141,8 @@ class RewardsInternalsContributionListController: TableViewController {
 /// including through auto-contribute, tips, etc.
 struct RewardsInternalsContributionsGenerator: RewardsInternalsFileGenerator {
   func generateFiles(at path: String, using builder: RewardsInternalsSharableBuilder, completion: @escaping (Error?) -> Void) {
-    let ledger = builder.ledger
-    ledger.allContributions { contributions in
+    let rewardsAPI = builder.rewardsAPI
+    rewardsAPI.allContributions { contributions in
       let conts = contributions.map { cont -> [String: Any] in
         return [
           "ID": cont.contributionId,

--- a/Sources/Brave/Frontend/Settings/Rewards Internals/RewardsInternalsPromotionListController.swift
+++ b/Sources/Brave/Frontend/Settings/Rewards Internals/RewardsInternalsPromotionListController.swift
@@ -34,10 +34,10 @@ extension BraveCore.BraveRewards.PromotionType {
 }
 
 class RewardsInternalsPromotionListController: TableViewController {
-  private let ledger: BraveLedger
+  private let rewardsAPI: BraveRewardsAPI
 
-  init(ledger: BraveLedger) {
-    self.ledger = ledger
+  init(rewardsAPI: BraveRewardsAPI) {
+    self.rewardsAPI = rewardsAPI
     super.init(style: .grouped)
   }
 
@@ -53,7 +53,7 @@ class RewardsInternalsPromotionListController: TableViewController {
       $0.accessibilityLabel = Strings.RewardsInternals.shareInternalsTitle
     }
 
-    ledger.updatePendingAndFinishedPromotions {
+    rewardsAPI.updatePendingAndFinishedPromotions {
       self.reloadData()
     }
   }
@@ -69,7 +69,7 @@ class RewardsInternalsPromotionListController: TableViewController {
       $0.maximumFractionDigits = 3
     }
 
-    let promotions = (ledger.pendingPromotions + ledger.finishedPromotions).sorted(by: { $0.claimedAt < $1.claimedAt })
+    let promotions = (rewardsAPI.pendingPromotions + rewardsAPI.finishedPromotions).sorted(by: { $0.claimedAt < $1.claimedAt })
     dataSource.sections = promotions.map { promo in
       var rows = [
         Row(text: Strings.RewardsInternals.status, detailText: promo.status.displayText),
@@ -94,7 +94,7 @@ class RewardsInternalsPromotionListController: TableViewController {
   }
 
   @objc private func tappedShare() {
-    let controller = RewardsInternalsShareController(ledger: self.ledger, initiallySelectedSharables: [.promotions])
+    let controller = RewardsInternalsShareController(rewardsAPI: self.rewardsAPI, initiallySelectedSharables: [.promotions])
     let container = UINavigationController(rootViewController: controller)
     present(container, animated: true)
   }
@@ -104,9 +104,9 @@ class RewardsInternalsPromotionListController: TableViewController {
 /// or has pending to claim
 struct RewardsInternalsPromotionsGenerator: RewardsInternalsFileGenerator {
   func generateFiles(at path: String, using builder: RewardsInternalsSharableBuilder, completion: @escaping (Error?) -> Void) {
-    let ledger = builder.ledger
-    ledger.updatePendingAndFinishedPromotions {
-      let promotions = ledger.finishedPromotions + ledger.pendingPromotions
+    let rewardsAPI = builder.rewardsAPI
+    rewardsAPI.updatePendingAndFinishedPromotions {
+      let promotions = rewardsAPI.finishedPromotions + rewardsAPI.pendingPromotions
       let promos = promotions.map { promo -> [String: Any] in
         var data: [String: Any] = [
           "ID": promo.id,

--- a/Sources/Brave/Frontend/Settings/Rewards Internals/RewardsInternalsSharable.swift
+++ b/Sources/Brave/Frontend/Settings/Rewards Internals/RewardsInternalsSharable.swift
@@ -10,7 +10,7 @@ import Shared
 /// A set of helpers for `RewardsInternalsFileGenerator` to use to generate data to share with support
 struct RewardsInternalsSharableBuilder {
   /// The rewards instance that we are generating the data from
-  var ledger: BraveLedger
+  var rewardsAPI: BraveRewardsAPI
   /// A formatter to use when adding dates to a file
   var dateFormatter: DateFormatter
   /// A formatter to use when adding dates and times to a file
@@ -113,7 +113,7 @@ private struct RewardsInternalsDatabaseGenerator: RewardsInternalsFileGenerator 
   func generateFiles(at path: String, using builder: RewardsInternalsSharableBuilder, completion: @escaping (Error?) -> Void) {
     // Move Rewards database to path
     do {
-      let dbPath = URL(fileURLWithPath: builder.ledger.rewardsDatabasePath)
+      let dbPath = URL(fileURLWithPath: builder.rewardsAPI.rewardsDatabasePath)
       let newPath = URL(fileURLWithPath: path).appendingPathComponent(dbPath.lastPathComponent)
       try FileManager.default.copyItem(atPath: dbPath.path, toPath: newPath.path)
       completion(nil)

--- a/Sources/Brave/Frontend/Settings/Rewards Internals/RewardsInternalsShareController.swift
+++ b/Sources/Brave/Frontend/Settings/Rewards Internals/RewardsInternalsShareController.swift
@@ -32,15 +32,15 @@ private class RewardsInternalsSharableCell: UITableViewCell, TableViewReusable {
 class RewardsInternalsShareController: UITableViewController {
   private(set) var initiallySelectedSharables: [Int]
 
-  private let ledger: BraveLedger
+  private let rewardsAPI: BraveRewardsAPI
   private let sharables: [RewardsInternalsSharable]
 
   init(
-    ledger: BraveLedger,
+    rewardsAPI: BraveRewardsAPI,
     initiallySelectedSharables: [RewardsInternalsSharable],
     sharables: [RewardsInternalsSharable] = RewardsInternalsSharable.all
   ) {
-    self.ledger = ledger
+    self.rewardsAPI = rewardsAPI
     self.sharables = sharables
     self.initiallySelectedSharables =
       initiallySelectedSharables
@@ -142,7 +142,7 @@ class RewardsInternalsShareController: UITableViewController {
       $0.dateStyle = .long
       $0.timeStyle = .long
     }
-    let builder = RewardsInternalsSharableBuilder(ledger: self.ledger, dateFormatter: dateFormatter, dateAndTimeFormatter: dateAndTimeFormatter)
+    let builder = RewardsInternalsSharableBuilder(rewardsAPI: self.rewardsAPI, dateFormatter: dateFormatter, dateAndTimeFormatter: dateAndTimeFormatter)
     do {
       if FileManager.default.fileExists(atPath: dropDirectory.path) {
         try FileManager.default.removeItem(at: dropDirectory)

--- a/Sources/Brave/Frontend/Settings/Rewards Internals/RewardsInternalsViewController.swift
+++ b/Sources/Brave/Frontend/Settings/Rewards Internals/RewardsInternalsViewController.swift
@@ -27,13 +27,13 @@ private class WarningCell: MultilineSubtitleCell {
 /// A place where all rewards debugging information will live.
 class RewardsInternalsViewController: TableViewController {
 
-  private let ledger: BraveLedger
+  private let rewardsAPI: BraveRewardsAPI
   private var internalsInfo: BraveCore.BraveRewards.RewardsInternalsInfo?
 
-  init(ledger: BraveLedger) {
-    self.ledger = ledger
+  init(rewardsAPI: BraveRewardsAPI) {
+    self.rewardsAPI = rewardsAPI
     super.init(style: .insetGrouped)
-    ledger.rewardsInternalInfo { [weak self] info in
+    rewardsAPI.rewardsInternalInfo { [weak self] info in
       self?.internalsInfo = info
       self?.reloadSections()
     }
@@ -57,7 +57,7 @@ class RewardsInternalsViewController: TableViewController {
   }
 
   @objc private func tappedShare() {
-    let controller = RewardsInternalsShareController(ledger: self.ledger, initiallySelectedSharables: RewardsInternalsSharable.default)
+    let controller = RewardsInternalsShareController(rewardsAPI: self.rewardsAPI, initiallySelectedSharables: RewardsInternalsSharable.default)
     let container = UINavigationController(rootViewController: controller)
     present(container, animated: true)
   }
@@ -109,7 +109,7 @@ struct RewardsInternalsBasicInfoGenerator: RewardsInternalsFileGenerator {
   func generateFiles(at path: String, using builder: RewardsInternalsSharableBuilder, completion: @escaping (Error?) -> Void) {
     // Only 1 file to make here
     var internals: BraveCore.BraveRewards.RewardsInternalsInfo?
-    builder.ledger.rewardsInternalInfo { info in
+    builder.rewardsAPI.rewardsInternalInfo { info in
       internals = info
     }
     guard let info = internals else {

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/SolanaProviderScriptHandler.swift
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/SolanaProviderScriptHandler.swift
@@ -8,6 +8,7 @@ import WebKit
 import BraveCore
 import BraveShared
 import os.log
+import Strings
 
 class SolanaProviderScriptHandler: TabContentScript {
   
@@ -142,7 +143,7 @@ class SolanaProviderScriptHandler: TabContentScript {
   /// Given optional args `{onlyIfTrusted: Bool}`, will return the base 58 encoded public key for success or the error dictionary for failures.
   @MainActor func connect(args: String?) async -> (Any?, String?) {
     guard let tab = tab, let provider = tab.walletSolProvider else {
-      return (nil, buildErrorJson(status: .internalError, errorMessage: "Internal error"))
+      return (nil, buildErrorJson(status: .internalError, errorMessage: Strings.Wallet.internalErrorMessage))
     }
     var param: [String: MojoBase.Value]?
     if let args = args {
@@ -233,7 +234,7 @@ class SolanaProviderScriptHandler: TabContentScript {
       return (publicKey, nil)
     } else {
       guard let encodedResult = MojoBase.Value(dictionaryValue: result).jsonObject else {
-        return (nil, buildErrorJson(status: .internalError, errorMessage: "Internal error"))
+        return (nil, buildErrorJson(status: .internalError, errorMessage: Strings.Wallet.internalErrorMessage))
       }
       return (encodedResult, nil)
     }
@@ -259,7 +260,7 @@ class SolanaProviderScriptHandler: TabContentScript {
       version: version
     )
     guard let transactionDict = transactionDict.jsonObject else {
-      return (nil, buildErrorJson(status: .internalError, errorMessage: "Internal error"))
+      return (nil, buildErrorJson(status: .internalError, errorMessage: Strings.Wallet.internalErrorMessage))
     }
     return (transactionDict, nil)
   }
@@ -293,7 +294,7 @@ class SolanaProviderScriptHandler: TabContentScript {
     }
     guard serializedTransactionDicts.count == serializedTxs.count,
           let encodedSerializedTxDicts = MojoBase.Value(listValue: serializedTransactionDicts).jsonObject else {
-      return (nil, buildErrorJson(status: .internalError, errorMessage: "Internal error"))
+      return (nil, buildErrorJson(status: .internalError, errorMessage: Strings.Wallet.internalErrorMessage))
     }
     return (encodedSerializedTxDicts, nil)
   }

--- a/Sources/BraveWallet/Crypto/Accounts/Add/AddAccountView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/Add/AddAccountView.swift
@@ -44,8 +44,8 @@ struct AddAccountView: View {
         }
       }
     } else {
-      let handler: (Bool, String) -> Void = { success, _ in
-        if success {
+      let handler: (BraveWallet.AccountInfo?) -> Void = { accountInfo in
+        if accountInfo != nil {
           onCreate?()
           appRatingRequest?()
           presentationMode.dismiss()

--- a/Sources/BraveWallet/Crypto/Stores/AccountActivityStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/AccountActivityStore.swift
@@ -294,14 +294,19 @@ extension AccountActivityStore: BraveWalletKeyringServiceObserver {
   func autoLockMinutesChanged() {
   }
   
-  func selectedAccountChanged(_ coin: BraveWallet.CoinType) {
-    guard observeAccountUpdates else { return }
-    keyringService.keyringInfo(coin.keyringId) { [self] keyringInfo in
-      keyringService.selectedAccount(coin) { [self] accountAddress in
-        account = keyringInfo.accountInfos.first(where: { $0.address == accountAddress }) ?? keyringInfo.accountInfos.first!
-        update()
-      }
-    }
+//  func selectedAccountChanged(_ coin: BraveWallet.CoinType) {
+//    guard observeAccountUpdates else { return }
+//    keyringService.keyringInfo(coin.keyringId) { [self] keyringInfo in
+//      keyringService.selectedAccount(coin) { [self] accountAddress in
+//        account = keyringInfo.accountInfos.first(where: { $0.address == accountAddress }) ?? keyringInfo.accountInfos.first!
+//        update()
+//      }
+//    }
+//  }
+  func selectedWalletAccountChanged(_ account: BraveWallet.AccountInfo) {
+  }
+  
+  func selectedDappAccountChanged(_ coin: BraveWallet.CoinType, account: BraveWallet.AccountInfo?) {
   }
   
   func accountsAdded(_ addedAccounts: [BraveWallet.AccountInfo]) {

--- a/Sources/BraveWallet/Crypto/Stores/AccountActivityStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/AccountActivityStore.swift
@@ -294,19 +294,16 @@ extension AccountActivityStore: BraveWalletKeyringServiceObserver {
   func autoLockMinutesChanged() {
   }
   
-//  func selectedAccountChanged(_ coin: BraveWallet.CoinType) {
-//    guard observeAccountUpdates else { return }
-//    keyringService.keyringInfo(coin.keyringId) { [self] keyringInfo in
-//      keyringService.selectedAccount(coin) { [self] accountAddress in
-//        account = keyringInfo.accountInfos.first(where: { $0.address == accountAddress }) ?? keyringInfo.accountInfos.first!
-//        update()
-//      }
-//    }
-//  }
   func selectedWalletAccountChanged(_ account: BraveWallet.AccountInfo) {
+    guard observeAccountUpdates else { return }
+    self.account = account
+    update()
   }
   
   func selectedDappAccountChanged(_ coin: BraveWallet.CoinType, account: BraveWallet.AccountInfo?) {
+    guard observeAccountUpdates, let account else { return }
+    self.account = account
+    update()
   }
   
   func accountsAdded(_ addedAccounts: [BraveWallet.AccountInfo]) {

--- a/Sources/BraveWallet/Crypto/Stores/AssetDetailStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/AssetDetailStore.swift
@@ -202,16 +202,16 @@ class AssetDetailStore: ObservableObject {
         self.isInitialState = false
         self.isLoadingChart = false
         
-//        // selected network used because we don't have `chainId` on CoinMarket
-//        let selectedCoin = await self.walletService.selectedCoin()
-//        let selectedNetwork = await self.rpcService.network(selectedCoin, origin: nil)
-//        self.isBuySupported = await self.isBuyButtonSupported(in: selectedNetwork, for: coinMarket.symbol)
-//
-//        // below is all not supported from Market tab
-//        self.isSendSupported = false
-//        self.isSwapSupported = false
-//        self.accounts = []
-//        self.transactionSummaries = []
+        let selectedCoin = await keyringService.allAccounts().selectedAccount?.coin ?? .eth
+        // selected network used because we don't have `chainId` on CoinMarket
+        let selectedNetwork = await self.rpcService.network(selectedCoin, origin: nil)
+        self.isBuySupported = await self.isBuyButtonSupported(in: selectedNetwork, for: coinMarket.symbol)
+
+        // below is all not supported from Market tab
+        self.isSendSupported = false
+        self.isSwapSupported = false
+        self.accounts = []
+        self.transactionSummaries = []
       }
     }
   }
@@ -384,8 +384,6 @@ extension AssetDetailStore: BraveWalletKeyringServiceObserver {
   func autoLockMinutesChanged() {
   }
 
-//  func selectedAccountChanged(_ coin: BraveWallet.CoinType) {
-//  }
   func selectedWalletAccountChanged(_ account: BraveWallet.AccountInfo) {
   }
   

--- a/Sources/BraveWallet/Crypto/Stores/AssetDetailStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/AssetDetailStore.swift
@@ -202,16 +202,16 @@ class AssetDetailStore: ObservableObject {
         self.isInitialState = false
         self.isLoadingChart = false
         
-        // selected network used because we don't have `chainId` on CoinMarket
-        let selectedCoin = await self.walletService.selectedCoin()
-        let selectedNetwork = await self.rpcService.network(selectedCoin, origin: nil)
-        self.isBuySupported = await self.isBuyButtonSupported(in: selectedNetwork, for: coinMarket.symbol)
-        
-        // below is all not supported from Market tab
-        self.isSendSupported = false
-        self.isSwapSupported = false
-        self.accounts = []
-        self.transactionSummaries = []
+//        // selected network used because we don't have `chainId` on CoinMarket
+//        let selectedCoin = await self.walletService.selectedCoin()
+//        let selectedNetwork = await self.rpcService.network(selectedCoin, origin: nil)
+//        self.isBuySupported = await self.isBuyButtonSupported(in: selectedNetwork, for: coinMarket.symbol)
+//
+//        // below is all not supported from Market tab
+//        self.isSendSupported = false
+//        self.isSwapSupported = false
+//        self.accounts = []
+//        self.transactionSummaries = []
       }
     }
   }
@@ -384,7 +384,12 @@ extension AssetDetailStore: BraveWalletKeyringServiceObserver {
   func autoLockMinutesChanged() {
   }
 
-  func selectedAccountChanged(_ coin: BraveWallet.CoinType) {
+//  func selectedAccountChanged(_ coin: BraveWallet.CoinType) {
+//  }
+  func selectedWalletAccountChanged(_ account: BraveWallet.AccountInfo) {
+  }
+  
+  func selectedDappAccountChanged(_ coin: BraveWallet.CoinType, account: BraveWallet.AccountInfo?) {
   }
   
   func accountsAdded(_ addedAccounts: [BraveWallet.AccountInfo]) {

--- a/Sources/BraveWallet/Crypto/Stores/BuyTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/BuyTokenStore.swift
@@ -158,27 +158,27 @@ public class BuyTokenStore: ObservableObject {
   
   @MainActor
   func updateInfo() async {
-    orderedSupportedBuyOptions = [.ramp, .sardine, .transak]
-    
-    let coin = await walletService.selectedCoin()
-    selectedNetwork = await rpcService.network(coin, origin: nil)
-    await validatePrefilledToken(on: selectedNetwork) // selectedNetwork may change
-    await fetchBuyTokens(network: selectedNetwork)
-    
-    // check if current selected network supports buy
-    if WalletConstants.supportedTestNetworkChainIds.contains(selectedNetwork.chainId) {
-      isSelectedNetworkSupported = false
-    } else {
-      isSelectedNetworkSupported = allTokens.contains(where: { token in
-        return token.chainId.caseInsensitiveCompare(selectedNetwork.chainId) == .orderedSame
-      })
-    }
-    
-    // fetch all available currencies for on ramp providers
-    supportedCurrencies = await blockchainRegistry.onRampCurrencies()
-    if let firstCurrency = supportedCurrencies.first {
-      selectedCurrency = firstCurrency
-    }
+//    orderedSupportedBuyOptions = [.ramp, .sardine, .transak]
+//    
+//    let coin = await walletService.selectedCoin()
+//    selectedNetwork = await rpcService.network(coin, origin: nil)
+//    await validatePrefilledToken(on: selectedNetwork) // selectedNetwork may change
+//    await fetchBuyTokens(network: selectedNetwork)
+//    
+//    // check if current selected network supports buy
+//    if WalletConstants.supportedTestNetworkChainIds.contains(selectedNetwork.chainId) {
+//      isSelectedNetworkSupported = false
+//    } else {
+//      isSelectedNetworkSupported = allTokens.contains(where: { token in
+//        return token.chainId.caseInsensitiveCompare(selectedNetwork.chainId) == .orderedSame
+//      })
+//    }
+//    
+//    // fetch all available currencies for on ramp providers
+//    supportedCurrencies = await blockchainRegistry.onRampCurrencies()
+//    if let firstCurrency = supportedCurrencies.first {
+//      selectedCurrency = firstCurrency
+//    }
   }
 }
 

--- a/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -190,6 +190,7 @@ public class CryptoStore: ObservableObject {
     }
     let store = BuyTokenStore(
       blockchainRegistry: blockchainRegistry,
+      keyringService: keyringService,
       rpcService: rpcService,
       walletService: walletService,
       assetRatioService: assetRatioService,
@@ -580,8 +581,6 @@ extension CryptoStore: BraveWalletKeyringServiceObserver {
   }
   public func autoLockMinutesChanged() {
   }
-//  public func selectedAccountChanged(_ coinType: BraveWallet.CoinType) {
-//  }
   public func selectedWalletAccountChanged(_ account: BraveWallet.AccountInfo) {
   }
   public func selectedDappAccountChanged(_ coin: BraveWallet.CoinType, account: BraveWallet.AccountInfo?) {

--- a/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -580,7 +580,11 @@ extension CryptoStore: BraveWalletKeyringServiceObserver {
   }
   public func autoLockMinutesChanged() {
   }
-  public func selectedAccountChanged(_ coinType: BraveWallet.CoinType) {
+//  public func selectedAccountChanged(_ coinType: BraveWallet.CoinType) {
+//  }
+  public func selectedWalletAccountChanged(_ account: BraveWallet.AccountInfo) {
+  }
+  public func selectedDappAccountChanged(_ coin: BraveWallet.CoinType, account: BraveWallet.AccountInfo?) {
   }
   public func accountsAdded(_ addedAccounts: [BraveWallet.AccountInfo]) {
   }

--- a/Sources/BraveWallet/Crypto/Stores/KeyringStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/KeyringStore.swift
@@ -420,7 +420,6 @@ extension KeyringStore: BraveWalletKeyringServiceObserver {
       let newKeyring = await keyringService.keyringInfo(keyringId)
       let selectedAccount = await keyringService.allAccounts().selectedAccount
       // if the new Keyring doesn't have a selected account, select the first account
-      // TODO: verify if still needed
       if selectedAccount == nil, let newAccount = newKeyring.accountInfos.first {
         await keyringService.setSelectedAccount(newAccount.accountId)
       }

--- a/Sources/BraveWallet/Crypto/Stores/KeyringStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/KeyringStore.swift
@@ -361,12 +361,16 @@ public class KeyringStore: ObservableObject {
     keyringService.notifyUserInteraction()
   }
   
-  @MainActor func selectedAccount(for coin: BraveWallet.CoinType) async -> BraveWallet.AccountInfo? {
-    let selectedAccount = await keyringService.allAccounts().selectedAccount
-    if selectedAccount?.coin != coin {
-      assertionFailure("Should not occur.")
+  @MainActor func selectedDappAccount(for coin: BraveWallet.CoinType) async -> BraveWallet.AccountInfo? {
+    let allAccounts = await keyringService.allAccounts()
+    switch coin {
+    case .eth:
+      return allAccounts.ethDappSelectedAccount
+    case .sol:
+      return allAccounts.solDappSelectedAccount
+    default:
+      return nil
     }
-    return selectedAccount
   }
 
   // MARK: - Keychain

--- a/Sources/BraveWallet/Crypto/Stores/NFTStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/NFTStore.swift
@@ -196,11 +196,6 @@ extension NFTStore: BraveWalletKeyringServiceObserver {
   }
   public func autoLockMinutesChanged() {
   }
-//  public func selectedAccountChanged(_ coinType: BraveWallet.CoinType) {
-//    DispatchQueue.main.async { [self] in
-//      update()
-//    }
-//  }
   public func selectedWalletAccountChanged(_ account: BraveWallet.AccountInfo) {
   }
   

--- a/Sources/BraveWallet/Crypto/Stores/NFTStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/NFTStore.swift
@@ -196,10 +196,15 @@ extension NFTStore: BraveWalletKeyringServiceObserver {
   }
   public func autoLockMinutesChanged() {
   }
-  public func selectedAccountChanged(_ coinType: BraveWallet.CoinType) {
-    DispatchQueue.main.async { [self] in
-      update()
-    }
+//  public func selectedAccountChanged(_ coinType: BraveWallet.CoinType) {
+//    DispatchQueue.main.async { [self] in
+//      update()
+//    }
+//  }
+  public func selectedWalletAccountChanged(_ account: BraveWallet.AccountInfo) {
+  }
+  
+  public func selectedDappAccountChanged(_ coin: BraveWallet.CoinType, account: BraveWallet.AccountInfo?) {
   }
   
   public func accountsAdded(_ addedAccounts: [BraveWallet.AccountInfo]) {

--- a/Sources/BraveWallet/Crypto/Stores/NetworkStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/NetworkStore.swift
@@ -81,16 +81,16 @@ public class NetworkStore: ObservableObject {
   
   /// Updates the `selectedChainId` and `isSwapSupported` for the network for the current `origin`.
   @MainActor private func updateSelectedChain() async {
-    // fetch current selected network
-    let selectedCoin = await walletService.selectedCoin()
-    let chain = await rpcService.network(selectedCoin, origin: nil)
-    // since we are fetch network from JsonRpcService,
-    // we don't need to call `setNetwork` on JsonRpcService
-    self.defaultSelectedChainId = chain.chainId
-    let chainForOrigin = await rpcService.network(selectedCoin, origin: origin)
-    self.selectedChainIdForOrigin = chainForOrigin.chainId
-    // update `isSwapSupported` for Buy/Send/Swap panel
-    self.isSwapSupported = await swapService.isSwapSupported(chain.chainId)
+//    // fetch current selected network
+//    let selectedCoin = await walletService.selectedCoin()
+//    let chain = await rpcService.network(selectedCoin, origin: nil)
+//    // since we are fetch network from JsonRpcService,
+//    // we don't need to call `setNetwork` on JsonRpcService
+//    self.defaultSelectedChainId = chain.chainId
+//    let chainForOrigin = await rpcService.network(selectedCoin, origin: origin)
+//    self.selectedChainIdForOrigin = chainForOrigin.chainId
+//    // update `isSwapSupported` for Buy/Send/Swap panel
+//    self.isSwapSupported = await swapService.isSwapSupported(chain.chainId)
   }
 
   @MainActor private func updateChainList() async {
@@ -115,35 +115,36 @@ public class NetworkStore: ObservableObject {
       // Need to prompt user to create new account via alert
       return .selectedChainHasNoAccounts
     } else {
-      let selectedCoin = await walletService.selectedCoin()
-      if isForOrigin {
-        if self.selectedChainIdForOrigin != network.chainId {
-          self.selectedChainIdForOrigin = network.chainId
-        }
-      } else {
-        if self.defaultSelectedChainId != network.chainId {
-          self.defaultSelectedChainId = network.chainId
-        }
-      }
-      if isForOrigin && selectedChainIdForOrigin != network.chainId {
-        self.selectedChainIdForOrigin = network.chainId
-      } else if defaultSelectedChainId != network.chainId {
-        self.defaultSelectedChainId = network.chainId
-      }
-      if selectedCoin != network.coin {
-        let success = await rpcService.setNetwork(network.chainId, coin: network.coin, origin: isForOrigin ? origin : nil)
-        return success ? nil : .unknown
-      } else {
-        let rpcServiceNetwork = await rpcService.network(network.coin, origin: isForOrigin ? origin : nil)
-        guard rpcServiceNetwork.chainId != network.chainId else {
-          if !isForOrigin { // `isSwapSupported` is for the `defaultSelectedChain`
-            self.isSwapSupported = await swapService.isSwapSupported(network.chainId)
-          }
-          return .chainAlreadySelected
-        }
-        let success = await rpcService.setNetwork(network.chainId, coin: network.coin, origin: isForOrigin ? origin : nil)
-        return success ? nil : .unknown
-      }
+//      let selectedCoin = await walletService.selectedCoin()
+//      if isForOrigin {
+//        if self.selectedChainIdForOrigin != network.chainId {
+//          self.selectedChainIdForOrigin = network.chainId
+//        }
+//      } else {
+//        if self.defaultSelectedChainId != network.chainId {
+//          self.defaultSelectedChainId = network.chainId
+//        }
+//      }
+//      if isForOrigin && selectedChainIdForOrigin != network.chainId {
+//        self.selectedChainIdForOrigin = network.chainId
+//      } else if defaultSelectedChainId != network.chainId {
+//        self.defaultSelectedChainId = network.chainId
+//      }
+//      if selectedCoin != network.coin {
+//        let success = await rpcService.setNetwork(network.chainId, coin: network.coin, origin: isForOrigin ? origin : nil)
+//        return success ? nil : .unknown
+//      } else {
+//        let rpcServiceNetwork = await rpcService.network(network.coin, origin: isForOrigin ? origin : nil)
+//        guard rpcServiceNetwork.chainId != network.chainId else {
+//          if !isForOrigin { // `isSwapSupported` is for the `defaultSelectedChain`
+//            self.isSwapSupported = await swapService.isSwapSupported(network.chainId)
+//          }
+//          return .chainAlreadySelected
+//        }
+//        let success = await rpcService.setNetwork(network.chainId, coin: network.coin, origin: isForOrigin ? origin : nil)
+//        return success ? nil : .unknown
+//      }
+      return nil
     }
   }
   
@@ -286,48 +287,53 @@ extension NetworkStore: BraveWalletJsonRpcServiceObserver {
     }
   }
   public func chainChangedEvent(_ chainId: String, coin: BraveWallet.CoinType, origin: URLOrigin?) {
-    Task { @MainActor in
-      walletService.setSelectedCoin(coin)
-      // since JsonRpcService notify us of change,
-      // we don't need to call `setNetwork` on JsonRpcService
-      if let origin {
-        if origin == self.origin {
-          selectedChainIdForOrigin = chainId
-        }
-      } else {
-        defaultSelectedChainId = chainId
-        isSwapSupported = await swapService.isSwapSupported(chainId)
-        if let origin = self.origin {
-          // The default network may be used for this origin if no
-          // other network was assigned for this origin. If so, we
-          // need to make sure the `selectedChainIdForOrigin` is updated
-          // to reflect the correct network.
-          let network = await rpcService.network(coin, origin: origin)
-          selectedChainIdForOrigin = network.chainId
-        }
-      }
-    }
+//    Task { @MainActor in
+//      walletService.setSelectedCoin(coin)
+//      // since JsonRpcService notify us of change,
+//      // we don't need to call `setNetwork` on JsonRpcService
+//      if let origin {
+//        if origin == self.origin {
+//          selectedChainIdForOrigin = chainId
+//        }
+//      } else {
+//        defaultSelectedChainId = chainId
+//        isSwapSupported = await swapService.isSwapSupported(chainId)
+//        if let origin = self.origin {
+//          // The default network may be used for this origin if no
+//          // other network was assigned for this origin. If so, we
+//          // need to make sure the `selectedChainIdForOrigin` is updated
+//          // to reflect the correct network.
+//          let network = await rpcService.network(coin, origin: origin)
+//          selectedChainIdForOrigin = network.chainId
+//        }
+//      }
+//    }
   }
 }
 
 extension NetworkStore: BraveWalletKeyringServiceObserver {
-  public func selectedAccountChanged(_ coin: BraveWallet.CoinType) {
-    walletService.setSelectedCoin(coin)
-    if defaultSelectedChain.coin != coin {
-      // selected coin updated, `NetworkStore` selected network(s) needs updated
-      Task { @MainActor in
-        let selectedNetwork = await rpcService.network(coin, origin: nil)
-        defaultSelectedChainId = selectedNetwork.chainId
-        if let origin = self.origin {
-          // The default network may be used for this origin if no
-          // other network was assigned for this origin. If so, we
-          // need to make sure the `selectedChainIdForOrigin` is updated
-          // to reflect the correct network.
-          let networkForOrigin = await rpcService.network(coin, origin: origin)
-          selectedChainIdForOrigin = networkForOrigin.chainId
-        }
-      }
-    }
+//  public func selectedAccountChanged(_ coin: BraveWallet.CoinType) {
+//    walletService.setSelectedCoin(coin)
+//    if defaultSelectedChain.coin != coin {
+//      // selected coin updated, `NetworkStore` selected network(s) needs updated
+//      Task { @MainActor in
+//        let selectedNetwork = await rpcService.network(coin, origin: nil)
+//        defaultSelectedChainId = selectedNetwork.chainId
+//        if let origin = self.origin {
+//          // The default network may be used for this origin if no
+//          // other network was assigned for this origin. If so, we
+//          // need to make sure the `selectedChainIdForOrigin` is updated
+//          // to reflect the correct network.
+//          let networkForOrigin = await rpcService.network(coin, origin: origin)
+//          selectedChainIdForOrigin = networkForOrigin.chainId
+//        }
+//      }
+//    }
+//  }
+  public func selectedWalletAccountChanged(_ account: BraveWallet.AccountInfo) {
+  }
+  
+  public func selectedDappAccountChanged(_ coin: BraveWallet.CoinType, account: BraveWallet.AccountInfo?) {
   }
   
   public func keyringCreated(_ keyringId: BraveWallet.KeyringId) {

--- a/Sources/BraveWallet/Crypto/Stores/NetworkStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/NetworkStore.swift
@@ -121,6 +121,15 @@ public class NetworkStore: ObservableObject {
         self.defaultSelectedChainId = network.chainId
       }
       
+      let currentlySelectedCoin = await keyringService.allAccounts().selectedAccount?.coin ?? .eth
+      let rpcServiceNetwork = await rpcService.network(currentlySelectedCoin, origin: isForOrigin ? origin : nil)
+      guard rpcServiceNetwork.chainId != network.chainId else {
+        if !isForOrigin { // `isSwapSupported` is for the `defaultSelectedChain`
+          self.isSwapSupported = await swapService.isSwapSupported(network.chainId)
+        }
+        return .chainAlreadySelected
+      }
+      
       let success = await rpcService.setNetwork(network.chainId, coin: network.coin, origin: isForOrigin ? origin : nil)
       if success {
         let account = await walletService.ensureSelectedAccount(forChain: network.coin, chainId: network.chainId)

--- a/Sources/BraveWallet/Crypto/Stores/NetworkStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/NetworkStore.swift
@@ -81,16 +81,16 @@ public class NetworkStore: ObservableObject {
   
   /// Updates the `selectedChainId` and `isSwapSupported` for the network for the current `origin`.
   @MainActor private func updateSelectedChain() async {
-//    // fetch current selected network
-//    let selectedCoin = await walletService.selectedCoin()
-//    let chain = await rpcService.network(selectedCoin, origin: nil)
-//    // since we are fetch network from JsonRpcService,
-//    // we don't need to call `setNetwork` on JsonRpcService
-//    self.defaultSelectedChainId = chain.chainId
-//    let chainForOrigin = await rpcService.network(selectedCoin, origin: origin)
-//    self.selectedChainIdForOrigin = chainForOrigin.chainId
-//    // update `isSwapSupported` for Buy/Send/Swap panel
-//    self.isSwapSupported = await swapService.isSwapSupported(chain.chainId)
+    // fetch current selected network
+    let selectedCoin = await keyringService.allAccounts().selectedAccount?.coin ?? .eth
+    let chain = await rpcService.network(selectedCoin, origin: nil)
+    // since we are fetch network from JsonRpcService,
+    // we don't need to call `setNetwork` on JsonRpcService
+    self.defaultSelectedChainId = chain.chainId
+    let chainForOrigin = await rpcService.network(selectedCoin, origin: origin)
+    self.selectedChainIdForOrigin = chainForOrigin.chainId
+    // update `isSwapSupported` for Buy/Send/Swap panel
+    self.isSwapSupported = await swapService.isSwapSupported(chain.chainId)
   }
 
   @MainActor private func updateChainList() async {
@@ -115,36 +115,23 @@ public class NetworkStore: ObservableObject {
       // Need to prompt user to create new account via alert
       return .selectedChainHasNoAccounts
     } else {
-//      let selectedCoin = await walletService.selectedCoin()
-//      if isForOrigin {
-//        if self.selectedChainIdForOrigin != network.chainId {
-//          self.selectedChainIdForOrigin = network.chainId
-//        }
-//      } else {
-//        if self.defaultSelectedChainId != network.chainId {
-//          self.defaultSelectedChainId = network.chainId
-//        }
-//      }
-//      if isForOrigin && selectedChainIdForOrigin != network.chainId {
-//        self.selectedChainIdForOrigin = network.chainId
-//      } else if defaultSelectedChainId != network.chainId {
-//        self.defaultSelectedChainId = network.chainId
-//      }
-//      if selectedCoin != network.coin {
-//        let success = await rpcService.setNetwork(network.chainId, coin: network.coin, origin: isForOrigin ? origin : nil)
-//        return success ? nil : .unknown
-//      } else {
-//        let rpcServiceNetwork = await rpcService.network(network.coin, origin: isForOrigin ? origin : nil)
-//        guard rpcServiceNetwork.chainId != network.chainId else {
-//          if !isForOrigin { // `isSwapSupported` is for the `defaultSelectedChain`
-//            self.isSwapSupported = await swapService.isSwapSupported(network.chainId)
-//          }
-//          return .chainAlreadySelected
-//        }
-//        let success = await rpcService.setNetwork(network.chainId, coin: network.coin, origin: isForOrigin ? origin : nil)
-//        return success ? nil : .unknown
-//      }
-      return nil
+      if isForOrigin && selectedChainIdForOrigin != network.chainId {
+        self.selectedChainIdForOrigin = network.chainId
+      } else if !isForOrigin && defaultSelectedChainId != network.chainId {
+        self.defaultSelectedChainId = network.chainId
+      }
+      
+      let success = await rpcService.setNetwork(network.chainId, coin: network.coin, origin: isForOrigin ? origin : nil)
+      if success {
+        let account = await walletService.ensureSelectedAccount(forChain: network.coin, chainId: network.chainId)
+        if account == nil {
+          assertionFailure("Should not have a nil selectedAccount for any network.")
+        }
+        if !isForOrigin { // `isSwapSupported` is for the `defaultSelectedChain`
+          self.isSwapSupported = await swapService.isSwapSupported(network.chainId)
+        }
+      }
+      return success ? nil : .unknown
     }
   }
   
@@ -287,50 +274,41 @@ extension NetworkStore: BraveWalletJsonRpcServiceObserver {
     }
   }
   public func chainChangedEvent(_ chainId: String, coin: BraveWallet.CoinType, origin: URLOrigin?) {
-//    Task { @MainActor in
-//      walletService.setSelectedCoin(coin)
-//      // since JsonRpcService notify us of change,
-//      // we don't need to call `setNetwork` on JsonRpcService
-//      if let origin {
-//        if origin == self.origin {
-//          selectedChainIdForOrigin = chainId
-//        }
-//      } else {
-//        defaultSelectedChainId = chainId
-//        isSwapSupported = await swapService.isSwapSupported(chainId)
-//        if let origin = self.origin {
-//          // The default network may be used for this origin if no
-//          // other network was assigned for this origin. If so, we
-//          // need to make sure the `selectedChainIdForOrigin` is updated
-//          // to reflect the correct network.
-//          let network = await rpcService.network(coin, origin: origin)
-//          selectedChainIdForOrigin = network.chainId
-//        }
-//      }
-//    }
+    Task { @MainActor in
+      if let origin, origin == self.origin {
+        selectedChainIdForOrigin = chainId
+      } else if origin == nil {
+        defaultSelectedChainId = chainId
+        isSwapSupported = await swapService.isSwapSupported(chainId)
+        if let origin = self.origin {
+          // The default network may be used for this origin if no
+          // other network was assigned for this origin. If so, we
+          // need to make sure the `selectedChainIdForOrigin` is updated
+          // to reflect the correct network.
+          let network = await rpcService.network(coin, origin: origin)
+          selectedChainIdForOrigin = network.chainId
+        }
+      }
+    }
   }
 }
 
 extension NetworkStore: BraveWalletKeyringServiceObserver {
-//  public func selectedAccountChanged(_ coin: BraveWallet.CoinType) {
-//    walletService.setSelectedCoin(coin)
-//    if defaultSelectedChain.coin != coin {
-//      // selected coin updated, `NetworkStore` selected network(s) needs updated
-//      Task { @MainActor in
-//        let selectedNetwork = await rpcService.network(coin, origin: nil)
-//        defaultSelectedChainId = selectedNetwork.chainId
-//        if let origin = self.origin {
-//          // The default network may be used for this origin if no
-//          // other network was assigned for this origin. If so, we
-//          // need to make sure the `selectedChainIdForOrigin` is updated
-//          // to reflect the correct network.
-//          let networkForOrigin = await rpcService.network(coin, origin: origin)
-//          selectedChainIdForOrigin = networkForOrigin.chainId
-//        }
-//      }
-//    }
-//  }
   public func selectedWalletAccountChanged(_ account: BraveWallet.AccountInfo) {
+    Task { @MainActor in
+      if defaultSelectedChain.coin != account.coin {
+        let selectedNetwork = await rpcService.network(account.coin, origin: nil)
+        defaultSelectedChainId = selectedNetwork.chainId
+      }
+      if let origin, selectedChainForOrigin.coin != account.coin {
+        // The default network may be used for this origin if no
+        // other network was assigned for this origin. If so, we
+        // need to make sure the `selectedChainIdForOrigin` is updated
+        // to reflect the correct network.
+        let selectedNetwork = await rpcService.network(account.coin, origin: origin)
+        selectedChainIdForOrigin = selectedNetwork.chainId
+      }
+    }
   }
   
   public func selectedDappAccountChanged(_ coin: BraveWallet.CoinType, account: BraveWallet.AccountInfo?) {

--- a/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
@@ -328,10 +328,15 @@ extension PortfolioStore: BraveWalletKeyringServiceObserver {
   }
   public func autoLockMinutesChanged() {
   }
-  public func selectedAccountChanged(_ coinType: BraveWallet.CoinType) {
-    DispatchQueue.main.async { [self] in
-      update()
-    }
+//  public func selectedAccountChanged(_ coinType: BraveWallet.CoinType) {
+//    DispatchQueue.main.async { [self] in
+//      update()
+//    }
+//  }
+  public func selectedWalletAccountChanged(_ account: BraveWallet.AccountInfo) {
+  }
+  
+  public func selectedDappAccountChanged(_ coin: BraveWallet.CoinType, account: BraveWallet.AccountInfo?) {
   }
   
   public func accountsAdded(_ addedAccounts: [BraveWallet.AccountInfo]) {

--- a/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
@@ -328,11 +328,6 @@ extension PortfolioStore: BraveWalletKeyringServiceObserver {
   }
   public func autoLockMinutesChanged() {
   }
-//  public func selectedAccountChanged(_ coinType: BraveWallet.CoinType) {
-//    DispatchQueue.main.async { [self] in
-//      update()
-//    }
-//  }
   public func selectedWalletAccountChanged(_ account: BraveWallet.AccountInfo) {
   }
   

--- a/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
@@ -299,7 +299,7 @@ public class SendTokenStore: ObservableObject {
     validateSendAddressTask?.cancel()
     validateSendAddressTask = Task { @MainActor in
       guard !sendAddress.isEmpty,
-              let selectedAccount = await keyringService.allAccounts().selectedAccount,
+            let selectedAccount = await keyringService.allAccounts().selectedAccount,
             !Task.isCancelled else {
         return
       }

--- a/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
@@ -471,13 +471,13 @@ public class SendTokenStore: ObservableObject {
     completion: @escaping (_ success: Bool, _ errMsg: String?) -> Void
   ) {
     guard let token = self.selectedSendToken else {
-      completion(false, "An Internal Error")
+      completion(false, Strings.Wallet.internalErrorMessage)
       return
     }
     let amount = (token.isErc721 || token.isNft) ? "1" : amount
     keyringService.allAccounts { allAccounts in
       guard let selectedAccount = allAccounts.selectedAccount else {
-        completion(false, "An Internal Error")
+        completion(false, Strings.Wallet.internalErrorMessage)
         return
       }
       switch selectedAccount.coin {
@@ -486,7 +486,7 @@ public class SendTokenStore: ObservableObject {
       case .sol:
         self.sendTokenOnSol(amount: amount, token: token, fromAddress: selectedAccount.address, completion: completion)
       default:
-        completion(false, "An Internal Error")
+        completion(false, Strings.Wallet.internalErrorMessage)
       }
     }
   }
@@ -499,7 +499,7 @@ public class SendTokenStore: ObservableObject {
   ) {
     let weiFormatter = WeiFormatter(decimalFormatStyle: .decimals(precision: 18))
     guard let weiHexString = weiFormatter.weiString(from: amount.normalizedDecimals, radix: .hex, decimals: Int(token.decimals)) else {
-      completion(false, "An Internal Error")
+      completion(false, Strings.Wallet.internalErrorMessage)
       return
     }
     
@@ -566,7 +566,7 @@ public class SendTokenStore: ObservableObject {
     completion: @escaping (_ success: Bool, _ errMsg: String?) -> Void
   ) {
     guard let amount = WeiFormatter.decimalToAmount(amount.normalizedDecimals, tokenDecimals: Int(token.decimals)) else {
-      completion(false, "An Internal Error")
+      completion(false, Strings.Wallet.internalErrorMessage)
       return
     }
     

--- a/Sources/BraveWallet/Crypto/Stores/SettingsStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SettingsStore.swift
@@ -184,7 +184,12 @@ extension SettingsStore: BraveWalletKeyringServiceObserver {
     }
   }
   
-  public func selectedAccountChanged(_ coin: BraveWallet.CoinType) {
+//  public func selectedAccountChanged(_ coin: BraveWallet.CoinType) {
+//  }
+  public func selectedWalletAccountChanged(_ account: BraveWallet.AccountInfo) {
+  }
+  
+  public func selectedDappAccountChanged(_ coin: BraveWallet.CoinType, account: BraveWallet.AccountInfo?) {
   }
   
   public func accountsAdded(_ addedAccounts: [BraveWallet.AccountInfo]) {

--- a/Sources/BraveWallet/Crypto/Stores/SettingsStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SettingsStore.swift
@@ -184,8 +184,6 @@ extension SettingsStore: BraveWalletKeyringServiceObserver {
     }
   }
   
-//  public func selectedAccountChanged(_ coin: BraveWallet.CoinType) {
-//  }
   public func selectedWalletAccountChanged(_ account: BraveWallet.AccountInfo) {
   }
   

--- a/Sources/BraveWallet/Crypto/Stores/SwapTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SwapTokenStore.swift
@@ -244,67 +244,68 @@ public class SwapTokenStore: ObservableObject {
   }
   
   @MainActor private func createEthSwapTransaction() async -> Bool {
-//    self.isMakingTx = true
-//    defer { self.isMakingTx = false }
-//    let coin = await walletService.selectedCoin()
-//    let network = await rpcService.network(coin, origin: nil)
-//    guard
-//      let accountInfo = self.accountInfo,
-//      let swapParams = self.swapParameters(for: .perSellAsset, in: network)
-//    else {
-//      self.state = .error(Strings.Wallet.unknownError)
-//      self.clearAllAmount()
-//      return false
-//    }
-//    let (swapResponse, _, _) = await swapService.transactionPayload(swapParams)
-//    guard let swapResponse = swapResponse else {
-//      self.state = .error(Strings.Wallet.unknownError)
-//      self.clearAllAmount()
-//      return false
-//    }
-//    let weiFormatter = WeiFormatter(decimalFormatStyle: .decimals(precision: 18))
-//    let gasPrice = "0x\(weiFormatter.weiString(from: swapResponse.gasPrice, radix: .hex, decimals: 0) ?? "0")"  // already in wei
-//    let gasLimit = "0x\(weiFormatter.weiString(from: swapResponse.estimatedGas, radix: .hex, decimals: 0) ?? "0")"  // already in wei
-//    let value = "0x\(weiFormatter.weiString(from: swapResponse.value, radix: .hex, decimals: 0) ?? "0")"  // already in wei
-//    let data: [NSNumber] = .init(hexString: swapResponse.data) ?? .init()
-//
-//    if network.isEip1559 {
-//      let baseData: BraveWallet.TxData = .init(
-//        nonce: "",
-//        gasPrice: "",  // no gas price in eip1559
-//        gasLimit: gasLimit,
-//        to: swapResponse.to,
-//        value: value,
-//        data: data,
-//        signOnly: false,
-//        signedTransaction: nil
-//      )
-//      let success = await self.makeEIP1559Tx(chainId: network.chainId, baseData: baseData, from: accountInfo)
-//      if !success {
-//        self.state = .error(Strings.Wallet.unknownError)
-//        self.clearAllAmount()
-//      }
-//      return success
-//    } else {
-//      let baseData: BraveWallet.TxData = .init(
-//        nonce: "",
-//        gasPrice: gasPrice,
-//        gasLimit: gasLimit,
-//        to: swapResponse.to,
-//        value: value,
-//        data: data,
-//        signOnly: false,
-//        signedTransaction: nil
-//      )
-//      let txDataUnion = BraveWallet.TxDataUnion(ethTxData: baseData)
-//      let (success, _, _) = await txService.addUnapprovedTransaction(txDataUnion, from: accountInfo.address, origin: nil, groupId: nil)
-//      if !success {
-//        self.state = .error(Strings.Wallet.unknownError)
-//        self.clearAllAmount()
-//      }
-//      return success
-//    }
-    return false
+    self.isMakingTx = true
+    defer { self.isMakingTx = false }
+    guard let accountInfo = self.accountInfo else {
+      self.state = .error(Strings.Wallet.unknownError)
+      self.clearAllAmount()
+      return false
+    }
+    let coin = accountInfo.coin
+    let network = await rpcService.network(coin, origin: nil)
+    guard let swapParams = self.swapParameters(for: .perSellAsset, in: network) else {
+      self.state = .error(Strings.Wallet.unknownError)
+      self.clearAllAmount()
+      return false
+    }
+    let (swapResponse, _, _) = await swapService.transactionPayload(swapParams)
+    guard let swapResponse = swapResponse else {
+      self.state = .error(Strings.Wallet.unknownError)
+      self.clearAllAmount()
+      return false
+    }
+    let weiFormatter = WeiFormatter(decimalFormatStyle: .decimals(precision: 18))
+    let gasPrice = "0x\(weiFormatter.weiString(from: swapResponse.gasPrice, radix: .hex, decimals: 0) ?? "0")"  // already in wei
+    let gasLimit = "0x\(weiFormatter.weiString(from: swapResponse.estimatedGas, radix: .hex, decimals: 0) ?? "0")"  // already in wei
+    let value = "0x\(weiFormatter.weiString(from: swapResponse.value, radix: .hex, decimals: 0) ?? "0")"  // already in wei
+    let data: [NSNumber] = .init(hexString: swapResponse.data) ?? .init()
+
+    if network.isEip1559 {
+      let baseData: BraveWallet.TxData = .init(
+        nonce: "",
+        gasPrice: "",  // no gas price in eip1559
+        gasLimit: gasLimit,
+        to: swapResponse.to,
+        value: value,
+        data: data,
+        signOnly: false,
+        signedTransaction: nil
+      )
+      let success = await self.makeEIP1559Tx(chainId: network.chainId, baseData: baseData, from: accountInfo)
+      if !success {
+        self.state = .error(Strings.Wallet.unknownError)
+        self.clearAllAmount()
+      }
+      return success
+    } else {
+      let baseData: BraveWallet.TxData = .init(
+        nonce: "",
+        gasPrice: gasPrice,
+        gasLimit: gasLimit,
+        to: swapResponse.to,
+        value: value,
+        data: data,
+        signOnly: false,
+        signedTransaction: nil
+      )
+      let txDataUnion = BraveWallet.TxDataUnion(ethTxData: baseData)
+      let (success, _, _) = await txService.addUnapprovedTransaction(txDataUnion, from: accountInfo.address, origin: nil, groupId: nil)
+      if !success {
+        self.state = .error(Strings.Wallet.unknownError)
+        self.clearAllAmount()
+      }
+      return success
+    }
   }
 
   private func clearAllAmount() {
@@ -355,60 +356,58 @@ public class SwapTokenStore: ObservableObject {
   @MainActor private func createERC20ApprovalTransaction(
       _ spenderAddress: String
   ) async -> Bool {
-//    guard
-//      let fromToken = selectedFromToken,
-//      let accountInfo = accountInfo
-//    else {
-//      return false
-//    }
-//
-//    // IMPORTANT SECURITY NOTICE
-//    //
-//    // The token allowance suggested by Swap is always unlimited,
-//    // i.e., max(uint256). While unlimited approvals are not safe from a
-//    // security standpoint, and this puts the entire token balance at risk
-//    // if 0x contracts are ever exploited, we still opted for this to give
-//    // users a frictionless UX and save on gas fees.
-//    //
-//    // The transaction confirmation screen for ERC20 approve() shows a loud
-//    // security notice, and still allows users to edit the default approval
-//    // amount.
-//    let allowance = WalletConstants.MAX_UINT256
-//    self.isMakingTx = true
-//    defer { self.isMakingTx = false }
-//    let coin = await walletService.selectedCoin()
-//    let network = await rpcService.network(coin, origin: nil)
-//    let (success, data) = await ethTxManagerProxy.makeErc20ApproveData(spenderAddress, amount: allowance)
-//    guard success else {
-//      return false
-//    }
-//    let baseData = BraveWallet.TxData(
-//      nonce: "",
-//      gasPrice: "",
-//      gasLimit: "",
-//      to: fromToken.contractAddress(in: network),
-//      value: "0x0",
-//      data: data,
-//      signOnly: false,
-//      signedTransaction: nil
-//    )
-//    if network.isEip1559 {
-//      let success = await self.makeEIP1559Tx(chainId: network.chainId, baseData: baseData, from: accountInfo)
-//      if !success {
-//        self.state = .error(Strings.Wallet.unknownError)
-//        self.clearAllAmount()
-//      }
-//      return success
-//    } else {
-//      let txDataUnion = BraveWallet.TxDataUnion(ethTxData: baseData)
-//      let (success, _, _) = await txService.addUnapprovedTransaction(txDataUnion, from: accountInfo.address, origin: nil, groupId: nil)
-//      if !success {
-//        self.state = .error(Strings.Wallet.unknownError)
-//        self.clearAllAmount()
-//      }
-//      return success
-//    }
-    return false
+    guard
+      let fromToken = selectedFromToken,
+      let accountInfo = accountInfo
+    else {
+      return false
+    }
+
+    // IMPORTANT SECURITY NOTICE
+    //
+    // The token allowance suggested by Swap is always unlimited,
+    // i.e., max(uint256). While unlimited approvals are not safe from a
+    // security standpoint, and this puts the entire token balance at risk
+    // if 0x contracts are ever exploited, we still opted for this to give
+    // users a frictionless UX and save on gas fees.
+    //
+    // The transaction confirmation screen for ERC20 approve() shows a loud
+    // security notice, and still allows users to edit the default approval
+    // amount.
+    let allowance = WalletConstants.MAX_UINT256
+    self.isMakingTx = true
+    defer { self.isMakingTx = false }
+    let network = await rpcService.network(accountInfo.coin, origin: nil)
+    let (success, data) = await ethTxManagerProxy.makeErc20ApproveData(spenderAddress, amount: allowance)
+    guard success else {
+      return false
+    }
+    let baseData = BraveWallet.TxData(
+      nonce: "",
+      gasPrice: "",
+      gasLimit: "",
+      to: fromToken.contractAddress(in: network),
+      value: "0x0",
+      data: data,
+      signOnly: false,
+      signedTransaction: nil
+    )
+    if network.isEip1559 {
+      let success = await self.makeEIP1559Tx(chainId: network.chainId, baseData: baseData, from: accountInfo)
+      if !success {
+        self.state = .error(Strings.Wallet.unknownError)
+        self.clearAllAmount()
+      }
+      return success
+    } else {
+      let txDataUnion = BraveWallet.TxDataUnion(ethTxData: baseData)
+      let (success, _, _) = await txService.addUnapprovedTransaction(txDataUnion, from: accountInfo.address, origin: nil, groupId: nil)
+      if !success {
+        self.state = .error(Strings.Wallet.unknownError)
+        self.clearAllAmount()
+      }
+      return success
+    }
   }
   
   @MainActor private func makeEIP1559Tx(
@@ -447,55 +446,54 @@ public class SwapTokenStore: ObservableObject {
   }
 
   @MainActor private func checkBalanceShowError(swapResponse: BraveWallet.SwapResponse) async {
-//    guard
-//      let accountInfo = accountInfo,
-//      let sellAmountValue = BDouble(sellAmount.normalizedDecimals),
-//      let gasLimit = BDouble(swapResponse.estimatedGas),
-//      let gasPrice = BDouble(swapResponse.gasPrice, over: "1000000000000000000"),
-//      let fromToken = selectedFromToken,
-//      let fromTokenBalance = selectedFromTokenBalance
-//    else { return }
-//
-//    // Check if balance is insufficient
-//    guard sellAmountValue <= fromTokenBalance else {
-//      state = .error(Strings.Wallet.insufficientBalance)
-//      return
-//    }
-//
-//    // Get ETH balance for this account because gas can only be paid in ETH
-//    let coin = await walletService.selectedCoin()
-//    let network = await rpcService.network(coin, origin: nil)
-//    let (balance, status, _) = await rpcService.balance(accountInfo.address, coin: network.coin, chainId: network.chainId)
-//    if status == BraveWallet.ProviderError.success {
-//      let fee = gasLimit * gasPrice
-//      let balanceFormatter = WeiFormatter(decimalFormatStyle: .balance)
-//      let currentBalance = BDouble(balanceFormatter.decimalString(for: balance.removingHexPrefix, radix: .hex, decimals: 18) ?? "") ?? 0
-//      if fromToken.symbol == network.symbol {
-//        if currentBalance < fee + sellAmountValue {
-//          self.state = .error(Strings.Wallet.insufficientFundsForGas)
-//          return
-//        }
-//      } else {
-//        if currentBalance < fee {
-//          self.state = .error(Strings.Wallet.insufficientFundsForGas)
-//          return
-//        }
-//      }
-//      self.state = .swap
-//      // check for ERC20 token allowance
-//      if fromToken.isErc20 {
-//        await self.checkAllowance(
-//          network: network,
-//          ownerAddress: accountInfo.address,
-//          spenderAddress: swapResponse.allowanceTarget,
-//          amountToSend: sellAmountValue,
-//          fromToken: fromToken
-//        )
-//      }
-//    } else {
-//      self.state = .error(Strings.Wallet.unknownError)
-//      self.clearAllAmount()
-//    }
+    guard
+      let accountInfo = accountInfo,
+      let sellAmountValue = BDouble(sellAmount.normalizedDecimals),
+      let gasLimit = BDouble(swapResponse.estimatedGas),
+      let gasPrice = BDouble(swapResponse.gasPrice, over: "1000000000000000000"),
+      let fromToken = selectedFromToken,
+      let fromTokenBalance = selectedFromTokenBalance
+    else { return }
+
+    // Check if balance is insufficient
+    guard sellAmountValue <= fromTokenBalance else {
+      state = .error(Strings.Wallet.insufficientBalance)
+      return
+    }
+
+    // Get ETH balance for this account because gas can only be paid in ETH
+    let network = await rpcService.network(accountInfo.coin, origin: nil)
+    let (balance, status, _) = await rpcService.balance(accountInfo.address, coin: network.coin, chainId: network.chainId)
+    if status == BraveWallet.ProviderError.success {
+      let fee = gasLimit * gasPrice
+      let balanceFormatter = WeiFormatter(decimalFormatStyle: .balance)
+      let currentBalance = BDouble(balanceFormatter.decimalString(for: balance.removingHexPrefix, radix: .hex, decimals: 18) ?? "") ?? 0
+      if fromToken.symbol == network.symbol {
+        if currentBalance < fee + sellAmountValue {
+          self.state = .error(Strings.Wallet.insufficientFundsForGas)
+          return
+        }
+      } else {
+        if currentBalance < fee {
+          self.state = .error(Strings.Wallet.insufficientFundsForGas)
+          return
+        }
+      }
+      self.state = .swap
+      // check for ERC20 token allowance
+      if fromToken.isErc20 {
+        await self.checkAllowance(
+          network: network,
+          ownerAddress: accountInfo.address,
+          spenderAddress: swapResponse.allowanceTarget,
+          amountToSend: sellAmountValue,
+          fromToken: fromToken
+        )
+      }
+    } else {
+      self.state = .error(Strings.Wallet.unknownError)
+      self.clearAllAmount()
+    }
   }
 
   @MainActor private func checkAllowance(
@@ -676,45 +674,49 @@ public class SwapTokenStore: ObservableObject {
   }
 
   @MainActor func createSwapTransaction() async -> Bool {
-//    switch state {
-//    case .error, .idle:
-//      // will never come here
-//      return false
-//    case let .lowAllowance(spenderAddress):
-//      return await createERC20ApprovalTransaction(spenderAddress)
-//    case .swap:
-//      let coin = await walletService.selectedCoin()
-//      switch coin {
-//      case .eth:
-//        return await createEthSwapTransaction()
-//      case .sol:
-//        return await createSolSwapTransaction()
-//      default:
-//        return false
-//      }
-//    }
-    return false
+    guard let accountInfo else {
+      return false
+    }
+    switch state {
+    case .error, .idle:
+      // will never come here
+      return false
+    case let .lowAllowance(spenderAddress):
+      return await createERC20ApprovalTransaction(spenderAddress)
+    case .swap:
+      switch accountInfo.coin {
+      case .eth:
+        return await createEthSwapTransaction()
+      case .sol:
+        return await createSolSwapTransaction()
+      default:
+        return false
+      }
+    }
   }
 
   func fetchPriceQuote(base: SwapParamsBase) {
-//    Task { @MainActor in
-//      // reset jupiter quote before fetching new quote
-//      self.jupiterQuote = nil
-//      let coin = await walletService.selectedCoin()
-//      let network = await rpcService.network(coin, origin: nil)
-//      guard let swapParams = self.swapParameters(for: base, in: network) else {
-//        self.state = .idle
-//        return
-//      }
-//      switch coin {
-//      case .eth:
-//        await fetchEthPriceQuote(base: base, swapParams: swapParams, network: network)
-//      case .sol:
-//        await fetchSolPriceQuote(base: base, swapParams: swapParams, network: network)
-//      default:
-//        break
-//      }
-//    }
+    Task { @MainActor in
+      // reset jupiter quote before fetching new quote
+      self.jupiterQuote = nil
+      guard let accountInfo else {
+        self.state = .idle
+        return
+      }
+      let network = await rpcService.network(accountInfo.coin, origin: nil)
+      guard let swapParams = self.swapParameters(for: base, in: network) else {
+        self.state = .idle
+        return
+      }
+      switch accountInfo.coin {
+      case .eth:
+        await fetchEthPriceQuote(base: base, swapParams: swapParams, network: network)
+      case .sol:
+        await fetchSolPriceQuote(base: base, swapParams: swapParams, network: network)
+      default:
+        break
+      }
+    }
   }
   
   @MainActor private func fetchEthPriceQuote(
@@ -789,66 +791,63 @@ public class SwapTokenStore: ObservableObject {
       }
     }
 
-//    // All tokens from token registry
-//    walletService.selectedCoin { [weak self] coinType in
-//      guard let self = self else { return }
-//      self.rpcService.network(coinType, origin: nil) { network in
-//        // Closure run after validating the prefilledToken (if applicable)
-//        let continueClosure: (BraveWallet.NetworkInfo) -> Void = { [weak self] network in
-//          guard let self = self else { return }
-//          self.blockchainRegistry.allTokens(network.chainId, coin: network.coin) { tokens in
-//            // Native token on the current selected network
-//            let nativeAsset = network.nativeToken
-//            // Custom tokens added by users
-//            let userAssets = self.assetManager.getAllUserAssetsInNetworkAssets(networks: [network]).flatMap { $0.tokens }
-//            let customTokens = userAssets.filter { asset in
-//              !tokens.contains(where: { $0.contractAddress(in: network).caseInsensitiveCompare(asset.contractAddress) == .orderedSame })
-//            }
-//            let sortedCustomTokens = customTokens.sorted {
-//              if $0.contractAddress(in: network).caseInsensitiveCompare(nativeAsset.contractAddress) == .orderedSame {
-//                return true
-//              } else {
-//                return $0.symbol < $1.symbol
-//              }
-//            }
-//            self.allTokens = (sortedCustomTokens + tokens.sorted(by: { $0.symbol < $1.symbol })).filter { !$0.isNft }
-//            // Seems like user assets always include the selected network's native asset
-//            // But let's make sure all token list includes the native asset
-//            if !self.allTokens.contains(where: { $0.symbol.lowercased() == nativeAsset.symbol.lowercased() }) {
-//              self.allTokens.insert(nativeAsset, at: 0)
-//            }
-//            updateSelectedTokens(in: network)
-//          }
-//        }
-//
-//        // validate the `prefilledToken`
-//        if let prefilledToken = self.prefilledToken {
-//          if prefilledToken.coin == network.coin && prefilledToken.chainId == network.chainId {
-//            self.selectedFromToken = prefilledToken
-//            continueClosure(network)
-//          } else {
-//            self.rpcService.allNetworks(prefilledToken.coin) { allNetworksForTokenCoin in
-//              guard let networkForToken = allNetworksForTokenCoin.first(where: { $0.chainId == prefilledToken.chainId }) else {
-//                // don't set prefilled token if it belongs to a network we don't know
-//                continueClosure(network)
-//                return
-//              }
-//              self.rpcService.setNetwork(networkForToken.chainId, coin: networkForToken.coin, origin: nil) { success in
-//                if success {
-//                  self.selectedFromToken = prefilledToken
-//                  continueClosure(networkForToken) // network changed
-//                } else {
-//                  continueClosure(network)
-//                }
-//              }
-//            }
-//          }
-//          self.prefilledToken = nil
-//        } else { // `prefilledToken` is nil
-//          continueClosure(network)
-//        }
-//      }
-//    }
+    // All tokens from token registry
+    self.rpcService.network(accountInfo.coin, origin: nil) { network in
+      // Closure run after validating the prefilledToken (if applicable)
+      let continueClosure: (BraveWallet.NetworkInfo) -> Void = { [weak self] network in
+        guard let self = self else { return }
+        self.blockchainRegistry.allTokens(network.chainId, coin: network.coin) { tokens in
+          // Native token on the current selected network
+          let nativeAsset = network.nativeToken
+          // Custom tokens added by users
+          let userAssets = self.assetManager.getAllUserAssetsInNetworkAssets(networks: [network]).flatMap { $0.tokens }
+          let customTokens = userAssets.filter { asset in
+            !tokens.contains(where: { $0.contractAddress(in: network).caseInsensitiveCompare(asset.contractAddress) == .orderedSame })
+          }
+          let sortedCustomTokens = customTokens.sorted {
+            if $0.contractAddress(in: network).caseInsensitiveCompare(nativeAsset.contractAddress) == .orderedSame {
+              return true
+            } else {
+              return $0.symbol < $1.symbol
+            }
+          }
+          self.allTokens = (sortedCustomTokens + tokens.sorted(by: { $0.symbol < $1.symbol })).filter { !$0.isNft }
+          // Seems like user assets always include the selected network's native asset
+          // But let's make sure all token list includes the native asset
+          if !self.allTokens.contains(where: { $0.symbol.lowercased() == nativeAsset.symbol.lowercased() }) {
+            self.allTokens.insert(nativeAsset, at: 0)
+          }
+          updateSelectedTokens(in: network)
+        }
+      }
+      
+      // validate the `prefilledToken`
+      if let prefilledToken = self.prefilledToken {
+        if prefilledToken.coin == network.coin && prefilledToken.chainId == network.chainId {
+          self.selectedFromToken = prefilledToken
+          continueClosure(network)
+        } else {
+          self.rpcService.allNetworks(prefilledToken.coin) { allNetworksForTokenCoin in
+            guard let networkForToken = allNetworksForTokenCoin.first(where: { $0.chainId == prefilledToken.chainId }) else {
+              // don't set prefilled token if it belongs to a network we don't know
+              continueClosure(network)
+              return
+            }
+            self.rpcService.setNetwork(networkForToken.chainId, coin: networkForToken.coin, origin: nil) { success in
+              if success {
+                self.selectedFromToken = prefilledToken
+                continueClosure(networkForToken) // network changed
+              } else {
+                continueClosure(network)
+              }
+            }
+          }
+        }
+        self.prefilledToken = nil
+      } else { // `prefilledToken` is nil
+        continueClosure(network)
+      }
+    }
   }
   
   func suggestedAmountTapped(_ amount: ShortcutAmountGrid.Amount) {
@@ -917,23 +916,21 @@ extension SwapTokenStore: BraveWalletKeyringServiceObserver {
   public func autoLockMinutesChanged() {
   }
 
-//  public func selectedAccountChanged(_ coinType: BraveWallet.CoinType) {
-//    Task { @MainActor in
-//      let network = await rpcService.network(coinType, origin: nil)
-//      let isSwapSupported = await swapService.isSwapSupported(network.chainId)
-//      guard isSwapSupported else { return }
-//
-//      let keyringInfo = await keyringService.keyringInfo(coinType.keyringId)
-//      if !keyringInfo.accountInfos.isEmpty {
-//        let accountAddress = await keyringService.selectedAccount(coinType)
-//        let selectedAccountInfo = keyringInfo.accountInfos.first(where: { $0.address == accountAddress }) ?? keyringInfo.accountInfos.first!
-//        prepare(with: selectedAccountInfo) { [self] in
-//          fetchPriceQuote(base: .perSellAsset)
-//        }
-//      }
-//    }
-//  }
   public func selectedWalletAccountChanged(_ account: BraveWallet.AccountInfo) {
+    Task { @MainActor in
+      let network = await rpcService.network(account.coin, origin: nil)
+      let isSwapSupported = await swapService.isSwapSupported(network.chainId)
+      guard isSwapSupported else {
+        accountInfo = account
+        return
+      }
+      
+      selectedFromToken = nil
+      selectedToToken = nil
+      prepare(with: account) { [self] in
+        fetchPriceQuote(base: .perSellAsset)
+      }
+    }
   }
   
   public func selectedDappAccountChanged(_ coin: BraveWallet.CoinType, account: BraveWallet.AccountInfo?) {
@@ -947,10 +944,15 @@ extension SwapTokenStore: BraveWalletJsonRpcServiceObserver {
   public func chainChangedEvent(_ chainId: String, coin: BraveWallet.CoinType, origin: URLOrigin?) {
     Task { @MainActor in
       let isSwapSupported = await swapService.isSwapSupported(chainId)
-      guard isSwapSupported, let accountInfo = accountInfo else { return }
+      guard isSwapSupported else { return }
+      guard let _ = await walletService.ensureSelectedAccount(forChain: coin, chainId: chainId),
+        let selectedAccount = await keyringService.allAccounts().selectedAccount else {
+        assertionFailure("selectedAccount should never be nil.")
+        return
+      }
       selectedFromToken = nil
       selectedToToken = nil
-      prepare(with: accountInfo) { [self] in
+      prepare(with: selectedAccount) { [self] in
         fetchPriceQuote(base: .perSellAsset)
       }
     }

--- a/Sources/BraveWallet/Crypto/Stores/SwapTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SwapTokenStore.swift
@@ -863,13 +863,14 @@ public class SwapTokenStore: ObservableObject {
 
   #if DEBUG
   func setUpTest(
+    fromAccount: BraveWallet.AccountInfo = .mockEthAccount,
     selectedFromToken: BraveWallet.BlockchainToken = .previewToken,
     selectedToToken: BraveWallet.BlockchainToken = .previewDaiToken,
     sellAmount: String? = "0.01",
     buyAmount: String? = nil,
     jupiterQuote: BraveWallet.JupiterQuote? = nil
   ) {
-    accountInfo = .init()
+    accountInfo = fromAccount
     self.selectedFromToken = selectedFromToken
     self.selectedToToken = selectedToToken
     if let sellAmount {

--- a/Sources/BraveWallet/Crypto/Stores/TransactionsActivityStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/TransactionsActivityStore.swift
@@ -212,7 +212,10 @@ extension TransactionsActivityStore: BraveWalletKeyringServiceObserver {
   
   func autoLockMinutesChanged() { }
   
-  func selectedAccountChanged(_ coin: BraveWallet.CoinType) { }
+//  func selectedAccountChanged(_ coin: BraveWallet.CoinType) { }
+  func selectedWalletAccountChanged(_ account: BraveWallet.AccountInfo) { }
+  
+  func selectedDappAccountChanged(_ coin: BraveWallet.CoinType, account: BraveWallet.AccountInfo?) { }
 }
 
 extension TransactionsActivityStore: BraveWalletTxServiceObserver {

--- a/Sources/BraveWallet/Crypto/Stores/TransactionsActivityStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/TransactionsActivityStore.swift
@@ -212,7 +212,6 @@ extension TransactionsActivityStore: BraveWalletKeyringServiceObserver {
   
   func autoLockMinutesChanged() { }
   
-//  func selectedAccountChanged(_ coin: BraveWallet.CoinType) { }
   func selectedWalletAccountChanged(_ account: BraveWallet.AccountInfo) { }
   
   func selectedDappAccountChanged(_ coin: BraveWallet.CoinType, account: BraveWallet.AccountInfo?) { }

--- a/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
@@ -256,7 +256,12 @@ extension UserAssetsStore: BraveWalletKeyringServiceObserver {
   public func autoLockMinutesChanged() {
   }
   
-  public func selectedAccountChanged(_ coin: BraveWallet.CoinType) {
+//  public func selectedAccountChanged(_ coin: BraveWallet.CoinType) {
+//  }
+  public func selectedWalletAccountChanged(_ account: BraveWallet.AccountInfo) {
+  }
+  
+  public func selectedDappAccountChanged(_ coin: BraveWallet.CoinType, account: BraveWallet.AccountInfo?) {
   }
   
   public func accountsAdded(_ addedAccounts: [BraveWallet.AccountInfo]) {

--- a/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
@@ -256,8 +256,6 @@ extension UserAssetsStore: BraveWalletKeyringServiceObserver {
   public func autoLockMinutesChanged() {
   }
   
-//  public func selectedAccountChanged(_ coin: BraveWallet.CoinType) {
-//  }
   public func selectedWalletAccountChanged(_ account: BraveWallet.AccountInfo) {
   }
   

--- a/Sources/BraveWallet/Extensions/KeyringServiceExtensions.swift
+++ b/Sources/BraveWallet/Extensions/KeyringServiceExtensions.swift
@@ -41,13 +41,13 @@ extension BraveWalletKeyringService {
     return await withTaskGroup(
       of: BraveWallet.AccountInfo?.self,
       body: { @MainActor group in
-        for coin in coins {
-          group.addTask { @MainActor in
-            let accounts = await self.keyringInfo(coin.keyringId).accountInfos
-            let selectedAccountAddress = await self.selectedAccount(coin)
-            return accounts.first(where: { $0.address.caseInsensitiveCompare(selectedAccountAddress ?? "") == .orderedSame })
-          }
-        }
+//        for coin in coins {
+//          group.addTask { @MainActor in
+//            let accounts = await self.keyringInfo(coin.keyringId).accountInfos
+//            let selectedAccountAddress = await self.selectedAccount(coin)
+//            return accounts.first(where: { $0.address.caseInsensitiveCompare(selectedAccountAddress ?? "") == .orderedSame })
+//          }
+//        }
         var defaultAccounts: [BraveWallet.AccountInfo] = []
         for await account in group {
           if let account = account {

--- a/Sources/BraveWallet/Extensions/KeyringServiceExtensions.swift
+++ b/Sources/BraveWallet/Extensions/KeyringServiceExtensions.swift
@@ -33,28 +33,4 @@ extension BraveWalletKeyringService {
     )
     return allKeyrings
   }
-  
-  // Fetches all default accounts for each of the given coin types
-  func defaultAccounts(
-    for coins: OrderedSet<BraveWallet.CoinType>
-  ) async -> [BraveWallet.AccountInfo] {
-    return await withTaskGroup(
-      of: BraveWallet.AccountInfo?.self,
-      body: { @MainActor group in
-//        for coin in coins {
-//          group.addTask { @MainActor in
-//            let accounts = await self.keyringInfo(coin.keyringId).accountInfos
-//            let selectedAccountAddress = await self.selectedAccount(coin)
-//            return accounts.first(where: { $0.address.caseInsensitiveCompare(selectedAccountAddress ?? "") == .orderedSame })
-//          }
-//        }
-        var defaultAccounts: [BraveWallet.AccountInfo] = []
-        for await account in group {
-          if let account = account {
-            defaultAccounts.append(account)
-          }
-        }
-        return defaultAccounts
-      })
-  }
 }

--- a/Sources/BraveWallet/Panels/Connect/NewSiteConnectionView.swift
+++ b/Sources/BraveWallet/Panels/Connect/NewSiteConnectionView.swift
@@ -171,9 +171,9 @@ public struct NewSiteConnectionView: View {
         selectedAccounts.insert(keyringStore.selectedAccount.id)
       } else { // Need to fetch selected account for coin
         Task { @MainActor in
-          if let selectedAccount = await keyringStore.selectedAccount(for: coin) {
+          if let selectedAccount = await keyringStore.selectedDappAccount(for: coin) {
             if accounts.contains(selectedAccount.address) {
-              // currently gselected account exists in permissions request, select it
+              // currently selected account exists in permissions request, select it
               selectedAccounts.insert(selectedAccount.id)
             } else if let firstAccount = accounts.first {
               // else select the first account by default

--- a/Sources/BraveWallet/Preview Content/MockBraveWalletService.swift
+++ b/Sources/BraveWallet/Preview Content/MockBraveWalletService.swift
@@ -250,5 +250,17 @@ class MockBraveWalletService: BraveWalletBraveWalletService {
   func simpleHashSpamNfTs(_ walletAddress: String, chainIds: [String], coin: BraveWallet.CoinType, cursor: String?, completion: @escaping ([BraveWallet.BlockchainToken], String?) -> Void) {
     completion([], nil)
   }
+  
+  func ensureSelectedAccount(forChain coin: BraveWallet.CoinType, chainId: String, completion: @escaping (BraveWallet.AccountId?) -> Void) {
+    completion(nil)
+  }
+  
+  func networkForSelectedAccount(onActiveOrigin completion: @escaping (BraveWallet.NetworkInfo?) -> Void) {
+    completion(nil)
+  }
+  
+  func setNetworkForSelectedAccountOnActiveOrigin(_ chainId: String, completion: @escaping (Bool) -> Void) {
+    completion(false)
+  }
 }
 #endif

--- a/Sources/BraveWallet/Preview Content/MockKeyringService.swift
+++ b/Sources/BraveWallet/Preview Content/MockKeyringService.swift
@@ -188,8 +188,8 @@ class MockKeyringService: BraveWalletKeyringService {
     }
     return address
   }
-
-  func importAccount(_ accountName: String, privateKey: String, completion: @escaping (Bool, String) -> Void) {
+  
+  func importAccount(_ accountName: String, privateKey: String, coin: BraveWallet.CoinType, completion: @escaping (BraveWallet.AccountInfo?) -> Void) {
     let address = nextImportedAddress()
     let info = BraveWallet.AccountInfo(
       accountId: .init(
@@ -208,15 +208,21 @@ class MockKeyringService: BraveWalletKeyringService {
     observers.allObjects.forEach {
       $0.accountsChanged()
     }
-    completion(true, info.address)
+    completion(info)
   }
 
-  func importFilecoinAccount(_ accountName: String, privateKey: String, network: String, completion: @escaping (Bool, String) -> Void) {
-    completion(false, "")
+//  func importFilecoinAccount(_ accountName: String, privateKey: String, network: String, completion: @escaping (Bool, String) -> Void) {
+//    completion(false, "")
+//  }
+  func importFilecoinAccount(_ accountName: String, privateKey: String, network: String, completion: @escaping (BraveWallet.AccountInfo?) -> Void) {
+    completion(nil)
   }
 
-  func importAccount(fromJson accountName: String, password: String, json: String, completion: @escaping (Bool, String) -> Void) {
-    completion(false, "")
+//  func importAccount(fromJson accountName: String, password: String, json: String, completion: @escaping (Bool, String) -> Void) {
+//    completion(false, "")
+//  }
+  func importAccount(fromJson accountName: String, password: String, json: String, completion: @escaping (BraveWallet.AccountInfo?) -> Void) {
+    completion(nil)
   }
 
   func importAccount(_ accountName: String, privateKey: String, coin: BraveWallet.CoinType, completion: @escaping (Bool, String) -> Void) {

--- a/Sources/BraveWallet/Preview Content/MockKeyringService.swift
+++ b/Sources/BraveWallet/Preview Content/MockKeyringService.swift
@@ -211,16 +211,10 @@ class MockKeyringService: BraveWalletKeyringService {
     completion(info)
   }
 
-//  func importFilecoinAccount(_ accountName: String, privateKey: String, network: String, completion: @escaping (Bool, String) -> Void) {
-//    completion(false, "")
-//  }
   func importFilecoinAccount(_ accountName: String, privateKey: String, network: String, completion: @escaping (BraveWallet.AccountInfo?) -> Void) {
     completion(nil)
   }
 
-//  func importAccount(fromJson accountName: String, password: String, json: String, completion: @escaping (Bool, String) -> Void) {
-//    completion(false, "")
-//  }
   func importAccount(fromJson accountName: String, password: String, json: String, completion: @escaping (BraveWallet.AccountInfo?) -> Void) {
     completion(nil)
   }

--- a/Sources/BraveWallet/Preview Content/MockStores.swift
+++ b/Sources/BraveWallet/Preview Content/MockStores.swift
@@ -257,7 +257,6 @@ extension BraveWallet.TestSolanaTxManagerProxy {
 extension BraveWallet.TestBraveWalletService {
   static var previewWalletService: BraveWallet.TestBraveWalletService {
     let walletService = BraveWallet.TestBraveWalletService()
-//    walletService._selectedCoin = { $0(.eth) }
     return walletService
   }
 }

--- a/Sources/BraveWallet/Preview Content/MockStores.swift
+++ b/Sources/BraveWallet/Preview Content/MockStores.swift
@@ -256,8 +256,7 @@ extension BraveWallet.TestSolanaTxManagerProxy {
 extension BraveWallet.TestBraveWalletService {
   static var previewWalletService: BraveWallet.TestBraveWalletService {
     let walletService = BraveWallet.TestBraveWalletService()
-    walletService._selectedCoin = { $0(.eth) }
-    
+//    walletService._selectedCoin = { $0(.eth) }
     return walletService
   }
 }

--- a/Sources/BraveWallet/Preview Content/MockStores.swift
+++ b/Sources/BraveWallet/Preview Content/MockStores.swift
@@ -93,6 +93,7 @@ extension BuyTokenStore {
   static var previewStore: BuyTokenStore {
     .init(
       blockchainRegistry: MockBlockchainRegistry(),
+      keyringService: MockKeyringService(),
       rpcService: MockJsonRpcService(),
       walletService: BraveWallet.TestBraveWalletService.previewWalletService,
       assetRatioService: BraveWallet.TestAssetRatioService.previewAssetRatioService,

--- a/Sources/BraveWallet/WalletConstants.swift
+++ b/Sources/BraveWallet/WalletConstants.swift
@@ -72,7 +72,7 @@ public struct WalletConstants {
   ]
   
   /// The currently supported coin types.
-  static var supportedCoinTypes: OrderedSet<BraveWallet.CoinType> {
+  public static var supportedCoinTypes: OrderedSet<BraveWallet.CoinType> {
     return [.eth, .sol]
   }
   

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -4114,5 +4114,12 @@ extension Strings {
       value: "Deselect All",
       comment: "The title of a button that Deselects all visible options."
     )
+    public static let internalErrorMessage = NSLocalizedString(
+      "wallet.internalErrorMessage",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "An internal error has occurred",
+      comment: "The title of a button that Deselects all visible options."
+    )
   }
 }

--- a/Tests/BraveWalletTests/AssetDetailStoreTests.swift
+++ b/Tests/BraveWalletTests/AssetDetailStoreTests.swift
@@ -230,11 +230,20 @@ class AssetDetailStoreTests: XCTestCase {
       completion(true, [.init(date: Date(), price: "0.99")])
     }
     
+    let keyring = BraveWallet.KeyringInfo.mockDefaultKeyringInfo
     let keyringService = BraveWallet.TestKeyringService()
     keyringService._keyringInfo = {
-      $1(.mockDefaultKeyringInfo)
+      $1(keyring)
     }
     keyringService._addObserver = { _ in }
+    keyringService._allAccounts = { completion in
+      completion(.init(
+        accounts: keyring.accountInfos,
+        selectedAccount: keyring.accountInfos.first,
+        ethDappSelectedAccount: keyring.accountInfos.first,
+        solDappSelectedAccount: nil
+      ))
+    }
     
     let mockEthBalance: Double = 1
     let ethBalanceWei = formatter.weiString(
@@ -256,9 +265,6 @@ class AssetDetailStoreTests: XCTestCase {
       $0("usd")
     }
     walletService._addObserver = { _ in }
-    walletService._selectedCoin = {
-      $0(.eth)
-    }
     
     let mockAssetManager = TestableWalletUserAssetManager()
     mockAssetManager._getAllUserAssetsInNetworkAssets = { _ in

--- a/Tests/BraveWalletTests/BuyTokenStoreTest.swift
+++ b/Tests/BraveWalletTests/BuyTokenStoreTest.swift
@@ -13,7 +13,7 @@ import BraveCore
 class BuyTokenStoreTests: XCTestCase {
   private var cancellables: Set<AnyCancellable> = []
   
-  private func setupServices(selectedNetwork: BraveWallet.NetworkInfo = .mockMainnet) -> (BraveWallet.TestBlockchainRegistry, BraveWallet.TestJsonRpcService, BraveWallet.TestBraveWalletService, BraveWallet.TestAssetRatioService) {
+  private func setupServices(selectedNetwork: BraveWallet.NetworkInfo = .mockMainnet) -> (BraveWallet.TestBlockchainRegistry, BraveWallet.TestKeyringService, BraveWallet.TestJsonRpcService, BraveWallet.TestBraveWalletService, BraveWallet.TestAssetRatioService) {
     let mockTokenList: [BraveWallet.BlockchainToken] = [
       .init(contractAddress: "0x0d8775f648430679a709e98d2b0cb6250d2887ef", name: "Basic Attention Token", logo: "", isErc20: true, isErc721: false, isErc1155: false, isNft: false, isSpam: false, symbol: "BAT", decimals: 18, visible: true, tokenId: "", coingeckoId: "", chainId: BraveWallet.MainnetChainId, coin: .eth),
       .init(contractAddress: "0xB8c77482e45F1F44dE1745F52C74426C631bDD52", name: "BNB", logo: "", isErc20: true, isErc721: false, isErc1155: false, isNft: false, isSpam: false, symbol: "BNB", decimals: 18, visible: true, tokenId: "", coingeckoId: "", chainId: "", coin: .eth),
@@ -30,6 +30,16 @@ class BuyTokenStoreTests: XCTestCase {
     blockchainRegistry._buyTokens = { $2(mockTokenList)}
     blockchainRegistry._onRampCurrencies = { $0(mockOnRampCurrencies) }
     
+    let keyringService = BraveWallet.TestKeyringService()
+    keyringService._allAccounts = { completion in
+      completion(.init(
+        accounts: [.previewAccount],
+        selectedAccount: .previewAccount,
+        ethDappSelectedAccount: .previewAccount,
+        solDappSelectedAccount: nil
+      ))
+    }
+    
     let rpcService = BraveWallet.TestJsonRpcService()
     rpcService._network = { $2(selectedNetwork) }
     rpcService._allNetworks = { coin, completion in
@@ -38,7 +48,6 @@ class BuyTokenStoreTests: XCTestCase {
     rpcService._addObserver = { _ in }
     
     let walletService = BraveWallet.TestBraveWalletService()
-    walletService._selectedCoin = { $0(.eth) }
     
     let buyURL = "https://crypto.sardine.ai/"
     let assetRatioService = BraveWallet.TestAssetRatioService()
@@ -46,13 +55,14 @@ class BuyTokenStoreTests: XCTestCase {
       completion(buyURL, nil)
     }
     
-    return (blockchainRegistry, rpcService, walletService, assetRatioService)
+    return (blockchainRegistry, keyringService, rpcService, walletService, assetRatioService)
   }
   
   @MainActor func testPrefilledToken() async {
-    let (blockchainRegistry, rpcService, walletService, assetRatioService) = setupServices()
+    let (blockchainRegistry, keyringService, rpcService, walletService, assetRatioService) = setupServices()
     var store = BuyTokenStore(
       blockchainRegistry: blockchainRegistry,
+      keyringService: keyringService,
       rpcService: rpcService,
       walletService: walletService,
       assetRatioService: assetRatioService,
@@ -62,6 +72,7 @@ class BuyTokenStoreTests: XCTestCase {
 
     store = BuyTokenStore(
       blockchainRegistry: blockchainRegistry,
+      keyringService: keyringService,
       rpcService: rpcService,
       walletService: walletService,
       assetRatioService: assetRatioService,
@@ -74,10 +85,8 @@ class BuyTokenStoreTests: XCTestCase {
   
   /// Test that given a `prefilledToken` that is not on the current network, the `BuyTokenStore` will switch networks to the `chainId` of the token.
   @MainActor func testPrefilledTokenSwitchNetwork() async {
-    var selectedCoin: BraveWallet.CoinType = .eth
     var selectedNetwork: BraveWallet.NetworkInfo = .mockMainnet
-    let (blockchainRegistry, rpcService, walletService, assetRatioService) = setupServices()
-    walletService._selectedCoin = { $0(selectedCoin) }
+    let (blockchainRegistry, keyringService, rpcService, walletService, assetRatioService) = setupServices()
     rpcService._network = { coin, origin, completion in
       completion(selectedNetwork)
     }
@@ -87,13 +96,13 @@ class BuyTokenStoreTests: XCTestCase {
     // simulate network switch when `setNetwork` is called
     rpcService._setNetwork = { chainId, coin, origin, completion in
       XCTAssertEqual(chainId, BraveWallet.SolanaMainnet) // verify network switched to SolanaMainnet
-      selectedCoin = coin
       selectedNetwork = coin == .eth ? .mockMainnet : .mockSolana
       completion(true)
     }
     
     let store = BuyTokenStore(
       blockchainRegistry: blockchainRegistry,
+      keyringService: keyringService,
       rpcService: rpcService,
       walletService: walletService,
       assetRatioService: assetRatioService,
@@ -104,9 +113,10 @@ class BuyTokenStoreTests: XCTestCase {
   }
   
   func testBuyDisabledForTestNetwork() {
-    let (blockchainRegistry, rpcService, walletService, assetRatioService) = setupServices(selectedNetwork: .mockGoerli)
+    let (blockchainRegistry, keyringService, rpcService, walletService, assetRatioService) = setupServices(selectedNetwork: .mockGoerli)
     let store = BuyTokenStore(
       blockchainRegistry: blockchainRegistry,
+      keyringService: keyringService,
       rpcService: rpcService,
       walletService: walletService,
       assetRatioService: assetRatioService,
@@ -125,9 +135,10 @@ class BuyTokenStoreTests: XCTestCase {
   }
 
   func testBuyEnabledForNonTestNetwork() {
-    let (blockchainRegistry, rpcService, walletService, assetRatioService) = setupServices(selectedNetwork: .mockMainnet)
+    let (blockchainRegistry, keyringService, rpcService, walletService, assetRatioService) = setupServices(selectedNetwork: .mockMainnet)
     let store = BuyTokenStore(
       blockchainRegistry: blockchainRegistry,
+      keyringService: keyringService,
       rpcService: rpcService,
       walletService: walletService,
       assetRatioService: assetRatioService,
@@ -147,7 +158,7 @@ class BuyTokenStoreTests: XCTestCase {
   
   @MainActor
   func testOrderedSupportedBuyOptions() async {
-    let (_, rpcService, walletService, assetRatioService) = setupServices()
+    let (_, keyringService, rpcService, walletService, assetRatioService) = setupServices()
     let blockchainRegistry = BraveWallet.TestBlockchainRegistry()
     blockchainRegistry._buyTokens = {
       if $0 == .ramp {
@@ -160,6 +171,7 @@ class BuyTokenStoreTests: XCTestCase {
     
     let store = BuyTokenStore(
       blockchainRegistry: blockchainRegistry,
+      keyringService: keyringService,
       rpcService: rpcService,
       walletService: walletService,
       assetRatioService: assetRatioService,
@@ -180,7 +192,7 @@ class BuyTokenStoreTests: XCTestCase {
   @MainActor
   func testAllTokens() async {
     let selectedNetwork: BraveWallet.NetworkInfo = .mockSolana
-    let (_, rpcService, walletService, assetRatioService) = setupServices(selectedNetwork: selectedNetwork)
+    let (_, keyringService, rpcService, walletService, assetRatioService) = setupServices(selectedNetwork: selectedNetwork)
     let blockchainRegistry = BraveWallet.TestBlockchainRegistry()
     blockchainRegistry._buyTokens = {
       if $0 == .ramp {
@@ -193,6 +205,7 @@ class BuyTokenStoreTests: XCTestCase {
     
     let store = BuyTokenStore(
       blockchainRegistry: blockchainRegistry,
+      keyringService: keyringService,
       rpcService: rpcService,
       walletService: walletService,
       assetRatioService: assetRatioService,

--- a/Tests/BraveWalletTests/KeyringStoreTests.swift
+++ b/Tests/BraveWalletTests/KeyringStoreTests.swift
@@ -15,7 +15,6 @@ class KeyringStoreTests: XCTestCase {
   private func setupServices() -> (BraveWallet.TestKeyringService, BraveWallet.TestJsonRpcService, BraveWallet.TestBraveWalletService) {
     let currentNetwork: BraveWallet.NetworkInfo = .mockMainnet
     let currentChainId = currentNetwork.chainId
-    let currentSelectedCoin: BraveWallet.CoinType = .eth
     let currentSelectedAccount: BraveWallet.AccountInfo = .mockEthAccount
     
     let keyringService = BraveWallet.TestKeyringService()
@@ -33,7 +32,14 @@ class KeyringStoreTests: XCTestCase {
     }
     keyringService._addObserver = { _ in }
     keyringService._isLocked = { $0(false) }
-    keyringService._selectedAccount = { $1(currentSelectedAccount.address) }
+    keyringService._allAccounts = { completion in
+      completion(.init(
+        accounts: [currentSelectedAccount],
+        selectedAccount: currentSelectedAccount,
+        ethDappSelectedAccount: [currentSelectedAccount].first(where: { $0.coin == .eth }),
+        solDappSelectedAccount: [currentSelectedAccount].first(where: { $0.coin == .sol })
+      ))
+    }
     keyringService._setSelectedAccount = { $1(true) }
     
     let rpcService = BraveWallet.TestJsonRpcService()
@@ -47,7 +53,6 @@ class KeyringStoreTests: XCTestCase {
     
     let walletService = BraveWallet.TestBraveWalletService()
     walletService._addObserver = { _ in }
-    walletService._selectedCoin = { $0(currentSelectedCoin) }
     
     return (keyringService, rpcService, walletService)
   }

--- a/Tests/BraveWalletTests/NetworkSelectionStoreTests.swift
+++ b/Tests/BraveWalletTests/NetworkSelectionStoreTests.swift
@@ -21,7 +21,6 @@ import Preferences
   private func setupServices() -> (BraveWallet.TestKeyringService, BraveWallet.TestJsonRpcService, BraveWallet.TestBraveWalletService, BraveWallet.TestSwapService) {
     let currentNetwork: BraveWallet.NetworkInfo = .mockMainnet
     let currentChainId = currentNetwork.chainId
-    let currentSelectedCoin: BraveWallet.CoinType = .eth
     
     let keyringService = BraveWallet.TestKeyringService()
     keyringService._keyringInfo = { keyringId, completion in
@@ -37,6 +36,14 @@ import Preferences
     }
     keyringService._addObserver = { _ in }
     keyringService._isLocked = { $0(false) }
+    keyringService._allAccounts = { completion in
+      completion(.init(
+        accounts: [.previewAccount],
+        selectedAccount: .previewAccount,
+        ethDappSelectedAccount: .previewAccount,
+        solDappSelectedAccount: nil
+      ))
+    }
     
     let rpcService = BraveWallet.TestJsonRpcService()
     rpcService._addObserver = { _ in }
@@ -52,7 +59,9 @@ import Preferences
     
     let walletService = BraveWallet.TestBraveWalletService()
     walletService._addObserver = { _ in }
-    walletService._selectedCoin = { $0(currentSelectedCoin) }
+    walletService._ensureSelectedAccountForChain = { coin, chainId, completion in
+      completion(BraveWallet.AccountInfo.previewAccount.accountId)
+    }
     
     let swapService = BraveWallet.TestSwapService()
     swapService._isSwapSupported = { $1(true) }
@@ -200,13 +209,12 @@ import Preferences
   }
   
   func testDismissAddAccountAfterCreation() async {
-    let (_, rpcService, walletService, swapService) = setupServices()
-    
+    let (keyringService, rpcService, walletService, swapService) = setupServices()
+
     var accountInfosDict: [BraveWallet.CoinType: [BraveWallet.AccountInfo]] = [
       .eth: [.mockEthAccount]
     ]
     
-    let keyringService = BraveWallet.TestKeyringService()
     keyringService._keyringInfo = { keyringId, completion in
       let accountInfos: [BraveWallet.AccountInfo]
       switch keyringId {
@@ -230,7 +238,15 @@ import Preferences
     }
     keyringService._addObserver = { _ in }
     keyringService._isLocked = { $0(false) }
-    
+    keyringService._allAccounts = { completion in
+      completion(.init(
+        accounts: accountInfosDict.values.flatMap { $0 },
+        selectedAccount: accountInfosDict[.eth]?.first,
+        ethDappSelectedAccount: accountInfosDict[.eth]?.first,
+        solDappSelectedAccount: accountInfosDict[.sol]?.first
+      ))
+    }
+
     let networkStore = NetworkStore(
       keyringService: keyringService,
       rpcService: rpcService,

--- a/Tests/BraveWalletTests/NetworkStoreTests.swift
+++ b/Tests/BraveWalletTests/NetworkStoreTests.swift
@@ -15,7 +15,6 @@ import BraveCore
   private func setupServices() -> (BraveWallet.TestKeyringService, BraveWallet.TestJsonRpcService, BraveWallet.TestBraveWalletService, BraveWallet.TestSwapService) {
     let currentNetwork: BraveWallet.NetworkInfo = .mockMainnet
     let currentChainId = currentNetwork.chainId
-    let currentSelectedCoin: BraveWallet.CoinType = .eth
     let allNetworks: [BraveWallet.CoinType: [BraveWallet.NetworkInfo]] = [
       .eth: [.mockMainnet, .mockGoerli, .mockSepolia, .mockPolygon, .mockCustomNetwork],
       .sol: [.mockSolana, .mockSolanaTestnet]
@@ -35,6 +34,14 @@ import BraveCore
     }
     keyringService._addObserver = { _ in }
     keyringService._isLocked = { $0(false) }
+    keyringService._allAccounts = { completion in
+      completion(.init(
+        accounts: [.previewAccount],
+        selectedAccount: .previewAccount,
+        ethDappSelectedAccount: .previewAccount,
+        solDappSelectedAccount: nil
+      ))
+    }
     
     let rpcService = BraveWallet.TestJsonRpcService()
     rpcService._addObserver = { _ in }
@@ -50,7 +57,9 @@ import BraveCore
     
     let walletService = BraveWallet.TestBraveWalletService()
     walletService._addObserver = { _ in }
-    walletService._selectedCoin = { $0(currentSelectedCoin) }
+    walletService._ensureSelectedAccountForChain = { coin, chainId, completion in
+      completion(BraveWallet.AccountInfo.previewAccount.accountId)
+    }
     
     let swapService = BraveWallet.TestSwapService()
     swapService._isSwapSupported = { $1(true) }

--- a/Tests/BraveWalletTests/PortfolioStoreTests.swift
+++ b/Tests/BraveWalletTests/PortfolioStoreTests.swift
@@ -161,7 +161,6 @@ class PortfolioStoreTests: XCTestCase {
     let walletService = BraveWallet.TestBraveWalletService()
     walletService._addObserver = { _ in }
     walletService._defaultBaseCurrency = { $0(CurrencyCode.usd.code) }
-    walletService._selectedCoin = { $0(BraveWallet.CoinType.eth) }
     let assetRatioService = BraveWallet.TestAssetRatioService()
     assetRatioService._price = { priceIds, _, _, completion in
       completion(true, [mockETHAssetPrice, mockUSDCAssetPrice, mockSOLAssetPrice])

--- a/Tests/BraveWalletTests/SendTokenStoreTests.swift
+++ b/Tests/BraveWalletTests/SendTokenStoreTests.swift
@@ -14,7 +14,7 @@ class SendTokenStoreTests: XCTestCase {
   private let batSymbol = "BAT"
   
   private func setupServices(
-    accountAddress: String = BraveWallet.AccountInfo.previewAccount.address,
+    selectedAccount: BraveWallet.AccountInfo = BraveWallet.AccountInfo.previewAccount,
     userAssets: [BraveWallet.NetworkInfo: [BraveWallet.BlockchainToken]] = [.mockMainnet: [.previewToken]],
     selectedCoin: BraveWallet.CoinType = .eth,
     selectedNetwork: BraveWallet.NetworkInfo = .mockGoerli,
@@ -30,9 +30,16 @@ class SendTokenStoreTests: XCTestCase {
   ) -> (BraveWallet.TestKeyringService, BraveWallet.TestJsonRpcService, BraveWallet.TestBraveWalletService, BraveWallet.TestEthTxManagerProxy, BraveWallet.TestSolanaTxManagerProxy, WalletUserAssetManagerType) {
     let keyringService = BraveWallet.TestKeyringService()
     keyringService._addObserver = { _ in }
-    keyringService._selectedAccount = { $1(accountAddress) }
     keyringService._setSelectedAccount = { _, completion in completion(true) }
     keyringService._checksumEthAddress = { address, completion in completion(address) }
+    keyringService._allAccounts = { completion in
+      completion(.init(
+        accounts: [selectedAccount],
+        selectedAccount: selectedAccount,
+        ethDappSelectedAccount: [selectedAccount].first(where: { $0.coin == .eth }),
+        solDappSelectedAccount: [selectedAccount].first(where: { $0.coin == .sol })
+      ))
+    }
     let rpcService = BraveWallet.TestJsonRpcService()
     rpcService._network = { $2(selectedNetwork) }
     rpcService._allNetworks = { $1(allNetworks) }
@@ -79,8 +86,10 @@ class SendTokenStoreTests: XCTestCase {
       completion("", metaData, .success, "")
     }
     let walletService = BraveWallet.TestBraveWalletService()
-    walletService._selectedCoin = { $0(selectedCoin) }
     walletService._isBase58EncodedSolanaPubkey = { _, completion in completion(true) }
+    walletService._ensureSelectedAccountForChain = { coin, chainId, completion in
+      completion(selectedAccount.accountId)
+    }
     let ethTxManagerProxy = BraveWallet.TestEthTxManagerProxy()
     ethTxManagerProxy._makeErc20TransferData = { _, _, completion in
       completion(true, .init())
@@ -99,35 +108,35 @@ class SendTokenStoreTests: XCTestCase {
   
   /// Test given a `prefilledToken` will be assigned to `selectedSendToken`
   func testPrefilledToken() {
-    let solTxManagerProxy = BraveWallet.TestSolanaTxManagerProxy()
+    let (keyringService, rpcService, walletService, ethTxManagerProxy, solTxManagerProxy, mockAssetManager) = setupServices()
 
     var store = SendTokenStore(
-      keyringService: MockKeyringService(),
-      rpcService: MockJsonRpcService(),
-      walletService: MockBraveWalletService(),
+      keyringService: keyringService,
+      rpcService: rpcService,
+      walletService: walletService,
       txService: MockTxService(),
       blockchainRegistry: MockBlockchainRegistry(),
       assetRatioService: MockAssetRatioService(),
-      ethTxManagerProxy: MockEthTxManagerProxy(),
+      ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: nil,
       ipfsApi: TestIpfsAPI(),
-      userAssetManager: TestableWalletUserAssetManager()
+      userAssetManager: mockAssetManager
     )
     XCTAssertNil(store.selectedSendToken)
 
     store = SendTokenStore(
-      keyringService: MockKeyringService(),
-      rpcService: MockJsonRpcService(),
-      walletService: MockBraveWalletService(),
+      keyringService: keyringService,
+      rpcService: rpcService,
+      walletService: walletService,
       txService: MockTxService(),
       blockchainRegistry: MockBlockchainRegistry(),
       assetRatioService: MockAssetRatioService(),
-      ethTxManagerProxy: MockEthTxManagerProxy(),
+      ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: .previewToken,
       ipfsApi: TestIpfsAPI(),
-      userAssetManager: TestableWalletUserAssetManager()
+      userAssetManager: mockAssetManager
     )
     let sendTokenExpectation = expectation(description: "update-sendTokenExpectation")
     store.$selectedSendToken
@@ -147,10 +156,8 @@ class SendTokenStoreTests: XCTestCase {
   /// Test that given a `prefilledToken` that is not on the current network, the `SendTokenStore`
   /// will switch networks to the `chainId` of the token before assigning the token.
   func testPrefilledTokenSwitchNetwork() {
-    var selectedCoin: BraveWallet.CoinType = .eth
     var selectedNetwork: BraveWallet.NetworkInfo = .mockMainnet
     let (keyringService, rpcService, walletService, ethTxManagerProxy, solTxManagerProxy, mockAssetManager) = setupServices()
-    walletService._selectedCoin = { $0(selectedCoin) }
     rpcService._network = { coin, _, completion in
       completion(selectedNetwork)
     }
@@ -160,7 +167,6 @@ class SendTokenStoreTests: XCTestCase {
     // simulate network switch when `setNetwork` is called
     rpcService._setNetwork = { chainId, coin, origin, completion in
       XCTAssertEqual(chainId, BraveWallet.SolanaMainnet) // verify network switched to SolanaMainnet
-      selectedCoin = coin
       selectedNetwork = coin == .eth ? .mockMainnet : .mockSolana
       completion(true)
     }
@@ -386,11 +392,11 @@ class SendTokenStoreTests: XCTestCase {
   
   /// Test `suggestedAmountTapped(.all)` will not round the amount
   func testSendFullBalanceNoRounding() {
+    let (keyringService, rpcService, walletService, ethTxManagerProxy, solTxManagerProxy, _) = setupServices()
     let formatter = WeiFormatter(decimalFormatStyle: .decimals(precision: 18))
     let mockBalance = "47.156499657504857477"
     let mockBalanceWei = formatter.weiString(from: mockBalance, radix: .hex, decimals: 18) ?? ""
 
-    let rpcService = BraveWallet.TestJsonRpcService()
     rpcService._chainIdForOrigin = { $2(BraveWallet.NetworkInfo.mockGoerli.chainId) }
     rpcService._network = { $2(BraveWallet.NetworkInfo.mockGoerli)}
     rpcService._allNetworks = { $1([.mockGoerli]) }
@@ -402,15 +408,7 @@ class SendTokenStoreTests: XCTestCase {
       completion("", "", .internalError, "")
     }
 
-    let walletService = BraveWallet.TestBraveWalletService()
     walletService._userAssets = { $2([.previewToken]) }
-    walletService._selectedCoin = { $0(BraveWallet.CoinType.eth) }
-
-    let keyringService = BraveWallet.TestKeyringService()
-    keyringService._selectedAccount = { $1("account-address") }
-    keyringService._addObserver = { _ in }
-
-    let solTxManagerProxy = BraveWallet.TestSolanaTxManagerProxy()
     
     let mockAssetManager = TestableWalletUserAssetManager()
     mockAssetManager._getAllUserAssetsInNetworkAssets = { _ in
@@ -424,7 +422,7 @@ class SendTokenStoreTests: XCTestCase {
       txService: MockTxService(),
       blockchainRegistry: MockBlockchainRegistry(),
       assetRatioService: MockAssetRatioService(),
-      ethTxManagerProxy: MockEthTxManagerProxy(),
+      ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
       prefilledToken: .previewToken,
       ipfsApi: TestIpfsAPI(),
@@ -715,6 +713,7 @@ class SendTokenStoreTests: XCTestCase {
     let expectedAddress = "xxxxxxxxxxyyyyyyyyyyzzzzzzzzzz0000000000"
     
     let (keyringService, rpcService, walletService, ethTxManagerProxy, solTxManagerProxy, mockAssetManager) = setupServices(
+      selectedAccount: .mockSolAccount,
       selectedCoin: .sol,
       snsGetSolAddr: expectedAddress
     )
@@ -754,6 +753,7 @@ class SendTokenStoreTests: XCTestCase {
     let domain = "brave.sol"
     let expectedAddress = ""
     let (keyringService, rpcService, walletService, ethTxManagerProxy, solTxManagerProxy, mockAssetManager) = setupServices(
+      selectedAccount: .mockSolAccount,
       selectedCoin: .sol,
       snsGetSolAddr: expectedAddress
     )
@@ -802,6 +802,7 @@ class SendTokenStoreTests: XCTestCase {
     let domain = "brave.sol"
     let expectedAddress = "xxxxxxxxxxyyyyyyyyyyzzzzzzzzzz0000000000"
     let (keyringService, rpcService, walletService, ethTxManagerProxy, solTxManagerProxy, mockAssetManager) = setupServices(
+      selectedAccount: .mockSolAccount,
       selectedCoin: .sol,
       selectedNetwork: .mockSolana,
       snsGetSolAddr: expectedAddress
@@ -1324,7 +1325,7 @@ class SendTokenStoreTests: XCTestCase {
   /// Test `didSelect(account:token:)` with a new token that is on the currently selected account and currently selected network.
   @MainActor func testDidSelectSameAccountSameNetwork() async {
     let (keyringService, rpcService, walletService, ethTxManagerProxy, solTxManagerProxy, mockAssetManager) = setupServices(
-      accountAddress: account.address,
+      selectedAccount: account,
       userAssets: [.mockGoerli: [ethGoerli, usdcGoerli]],
       selectedCoin: .eth,
       selectedNetwork: .mockGoerli
@@ -1373,7 +1374,7 @@ class SendTokenStoreTests: XCTestCase {
     let ethGoerli: BraveWallet.BlockchainToken = BraveWallet.NetworkInfo.mockGoerli.nativeToken
       .copy(asVisibleAsset: true)
     let (keyringService, rpcService, walletService, ethTxManagerProxy, solTxManagerProxy, mockAssetManager) = setupServices(
-      accountAddress: account.address,
+      selectedAccount: account,
       userAssets: [.mockGoerli: [ethGoerli]],
       selectedCoin: .eth,
       selectedNetwork: .mockGoerli
@@ -1421,7 +1422,7 @@ class SendTokenStoreTests: XCTestCase {
     var selectedNetwork: BraveWallet.NetworkInfo = .mockMainnet
     let allNetworks: [BraveWallet.NetworkInfo] = [.mockMainnet, .mockGoerli]
     let (keyringService, rpcService, walletService, ethTxManagerProxy, solTxManagerProxy, mockAssetManager) = setupServices(
-      accountAddress: account.address,
+      selectedAccount: account,
       userAssets: [.mockMainnet: [ethMainnet], .mockGoerli: [usdcGoerli]],
       selectedCoin: .eth,
       allNetworks: allNetworks
@@ -1487,7 +1488,7 @@ class SendTokenStoreTests: XCTestCase {
     var selectedNetwork: BraveWallet.NetworkInfo = .mockGoerli
     let allNetworks: [BraveWallet.NetworkInfo] = [.mockGoerli, .mockSolana]
     let (keyringService, rpcService, walletService, ethTxManagerProxy, solTxManagerProxy, mockAssetManager) = setupServices(
-      accountAddress: account.address,
+      selectedAccount: account,
       userAssets: [.mockGoerli: [usdcGoerli], .mockSolana: [solMainnet]],
       selectedCoin: .eth,
       allNetworks: allNetworks

--- a/Tests/BraveWalletTests/TransactionConfirmationStoreTests.swift
+++ b/Tests/BraveWalletTests/TransactionConfirmationStoreTests.swift
@@ -72,7 +72,6 @@ import BraveCore
     let walletService = BraveWallet.TestBraveWalletService()
     walletService._defaultBaseCurrency = { $0(CurrencyCode.usd.code) }
     walletService._addObserver = { _ in }
-    walletService._selectedCoin = { $0(BraveWallet.CoinType.eth) }
     let mockAssetManager = TestableWalletUserAssetManager()
     mockAssetManager._getAllUserAssetsInNetworkAssets = { _ in
       []

--- a/Tests/ClientTests/SolanaProviderScriptHandlerTests.swift
+++ b/Tests/ClientTests/SolanaProviderScriptHandlerTests.swift
@@ -16,7 +16,7 @@ import XCTest
   func testConnectFailure() async {
     let provider: BraveWallet.TestSolanaProvider = .init()
     provider._connect = { params, completion in
-      completion(.internalError, "Internal error", "")
+      completion(.internalError, Strings.Wallet.internalErrorMessage, "")
     }
     let tab = Tab(configuration: .init())
     let solProviderHelper = SolanaProviderScriptHandler(tab: tab)
@@ -31,7 +31,7 @@ import XCTest
       return
     }
     XCTAssertEqual(code, Int32(BraveWallet.SolanaProviderError.internalError.rawValue))
-    XCTAssertEqual(message, "Internal error")
+    XCTAssertEqual(message, Strings.Wallet.internalErrorMessage)
   }
   
   /// Test `connect()`, given no parameters, the success flow will return a tuple `(result: Any?, error: String?)`
@@ -94,7 +94,7 @@ import XCTest
     
     let provider: BraveWallet.TestSolanaProvider = .init()
     provider._signAndSendTransaction = { signTransactionParam, sendOptions, completion in
-      completion(.internalError, "Internal error", [:])
+      completion(.internalError, Strings.Wallet.internalErrorMessage, [:])
     }
     let tab = Tab(configuration: .init())
     let solProviderHelper = SolanaProviderScriptHandler(tab: tab)
@@ -109,7 +109,7 @@ import XCTest
       return
     }
     XCTAssertEqual(code, Int32(BraveWallet.SolanaProviderError.internalError.rawValue))
-    XCTAssertEqual(message, "Internal error")
+    XCTAssertEqual(message, Strings.Wallet.internalErrorMessage)
   }
   
   /// Test `signAndSendTransaction()`, given a json string `{serializedMessage: [Uint8], signatures: [Buffer]}`, the success flow will
@@ -193,7 +193,7 @@ import XCTest
     
     let provider: BraveWallet.TestSolanaProvider = .init()
     provider._signMessage = { _, _, completion in
-      completion(.internalError, "Internal error", [:])
+      completion(.internalError, Strings.Wallet.internalErrorMessage, [:])
     }
     let tab = Tab(configuration: .init())
     let solProviderHelper = SolanaProviderScriptHandler(tab: tab)
@@ -208,7 +208,7 @@ import XCTest
       return
     }
     XCTAssertEqual(code, Int32(BraveWallet.SolanaProviderError.internalError.rawValue))
-    XCTAssertEqual(message, "Internal error")
+    XCTAssertEqual(message, Strings.Wallet.internalErrorMessage)
   }
   
   /// Test `signMessage()`, given a json string `{[[UInt8]]}`, the success flow will return a tuple `(result: Any?, error: String?)`
@@ -303,7 +303,7 @@ import XCTest
     
     let provider: BraveWallet.TestSolanaProvider = .init()
     provider._signTransaction = { _, completion in
-      completion(.internalError, "Internal error", [], .legacy)
+      completion(.internalError, Strings.Wallet.internalErrorMessage, [], .legacy)
     }
     let tab = Tab(configuration: .init())
     let solProviderHelper = SolanaProviderScriptHandler(tab: tab)
@@ -318,7 +318,7 @@ import XCTest
       return
     }
     XCTAssertEqual(code, Int32(BraveWallet.SolanaProviderError.internalError.rawValue))
-    XCTAssertEqual(message, "Internal error")
+    XCTAssertEqual(message, Strings.Wallet.internalErrorMessage)
   }
   
   /// Test `signTransaction()`, given a json string `{serializedMessage: Buffer, signatures: {publicKey: String, signature: Buffer}}`,
@@ -417,7 +417,7 @@ import XCTest
     
     let provider: BraveWallet.TestSolanaProvider = .init()
     provider._signAllTransactions = { _, completion in
-      completion(.internalError, "Internal error", [], [])
+      completion(.internalError, Strings.Wallet.internalErrorMessage, [], [])
     }
     let tab = Tab(configuration: .init())
     let solProviderHelper = SolanaProviderScriptHandler(tab: tab)
@@ -432,7 +432,7 @@ import XCTest
       return
     }
     XCTAssertEqual(code, Int32(BraveWallet.SolanaProviderError.internalError.rawValue))
-    XCTAssertEqual(message, "Internal error")
+    XCTAssertEqual(message, Strings.Wallet.internalErrorMessage)
   }
   
   /// Test `signAllTransactions()`, given a json string `[{serializedMessage: Buffer, signatures: {publicKey: String, signature: Buffer}}]`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@mozilla/readability": "^0.4.2",
-        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.58.10/brave-core-ios-1.58.10.tgz",
+        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.58.26/brave-core-ios-1.58.26.tgz",
         "leo-sf-symbols": "github:brave/leo-sf-symbols#60a41d77d4e58bd48284848a04ad3f9b79bf7daa",
         "page-metadata-parser": "^1.1.3",
         "webpack-cli": "^4.8.0"
@@ -356,9 +356,9 @@
       }
     },
     "node_modules/brave-core-ios": {
-      "version": "1.58.10",
-      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.58.10/brave-core-ios-1.58.10.tgz",
-      "integrity": "sha512-ZAzq0PaleVIdYTWB4O+58Q1DEdJy7/HbQpW45/th/CwjAtvYKnLyJXFqmSnQuViYBEfZsEdfJpCAgUZgld1Heg==",
+      "version": "1.58.26",
+      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.58.26/brave-core-ios-1.58.26.tgz",
+      "integrity": "sha512-aH8GOWXITCSJ63BMP0NajSHd7u7pAtgWuUyWRFRKk1vyGkLRySZHzZTWGZsb7HptywdrdBuhMwHQOGApguOOaw==",
       "license": "ISC"
     },
     "node_modules/browserslist": {
@@ -1738,8 +1738,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-browser/releases/download/v1.58.10/brave-core-ios-1.58.10.tgz",
-      "integrity": "sha512-ZAzq0PaleVIdYTWB4O+58Q1DEdJy7/HbQpW45/th/CwjAtvYKnLyJXFqmSnQuViYBEfZsEdfJpCAgUZgld1Heg=="
+      "version": "https://github.com/brave/brave-browser/releases/download/v1.58.26/brave-core-ios-1.58.26.tgz",
+      "integrity": "sha512-aH8GOWXITCSJ63BMP0NajSHd7u7pAtgWuUyWRFRKk1vyGkLRySZHzZTWGZsb7HptywdrdBuhMwHQOGApguOOaw=="
     },
     "browserslist": {
       "version": "4.17.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@mozilla/readability": "^0.4.2",
-        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.58.2/brave-core-ios-1.58.2.tgz",
+        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.58.10/brave-core-ios-1.58.10.tgz",
         "leo-sf-symbols": "github:brave/leo-sf-symbols#60a41d77d4e58bd48284848a04ad3f9b79bf7daa",
         "page-metadata-parser": "^1.1.3",
         "webpack-cli": "^4.8.0"
@@ -356,9 +356,9 @@
       }
     },
     "node_modules/brave-core-ios": {
-      "version": "1.58.2",
-      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.58.2/brave-core-ios-1.58.2.tgz",
-      "integrity": "sha512-fvUhCYXasBl/fieAjIUhoEVnv086kmtxO1FahRRfar4aZwW3ZceO0KlC/d0t5ps6dTTsQffkRtmZ76q3gb8JXQ==",
+      "version": "1.58.10",
+      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.58.10/brave-core-ios-1.58.10.tgz",
+      "integrity": "sha512-ZAzq0PaleVIdYTWB4O+58Q1DEdJy7/HbQpW45/th/CwjAtvYKnLyJXFqmSnQuViYBEfZsEdfJpCAgUZgld1Heg==",
       "license": "ISC"
     },
     "node_modules/browserslist": {
@@ -1738,8 +1738,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-browser/releases/download/v1.58.2/brave-core-ios-1.58.2.tgz",
-      "integrity": "sha512-fvUhCYXasBl/fieAjIUhoEVnv086kmtxO1FahRRfar4aZwW3ZceO0KlC/d0t5ps6dTTsQffkRtmZ76q3gb8JXQ=="
+      "version": "https://github.com/brave/brave-browser/releases/download/v1.58.10/brave-core-ios-1.58.10.tgz",
+      "integrity": "sha512-ZAzq0PaleVIdYTWB4O+58Q1DEdJy7/HbQpW45/th/CwjAtvYKnLyJXFqmSnQuViYBEfZsEdfJpCAgUZgld1Heg=="
     },
     "browserslist": {
       "version": "4.17.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "license": "MPL-2.0",
   "dependencies": {
     "@mozilla/readability": "^0.4.2",
-    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.58.10/brave-core-ios-1.58.10.tgz",
+    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.58.26/brave-core-ios-1.58.26.tgz",
     "leo-sf-symbols": "github:brave/leo-sf-symbols#60a41d77d4e58bd48284848a04ad3f9b79bf7daa",
     "page-metadata-parser": "^1.1.3",
     "webpack-cli": "^4.8.0"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "license": "MPL-2.0",
   "dependencies": {
     "@mozilla/readability": "^0.4.2",
-    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.58.2/brave-core-ios-1.58.2.tgz",
+    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.58.10/brave-core-ios-1.58.10.tgz",
     "leo-sf-symbols": "github:brave/leo-sf-symbols#60a41d77d4e58bd48284848a04ad3f9b79bf7daa",
     "page-metadata-parser": "^1.1.3",
     "webpack-cli": "^4.8.0"


### PR DESCRIPTION
## Summary of Changes
- Address changes for the Selected Account Refactor in BraveCore.
- `GetSelectedCoin()` was removed. In most places we were fetching the selected coin so we knew which account or network to fetch. 
    - We now use `GetAllAccounts()` on KeyringService which returns a `selectedAccount` which we can get it's `CoinType` from. In the cases where we were previously fetching coin to get the account, this works well. In a couple spots we now call `GetAllAccounts()` to get the `selectedAccount` coin type so we can fetch the currently selected network (ex. `BuyTokenStore` now hold a reference to KeyringService for this purpose).
    - This method will also return the `ethDappSelectedAccount`/`solDappSelectedAccount` account for use with DApps.

This pull request fixes #7723

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
The underlying core change refactored how selected account's work. This touched every view that uses a selected account, so requires a bit of regression testing.
- Wallet Panel
    - Verify switching selected account via the panel is still working as expected. If changing between Ethereum / Solana account, the network must also update.
    - Verify switching network via the panel is still working as expected. If changing between Ethereum / Solana networks, the account must also update
- DApp connections
    - Verify the selected account is selected by default when connecting to an Etheruem DApp for the first time. ex. have Ethereum Account 2 selected in the wallet panel, then on the Ethereum DApp tap 'connect wallet'. Ethereum Account 2 should be selected by default.
- Buy Token View
    - Verify switching selected account, verify switching selected network
- Send Token View
    - Verify selecting a token switches to the correct network and account. Test switching from EthAccount1 -> SolAccount1 -> EthAccount2 for example.
- Swap Token View
    - Verify switching selected account, verify switching selected network
- Asset Detail View
    - Verify 'send' button on asset detail screens will open with the expected token selected by default.
    - Verify 'swap' button on asset detail screens will open with the expected token selected by default.
- Add Account
    - Verify you can add an account for both Ethereum & Solana.


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
