### PR TITLE
Fix #7758: Use correct theme values for the media settings section.

### DIFF
--- a/Sources/Brave/Frontend/Settings/MediaSettingsView.swift
+++ b/Sources/Brave/Frontend/Settings/MediaSettingsView.swift
@@ -19,6 +19,7 @@ struct MediaSettingsView: View {
         }
         .toggleStyle(SwitchToggleStyle(tint: .accentColor))
       }
+      .listRowBackground(Color(.secondaryBraveGroupedBackground))
       
       Section(header: Text(Strings.Settings.youtube)) {
         NavigationLink(destination: QualitySettingsView()) {
@@ -30,9 +31,11 @@ struct MediaSettingsView: View {
           }
         }
       }
+      .listRowBackground(Color(.secondaryBraveGroupedBackground))
     }
     .navigationBarTitle(Strings.Settings.mediaRootSetting)
     .navigationBarTitleDisplayMode(.inline)
+    .listBackgroundColor(Color(UIColor.braveGroupedBackground))
   }
 }
 
@@ -64,14 +67,16 @@ fileprivate struct QualitySettingsView: View {
           qualityOption(preference: .off)
         })
       }
+      .listRowBackground(Color(.secondaryBraveGroupedBackground))
     }
     .navigationBarTitle(Strings.Settings.qualitySettings)
+    .listBackgroundColor(Color(UIColor.braveGroupedBackground))
   }
   
   func qualityOption(preference: YoutubeHighQualityPreference) -> some View {
     HStack {
       Text(preference.displayString)
-        .foregroundColor(.black)
+        .foregroundColor(Color(.braveLabel))
       Spacer()
       if Preferences.General.youtubeHighQuality.value == preference.rawValue {
         Image(systemName: "checkmark")


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7758 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->
<img width="880" alt="Zrzut ekranu 2023-07-24 o 19 38 52" src="https://github.com/brave/brave-ios/assets/6950387/370101d6-5d89-44bd-808c-5c60f7a9b6c0">




## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
