### PR TITLE
Fix #7771: When no qualities exist, try again for the YT-auto-quality.

### DIFF
--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Paged/YoutubeQualityScript.js
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Paged/YoutubeQualityScript.js
@@ -64,7 +64,7 @@ window.__firefox__.includeOnce("YoutubeQuality", function($) {
       timeout = setInterval($(() => {
         let player = findPlayer();
         if (attemptCount++ > maxAttempts) {
-          clearInterval();
+          clearInterval(timeout);
           return;
         }
         

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Paged/YoutubeQualityScript.js
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Paged/YoutubeQualityScript.js
@@ -46,7 +46,7 @@ window.__firefox__.includeOnce("YoutubeQuality", function($) {
     }
   }
   
-  var timeout = 0;
+  var ytQualityTimerId = 0;
   var chosenQuality = "";
   
   Object.defineProperty(window.__firefox__, '$<set_youtube_quality>', {
@@ -60,16 +60,16 @@ window.__firefox__.includeOnce("YoutubeQuality", function($) {
       
       chosenQuality = newVideoQuality;
       
-      clearInterval(timeout);
-      timeout = setInterval($(() => {
+      clearInterval(ytQualityTimerId);
+      ytQualityTimerId = setInterval($(() => {
         let player = findPlayer();
         if (attemptCount++ > maxAttempts) {
-          clearInterval(timeout);
+          clearInterval(ytQualityTimerId);
           return;
         }
         
         if (updatePlayerQuality(player, chosenQuality)) {
-          clearInterval(timeout);
+          clearInterval(ytQualityTimerId);
         }
       }), 500);
     })

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Paged/YoutubeQualityScript.js
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Paged/YoutubeQualityScript.js
@@ -18,16 +18,6 @@ window.__firefox__.includeOnce("YoutubeQuality", function($) {
   function findPlayer() {
     return document.getElementById('movie_player') || document.querySelector('.html5-video-player');
   }
-  
-  // Returns -1 if the api does not exist.
-  // If it does exist it returns number of available video qualities of the player.
-  function hasAPIsAndEnoughVideoQualities(player) {
-    if (!player || typeof player.getAvailableQualityLevels === 'undefined') {
-      return -1;
-    }
-    
-    return player.getAvailableQualityLevels().length;
-  }
 
   // Returns false if something failed in the process - we may retry after a small delay
   function updatePlayerQuality(player, requestedQuality) {


### PR DESCRIPTION
From my tests, getAvailableQualityLevels sometimes returns an empty array. In this case we should try again few times before going with default option.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7771 

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
