### PR TITLE
Fix #7692: Fix performance issues with cosmetic filters

### DIFF
--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Sandboxed/SelectorsPollerScript.js
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Sandboxed/SelectorsPollerScript.js
@@ -979,7 +979,7 @@ window.__firefox__.execute(function($) {
 
     // Start a timer that moves the stylesheet down
     window.setInterval(() => {
-      if (styleElm.nextElementSibling === null || styleElm.parentElement === targetElm) {
+      if (styleElm.nextElementSibling === null || styleElm.parentElement !== targetElm) {
         return
       }
       moveStyle()

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Sandboxed/SelectorsPollerScript.js
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Sandboxed/SelectorsPollerScript.js
@@ -335,12 +335,8 @@ window.__firefox__.execute(function($) {
 
   const usePolling = (observer) => {
     if (observer) {
-      const mutations = observer.takeRecords()
       observer.disconnect()
-
-      if (mutations) {
-        queueSelectorsFromMutations(mutations)
-      }
+      notYetQueriedElements.length = 0
     }
 
     const futureTimeMs = window.Date.now() + returnToMutationObserverIntervalMs

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Sandboxed/SelectorsPollerScript.js
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Sandboxed/SelectorsPollerScript.js
@@ -738,7 +738,7 @@ window.__firefox__.execute(function($) {
 
     if (switchToMutationObserverAtTime !== undefined &&
       window.Date.now() >= switchToMutationObserverAtTime) {
-      useMutationObserver('CALLBACK')
+      useMutationObserver()
     }
   }
 


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7692

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
1. Check STR in issue
2. Go to sites like reddit.com and ensure cookie consent and open in app notifications are blocked (Make sure the appropriate filter lists are enabled)
3. Go to theverge.com and ensure that the cookie notices are blocked
4. Go to https://dev-pages.brave.software/filtering/cosmetic-filtering.html and click run test: on aggressive all images are hidden, on standard only 3rd party images are hidden
5. Enable a VPN and ensure you're in the USA. Search for trezor: on standard mode AdBeta appears, on aggressive it does not (it takes a moment to hide the ad).

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
