### PR TITLE
Fix #7677: Add 'Media' settings section.

### DIFF
--- a/Sources/Brave/Frontend/Settings/MediaSettingsView.swift
+++ b/Sources/Brave/Frontend/Settings/MediaSettingsView.swift
@@ -1,0 +1,105 @@
+// Copyright 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import SwiftUI
+import BraveStrings
+import Preferences
+import BraveUI
+
+struct MediaSettingsView: View {
+  @ObservedObject var enableBackgroundAudio = Preferences.General.mediaAutoBackgrounding
+  
+  var body: some View {
+    Form {
+      Section(header: Text(Strings.Settings.mediaGeneralSection)) {
+        Toggle(isOn: $enableBackgroundAudio.value) {
+          Text(Strings.mediaAutoBackgrounding)
+        }
+        .toggleStyle(SwitchToggleStyle(tint: .accentColor))
+      }
+      
+      Section(header: Text(Strings.Settings.youtube)) {
+        NavigationLink(destination: QualitySettingsView()) {
+          VStack(alignment: .leading) {
+            Text(Strings.Settings.highestQualityPlayback)
+            Text(Strings.Settings.highestQualityPlaybackDetail)
+              .font(.footnote)
+              .foregroundColor(Color(.secondaryBraveLabel))
+          }
+        }
+      }
+    }
+    .navigationBarTitle(Strings.Settings.mediaRootSetting)
+    .navigationBarTitleDisplayMode(.inline)
+  }
+}
+
+fileprivate struct QualitySettingsView: View {
+  @Environment(\.presentationMode) @Binding var presentationMode
+  @ObservedObject var qualityOption = Preferences.General.youtubeHighQuality
+  
+  var body: some View {
+    Form {
+      Section(header: Text("")) {
+        Button(action: {
+          qualityOption.value = YoutubeHighQualityPreference.on.rawValue
+          presentationMode.dismiss()
+        }, label: {
+          qualityOption(preference: .on)
+        })
+        
+        Button(action: {
+          qualityOption.value = YoutubeHighQualityPreference.wifi.rawValue
+          presentationMode.dismiss()
+        }, label: {
+          qualityOption(preference: .wifi)
+        })
+        
+        Button(action: {
+          qualityOption.value = YoutubeHighQualityPreference.off.rawValue
+          presentationMode.dismiss()
+        }, label: {
+          qualityOption(preference: .off)
+        })
+      }
+    }
+    .navigationBarTitle(Strings.Settings.qualitySettings)
+  }
+  
+  func qualityOption(preference: YoutubeHighQualityPreference) -> some View {
+    HStack {
+      Text(preference.displayString)
+        .foregroundColor(.black)
+      Spacer()
+      if Preferences.General.youtubeHighQuality.value == preference.rawValue {
+        Image(systemName: "checkmark")
+      }
+    }
+  }
+}
+
+enum YoutubeHighQualityPreference: String, CaseIterable {
+  case wifi
+  case on
+  case off
+}
+
+extension YoutubeHighQualityPreference: RepresentableOptionType {
+  var displayString: String {
+    switch self {
+    case .off: return Strings.youtubeMediaQualityOff
+    case .wifi: return Strings.youtubeMediaQualityWifi
+    case .on: return Strings.youtubeMediaQualityOn
+    }
+  }
+}
+
+#if DEBUG
+struct MediaSettingsView_Previews: PreviewProvider {
+  static var previews: some View {
+    MediaSettingsView()
+  }
+}
+#endif

--- a/Sources/Brave/Frontend/Settings/SettingsViewController.swift
+++ b/Sources/Brave/Frontend/Settings/SettingsViewController.swift
@@ -371,10 +371,6 @@ class SettingsViewController: TableViewController {
         title: Strings.enablePullToRefresh,
         option: Preferences.General.enablePullToRefresh,
         image: UIImage(braveSystemNamed: "leo.browser.refresh")),
-      .boolRow(
-        title: Strings.mediaAutoBackgrounding,
-        option: Preferences.General.mediaAutoBackgrounding,
-        image: UIImage(braveSystemNamed: "leo.audio.active")),
       .boolRow(title: Strings.blockPopups, option: Preferences.General.blockPopups,
                image: UIImage(braveSystemNamed: "leo.shield.block")),
     ])
