### PR TITLE
Fix #7743: Removed assertionFailure in scripts.

### DIFF
--- a/Sources/Brave/Frontend/Browser/UserScriptManager.swift
+++ b/Sources/Brave/Frontend/Browser/UserScriptManager.swift
@@ -276,7 +276,7 @@ class UserScriptManager {
     customScripts: Set<UserScriptType>
   ) {
     guard let webView = tab.webView else {
-      assertionFailure("Injecting Scripts into a Tab that has no WebView")
+      Logger.module.info("Injecting Scripts into a Tab that has no WebView")
       return
     }
     


### PR DESCRIPTION
## Summary of Changes
- This bug is being triggered because of lazy loading which is a new feature that didn't exist before.
- Because the webView is NOT created on load, attempting to inject scripts into it will trigger the assertionFailure. Instead, it should just log it and do nothing as this is normal now. Scripts will be injected anyway, once the webView is actually created.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7743

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
None

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
