### PR TITLE
Fix #7699: NFT filters and display settings

### DIFF
--- a/Sources/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
@@ -96,7 +96,7 @@ struct AccountActivityView: View {
                 title: nftAsset.token.nftTokenTitle,
                 symbol: nftAsset.token.symbol,
                 networkName: nftAsset.network.chainName,
-                quantity: "\(nftAsset.balance)"
+                quantity: "\(nftAsset.balanceForAccounts[activityStore.account.address] ?? 0)"
               )
             }
           }

--- a/Sources/BraveWallet/Crypto/FiltersDisplaySettingsView.swift
+++ b/Sources/BraveWallet/Crypto/FiltersDisplaySettingsView.swift
@@ -51,6 +51,8 @@ struct Filters {
   let sortOrder: SortOrder
   /// If we are hiding small balances (less than $1 value). Default is true.
   let isHidingSmallBalances: Bool
+  /// If we are hiding unowned NFTs. Default is false.
+  let isHidingUnownedNFTs: Bool
   /// If we are showing the network logo on NFTs. Default is true.
   let isShowingNFTNetworkLogo: Bool
   /// All accounts and if they are currently selected. Default is all accounts selected.
@@ -67,6 +69,8 @@ struct FiltersDisplaySettingsView: View {
   @State var sortOrder: SortOrder
   /// If we are hiding small balances (less than $1 value). Default is false.
   @State var isHidingSmallBalances: Bool
+  /// If we are hiding unowned NFTs. Default is false.
+  @State var isHidingUnownedNFTs: Bool
   /// If we are showing the network logo on NFTs. Default is true.
   @State var isShowingNFTNetworkLogo: Bool
   
@@ -114,6 +118,7 @@ struct FiltersDisplaySettingsView: View {
     self._groupBy = State(initialValue: filters.groupBy)
     self._sortOrder = State(initialValue: filters.sortOrder)
     self._isHidingSmallBalances = State(initialValue: filters.isHidingSmallBalances)
+    self._isHidingUnownedNFTs = State(initialValue: filters.isHidingUnownedNFTs)
     self._isShowingNFTNetworkLogo = State(initialValue: filters.isShowingNFTNetworkLogo)
     self._accounts = State(initialValue: filters.accounts)
     self._networks = State(initialValue: filters.networks)
@@ -132,26 +137,24 @@ struct FiltersDisplaySettingsView: View {
             .padding(.vertical, rowPadding)
            */
 
-          if !isNFTFilters {
+          if isNFTFilters {
+            showNFTNetworkLogo
+              .padding(.vertical, rowPadding)
+            
+            hideUnownedNFTs
+              .padding(.vertical, rowPadding)
+          } else { // Portfolio filters
             sortAssets
               .padding(.vertical, rowPadding)
             
             hideSmallBalances
               .padding(.vertical, rowPadding)
           }
-          
-          if isNFTFilters {
-            showNFTNetworkLogo
-              .padding(.vertical, rowPadding)
-          }
 
           DividerLine()
-
-          if !isNFTFilters {
-            // Unavailable for NFTs until NFT supports grouping.
-            accountFilters
-              .padding(.vertical, rowPadding)
-          }
+          
+          accountFilters
+            .padding(.vertical, rowPadding)
 
           networkFilters
             .padding(.vertical, rowPadding)
@@ -212,6 +215,20 @@ struct FiltersDisplaySettingsView: View {
       FilterLabelView(
         title: Strings.Wallet.hideSmallBalancesTitle,
         description: Strings.Wallet.hideSmallBalancesDescription,
+        icon: .init(
+          braveSystemName: "leo.eye.on",
+          iconContainerSize: min(iconContainerSize, maxIconContainerSize)
+        )
+      )
+    }
+    .tint(Color(.braveBlurpleTint))
+  }
+  
+  private var hideUnownedNFTs: some View {
+    Toggle(isOn: $isHidingUnownedNFTs) {
+      FilterLabelView(
+        title: Strings.Wallet.hideUnownedNFTsTitle,
+        description: Strings.Wallet.hideUnownedNFTsDescription,
         icon: .init(
           braveSystemName: "leo.eye.on",
           iconContainerSize: min(iconContainerSize, maxIconContainerSize)
@@ -302,6 +319,7 @@ struct FiltersDisplaySettingsView: View {
           groupBy: groupBy,
           sortOrder: sortOrder,
           isHidingSmallBalances: isHidingSmallBalances,
+          isHidingUnownedNFTs: isHidingUnownedNFTs,
           isShowingNFTNetworkLogo: isShowingNFTNetworkLogo,
           accounts: accounts,
           networks: networks
@@ -372,6 +390,7 @@ struct FiltersDisplaySettingsView_Previews: PreviewProvider {
         groupBy: .none,
         sortOrder: .valueDesc,
         isHidingSmallBalances: false,
+        isHidingUnownedNFTs: false,
         isShowingNFTNetworkLogo: false,
         accounts: [
           .init(isSelected: true, model: .mockEthAccount),

--- a/Sources/BraveWallet/Crypto/FiltersDisplaySettingsView.swift
+++ b/Sources/BraveWallet/Crypto/FiltersDisplaySettingsView.swift
@@ -51,6 +51,8 @@ struct Filters {
   let sortOrder: SortOrder
   /// If we are hiding small balances (less than $1 value). Default is true.
   let isHidingSmallBalances: Bool
+  /// If we are showing the network logo on NFTs. Default is true.
+  let isShowingNFTNetworkLogo: Bool
   /// All accounts and if they are currently selected. Default is all accounts selected.
   var accounts: [Selectable<BraveWallet.AccountInfo>]
   /// All networks and if they are currently selected. Default is all selected except known test networks.
@@ -65,13 +67,16 @@ struct FiltersDisplaySettingsView: View {
   @State var sortOrder: SortOrder
   /// If we are hiding small balances (less than $1 value). Default is false.
   @State var isHidingSmallBalances: Bool
+  /// If we are showing the network logo on NFTs. Default is true.
+  @State var isShowingNFTNetworkLogo: Bool
   
   /// All accounts and if they are currently selected. Default is all accounts selected.
   @State var accounts: [Selectable<BraveWallet.AccountInfo>]
   /// All networks and if they are currently selected. Default is all selected except known test networks.
   @State var networks: [Selectable<BraveWallet.NetworkInfo>]
   
-  var networkStore: NetworkStore
+  let isNFTFilters: Bool
+  let networkStore: NetworkStore
   let save: (Filters) -> Void
   
   /// Returns true if all accounts are selected
@@ -102,14 +107,17 @@ struct FiltersDisplaySettingsView: View {
   
   init(
     filters: Filters,
+    isNFTFilters: Bool,
     networkStore: NetworkStore,
     save: @escaping (Filters) -> Void
   ) {
     self._groupBy = State(initialValue: filters.groupBy)
     self._sortOrder = State(initialValue: filters.sortOrder)
     self._isHidingSmallBalances = State(initialValue: filters.isHidingSmallBalances)
+    self._isShowingNFTNetworkLogo = State(initialValue: filters.isShowingNFTNetworkLogo)
     self._accounts = State(initialValue: filters.accounts)
     self._networks = State(initialValue: filters.networks)
+    self.isNFTFilters = isNFTFilters
     self.networkStore = networkStore
     self.save = save
   }
@@ -124,16 +132,26 @@ struct FiltersDisplaySettingsView: View {
             .padding(.vertical, rowPadding)
            */
 
-          sortAssets
-            .padding(.vertical, rowPadding)
-
-          hideSmallBalances
-            .padding(.vertical, rowPadding)
+          if !isNFTFilters {
+            sortAssets
+              .padding(.vertical, rowPadding)
+            
+            hideSmallBalances
+              .padding(.vertical, rowPadding)
+          }
+          
+          if isNFTFilters {
+            showNFTNetworkLogo
+              .padding(.vertical, rowPadding)
+          }
 
           DividerLine()
 
-          accountFilters
-            .padding(.vertical, rowPadding)
+          if !isNFTFilters {
+            // Unavailable for NFTs until NFT supports grouping.
+            accountFilters
+              .padding(.vertical, rowPadding)
+          }
 
           networkFilters
             .padding(.vertical, rowPadding)
@@ -196,6 +214,20 @@ struct FiltersDisplaySettingsView: View {
         description: Strings.Wallet.hideSmallBalancesDescription,
         icon: .init(
           braveSystemName: "leo.eye.on",
+          iconContainerSize: min(iconContainerSize, maxIconContainerSize)
+        )
+      )
+    }
+    .tint(Color(.braveBlurpleTint))
+  }
+  
+  private var showNFTNetworkLogo: some View {
+    Toggle(isOn: $isShowingNFTNetworkLogo) {
+      FilterLabelView(
+        title: Strings.Wallet.showNFTNetworkLogoTitle,
+        description: Strings.Wallet.showNFTNetworkLogoDescription,
+        icon: .init(
+          braveSystemName: "leo.web3",
           iconContainerSize: min(iconContainerSize, maxIconContainerSize)
         )
       )
@@ -270,6 +302,7 @@ struct FiltersDisplaySettingsView: View {
           groupBy: groupBy,
           sortOrder: sortOrder,
           isHidingSmallBalances: isHidingSmallBalances,
+          isShowingNFTNetworkLogo: isShowingNFTNetworkLogo,
           accounts: accounts,
           networks: networks
         )
@@ -339,6 +372,7 @@ struct FiltersDisplaySettingsView_Previews: PreviewProvider {
         groupBy: .none,
         sortOrder: .valueDesc,
         isHidingSmallBalances: false,
+        isShowingNFTNetworkLogo: false,
         accounts: [
           .init(isSelected: true, model: .mockEthAccount),
           .init(isSelected: true, model: .mockSolAccount)
@@ -351,6 +385,7 @@ struct FiltersDisplaySettingsView_Previews: PreviewProvider {
           .init(isSelected: false, model: .mockGoerli)
         ]
       ),
+      isNFTFilters: false,
       networkStore: .previewStore,
       save: { _ in }
     )

--- a/Sources/BraveWallet/Crypto/FiltersDisplaySettingsView.swift
+++ b/Sources/BraveWallet/Crypto/FiltersDisplaySettingsView.swift
@@ -59,6 +59,37 @@ struct Filters {
   var accounts: [Selectable<BraveWallet.AccountInfo>]
   /// All networks and if they are currently selected. Default is all selected except known test networks.
   var networks: [Selectable<BraveWallet.NetworkInfo>]
+  
+  init(
+    groupBy: GroupBy = .none,
+    sortOrder: SortOrder = SortOrder(rawValue: Preferences.Wallet.sortOrderFilter.value) ?? .valueDesc,
+    isHidingSmallBalances: Bool = Preferences.Wallet.isHidingSmallBalancesFilter.value,
+    isHidingUnownedNFTs: Bool = Preferences.Wallet.isHidingUnownedNFTsFilter.value,
+    isShowingNFTNetworkLogo: Bool = Preferences.Wallet.isShowingNFTNetworkLogoFilter.value,
+    accounts: [Selectable<BraveWallet.AccountInfo>],
+    networks: [Selectable<BraveWallet.NetworkInfo>]
+  ) {
+    self.groupBy = groupBy
+    self.sortOrder = sortOrder
+    self.isHidingSmallBalances = isHidingSmallBalances
+    self.isHidingUnownedNFTs = isHidingUnownedNFTs
+    self.isShowingNFTNetworkLogo = isShowingNFTNetworkLogo
+    self.accounts = accounts
+    self.networks = networks
+  }
+  
+  func save() {
+    Preferences.Wallet.sortOrderFilter.value = sortOrder.rawValue
+    Preferences.Wallet.isHidingSmallBalancesFilter.value = isHidingSmallBalances
+    Preferences.Wallet.isShowingNFTNetworkLogoFilter.value = isShowingNFTNetworkLogo
+    Preferences.Wallet.isHidingUnownedNFTsFilter.value = isHidingUnownedNFTs
+    Preferences.Wallet.nonSelectedAccountsFilter.value = accounts
+      .filter({ !$0.isSelected })
+      .map(\.model.address)
+    Preferences.Wallet.nonSelectedNetworksFilter.value = networks
+      .filter({ !$0.isSelected })
+      .map(\.model.chainId)
+  }
 }
 
 struct FiltersDisplaySettingsView: View {

--- a/Sources/BraveWallet/Crypto/NFT/NFTView.swift
+++ b/Sources/BraveWallet/Crypto/NFT/NFTView.swift
@@ -13,7 +13,7 @@ struct NFTView: View {
   @ObservedObject var networkStore: NetworkStore
   @ObservedObject var nftStore: NFTStore
   
-  @State private var isPresentingNetworkFilter: Bool = false
+  @State private var isPresentingFiltersDisplaySettings: Bool = false
   @State private var isPresentingEditUserAssets: Bool = false
   @State private var selectedNFTViewModel: NFTAssetViewModel?
   @State private var isShowingNFTDiscoveryAlert: Bool = false
@@ -66,7 +66,7 @@ struct NFTView: View {
   private let nftGrids = [GridItem(.adaptive(minimum: 120), spacing: 16, alignment: .top)]
   
   @ViewBuilder private func nftLogo(_ nftViewModel: NFTAssetViewModel) -> some View {
-    if let image = nftViewModel.network.nativeTokenLogoImage {
+    if let image = nftViewModel.network.nativeTokenLogoImage, nftStore.filters.isShowingNFTNetworkLogo {
       Image(uiImage: image)
         .resizable()
         .frame(width: 20, height: 20)
@@ -99,29 +99,35 @@ struct NFTView: View {
       .aspectRatio(1.0, contentMode: .fit)
   }
   
-  private var networkFilterButton: some View {
+  private var filtersButton: some View {
     Button(action: {
-      self.isPresentingNetworkFilter = true
+      self.isPresentingFiltersDisplaySettings = true
     }) {
       Image(braveSystemName: "leo.tune")
         .font(.footnote.weight(.medium))
         .foregroundColor(Color(.braveBlurpleTint))
         .clipShape(Rectangle())
     }
-    .sheet(isPresented: $isPresentingNetworkFilter) {
-      NavigationView {
-        NetworkFilterView(
-          networks: nftStore.networkFilters,
-          networkStore: networkStore,
-          saveAction: { selectedNetworks in
-            nftStore.networkFilters = selectedNetworks
-          }
-        )
-      }
-      .navigationViewStyle(.stack)
-      .onDisappear {
-        networkStore.closeNetworkSelectionStore()
-      }
+    .sheet(isPresented: $isPresentingFiltersDisplaySettings) {
+      FiltersDisplaySettingsView(
+        filters: nftStore.filters,
+        isNFTFilters: true,
+        networkStore: networkStore,
+        save: { filters in
+          nftStore.saveFilters(filters)
+        }
+      )
+      .osAvailabilityModifiers({ view in
+        if #available(iOS 16, *) {
+          view
+            .presentationDetents([
+              .fraction(0.5),
+              .large
+            ])
+        } else {
+          view
+        }
+      })
     }
   }
   
@@ -136,7 +142,7 @@ struct NFTView: View {
           .padding(.leading, 5)
       }
       Spacer()
-      networkFilterButton
+      filtersButton
         .padding(.trailing, 10)
       addCustomAssetButton
     }

--- a/Sources/BraveWallet/Crypto/NFT/NFTView.swift
+++ b/Sources/BraveWallet/Crypto/NFT/NFTView.swift
@@ -121,7 +121,7 @@ struct NFTView: View {
         if #available(iOS 16, *) {
           view
             .presentationDetents([
-              .fraction(0.5),
+              .fraction(0.6),
               .large
             ])
         } else {

--- a/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
@@ -106,6 +106,7 @@ struct PortfolioView: View {
     .sheet(isPresented: $isPresentingFiltersDisplaySettings) {
       FiltersDisplaySettingsView(
         filters: portfolioStore.filters,
+        isNFTFilters: false,
         networkStore: networkStore,
         save: { filters in
           portfolioStore.saveFilters(filters)

--- a/Sources/BraveWallet/Crypto/Stores/AccountActivityStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/AccountActivityStore.swift
@@ -95,7 +95,7 @@ class AccountActivityStore: ObservableObject {
               NFTAssetViewModel(
                 token: token,
                 network: networkAssets.network,
-                balance: 0
+                balanceForAccounts: [:]
               )
             )
           } else {
@@ -170,7 +170,7 @@ class AccountActivityStore: ObservableObject {
               NFTAssetViewModel(
                 token: token,
                 network: networkAssets.network,
-                balance: Int(totalBalances[token.assetBalanceId] ?? 0),
+                balanceForAccounts: [account.address: Int(totalBalances[token.assetBalanceId] ?? 0)],
                 nftMetadata: allNFTMetadata[token.id]
               )
             )

--- a/Sources/BraveWallet/Crypto/Stores/KeyringStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/KeyringStore.swift
@@ -315,6 +315,7 @@ public class KeyringStore: ObservableObject {
       }
       Preferences.Wallet.sortOrderFilter.reset()
       Preferences.Wallet.isHidingSmallBalancesFilter.reset()
+      Preferences.Wallet.isHidingUnownedNFTsFilter.reset()
       Preferences.Wallet.isShowingNFTNetworkLogoFilter.reset()
       Preferences.Wallet.nonSelectedAccountsFilter.reset()
       Preferences.Wallet.nonSelectedNetworksFilter.reset()

--- a/Sources/BraveWallet/Crypto/Stores/KeyringStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/KeyringStore.swift
@@ -315,6 +315,7 @@ public class KeyringStore: ObservableObject {
       }
       Preferences.Wallet.sortOrderFilter.reset()
       Preferences.Wallet.isHidingSmallBalancesFilter.reset()
+      Preferences.Wallet.isShowingNFTNetworkLogoFilter.reset()
       Preferences.Wallet.nonSelectedAccountsFilter.reset()
       Preferences.Wallet.nonSelectedNetworksFilter.reset()
       completion?(isMnemonicValid)

--- a/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
@@ -101,6 +101,7 @@ public class PortfolioStore: ObservableObject {
       groupBy: .none,
       sortOrder: SortOrder(rawValue: Preferences.Wallet.sortOrderFilter.value) ?? .valueDesc,
       isHidingSmallBalances: Preferences.Wallet.isHidingSmallBalancesFilter.value,
+      isHidingUnownedNFTs: Preferences.Wallet.isHidingUnownedNFTsFilter.value, // only shown from NFT tab
       isShowingNFTNetworkLogo: Preferences.Wallet.isShowingNFTNetworkLogoFilter.value, // only shown from NFT tab
       accounts: allAccounts.map { account in
           .init(

--- a/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
@@ -101,6 +101,7 @@ public class PortfolioStore: ObservableObject {
       groupBy: .none,
       sortOrder: SortOrder(rawValue: Preferences.Wallet.sortOrderFilter.value) ?? .valueDesc,
       isHidingSmallBalances: Preferences.Wallet.isHidingSmallBalancesFilter.value,
+      isShowingNFTNetworkLogo: Preferences.Wallet.isShowingNFTNetworkLogoFilter.value, // only shown from NFT tab
       accounts: allAccounts.map { account in
           .init(
             isSelected: !nonSelectedAccountAddresses.contains(where: { $0 == account.address }),

--- a/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
@@ -98,11 +98,6 @@ public class PortfolioStore: ObservableObject {
     let nonSelectedAccountAddresses = Preferences.Wallet.nonSelectedAccountsFilter.value
     let nonSelectedNetworkChainIds = Preferences.Wallet.nonSelectedNetworksFilter.value
     return Filters(
-      groupBy: .none,
-      sortOrder: SortOrder(rawValue: Preferences.Wallet.sortOrderFilter.value) ?? .valueDesc,
-      isHidingSmallBalances: Preferences.Wallet.isHidingSmallBalancesFilter.value,
-      isHidingUnownedNFTs: Preferences.Wallet.isHidingUnownedNFTsFilter.value, // only shown from NFT tab
-      isShowingNFTNetworkLogo: Preferences.Wallet.isShowingNFTNetworkLogoFilter.value, // only shown from NFT tab
       accounts: allAccounts.map { account in
           .init(
             isSelected: !nonSelectedAccountAddresses.contains(where: { $0 == account.address }),
@@ -448,18 +443,9 @@ extension PortfolioStore: BraveWalletBraveWalletServiceObserver {
 extension PortfolioStore: PreferencesObserver {
   func saveFilters(_ filters: Filters) {
     isSavingFilters = true
-    defer {
-      isSavingFilters = false
-      update()
-    }
-    Preferences.Wallet.sortOrderFilter.value = filters.sortOrder.rawValue
-    Preferences.Wallet.isHidingSmallBalancesFilter.value = filters.isHidingSmallBalances
-    Preferences.Wallet.nonSelectedAccountsFilter.value = filters.accounts
-      .filter({ !$0.isSelected })
-      .map(\.model.address)
-    Preferences.Wallet.nonSelectedNetworksFilter.value = filters.networks
-      .filter({ !$0.isSelected })
-      .map(\.model.chainId)
+    filters.save()
+    isSavingFilters = false
+    update()
   }
   public func preferencesDidChange(for key: String) {
     guard !isSavingFilters else { return }

--- a/Sources/BraveWallet/Crypto/Stores/SettingsStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SettingsStore.swift
@@ -131,6 +131,7 @@ public class SettingsStore: ObservableObject {
     // Portfolio/NFT Filters
     Preferences.Wallet.sortOrderFilter.reset()
     Preferences.Wallet.isHidingSmallBalancesFilter.reset()
+    Preferences.Wallet.isShowingNFTNetworkLogoFilter.reset()
     Preferences.Wallet.nonSelectedAccountsFilter.reset()
     Preferences.Wallet.nonSelectedNetworksFilter.reset()
     

--- a/Sources/BraveWallet/Crypto/Stores/SettingsStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SettingsStore.swift
@@ -131,6 +131,7 @@ public class SettingsStore: ObservableObject {
     // Portfolio/NFT Filters
     Preferences.Wallet.sortOrderFilter.reset()
     Preferences.Wallet.isHidingSmallBalancesFilter.reset()
+    Preferences.Wallet.isHidingUnownedNFTsFilter.reset()
     Preferences.Wallet.isShowingNFTNetworkLogoFilter.reset()
     Preferences.Wallet.nonSelectedAccountsFilter.reset()
     Preferences.Wallet.nonSelectedNetworksFilter.reset()

--- a/Sources/BraveWallet/Preview Content/MockContent.swift
+++ b/Sources/BraveWallet/Preview Content/MockContent.swift
@@ -112,7 +112,7 @@ extension BraveWallet.BlockchainToken {
   )
   
   static let mockSolanaNFTToken: BraveWallet.BlockchainToken = .init(
-    contractAddress: "0xaaaaaaaaaa222222222233333333334444444444",
+    contractAddress: "aaaaaaaaaa222222222233333333334444444444",
     name: "SOLNFT",
     logo: "",
     isErc20: false,

--- a/Sources/BraveWallet/WalletPreferences.swift
+++ b/Sources/BraveWallet/WalletPreferences.swift
@@ -50,6 +50,7 @@ extension Preferences {
     // MARK: Portfolio & NFT filters
     public static let sortOrderFilter = Option<Int>(key: "wallet.sortOrderFilter", default: SortOrder.valueDesc.rawValue)
     public static let isHidingSmallBalancesFilter = Option<Bool>(key: "wallet.isHidingSmallBalancesFilter", default: false)
+    public static let isHidingUnownedNFTsFilter = Option<Bool>(key: "wallet.isHidingUnownedNFTsFilter", default: false)
     public static let isShowingNFTNetworkLogoFilter = Option<Bool>(key: "wallet.isShowingNFTNetworkLogoFilter", default: false)
     public static let nonSelectedAccountsFilter = Option<[String]>(key: "wallet.nonSelectedAccountsFilter", default: [])
     public static let nonSelectedNetworksFilter = Option<[String]>(

--- a/Sources/BraveWallet/WalletPreferences.swift
+++ b/Sources/BraveWallet/WalletPreferences.swift
@@ -50,6 +50,7 @@ extension Preferences {
     // MARK: Portfolio & NFT filters
     public static let sortOrderFilter = Option<Int>(key: "wallet.sortOrderFilter", default: SortOrder.valueDesc.rawValue)
     public static let isHidingSmallBalancesFilter = Option<Bool>(key: "wallet.isHidingSmallBalancesFilter", default: false)
+    public static let isShowingNFTNetworkLogoFilter = Option<Bool>(key: "wallet.isShowingNFTNetworkLogoFilter", default: false)
     public static let nonSelectedAccountsFilter = Option<[String]>(key: "wallet.nonSelectedAccountsFilter", default: [])
     public static let nonSelectedNetworksFilter = Option<[String]>(
       key: "wallet.nonSelectedNetworksFilter",

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -4184,6 +4184,20 @@ extension Strings {
       value: "Assets with value less than $1",
       comment: "The description label of the filter option that hides assets if their fiat value is below $1, shown below the title. Used in Portfolio/NFT filters and display settings."
     )
+    public static let showNFTNetworkLogoTitle = NSLocalizedString(
+      "wallet.showNFTNetworkLogoTitle",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Network Logo",
+      comment: "The label of the filter option that hides the network logo on NFTs displayed in the grid. Used in NFT filters and display settings."
+    )
+    public static let showNFTNetworkLogoDescription = NSLocalizedString(
+      "wallet.showNFTNetworkLogoDescription",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Show network logo on NFTs",
+      comment: "The description label of the filter option that hides the network logo on NFTs displayed in the grid. Used in NFT filters and display settings."
+    )
     public static let selectAccountsTitle = NSLocalizedString(
       "wallet.selectAccountsTitle",
       tableName: "BraveWallet",
@@ -4262,7 +4276,7 @@ extension Strings {
       comment: "The title of the sort option that groups assets by each account. Used in Portfolio/NFT filters and display settings."
     )
     public static let groupByNetworksOptionTitle = NSLocalizedString(
-      "wallet.groupByNetworksTitle",
+      "wallet.groupByNetworksOptionTitle",
       tableName: "BraveWallet",
       bundle: .module,
       value: "Networks",

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -4184,6 +4184,20 @@ extension Strings {
       value: "Assets with value less than $1",
       comment: "The description label of the filter option that hides assets if their fiat value is below $1, shown below the title. Used in Portfolio/NFT filters and display settings."
     )
+    public static let hideUnownedNFTsTitle = NSLocalizedString(
+      "wallet.hideUnownedNFTsTitle",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Hide Unowned",
+      comment: "The label of the filter option that hides NFTs if they are not owned by the user. Used in Portfolio/NFT filters and display settings."
+    )
+    public static let hideUnownedNFTsDescription = NSLocalizedString(
+      "wallet.hideUnownedNFTsDescription",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Hide NFTs that have no balance",
+      comment: "The description label of the filter option that hides NFTs if they are not owned by the user. Used in Portfolio/NFT filters and display settings."
+    )
     public static let showNFTNetworkLogoTitle = NSLocalizedString(
       "wallet.showNFTNetworkLogoTitle",
       tableName: "BraveWallet",

--- a/Sources/DesignSystem/Icons/Symbols.xcassets/leo.web3.symbolset/Contents.json
+++ b/Sources/DesignSystem/Icons/Symbols.xcassets/leo.web3.symbolset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "symbols" : [
+    {
+      "idiom" : "universal"
+    }
+  ]
+}

--- a/Tests/BraveWalletTests/AccountActivityStoreTests.swift
+++ b/Tests/BraveWalletTests/AccountActivityStoreTests.swift
@@ -204,7 +204,7 @@ class AccountActivityStoreTests: XCTestCase {
         }
         XCTAssertEqual(lastUpdatedVisibleNFTs.count, 1)
         XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 0]?.token.symbol, BraveWallet.BlockchainToken.mockERC721NFTToken.symbol)
-        XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 0]?.balance, Int(mockNFTBalance))
+        XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 0]?.balanceForAccounts[account.address], Int(mockNFTBalance))
         XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 0]?.nftMetadata?.imageURLString, mockERC721Metadata.imageURLString)
         XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 0]?.nftMetadata?.name, mockERC721Metadata.name)
         XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 0]?.nftMetadata?.description, mockERC721Metadata.description)
@@ -329,7 +329,7 @@ class AccountActivityStoreTests: XCTestCase {
         }
         XCTAssertEqual(lastUpdatedVisibleNFTs.count, 1)
         XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 0]?.token.symbol, BraveWallet.BlockchainToken.mockSolanaNFTToken.symbol)
-        XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 0]?.balance, Int(mockSolanaNFTTokenBalance))
+        XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 0]?.balanceForAccounts[account.address], Int(mockSolanaNFTTokenBalance))
         XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 0]?.nftMetadata?.imageURLString, mockSolMetadata.imageURLString)
         XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 0]?.nftMetadata?.name, mockSolMetadata.name)
         XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 0]?.nftMetadata?.description, mockSolMetadata.description)

--- a/Tests/BraveWalletTests/NFTStoreTests.swift
+++ b/Tests/BraveWalletTests/NFTStoreTests.swift
@@ -6,24 +6,49 @@
 import Combine
 import XCTest
 import BraveCore
+import Preferences
 @testable import BraveWallet
 
 class NFTStoreTests: XCTestCase {
   
   private var cancellables: Set<AnyCancellable> = .init()
   
-  func testUpdate() {
+  override func setUp() {
+    resetFilters()
+  }
+  override func tearDown() {
+    resetFilters()
+  }
+  private func resetFilters() {
+    Preferences.Wallet.isHidingUnownedNFTsFilter.reset()
+    Preferences.Wallet.isShowingNFTNetworkLogoFilter.reset()
+    Preferences.Wallet.nonSelectedAccountsFilter.reset()
+    Preferences.Wallet.nonSelectedNetworksFilter.reset()
+  }
+  
+  func testUpdate() async {
     let ethNetwork: BraveWallet.NetworkInfo = .mockMainnet
+    let ethAccount1: BraveWallet.AccountInfo = .mockEthAccount
+    let ethAccount2 = (BraveWallet.AccountInfo.mockEthAccount.copy() as! BraveWallet.AccountInfo).then {
+      $0.address = "mock_eth_id_2"
+      $0.name = "Ethereum Account 2"
+    }
+    let unownedEthNFT = (BraveWallet.BlockchainToken.mockERC721NFTToken.copy() as! BraveWallet.BlockchainToken).then {
+      $0.contractAddress = "0xbbbbbbbbbb222222222233333333334444444444"
+      $0.name = "Unowned NFT"
+    }
     let mockEthUserAssets: [BraveWallet.BlockchainToken] = [
-      .previewToken.then { $0.visible = true },
-      .mockUSDCToken.then { $0.visible = false }, // Verify non-visible assets not displayed #6386
-      .mockERC721NFTToken
+      .previewToken.copy(asVisibleAsset: true),
+      .mockUSDCToken.copy(asVisibleAsset: false), // Verify non-visible assets not displayed #6386
+      .mockERC721NFTToken,
+      unownedEthNFT
     ]
     
     let solNetwork: BraveWallet.NetworkInfo = .mockSolana
+    let solAccount: BraveWallet.AccountInfo = .mockSolAccount
     let mockSolUserAssets: [BraveWallet.BlockchainToken] = [
-      BraveWallet.NetworkInfo.mockSolana.nativeToken.then { $0.visible = true },
-      .mockSpdToken.then { $0.visible = false }, // Verify non-visible assets not displayed #6386
+      BraveWallet.NetworkInfo.mockSolana.nativeToken.copy(asVisibleAsset: true),
+      .mockSpdToken.copy(asVisibleAsset: false), // Verify non-visible assets not displayed #6386
       .mockSolanaNFTToken
     ]
     
@@ -36,6 +61,9 @@ class NFTStoreTests: XCTestCase {
     keyringService._isLocked = { completion in
       // unlocked would cause `update()` from call in `init` to be called prior to test being setup.g
       completion(true)
+    }
+    keyringService._allAccounts = {
+      $0(.init(accounts: [solAccount, ethAccount1, ethAccount2]))
     }
     let rpcService = BraveWallet.TestJsonRpcService()
     rpcService._addObserver = { _ in }
@@ -53,7 +81,11 @@ class NFTStoreTests: XCTestCase {
         XCTFail("Should not fetch unknown network")
       }
     }
-    rpcService._erc721Metadata = { _, _, _, completion in
+    rpcService._erc721Metadata = { contractAddress, tokenId, chainId, completion in
+      guard contractAddress == BraveWallet.BlockchainToken.mockERC721NFTToken.contractAddress else {
+        completion("", "", .internalError, "Error")
+        return
+      }
       let metadata = """
       {
         "image": "mock.image.url",
@@ -73,16 +105,40 @@ class NFTStoreTests: XCTestCase {
       """
       completion("", metadata, .success, "")
     }
+    rpcService._erc721TokenBalance = { contractAddress, tokenId, accountAddress, chainId, completion in
+      guard accountAddress == ethAccount1.address,
+            contractAddress == BraveWallet.BlockchainToken.mockERC721NFTToken.contractAddress else {
+        completion("", .internalError, "Error")
+        return
+      }
+      completion("0x1", .success, "")
+    }
+    rpcService._splTokenAccountBalance = { accountAddress, tokenMintAddress, chainId, completion in
+      guard accountAddress == solAccount.address,
+            tokenMintAddress == mockSolUserAssets[safe: 2]?.contractAddress else {
+        completion("", 0, "", .internalError, "Error")
+        return
+      }
+      completion("1", 0, "1", .success, "")
+    }
     let walletService = BraveWallet.TestBraveWalletService()
     walletService._addObserver = { _ in }
     let assetRatioService = BraveWallet.TestAssetRatioService()
     
     let mockAssetManager = TestableWalletUserAssetManager()
-    mockAssetManager._getAllVisibleAssetsInNetworkAssets = { _ in
+    mockAssetManager._getAllVisibleAssetsInNetworkAssets = { networks in
       [
-        NetworkAssets(network: .mockMainnet, tokens: [.previewToken.copy(asVisibleAsset: true), .mockERC721NFTToken.copy(asVisibleAsset: true)], sortOrder: 0),
-        NetworkAssets(network: .mockSolana, tokens: [BraveWallet.NetworkInfo.mockSolana.nativeToken.copy(asVisibleAsset: true), .mockSolanaNFTToken.copy(asVisibleAsset: true)], sortOrder: 1)
-      ]
+        NetworkAssets(
+          network: .mockMainnet,
+          tokens: mockEthUserAssets.filter(\.visible),
+          sortOrder: 0
+        ),
+        NetworkAssets(
+          network: .mockSolana,
+          tokens: mockSolUserAssets.filter(\.visible),
+          sortOrder: 1
+        )
+      ].filter { networkAsset in networks.contains(where: { $0 == networkAsset.network }) }
     }
     
     // setup store
@@ -109,132 +165,112 @@ class NFTStoreTests: XCTestCase {
           XCTFail("Unexpected test result")
           return
         }
-        XCTAssertEqual(lastUpdatedVisibleNFTs.count, 2)
-        XCTAssertEqual(lastUpdatedVisibleNFTs[0].token.symbol, mockEthUserAssets.last?.symbol)
-        
-        XCTAssertEqual(lastUpdatedVisibleNFTs[1].token.symbol, mockSolUserAssets.last?.symbol)
+        XCTAssertEqual(lastUpdatedVisibleNFTs.count, 3)
+        XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 0]?.token.symbol, mockEthUserAssets[safe: 2]?.symbol)
         XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 0]?.nftMetadata?.imageURLString, mockERC721Metadata.imageURLString)
         XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 0]?.nftMetadata?.name, mockERC721Metadata.name)
         XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 0]?.nftMetadata?.description, mockERC721Metadata.description)
-        XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 1]?.nftMetadata?.imageURLString, mockSolMetadata.imageURLString)
-        XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 1]?.nftMetadata?.name, mockSolMetadata.name)
-        XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 1]?.nftMetadata?.description, mockSolMetadata.description)
+        XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 1]?.token.symbol, mockEthUserAssets[safe: 3]?.symbol)
+        XCTAssertNil(lastUpdatedVisibleNFTs[safe: 1]?.nftMetadata)
+        
+        XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 2]?.token.symbol, mockSolUserAssets[safe: 2]?.symbol)
+        XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 2]?.nftMetadata?.imageURLString, mockSolMetadata.imageURLString)
+        XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 2]?.nftMetadata?.name, mockSolMetadata.name)
+        XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 2]?.nftMetadata?.description, mockSolMetadata.description)
       }.store(in: &cancellables)
     
     store.update()
-    waitForExpectations(timeout: 1) { error in
-      XCTAssertNil(error)
-    }
-  }
-  
-  @MainActor func testUpdateAfterNetworkFilter() async {
-    let ethNetwork: BraveWallet.NetworkInfo = .mockMainnet
-    let solNetwork: BraveWallet.NetworkInfo = .mockSolana
-    let mockSolUserAssets: [BraveWallet.BlockchainToken] = [
-      BraveWallet.NetworkInfo.mockSolana.nativeToken.then { $0.visible = true },
-      .mockSpdToken.then { $0.visible = false }, // Verify non-visible assets not displayed #6386
-      .mockSolanaNFTToken
-    ]
-    
-    let mockSolMetadata: NFTMetadata = .init(imageURLString: "sol.mock.image.url", name: "sol mock nft name", description: "sol mock nft description")
-    
-    // setup test services
-    let keyringService = BraveWallet.TestKeyringService()
-    keyringService._addObserver = { _ in }
-    keyringService._isLocked = { completion in
-      // unlocked would cause `update()` from call in `init` to be called prior to test being setup.g
-      completion(true)
-    }
-    let rpcService = BraveWallet.TestJsonRpcService()
-    rpcService._addObserver = { _ in }
-    rpcService._allNetworks = { coin, completion in
-      switch coin {
-      case .eth:
-        completion([ethNetwork])
-      case .sol:
-        completion([solNetwork])
-      case .fil:
-        XCTFail("Should not fetch filecoin network")
-      case .btc:
-        XCTFail("Should not fetch btc network")
-      @unknown default:
-        XCTFail("Should not fetch unknown network")
-      }
-    }
-    rpcService._erc721Metadata = { _, _, _, completion in
-      let metadata = """
-      {
-        "image": "mock.image.url",
-        "name": "mock nft name",
-        "description": "mock nft description"
-      }
-      """
-      completion("", metadata, .success, "")
-    }
-    rpcService._solTokenMetadata = { _, _, completion in
-      let metadata = """
-      {
-        "image": "sol.mock.image.url",
-        "name": "sol mock nft name",
-        "description": "sol mock nft description"
-      }
-      """
-      completion("", metadata, .success, "")
-    }
-    let walletService = BraveWallet.TestBraveWalletService()
-    walletService._addObserver = { _ in }
-    let assetRatioService = BraveWallet.TestAssetRatioService()
-    
-    let mockAssetManager = TestableWalletUserAssetManager()
-    mockAssetManager._getAllVisibleAssetsInNetworkAssets = { _ in
-      [
-        NetworkAssets(network: .mockSolana, tokens: [BraveWallet.NetworkInfo.mockSolana.nativeToken.copy(asVisibleAsset: true), .mockSolanaNFTToken.copy(asVisibleAsset: true)], sortOrder: 1)
-      ]
-    }
-    
-    // setup store
-    let store = NFTStore(
-      keyringService: keyringService,
-      rpcService: rpcService,
-      walletService: walletService,
-      assetRatioService: assetRatioService,
-      blockchainRegistry: BraveWallet.TestBlockchainRegistry(),
-      ipfsApi: TestIpfsAPI(),
-      userAssetManager: mockAssetManager
-    )
-    
-    // Initial update() with all networks
-    let setupException = expectation(description: "setup")
-    store.$userVisibleNFTs
-      .dropFirst() // initial
-      .collect(2) // empty nfts, populated nfts
-      .sink { userVisibleNFTs in
-        setupException.fulfill()
-      }.store(in: &cancellables)
-    store.update()
-    await fulfillment(of: [setupException], timeout: 1)
+    await fulfillment(of: [userVisibleNFTsException], timeout: 1)
     cancellables.removeAll()
     
-    // Test that `update()` will assign new value to `userVisibleNFTs` publisher
-    let userVisibleNFTsException = expectation(description: "update-userVisibleNFTs")
+    let defaultFilters = store.filters
+    
+    // MARK: Network Filter Test
+    let networksExpectation = expectation(description: "update-networks")
     store.$userVisibleNFTs
       .dropFirst()
       .collect(2)
       .sink { userVisibleNFTs in
-        defer { userVisibleNFTsException.fulfill() }
+        defer { networksExpectation.fulfill() }
+        XCTAssertEqual(userVisibleNFTs.count, 2) // empty nfts, populated nfts
+        guard let lastUpdatedVisibleNFTs = userVisibleNFTs.last else {
+          XCTFail("Unexpected test result")
+          return
+        }
+        XCTAssertEqual(lastUpdatedVisibleNFTs.count, 2)
+        XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 0]?.token.symbol, mockEthUserAssets[safe: 2]?.symbol)
+        XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 1]?.token.symbol, mockEthUserAssets[safe: 3]?.symbol)
+        // solana NFT hidden
+      }.store(in: &cancellables)
+    store.saveFilters(.init(
+      groupBy: defaultFilters.groupBy,
+      sortOrder: defaultFilters.sortOrder,
+      isHidingSmallBalances: defaultFilters.isHidingSmallBalances,
+      isHidingUnownedNFTs: defaultFilters.isHidingUnownedNFTs,
+      isShowingNFTNetworkLogo: defaultFilters.isShowingNFTNetworkLogo,
+      accounts: defaultFilters.accounts,
+      networks: defaultFilters.networks.map {
+        .init(isSelected: $0.model.coin == .eth, model: $0.model)
+      }
+    ))
+    await fulfillment(of: [networksExpectation], timeout: 1)
+    cancellables.removeAll()
+    
+    // MARK: Hiding Unowned Filter Test
+    let hidingUnownedExpectation = expectation(description: "update-hidingUnowned")
+    store.$userVisibleNFTs
+      .dropFirst()
+      .collect(2)
+      .sink { userVisibleNFTs in
+        defer { hidingUnownedExpectation.fulfill() }
+        XCTAssertEqual(userVisibleNFTs.count, 2) // empty nfts, populated nfts
+        guard let lastUpdatedVisibleNFTs = userVisibleNFTs.last else {
+          XCTFail("Unexpected test result")
+          return
+        }
+        XCTAssertEqual(lastUpdatedVisibleNFTs.count, 2)
+        XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 0]?.token.symbol, mockEthUserAssets[safe: 2]?.symbol)
+        XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 1]?.token.symbol, mockSolUserAssets[safe: 2]?.symbol)
+      }.store(in: &cancellables)
+    store.saveFilters(.init(
+      groupBy: defaultFilters.groupBy,
+      sortOrder: defaultFilters.sortOrder,
+      isHidingSmallBalances: defaultFilters.isHidingSmallBalances,
+      isHidingUnownedNFTs: true,
+      isShowingNFTNetworkLogo: defaultFilters.isShowingNFTNetworkLogo,
+      accounts: defaultFilters.accounts,
+      networks: defaultFilters.networks
+    ))
+    await fulfillment(of: [hidingUnownedExpectation], timeout: 1)
+    cancellables.removeAll()
+    
+    // MARK: Accounts Filter Test
+    let accountsExpectation = expectation(description: "update-accounts")
+    store.$userVisibleNFTs
+      .dropFirst()
+      .collect(2)
+      .sink { userVisibleNFTs in
+        defer { accountsExpectation.fulfill() }
         XCTAssertEqual(userVisibleNFTs.count, 2) // empty nfts, populated nfts
         guard let lastUpdatedVisibleNFTs = userVisibleNFTs.last else {
           XCTFail("Unexpected test result")
           return
         }
         XCTAssertEqual(lastUpdatedVisibleNFTs.count, 1)
-        XCTAssertEqual(lastUpdatedVisibleNFTs[0].token.symbol, mockSolUserAssets.last?.symbol)
-        XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 0]?.nftMetadata?.imageURLString, mockSolMetadata.imageURLString)
-        XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 0]?.nftMetadata?.name, mockSolMetadata.name)
-        XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 0]?.nftMetadata?.description, mockSolMetadata.description)
+        XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 0]?.token.symbol, mockEthUserAssets[safe: 2]?.symbol)
       }.store(in: &cancellables)