@@ -386,22 +382,6 @@ class SettingsViewController: TableViewController {
         self.navigationController?.pushViewController(controller, animated: true)
       }, image: UIImage(braveSystemNamed: "leo.swap.horizontal"), accessory: .disclosureIndicator, cellClass: MultilineSubtitleCell.self)
     general.rows.append(websiteRedirectsRow)
-    
-    var youtubeQualityRow = Row(text: Strings.youtubeMediaQuality, detailText: Strings.youtubeMediaQualityDetails, image: UIImage(braveSystemNamed: "leo.headphones"), accessory: .disclosureIndicator, cellClass: MultilineValue1Cell.self)
-    
-    youtubeQualityRow.selection = { [unowned self] in
-      let optionsViewController = OptionSelectionViewController<YoutubeHighQualityPreference>(
-        options: YoutubeHighQualityPreference.allCases,
-        selectedOption: YoutubeHighQualityPreference(rawValue: Preferences.General.youtubeHighQuality.value),
-        optionChanged: { _, option in
-          Preferences.General.youtubeHighQuality.value = option.rawValue
-          self.dataSource.reloadCell(row: youtubeQualityRow, section: general, displayText: option.displayString)
-        }
-      )
-      optionsViewController.headerText = Strings.youtubeMediaQualitySettingsTitle
-      self.navigationController?.pushViewController(optionsViewController, animated: true)
-    }
-    general.rows.append(youtubeQualityRow)
 
     return general
   }()
@@ -478,6 +458,17 @@ class SettingsViewController: TableViewController {
       header: .title(Strings.displaySettingsSection),
       rows: []
     )
+    
+    display.rows.append(.init(
+      text: Strings.Settings.mediaRootSetting,
+      selection: { [unowned self] in
+        let vc = UIHostingController(rootView: MediaSettingsView())
+        self.navigationController?.pushViewController(vc, animated: true)
+      },
+      image: UIImage(braveSystemNamed: "leo.media.player"),
+      accessory: .disclosureIndicator,
+      cellClass: MultilineValue1Cell.self
+    ))
 
     let themeSubtitle = DefaultTheme(rawValue: Preferences.General.themeNormalMode.value)?.displayString
     var row = Row(text: Strings.themesDisplayBrightness, detailText: themeSubtitle, image: UIImage(braveSystemNamed: "leo.appearance"), accessory: .disclosureIndicator, cellClass: MultilineSubtitleCell.self)

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/YoutubeQualityScriptHandler.swift
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/YoutubeQualityScriptHandler.swift
@@ -9,22 +9,6 @@ import Preferences
 import Shared
 import BraveUI
 
-enum YoutubeHighQualityPreference: String, CaseIterable {
-  case off
-  case wifi
-  case on
-}
-
-extension YoutubeHighQualityPreference: RepresentableOptionType {
-  var displayString: String {
-    switch self {
-    case .off: return Strings.youtubeMediaQualityOff
-    case .wifi: return Strings.youtubeMediaQualityWifi
-    case .on: return Strings.youtubeMediaQualityOn
-    }
-  }
-}
-
 class YoutubeQualityScriptHandler: NSObject, TabContentScript {
   private weak var tab: Tab?
   private var url: URL?

--- a/Sources/BraveStrings/BraveStrings.swift
+++ b/Sources/BraveStrings/BraveStrings.swift
@@ -850,6 +850,60 @@ extension Strings {
         bundle: .module,
         value: "After One Month",
         comment: "Settings option to close old tabs after 1 month")
+    
+    public static let mediaRootSetting =
+    NSLocalizedString(
+      "settings.media.rootSetting",
+      tableName: "BraveShared",
+      bundle: .module,
+      value: "Media",
+      comment: "Setting title for 'Media' sections. Media section offerts various options to manipulate media playback"
+    )
+    
+    public static let mediaGeneralSection =
+    NSLocalizedString(
+      "settings.media.general",
+      tableName: "BraveShared",
+      bundle: .module,
+      value: "General",
+      comment: "Header for the general settings section"
+    )
+    
+    public static let youtube =
+    NSLocalizedString(
+      "settings.youtube",
+      tableName: "BraveShared",
+      bundle: .module,
+      value: "Youtube",
+      comment: "Header for the Youtube settings section"
+    )
+    
+    public static let highestQualityPlayback =
+    NSLocalizedString(
+      "settings.highestQualityPlayback",
+      tableName: "BraveShared",
+      bundle: .module,
+      value: "Highest Quality Playback",
+      comment: "Label for the navigation link to quality settings view"
+    )
+    
+    public static let highestQualityPlaybackDetail =
+    NSLocalizedString(
+      "settings.highestQualityPlaybackDetail",
+      tableName: "BraveShared",
+      bundle: .module,
+      value: "Allows desktop-quality resolution",
+      comment: "Detail text for the navigation link to quality settings view"
+    )
+    
+    public static let qualitySettings =
+    NSLocalizedString(
+      "settings.qualitySettings",
+      tableName: "BraveShared",
+      bundle: .module,
+      value: "Quality Settings",
+      comment: "Title for the quality settings view"
+    )
   }
 }
 
