### PR TITLE
No Bug: Attempted fixes for collection view assertions in 16.4+

### DIFF
--- a/Sources/Brave/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
+++ b/Sources/Brave/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
@@ -286,10 +286,13 @@ class NewTabPageViewController: UIViewController {
       provider.registerCells(to: collectionView)
       if let observableProvider = provider as? NTPObservableSectionProvider {
         observableProvider.sectionDidChange = { [weak self] in
-          UIView.performWithoutAnimation {
-            self?.collectionView.reloadSections(IndexSet(integer: index))
+          guard let self = self else { return }
+          if self.parent != nil {
+            UIView.performWithoutAnimation {
+              self.collectionView.reloadSections(IndexSet(integer: index))
+            }
           }
-          self?.collectionView.collectionViewLayout.invalidateLayout()
+          self.collectionView.collectionViewLayout.invalidateLayout()
         }
       }
     }
@@ -656,7 +659,7 @@ class NewTabPageViewController: UIViewController {
     _ oldValue: FeedDataSource.State,
     _ newValue: FeedDataSource.State
   ) {
-    guard let section = layout.braveNewsSection else { return }
+    guard let section = layout.braveNewsSection, parent != nil else { return }
 
     func _completeLoading() {
       UIView.animate(
@@ -712,13 +715,9 @@ class NewTabPageViewController: UIViewController {
         feedOverlayView.loaderView.isHidden = false
         feedOverlayView.loaderView.start()
 
-        if let section = layout.braveNewsSection {
-          let numberOfItems = collectionView.numberOfItems(inSection: section)
-          if numberOfItems > 0 {
-            collectionView.deleteItems(
-              at: (0..<numberOfItems).map({ IndexPath(item: $0, section: section) })
-            )
-          }
+        let numberOfItems = collectionView.numberOfItems(inSection: section)
+        if numberOfItems > 0 {
+          collectionView.reloadSections(IndexSet(integer: section))
         }
       }
     case (.loading, _):

--- a/Sources/Brave/Frontend/Browser/New Tab Page/Sections/FavoritesOverflowSectionProvider.swift
+++ b/Sources/Brave/Frontend/Browser/New Tab Page/Sections/FavoritesOverflowSectionProvider.swift
@@ -101,6 +101,8 @@ class FavoritesOverflowSectionProvider: NSObject, NTPObservableSectionProvider {
 extension FavoritesOverflowSectionProvider: NSFetchedResultsControllerDelegate {
   func controllerDidChangeContent(_ controller: NSFetchedResultsController<NSFetchRequestResult>) {
     try? frc.performFetch()
-    sectionDidChange?()
+    DispatchQueue.main.async {
+      self.sectionDidChange?()
+    }
   }
 }

--- a/Sources/Brave/Frontend/Browser/New Tab Page/Sections/FavoritesSectionProvider.swift
+++ b/Sources/Brave/Frontend/Browser/New Tab Page/Sections/FavoritesSectionProvider.swift
@@ -211,6 +211,8 @@ class FavoritesSectionProvider: NSObject, NTPObservableSectionProvider {
 extension FavoritesSectionProvider: NSFetchedResultsControllerDelegate {
   func controllerDidChangeContent(_ controller: NSFetchedResultsController<NSFetchRequestResult>) {
     try? frc.performFetch()
-    sectionDidChange?()
+    DispatchQueue.main.async {
+      self.sectionDidChange?()
+    }
   }
 }


### PR DESCRIPTION
## Summary of Changes

A number of changes that hopefully fix the following assertions crashes in NTP for 16.4+ users:

- `_Bug_Detected_In_Client_Of_UICollectionView_Invalid_Number_Of_Items_In_Section`
- `_Bug_Detected_In_Client_Of_UICollectionView_Invalid_Batch_Updates` 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