-    
-//    store.networkFilters = [.init(isSelected: true, model: solNetwork)]
-    await fulfillment(of: [userVisibleNFTsException], timeout: 1)
+    store.saveFilters(.init(
+      groupBy: defaultFilters.groupBy,
+      sortOrder: defaultFilters.sortOrder,
+      isHidingSmallBalances: defaultFilters.isHidingSmallBalances,
+      isHidingUnownedNFTs: true,
+      isShowingNFTNetworkLogo: defaultFilters.isShowingNFTNetworkLogo,
+      accounts: defaultFilters.accounts.map { // only ethereum accounts selected
+        .init(isSelected: $0.model.coin == .eth, model: $0.model)
+      },
+      networks: defaultFilters.networks
+    ))
+    await fulfillment(of: [accountsExpectation], timeout: 1)
+    cancellables.removeAll()
   }
 }

--- a/Tests/BraveWalletTests/NFTStoreTests.swift
+++ b/Tests/BraveWalletTests/NFTStoreTests.swift
@@ -234,7 +234,7 @@ class NFTStoreTests: XCTestCase {
         XCTAssertEqual(lastUpdatedVisibleNFTs[safe: 0]?.nftMetadata?.description, mockSolMetadata.description)
       }.store(in: &cancellables)
     
-    store.networkFilters = [.init(isSelected: true, model: solNetwork)]
+//    store.networkFilters = [.init(isSelected: true, model: solNetwork)]
     await fulfillment(of: [userVisibleNFTsException], timeout: 1)
   }
 }

