### PR TITLE
No bug: fix panel onboarding state is displaying in loading state instead

### DIFF
--- a/Sources/BraveWallet/Crypto/Stores/KeyringStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/KeyringStore.swift
@@ -74,6 +74,8 @@ public class KeyringStore: ObservableObject {
     isBackedUp: false,
     accountInfos: []
   )
+  /// A boolean indciates front-end has or has not loaded Keyring from the core
+  @Published var isDefaultKeyringLoaded = false
   /// Whether or not the user should be viewing the onboarding flow to setup a keyring
   @Published private(set) var isOnboardingVisible: Bool = false
   /// Whether or not the last time the wallet was locked was due to the user manually locking it
@@ -181,6 +183,7 @@ public class KeyringStore: ObservableObject {
       self.defaultAccounts = await keyringService.defaultAccounts(for: WalletConstants.supportedCoinTypes)
       if let defaultKeyring = allKeyrings.first(where: { $0.id == BraveWallet.KeyringId.default }) {
         self.defaultKeyring = defaultKeyring
+        self.isDefaultKeyringLoaded = true
         self.isDefaultKeyringCreated = defaultKeyring.isKeyringCreated
       }
       self.allKeyrings = allKeyrings

--- a/Sources/BraveWallet/Panels/WalletPanelView.swift
+++ b/Sources/BraveWallet/Panels/WalletPanelView.swift
@@ -490,7 +490,7 @@ struct WalletPanelView: View {
     }
     .foregroundColor(.white)
     .background(
-      BlockieMaterial(address: keyringStore.selectedAccount.id)
+      BlockieMaterial(address: keyringStore.selectedAccount.address)
       .ignoresSafeArea()
     )
     .onChange(of: cryptoStore.pendingRequest) { newValue in

--- a/Sources/BraveWallet/Panels/WalletPanelView.swift
+++ b/Sources/BraveWallet/Panels/WalletPanelView.swift
@@ -39,8 +39,7 @@ public struct WalletPanelContainerView: View {
   private var visibleScreen: VisibleScreen {
     let keyring = keyringStore.defaultKeyring
     // check if we are still fetching the `defaultKeyring`
-    if keyringStore.defaultKeyring.id == .default,
-       keyringStore.defaultKeyring.accountInfos.isEmpty {
+    if !keyringStore.isDefaultKeyringLoaded {
       return .loading
     }
     // keyring fetched, check if user has created a wallet

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -4223,8 +4223,8 @@ extension Strings {
       "wallet.allNetworksLabel",
       tableName: "BraveWallet",
       bundle: .module,
-      value: "All accounts",
-      comment: "The label of badge beside the filter option that allows users to select which accounts to filter assets by, when all accounts are selected. Used in Portfolio/NFT filters and display settings."
+      value: "All networks",
+      comment: "The label of badge beside the filter option that allows users to select which networks to filter assets by, when all networks are selected. Used in Portfolio/NFT filters and display settings."
     )
     public static let saveChangesButtonTitle = NSLocalizedString(
       "wallet.saveChangesButtonTitle",


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
Since now `keyringId` is an enum without a placeholder value, front-end is no longer able to tell it's in the initial value that our UI needs. Adding a boolean value to track if the default keyring has been fetched from core to solve this problem. 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Test for dev:
1. Make sure you have no wallet set up
2. Open Brave Browser and visit an eth or solana dapp.
3. Make the dapp try to connect wallet
4. you should get a notification. but ignore the notificaiton
5. you should see a wallet icon in the omnibox and click it
6. it will directly prompt the wallet welcome screen which you can create a wallet or restore a wallet
7. close this screen
8. check if the panel is in the onboarding state instead of loading state.


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
