### PR TITLE
Fix #7733: Allow Custom Search Engines to be default in Private Mode

### DIFF
--- a/Sources/Brave/Frontend/Browser/Search/SearchSuggestionDataSource.swift
+++ b/Sources/Brave/Frontend/Browser/Search/SearchSuggestionDataSource.swift
@@ -109,7 +109,7 @@ class SearchSuggestionDataSource {
   
   func querySuggestClient() {
     // Do not query suggestions if user is not opt_ed in
-    if !Preferences.Search.shouldShowSuggestionsOptIn.value {
+    if !Preferences.Search.showSuggestions.value {
       Logger.module.info("Suggestions are not enabled")
       return
     }

--- a/Sources/Brave/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/Sources/Brave/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -67,12 +67,6 @@ class SearchSettingsTableViewController: UITableViewController {
       .sorted { $0.shortName < $1.shortName }
       .sorted { engine, _ in engine.shortName == OpenSearchEngine.EngineNames.brave }
 
-    if isPrivate {
-      orderedEngines =
-        orderedEngines
-        .filter { !$0.isCustomEngine || $0.engineID == OpenSearchEngine.migratedYahooEngineID }
-    }
-
     if let priorityEngine = InitialSearchEngines().priorityEngine?.rawValue {
       orderedEngines =
         orderedEngines


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

Allowing custom Search Engines be default search engine for private mode
Fixing a problem blocking show search suggestions

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7733 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Add a custom Search Engine
Go Settings - Search - Private Tab
Use a custom search engine a default

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


https://github.com/brave/brave-ios/assets/6643505/295291a8-de75-41f3-a9ff-8eb34ae88f74


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