--- a/Tests/BraveWalletTests/PortfolioStoreTests.swift
+++ b/Tests/BraveWalletTests/PortfolioStoreTests.swift
@@ -353,6 +353,7 @@ class PortfolioStoreTests: XCTestCase {
       groupBy: store.filters.groupBy,
       sortOrder: .valueAsc,
       isHidingSmallBalances: store.filters.isHidingSmallBalances,
+      isHidingUnownedNFTs: store.filters.isHidingUnownedNFTs,
       isShowingNFTNetworkLogo: store.filters.isShowingNFTNetworkLogo,
       accounts: store.filters.accounts,
       networks: store.filters.networks
@@ -399,6 +400,7 @@ class PortfolioStoreTests: XCTestCase {
       groupBy: store.filters.groupBy,
       sortOrder: .valueDesc,
       isHidingSmallBalances: true,
+      isHidingUnownedNFTs: store.filters.isHidingUnownedNFTs,
       isShowingNFTNetworkLogo: store.filters.isShowingNFTNetworkLogo,
       accounts: store.filters.accounts,
       networks: store.filters.networks
@@ -452,6 +454,7 @@ class PortfolioStoreTests: XCTestCase {
       groupBy: store.filters.groupBy,
       sortOrder: .valueDesc,
       isHidingSmallBalances: false,
+      isHidingUnownedNFTs: store.filters.isHidingUnownedNFTs,
       isShowingNFTNetworkLogo: store.filters.isShowingNFTNetworkLogo,
       accounts: store.filters.accounts.map { // deselect ethAccount2
         .init(isSelected: $0.model.address != ethAccount2.address, model: $0.model)
@@ -500,6 +503,7 @@ class PortfolioStoreTests: XCTestCase {
       groupBy: store.filters.groupBy,
       sortOrder: .valueDesc,
       isHidingSmallBalances: false,
+      isHidingUnownedNFTs: store.filters.isHidingUnownedNFTs,
       isShowingNFTNetworkLogo: store.filters.isShowingNFTNetworkLogo,
       accounts: store.filters.accounts.map { // re-select all accounts
         .init(isSelected: true, model: $0.model)

--- a/Tests/BraveWalletTests/PortfolioStoreTests.swift
+++ b/Tests/BraveWalletTests/PortfolioStoreTests.swift
@@ -353,6 +353,7 @@ class PortfolioStoreTests: XCTestCase {
       groupBy: store.filters.groupBy,
       sortOrder: .valueAsc,
       isHidingSmallBalances: store.filters.isHidingSmallBalances,
+      isShowingNFTNetworkLogo: store.filters.isShowingNFTNetworkLogo,
       accounts: store.filters.accounts,
       networks: store.filters.networks
     ))
@@ -398,6 +399,7 @@ class PortfolioStoreTests: XCTestCase {
       groupBy: store.filters.groupBy,
       sortOrder: .valueDesc,
       isHidingSmallBalances: true,
+      isShowingNFTNetworkLogo: store.filters.isShowingNFTNetworkLogo,
       accounts: store.filters.accounts,
       networks: store.filters.networks
     ))
@@ -450,6 +452,7 @@ class PortfolioStoreTests: XCTestCase {
       groupBy: store.filters.groupBy,
       sortOrder: .valueDesc,
       isHidingSmallBalances: false,
+      isShowingNFTNetworkLogo: store.filters.isShowingNFTNetworkLogo,
       accounts: store.filters.accounts.map { // deselect ethAccount2
         .init(isSelected: $0.model.address != ethAccount2.address, model: $0.model)
       },
@@ -497,6 +500,7 @@ class PortfolioStoreTests: XCTestCase {
       groupBy: store.filters.groupBy,
       sortOrder: .valueDesc,
       isHidingSmallBalances: false,
+      isShowingNFTNetworkLogo: store.filters.isShowingNFTNetworkLogo,
       accounts: store.filters.accounts.map { // re-select all accounts
         .init(isSelected: true, model: $0.model)
       },


### PR DESCRIPTION
## Summary of Changes
- Integrates Filters and Display Settings modal into the NFT tab
- NFT tab has a `Hide Unowned` and `Show Network Logo` display setting instead of the `Sort Assets` & `Hide Small Balances` seen on Portfolio.
- Selected accounts & networks are shared with Portfolio

This pull request fixes #7699

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

### Test `Show Network Logo`:
1. Have at least 1 NFT visible in NFT tab.
2. Tap filter button on NFT tab to open Filters and Display Settings.
3. Toggle `Show Network Logo` on/off, then tap `Save Changes`.
4. Verify logo is shown on NFTs in grid when enabled and not shown when hidden.

https://github.com/brave/brave-ios/assets/5314553/ee3b8910-22dc-485f-bac5-33da2b3ad1a7


### Test `Hide Unowned`:
1. Have at least 1 NFT that you own, and one NFT that you do not own added to NFT tab.
2. Tap filter button on NFT tab to open Filters and Display Settings.
3. Toggle `Hide Unowned` on/off, then tap `Save Changes`.
4. When enabled, verify only the owned NFT is displayed. When disabled, verify all NFTs are shown (owned and unowned).

https://github.com/brave/brave-ios/assets/5314553/a427725c-26b2-476a-ad19-04d0e5beb95f


### Test `Accounts`:
1. Have at least 1 NFT that you own added to NFT tab.
2. Enable `Hide Unowned` toggle (required for Accounts filters to be used until Grouping support).
3. Tap filter button on NFT tab to open Filters and Display Settings.
4. Tap accounts and de-select the account that owns the NFT, tap back then tap `Save Changes`.
5. Verify the NFT is no longer displayed in the grid.

https://github.com/brave/brave-ios/assets/5314553/619d77f4-3b9f-4c53-bc34-7872d5013f05


### Test `Networks`:
1. Have at least 1 NFT that you own added to NFT tab.
2. Tap filter button on NFT tab to open Filters and Display Settings.
3. De-select the network the NFT belongs to, tap back then tap `Save Changes`.
4. Verify the NFT belonging to the de-selected network is hidden.
5. Repeat from step 2 but de-select all networks, then select the network the NFT belongs to.
6. Verify the NFT belonging to the selected network is shown.

https://github.com/brave/brave-ios/assets/5314553/9cd9da57-42e7-4399-af83-b189e90c724e



## Screenshots:

![NFT Filters   Display Settings - light](https://github.com/brave/brave-ios/assets/5314553/c4381ba6-fd7e-4f01-b0d3-895390e02205) | ![NFT Filters   Display Settings - dark](https://github.com/brave/brave-ios/assets/5314553/d17cf4e3-b3b0-456b-934d-a8061a661ffa)
--|--

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
