### PR TITLE
No Bug: Fix NTP collection view crash when launching a fresh install

### DIFF
--- a/Sources/Brave/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
+++ b/Sources/Brave/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
@@ -289,7 +289,11 @@ class NewTabPageViewController: UIViewController {
           guard let self = self else { return }
           if self.parent != nil {
             UIView.performWithoutAnimation {
-              self.collectionView.reloadSections(IndexSet(integer: index))
+              // As of iOS 16.4, reloadSections seems to do some sort of validation of the underlying data
+              // for other sections that aren't being refreshed. This can cause assertions for sections that
+              // may need to reload in the same batch but don't. Since we don't animate this section anyways
+              // we can just switch to `reloadData` here.
+              self.collectionView.reloadData()
             }
           }
           self.collectionView.collectionViewLayout.invalidateLayout()


### PR DESCRIPTION
## Summary of Changes

Ref #7782 which actually made this crash reproducible on fresh installs 

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
