### PR TITLE
Fix #7737: Crash at Browsing Mode Change while drag-drop action in Tab Tray

### DIFF
--- a/Sources/Brave/Frontend/Browser/Tabs/TabTray/TabTrayController.swift
+++ b/Sources/Brave/Frontend/Browser/Tabs/TabTray/TabTrayController.swift
@@ -588,6 +588,12 @@ class TabTrayController: LoadingViewController {
 
   @objc func togglePrivateModeAction() {
     tabTraySearchController.isActive = false
+    
+    // Mode Change action disabled while drap-drop is active
+    // Added to prevent Diffable Data source crash
+    if tabTrayView.collectionView.hasActiveDrag || tabTrayView.collectionView.hasActiveDrop {
+      return
+    }
 
     // Record the slected index before private mode navigation
     if !privateMode {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

Adding check for active drag and drop while mode change

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7737

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
- Launch Brave
- Open at least 2 tabs
- Tap on Tab switch button
- Tap and hold on any tab, so you can drag the tab around
- Now keep holding/dragging the tab and with another finger tap Private button > Observe Brave is crashing

## Screenshots:



https://github.com/brave/brave-ios/assets/6643505/ed54d694-c3e1-48a0-b6e8-69a4f5d68332



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
