### PR TITLE
Fix #7608: Turn Sardine on for all wallet users

### DIFF
--- a/Sources/BraveWallet/Crypto/Stores/AssetDetailStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/AssetDetailStore.swift
@@ -217,12 +217,7 @@ class AssetDetailStore: ObservableObject {
   }
   
   @MainActor private func isBuyButtonSupported(in network: BraveWallet.NetworkInfo, for symbol: String) async -> Bool {
-    let buyOptions: [BraveWallet.OnRampProvider]
-    if Locale.preferredLanguages.first?.caseInsensitiveCompare("en-us") == .orderedSame {
-      buyOptions = [.ramp, .sardine, .transak]
-    } else {
-      buyOptions = [.ramp, .transak]
-    }
+    let buyOptions: [BraveWallet.OnRampProvider] = [.ramp, .sardine, .transak]
     self.allBuyTokensAllOptions = await blockchainRegistry.allBuyTokens(in: network, for: buyOptions)
     let buyTokens = allBuyTokensAllOptions.flatMap { $0.value }
     return buyTokens.first(where: { $0.symbol.caseInsensitiveCompare(symbol) == .orderedSame }) != nil

--- a/Sources/BraveWallet/Crypto/Stores/BuyTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/BuyTokenStore.swift
@@ -158,12 +158,7 @@ public class BuyTokenStore: ObservableObject {
   
   @MainActor
   func updateInfo() async {
-    // check device language to determine if we support `Sardine`
-    if Locale.preferredLanguages.first?.caseInsensitiveCompare("en-us") == .orderedSame {
-      orderedSupportedBuyOptions = [.ramp, .sardine, .transak]
-    } else {
-      orderedSupportedBuyOptions = [.ramp, .transak]
-    }
+    orderedSupportedBuyOptions = [.ramp, .sardine, .transak]
     
     let coin = await walletService.selectedCoin()
     selectedNetwork = await rpcService.network(coin, origin: nil)

--- a/Tests/BraveWalletTests/BuyTokenStoreTest.swift
+++ b/Tests/BraveWalletTests/BuyTokenStoreTest.swift
@@ -168,11 +168,13 @@ class BuyTokenStoreTests: XCTestCase {
     
     await store.updateInfo()
     
-    XCTAssertEqual(store.orderedSupportedBuyOptions.count, 2)
+    XCTAssertEqual(store.orderedSupportedBuyOptions.count, 3)
     XCTAssertNotNil(store.orderedSupportedBuyOptions.first)
-    XCTAssertEqual(store.orderedSupportedBuyOptions.first!, .ramp)
+    XCTAssertEqual(store.orderedSupportedBuyOptions.first, .ramp)
+    XCTAssertNotNil(store.orderedSupportedBuyOptions[safe: 1])
+    XCTAssertEqual(store.orderedSupportedBuyOptions[safe: 1], .sardine)
     XCTAssertNotNil(store.orderedSupportedBuyOptions.last)
-    XCTAssertEqual(store.orderedSupportedBuyOptions.last!, .transak)
+    XCTAssertEqual(store.orderedSupportedBuyOptions.last, .transak)
   }
   
   @MainActor


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #7608

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Open Buy Token modal in a non-US region
2. Select Ethereum Mainnet network / ETH token (any token Sardine supports should be fine for verification).
    - SOL token is not yet available for purchase in Canada, but ETH is fine 🤔.
3. Tap `Select purchase method`
4. Verify Sardine is listed as an option.


## Screenshots:

https://github.com/brave/brave-ios/assets/5314553/7667e267-baa2-439b-9c99-967969a33474


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
