### PR TITLE
Fix #7686: Voice search not detecting sound

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController.swift
@@ -52,7 +52,7 @@ public class BrowserViewController: UIViewController {
   
   private(set) lazy var topToolbar: TopToolbarView = {
     // Setup the URL bar, wrapped in a view to get transparency effect
-    let topToolbar = TopToolbarView()
+    let topToolbar = TopToolbarView(voiceSearchSupported: speechRecognizer.isVoiceSearchAvailable)
     topToolbar.translatesAutoresizingMaskIntoConstraints = false
     topToolbar.delegate = self
     topToolbar.tabToolbarDelegate = self
@@ -145,7 +145,8 @@ public class BrowserViewController: UIViewController {
   /// Voice Search
   var voiceSearchViewController: PopupViewController<VoiceSearchInputView>?
   var voiceSearchCancelable: AnyCancellable?
-
+  let speechRecognizer = SpeechRecognizer()
+  
   /// Custom Search Engine
   var openSearchEngine: OpenSearchReference?
 

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
@@ -535,8 +535,6 @@ extension BrowserViewController: TopToolbarDelegate {
   
   func topToolbarDidPressVoiceSearchButton(_ urlBar: TopToolbarView) {
     Task { @MainActor in
-      let speechRecognizer = SpeechRecognizer()
-
       onPendingRequestUpdatedCancellable = speechRecognizer.$finalizedRecognition.sink { [weak self] finalizedRecognition in
         guard let self else { return }
         

--- a/Sources/Brave/Frontend/Browser/Search/Voice Search/SpeechRecognizer.swift
+++ b/Sources/Brave/Frontend/Browser/Search/Voice Search/SpeechRecognizer.swift
@@ -42,7 +42,7 @@ class SpeechRecognizer: ObservableObject {
   @Published private(set) var animationType: AnimationType = .pulse(scale: 1)
 
   var isVoiceSearchAvailable: Bool {
-    if let recognizer, recognizer.isAvailable {
+    if let recognizer, recognizer.isAvailable, recognizer.supportsOnDeviceRecognition {
       return true
     }
     


### PR DESCRIPTION
Checking availability of speech recognizer and device recognizer in order to display voice search icon

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7686

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

- Once on new tab, select the microphone icon in the URL bar
- Enable mic permissions for Brave
- Once the voice search modal opens, search query with your voice

And if the region of the user is not allowing voice search the button should be totally hidden

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
