### PR TITLE
No bug: Wallet unit test fixup

### DIFF
--- a/Tests/BraveWalletTests/AccountActivityStoreTests.swift
+++ b/Tests/BraveWalletTests/AccountActivityStoreTests.swift
@@ -111,6 +111,7 @@ class AccountActivityStoreTests: XCTestCase {
   }
   
   func testUpdateEthereumAccount() {
+    let firstTransactionDate = Date(timeIntervalSince1970: 1636399671) // Monday, November 8, 2021 7:27:51 PM
     let account: BraveWallet.AccountInfo = .mockEthAccount
     let formatter = WeiFormatter(decimalFormatStyle: .decimals(precision: 18))
     let mockEthDecimalBalance: Double = 0.0896
@@ -131,7 +132,11 @@ class AccountActivityStoreTests: XCTestCase {
       mockEthBalanceWei: mockEthBalanceWei,
       mockERC20BalanceWei: mockERC20BalanceWei,
       mockERC721BalanceWei: mockERC721BalanceWei,
-      transactions: [ethSendTxCopy, goerliSwapTxCopy]
+      transactions: [goerliSwapTxCopy, ethSendTxCopy].enumerated().map { (index, tx) in
+        // transactions sorted by created time, make sure they are in-order
+        tx.createdTime = firstTransactionDate.addingTimeInterval(TimeInterval(index * 10))
+        return tx
+      }
     )
     
     let mockAssetManager = TestableWalletUserAssetManager()
@@ -232,6 +237,7 @@ class AccountActivityStoreTests: XCTestCase {
   }
   
   func testUpdateSolanaAccount() {
+    let firstTransactionDate = Date(timeIntervalSince1970: 1636399671) // Monday, November 8, 2021 7:27:51 PM
     let account: BraveWallet.AccountInfo = .mockSolAccount
     let mockLamportBalance: UInt64 = 3876535000 // ~3.8765 SOL
     let mockSolDecimalBalance: Double = 3.8765 // rounded
@@ -253,7 +259,11 @@ class AccountActivityStoreTests: XCTestCase {
     let (keyringService, rpcService, walletService, blockchainRegistry, assetRatioService, txService, solTxManagerProxy, ipfsApi) = setupServices(
       mockLamportBalance: mockLamportBalance,
       mockSplTokenBalances: mockSplTokenBalances,
-      transactions: [solSendTxCopy, solTestnetSendTxCopy]
+      transactions: [solTestnetSendTxCopy, solSendTxCopy].enumerated().map { (index, tx) in
+        // transactions sorted by created time, make sure they are in-order
+        tx.createdTime = firstTransactionDate.addingTimeInterval(TimeInterval(index * 10))
+        return tx
+      }
     )
     
     let mockAssetManager = TestableWalletUserAssetManager()

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -53,20 +53,17 @@ platform :ios do
         "ClientTests/UserAgentTests",
         "ClientTests/AdBlockEngineManagerTests/testPerformance",
         "DataTests",
-      	"BraveWalletTests/ManageSiteConnectionsStoreTests/testRemoveAllPermissions",
-      	"BraveWalletTests/ManageSiteConnectionsStoreTests/testRemovePermissions",
-      	"BraveWalletTests/ManageSiteConnectionsStoreTests/testRemovePermissionsLastPermission",
-        "BraveWalletTests/SendTokenStoreTests/testSNSAddressResolution",
-        "BraveWalletTests/SendTokenStoreTests/testSNSAddressResolutionFailure",
+        "BraveWalletTests/ManageSiteConnectionsStoreTests/testRemoveAllPermissions",
+        "BraveWalletTests/ManageSiteConnectionsStoreTests/testRemovePermissions",
+        "BraveWalletTests/ManageSiteConnectionsStoreTests/testRemovePermissionsLastPermission",
         "BraveWalletTests/SendTokenStoreTests/testResolvedAddressUsedInSolTxIfAvailable",
-        "BraveWalletTests/SendTokenStoreTests/testENSAddressResolution",
-        "BraveWalletTests/SendTokenStoreTests/testENSAddressResolutionOffchain",
-        "BraveWalletTests/SendTokenStoreTests/testENSAddressResolutionFailure",
         "BraveWalletTests/SendTokenStoreTests/testResolvedAddressUsedInEthTxIfAvailable",
         "BraveWalletTests/SendTokenStoreTests/testUDAddressResolutionEthNetwork",
-        "BraveWalletTests/SendTokenStoreTests/testUDAddressResolutionFailure",
         "BraveWalletTests/SendTokenStoreTests/testUDAddressResolutionSolNetwork",
-        "BraveWalletTests/SendTokenStoreTests/testUDAddressResolutionTokenChange"
+        "BraveWalletTests/SendTokenStoreTests/testUDAddressResolutionFailure",
+        "BraveWalletTests/SendTokenStoreTests/testUDAddressResolutionTokenChange",
+        "BraveWalletTests/TransactionConfirmationStoreTests/testPrepareERC20Approve",
+        "BraveWalletTests/TransactionConfirmationStoreTests/testPrepareTransactionNotOnSelectedNetwork",
       ]
     )
 


### PR DESCRIPTION
## Summary of Changes
- Resolve `AccountActivityStoreTests.testUpdateEthereumAccount()` flakey test
- Disabled:
    - `TransactionConfirmationStoreTests.testPrepareERC20Approve()`
    - `TransactionConfirmationStoreTests.testPrepareTransactionNotOnSelectedNetwork()`
- Updated disabled `SendTokenStoreTests` tests. Reduced from 11 disabled tests to 6.
- Opened https://github.com/brave/brave-ios/issues/7757 to resolve the disabled tests.

This pull request fixes #<number>

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. In the `Brave.xctestplan`, disable each of the disabled tests in our `Fastfile`
2. In Xcode, open Test navigator panel
3. Right-click on `BraveWalletTests` and select `Run "BraveWalletTests" Repeatedly...`
<img width="401" alt="Screenshot 2023-07-19 at 5 05 17 PM" src="https://github.com/brave/brave-ios/assets/5314553/52484bf1-aa54-402b-ad59-c9033d48979b">

4. Change `Stop After` to maximum repetitions and set `Maximum Repetitions` to >100 (100 wasn't catching them all, I used 1000 but less likely suffices).
<img width="484" alt="Screenshot 2023-07-19 at 5 05 25 PM" src="https://github.com/brave/brave-ios/assets/5314553/36bcdf53-e2ad-406d-b33c-6004ee9e5116">

5. Click `Run`
6. Make sure no other tests are failing.


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
