### PR TITLE
Fix #7752: Reopen last closed tab in tab tray context menu

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+TabManagerDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+TabManagerDelegate.swift
@@ -293,8 +293,9 @@ extension BrowserViewController: TabManagerDelegate {
     
     var recentlyClosedMenuChildren: [UIAction] = []
 
+    // Recently Closed Actions are only in normal mode
     if !PrivateBrowsingManager.shared.isPrivateBrowsing {
-      let recentlyClosedTab = UIAction(
+      let viewRecentlyClosedTabs = UIAction(
         title: Strings.RecentlyClosed.viewRecentlyClosedTab,
         image: UIImage(braveSystemNamed: "leo.browser.mobile-recent-tabs"),
         handler: UIAction.deferredActionHandler { [weak self] _ in
@@ -315,7 +316,26 @@ extension BrowserViewController: TabManagerDelegate {
           self.present(UIHostingController(rootView: recentlyClosedTabsView), animated: true)
         })
       
-      recentlyClosedMenuChildren.append(recentlyClosedTab)
+      recentlyClosedMenuChildren.append(viewRecentlyClosedTabs)
+      
+      // Fetch last item in Recently Closed
+      if let recentlyClosedTab = RecentlyClosed.all().first {
+        let reopenLastClosedTab = UIAction(
+          title: Strings.RecentlyClosed.recentlyClosedReOpenLastActionTitle,
+          image: UIImage(braveSystemNamed: "leo.browser.mobile-tab-ntp"),
+          handler: UIAction.deferredActionHandler { [weak self] _ in
+            guard let self = self else { return }
+            
+            if PrivateBrowsingManager.shared.isPrivateBrowsing {
+              return
+            }
+            
+            self.tabManager.addAndSelectRecentlyClosed(recentlyClosedTab)
+            RecentlyClosed.remove(with: recentlyClosedTab.url)
+          })
+        
+        recentlyClosedMenuChildren.append(reopenLastClosedTab)
+      }
     }
     
     var closeTabMenuChildren: [UIAction] = []

--- a/Sources/Brave/Frontend/Browser/TabManager.swift
+++ b/Sources/Brave/Frontend/Browser/TabManager.swift
@@ -1067,6 +1067,13 @@ class TabManager: NSObject {
   @MainActor func addAndSelectRecentlyClosed(_ recentlyClosed: RecentlyClosed) {
     guard let url = NSURL(idnString: recentlyClosed.url) as? URL ?? URL(string: recentlyClosed.url) else { return }
     
+    // The NTP shold be removed if last recently close opened using empty tab
+    if let currentTab = selectedTab,
+      let currentTabURL = currentTab.url,
+      InternalURL(currentTabURL)?.isAboutHomeURL == true {
+      removeTab(currentTab)
+    }
+    
     let tab = addTab(URLRequest(url: url), isPrivate: false)
     guard let webView = tab.webView else { return }
 

--- a/Sources/BraveStrings/BraveStrings.swift
+++ b/Sources/BraveStrings/BraveStrings.swift
@@ -4558,7 +4558,14 @@ extension Strings {
         bundle: .module,
         value: "Open",
         comment: "Open Tab action title")
-
+    
+    public static let recentlyClosedReOpenLastActionTitle =
+      NSLocalizedString(
+        "recently.closed.reopen.latest",
+        tableName: "BraveShared",
+        bundle: .module,
+        value: "Reopen Last Closed Tab",
+        comment: "Re-open Last Tab action title")
   }
 }
 

--- a/Sources/DesignSystem/Icons/Symbols.xcassets/leo.browser.mobile-tab-ntp.symbolset/Contents.json
+++ b/Sources/DesignSystem/Icons/Symbols.xcassets/leo.browser.mobile-tab-ntp.symbolset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "symbols" : [
+    {
+      "idiom" : "universal"
+    }
+  ]
+}


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

Adding re-open last closed  tab action menu both for existing tab and empty tab interface

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7752

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

- Close a tab
- Long press on tab icon bottom menu
- Choose Reopen Last Closed Tab

## Screenshots:

https://github.com/brave/brave-ios/assets/6643505/cd157a32-ea59-43cf-bf76-fda89506774a

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
