### PR TITLE
Fix #7759: Send token view default token

### DIFF
--- a/Sources/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
+++ b/Sources/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
@@ -16,6 +16,7 @@ struct SendTokenView: View {
 
   @State private var isShowingScanner = false
   @State private var isShowingError = false
+  @State private var didAutoShowSelectAccountToken = false
   @State private var isShowingSelectAccountTokenView: Bool = false
 
   @ScaledMetric private var length: CGFloat = 16.0
@@ -292,6 +293,10 @@ struct SendTokenView: View {
       }
     }
     .task {
+      if !didAutoShowSelectAccountToken {
+        isShowingSelectAccountTokenView = true
+        didAutoShowSelectAccountToken = true
+      }
       sendTokenStore.update()
       await sendTokenStore.selectTokenStore.update()
     }

--- a/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
@@ -247,7 +247,9 @@ public class SendTokenStore: ObservableObject {
       let allTokens = await self.blockchainRegistry.allTokens(network.chainId, coin: network.coin)
       guard !Task.isCancelled else { return }
       if selectedSendToken == nil {
-        self.selectedSendToken = userAssets.first
+        self.selectedSendToken = userAssets.first(where: { network.isNativeAsset($0) })
+        ?? userAssets.first(where: { $0.symbol.caseInsensitiveCompare("bat") == .orderedSame })
+        ?? userAssets.sorted(by: { $0.name < $1.name }).first
       }
       self.userAssets = userAssets
       self.allTokens = allTokens


### PR DESCRIPTION
## Summary of Changes
- Send was picking a random token for the currently selected network after the [Migrate User Assets from BraveCore to CoreData](https://github.com/brave/brave-ios/pull/7534) change because core data returns the models in a non-deterministic order and we were just selecting the first token.
- Logic is updated to now try and select the current networks default token, fallback to BAT, with fallback to the first visible asset when sorted by name.
- Additionally, we are now presenting `Select a Token to Send` modal when you first open Send view.

This pull request fixes #7759

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Have at least 2 tokens on a single network as visible assets (ex. SOL & USDC on Solana Mainnet).
2. Open Buy/Swap and change network to the network with 2 or more visible assets, then close Buy/Swap.
3. Open Send.
4. Verify Select Token to Send automatically presents.
5. Without selecting a token, press `Cancel` or swipe to dismiss.
6. Verify the selected token is the native asset on network.
7. Close Send & repeat test from step 3 a couple times. Verify the same token is selected by default.


## Screenshots:

https://github.com/brave/brave-ios/assets/5314553/8b25a591-d205-404d-820b-b71a15126a7e


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
