### PR TITLE
Fix #7751: Fix Transaction Summary blockie colours for Solana transaction

### DIFF
--- a/Sources/BraveWallet/Crypto/Transactions/TransactionParser+TransactionSummary.swift
+++ b/Sources/BraveWallet/Crypto/Transactions/TransactionParser+TransactionSummary.swift
@@ -14,7 +14,7 @@ struct TransactionSummary: Equatable, Identifiable {
   /// Account name for the from address of the transaction
   let namedFromAddress: String
   /// To address of the transaction
-  var toAddress: String { txInfo.ethTxToAddress }
+  var toAddress: String
   /// Account name for the to address of the transaction
   let namedToAddress: String
   /// The title for the transaction summary.
@@ -58,9 +58,19 @@ extension TransactionParser {
       currencyFormatter: currencyFormatter,
       decimalFormatStyle: .balance // use 4 digit precision for summary
     ) else {
+      let toAddress: String
+      switch transaction.coin {
+      case .eth:
+        toAddress = transaction.ethTxToAddress
+      case .sol:
+        toAddress = transaction.txDataUnion.solanaTxData?.toWalletAddress ?? ""
+      default:
+        toAddress = ""
+      }
       return .init(
         txInfo: transaction,
         namedFromAddress: NamedAddresses.name(for: transaction.fromAddress, accounts: accountInfos),
+        toAddress: toAddress,
         namedToAddress: NamedAddresses.name(for: transaction.ethTxToAddress, accounts: accountInfos),
         title: "",
         gasFee: gasFee(
@@ -78,6 +88,7 @@ extension TransactionParser {
       return .init(
         txInfo: transaction,
         namedFromAddress: parsedTransaction.namedFromAddress,
+        toAddress: parsedTransaction.toAddress,
         namedToAddress: parsedTransaction.namedToAddress,
         title: title,
         gasFee: details.gasFee,
@@ -88,6 +99,7 @@ extension TransactionParser {
       return .init(
         txInfo: transaction,
         namedFromAddress: parsedTransaction.namedFromAddress,
+        toAddress: parsedTransaction.toAddress,
         namedToAddress: parsedTransaction.namedToAddress,
         title: title,
         gasFee: details.gasFee,
@@ -102,6 +114,7 @@ extension TransactionParser {
       return .init(
         txInfo: transaction,
         namedFromAddress: parsedTransaction.namedFromAddress,
+        toAddress: parsedTransaction.toAddress,
         namedToAddress: parsedTransaction.namedToAddress,
         title: title,
         gasFee: details.gasFee,
@@ -117,6 +130,7 @@ extension TransactionParser {
       return .init(
         txInfo: transaction,
         namedFromAddress: parsedTransaction.namedFromAddress,
+        toAddress: parsedTransaction.toAddress,
         namedToAddress: parsedTransaction.namedToAddress,
         title: title,
         gasFee: details.gasFee,
@@ -132,6 +146,7 @@ extension TransactionParser {
       return .init(
         txInfo: transaction,
         namedFromAddress: parsedTransaction.namedFromAddress,
+        toAddress: parsedTransaction.toAddress,
         namedToAddress: parsedTransaction.namedToAddress,
         title: title,
         gasFee: nil,
@@ -142,6 +157,7 @@ extension TransactionParser {
       return .init(
         txInfo: transaction,
         namedFromAddress: parsedTransaction.namedFromAddress,
+        toAddress: parsedTransaction.toAddress,
         namedToAddress: parsedTransaction.namedToAddress,
         title: title,
         gasFee: details.gasFee,
@@ -157,13 +173,14 @@ extension TransactionParser {
       return .init(
         txInfo: transaction,
         namedFromAddress: parsedTransaction.namedFromAddress,
+        toAddress: parsedTransaction.toAddress,
         namedToAddress: parsedTransaction.namedToAddress,
         title: title,
         gasFee: parsedTransaction.gasFee,
         networkSymbol: parsedTransaction.networkSymbol
       )
     case .other:
-      return .init(txInfo: .init(), namedFromAddress: "", namedToAddress: "", title: "", gasFee: nil, networkSymbol: "")
+      return .init(txInfo: .init(), namedFromAddress: "", toAddress: "", namedToAddress: "", title: "", gasFee: nil, networkSymbol: "")
     }
   }
 }


### PR DESCRIPTION
## Summary of Changes
- `TransactionSummary` model was using a computed property to fetch the `toAddress` which was used for the blockie colours, but it was only checking the ethereum to address regardless of the transaction type.

This pull request fixes #7751

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Create a Solana send transaction from one Solana account to another (easier to know expected blockie colours if it's your own account). 
2. Either approve the transaction, or dismiss it (don't reject or it won't be visible in Activity tab :))
3. Open Activity tab and verify the small blockie is the correct blockie for the to address / to account. It should match the transaction detail modal
4. Open Accounts tab and tap the account that sent the transaction. Verify the small blockie is the correct to address / to account blockie.


## Screenshots:

https://github.com/brave/brave-ios/assets/5314553/9a50e9c3-03ea-42c8-86e2-560a5e3a8f48



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
