### PR TITLE
No bug: Attempted fix for KVO crash in iOS17

### DIFF
--- a/Sources/BraveWallet/Crypto/Stores/TabbedPageViewController.swift
+++ b/Sources/BraveWallet/Crypto/Stores/TabbedPageViewController.swift
@@ -108,8 +108,8 @@ class TabbedPageViewController: UIViewController {
 
     if let scrollView = pageViewController.scrollView {
       contentOffsetObservation =
-        scrollView.observe(\.contentOffset) { [unowned self] scrollView, _ in
-          updateTabsBarSelectionIndicator(contentOffset: scrollView.contentOffset)
+        scrollView.observe(\.contentOffset) { [weak self] scrollView, _ in
+          self?.updateTabsBarSelectionIndicator(contentOffset: scrollView.contentOffset)
         }
     }
   }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
In iOS 17, KVO is somehow not correctly being invalidated after view is dead. 
Found a crash caused by this in wallet's `TabbedPageViewController`

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #<number>

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
