### PR TITLE
Ref #7728: Bump BraveCore to 1.57.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@mozilla/readability": "^0.4.2",
-        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.57.9/brave-core-ios-1.57.9.tgz",
+        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.57.13/brave-core-ios-1.57.13.tgz",
         "leo-sf-symbols": "github:brave/leo-sf-symbols#60a41d77d4e58bd48284848a04ad3f9b79bf7daa",
         "page-metadata-parser": "^1.1.3",
         "webpack-cli": "^4.8.0"
@@ -356,9 +356,9 @@
       }
     },
     "node_modules/brave-core-ios": {
-      "version": "1.57.9",
-      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.57.9/brave-core-ios-1.57.9.tgz",
-      "integrity": "sha512-aE2rjvN9RF9GIC23gg6Im9TK88zv6dCb6jRqZ/pnJb0c7xqRCy2Fp6rclhTptkjzR9hvFMankSazt4nNoNZZZw==",
+      "version": "1.57.13",
+      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.57.13/brave-core-ios-1.57.13.tgz",
+      "integrity": "sha512-btrkAmp+/dfakYOxIa73SuxrTvJ99vaV/TsdOZPLLDP4VGZU+5DNQBrpkVIFBcBTDawC0zj5MYNGz2SaMxGr3w==",
       "license": "ISC"
     },
     "node_modules/browserslist": {
@@ -1738,8 +1738,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-browser/releases/download/v1.57.9/brave-core-ios-1.57.9.tgz",
-      "integrity": "sha512-aE2rjvN9RF9GIC23gg6Im9TK88zv6dCb6jRqZ/pnJb0c7xqRCy2Fp6rclhTptkjzR9hvFMankSazt4nNoNZZZw=="
+      "version": "https://github.com/brave/brave-browser/releases/download/v1.57.13/brave-core-ios-1.57.13.tgz",
+      "integrity": "sha512-btrkAmp+/dfakYOxIa73SuxrTvJ99vaV/TsdOZPLLDP4VGZU+5DNQBrpkVIFBcBTDawC0zj5MYNGz2SaMxGr3w=="
     },
     "browserslist": {
       "version": "4.17.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "license": "MPL-2.0",
   "dependencies": {
     "@mozilla/readability": "^0.4.2",
-    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.57.9/brave-core-ios-1.57.9.tgz",
+    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.57.13/brave-core-ios-1.57.13.tgz",
     "leo-sf-symbols": "github:brave/leo-sf-symbols#60a41d77d4e58bd48284848a04ad3f9b79bf7daa",
     "page-metadata-parser": "^1.1.3",
     "webpack-cli": "^4.8.0"


### PR DESCRIPTION
## Summary of Changes

This includes a fix for #7728 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