@@ -1045,9 +1099,9 @@ extension Strings {
   public static let youtubeMediaQualitySettingsTitle = NSLocalizedString("YoutubeMediaQualitySettingsTitle", tableName: "BraveShared", bundle: .module, value: "Youtube Playback Quality", comment: "Title for youtube playback quality settings")
   public static let youtubeMediaQuality = NSLocalizedString("YoutubeMediaQuality", tableName: "BraveShared", bundle: .module, value: "Enable High-Quality Youtube Videos", comment: "Setting to enable high quality youtube videos")
   public static let youtubeMediaQualityDetails = NSLocalizedString("YoutubeMediaQualityDetails", tableName: "BraveShared", bundle: .module, value: "Enabling this experimental feature will playback video at the maximum quality available and will use additional data.", comment: "Description of setting to enable high quality youtube videos")
-  public static let youtubeMediaQualityOff = NSLocalizedString("YoutubeMediaQualityOff", tableName: "BraveShared", bundle: .module, value: "Disabled", comment: "Setting that disables highest quality video playback")
-  public static let youtubeMediaQualityWifi = NSLocalizedString("YoutubeMediaQualityWifi", tableName: "BraveShared", bundle: .module, value: "Enabled if Wifi is on", comment: "Setting that enables high quality playback on wifi only")
-  public static let youtubeMediaQualityOn = NSLocalizedString("YoutubeMediaQualityOn", tableName: "BraveShared", bundle: .module, value: "Always enabled", comment: "Setting that enables high quality playback always")
+  public static let youtubeMediaQualityOff = NSLocalizedString("YoutubeMediaQualityOff", tableName: "BraveShared", bundle: .module, value: "Off", comment: "Setting that disables highest quality video playback")
+  public static let youtubeMediaQualityWifi = NSLocalizedString("YoutubeMediaQualityWifi", tableName: "BraveShared", bundle: .module, value: "Only while using wi-fi", comment: "Setting that enables high quality playback on wifi only")
+  public static let youtubeMediaQualityOn = NSLocalizedString("YoutubeMediaQualityOn", tableName: "BraveShared", bundle: .module, value: "Always on", comment: "Setting that enables high quality playback always")
   public static let showTabsBar = NSLocalizedString("ShowTabsBar", tableName: "BraveShared", bundle: .module, value: "Tabs Bar", comment: "Setting to show/hide the tabs bar")
   public static let privateBrowsingOnly = NSLocalizedString("PrivateBrowsingOnly", tableName: "BraveShared", bundle: .module, value: "Private Browsing Only", comment: "Setting to keep app in private mode")
   public static let shieldsDefaults = NSLocalizedString("ShieldsDefaults", tableName: "BraveShared", bundle: .module, value: "Brave Shields Global Defaults", comment: "Section title for adbblock, tracking protection, HTTPS-E, and cookies")


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7677 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
There is a new 'Media' settings section. Make sure it displays correctly

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
