### PR TITLE
Fix #7786: Don't update the tabs bar for each tab restoring/deleting

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController.swift
@@ -2435,9 +2435,9 @@ extension BrowserViewController: SettingsDelegate {
     self.openURLInNewTab(url, isPrivate: forcedPrivate, isPrivileged: false)
   }
 
-  func settingsOpenURLs(_ urls: [URL]) {
+  func settingsOpenURLs(_ urls: [URL], loadImmediately: Bool) {
     let tabIsPrivate = TabType.of(tabManager.selectedTab).isPrivate
-    self.tabManager.addTabsForURLs(urls, zombie: false, isPrivate: tabIsPrivate)
+    self.tabManager.addTabsForURLs(urls, zombie: !loadImmediately, isPrivate: tabIsPrivate)
   }
 }
 

--- a/Sources/Brave/Frontend/Browser/TabManager.swift
+++ b/Sources/Brave/Frontend/Browser/TabManager.swift
@@ -73,6 +73,7 @@ class TabManager: NSObject {
   private var _selectedIndex = -1
   private let navDelegate: TabManagerNavDelegate
   private(set) var isRestoring = false
+  private(set) var isBulkDeleting = false
 
   // A WKWebViewConfiguration used for normal tabs
   lazy fileprivate var configuration: WKWebViewConfiguration = {
@@ -719,6 +720,7 @@ class TabManager: NSObject {
   }
 
   @MainActor func removeTabsWithUndoToast(_ tabs: [Tab]) {
+    isBulkDeleting = true
     tempTabs = tabs
     var tabsCopy = tabs
 
@@ -750,6 +752,7 @@ class TabManager: NSObject {
         })
     }
 
+    isBulkDeleting = false
     delegates.forEach { $0.get()?.tabManagerDidRemoveAllTabs(self, toast: toast) }
   }
 
@@ -790,11 +793,17 @@ class TabManager: NSObject {
   }
 
   @MainActor func removeAll() {
+    isBulkDeleting = true
     removeTabs(self.allTabs)
+    isBulkDeleting = false
+    delegates.forEach { $0.get()?.tabManagerDidRemoveAllTabs(self, toast: nil) }
   }
   
   @MainActor func removeAllForCurrentMode() {
+    isBulkDeleting = true
     removeTabs(tabsForCurrentMode)
+    isBulkDeleting = false
+    delegates.forEach { $0.get()?.tabManagerDidRemoveAllTabs(self, toast: nil) }
   }
 
   func getIndex(_ tab: Tab) -> Int? {

--- a/Sources/Brave/Frontend/Browser/Tabs/TabBar/TabsBarViewController.swift
+++ b/Sources/Brave/Frontend/Browser/Tabs/TabBar/TabsBarViewController.swift
@@ -209,11 +209,12 @@ class TabsBarViewController: UIViewController {
   }
 
   func updateData() {
-    tabList = WeakList<Tab>()
-
-    tabManager?.tabsForCurrentMode.forEach {
-      tabList.insert($0)
+    // Don't waste time/resources updating data when we're in the middle of a restore or bulk delete
+    guard let tabManager = tabManager, !tabManager.isRestoring && !tabManager.isBulkDeleting else {
+      return
     }
+    
+    tabList = WeakList<Tab>(tabManager.tabsForCurrentMode)
 
     overflowIndicators()
     reloadDataAndRestoreSelectedTab()
@@ -441,6 +442,10 @@ extension TabsBarViewController: TabManagerDelegate {
 
   func tabManagerDidRestoreTabs(_ tabManager: TabManager) {
     assert(Thread.current.isMainThread)
+    updateData()
+  }
+  
+  func tabManagerDidRemoveAllTabs(_ tabManager: TabManager, toast: ButtonToast?) {
     updateData()
   }
 }

--- a/Sources/Brave/Frontend/Settings/SettingsViewController.swift
+++ b/Sources/Brave/Frontend/Settings/SettingsViewController.swift
@@ -43,7 +43,7 @@ extension Preferences.AutoCloseTabsOption: RepresentableOptionType {
 
 protocol SettingsDelegate: AnyObject {
   func settingsOpenURLInNewTab(_ url: URL)
-  func settingsOpenURLs(_ urls: [URL])
+  func settingsOpenURLs(_ urls: [URL], loadImmediately: Bool)
 }
 
 class SettingsViewController: TableViewController {
@@ -279,7 +279,7 @@ class SettingsViewController: TableViewController {
           let controller = NewsSettingsViewController(dataSource: self.feedDataSource, openURL: { [weak self] url in
             guard let self else { return }
             self.dismiss(animated: true)
-            self.settingsDelegate?.settingsOpenURLs([url])
+            self.settingsDelegate?.settingsOpenURLs([url], loadImmediately: true)
           })
           controller.viewDidDisappear = {
             if Preferences.Review.braveNewsCriteriaPassed.value {
@@ -767,9 +767,18 @@ class SettingsViewController: TableViewController {
             let url = URL(string: "https://raw.githubusercontent.com/brave/qa-resources/master/testlinks.json")!
             let string = try? String(contentsOf: url)
             let urls = JSON(parseJSON: string!)["links"].arrayValue.compactMap { URL(string: $0.stringValue) }
-            self.settingsDelegate?.settingsOpenURLs(urls)
+            self.settingsDelegate?.settingsOpenURLs(urls, loadImmediately: false)
             self.dismiss(animated: true)
           }, cellClass: MultilineButtonCell.self),
+        Row(
+          text: "Create 1000 Tabs",
+          selection: { [unowned self] in
+            let urls = (0..<1000).map { URL(string: "https://search.brave.com/search?q=\($0)")! }
+            self.settingsDelegate?.settingsOpenURLs(urls, loadImmediately: false)
+            self.dismiss(animated: true)
+          },
+          cellClass: ButtonCell.self
+        ),
         Row(
           text: "CRASH!!!",
           selection: { [unowned self] in

--- a/Sources/Shared/WeakList.swift
+++ b/Sources/Shared/WeakList.swift
@@ -17,6 +17,10 @@ open class WeakList<T: AnyObject>: Sequence {
   private var items = [WeakRef<T>]()
 
   public init() {}
+  
+  public init(_ items: some Collection<T>) {
+    self.items = items.map { WeakRef($0) }
+  }
 
   /**
      * Adds an item to the list.


### PR DESCRIPTION
Also adds a new Debug settings button "Create 1000 Tabs" to help with testing against large tab sets

## Summary of Changes

This pull request fixes #7786 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
