### PR TITLE
Fix #7785: User assets are not migrated if user restore wallet from lock screen

### DIFF
--- a/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -103,6 +103,7 @@ public class CryptoStore: ObservableObject {
   private let solTxManagerProxy: BraveWalletSolanaTxManagerProxy
   private let ipfsApi: IpfsAPI
   private let userAssetManager: WalletUserAssetManager
+  private var isUpdatingUserAssets: Bool = false
   
   public init(
     keyringService: BraveWalletKeyringService,
@@ -561,11 +562,18 @@ extension CryptoStore: BraveWalletKeyringServiceObserver {
     }
   }
   public func keyringRestored(_ keyringId: BraveWallet.KeyringId) {
-    // if a keyring is restored, we want to reset user assets local storage
-    // and migrate with for new keyring
+    // This observer method will only get called when user restore a wallet
+    // from the lock screen
+    // We will need to
+    // 1. reset wallet user asset migration flag
+    // 2. wipe user assets local storage
+    // 3. migrate user assets with new keyring
+    guard !isUpdatingUserAssets else { return }
+    Preferences.Wallet.migrateCoreToWalletUserAssetCompleted.reset()
     WalletUserAssetGroup.removeAllGroup() { [weak self] in
       self?.userAssetManager.migrateUserAssets(completion: {
         self?.updateAssets()
+        self?.isUpdatingUserAssets = false
       })
     }
   }

--- a/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -569,6 +569,7 @@ extension CryptoStore: BraveWalletKeyringServiceObserver {
     // 2. wipe user assets local storage
     // 3. migrate user assets with new keyring
     guard !isUpdatingUserAssets else { return }
+    isUpdatingUserAssets = true
     Preferences.Wallet.migrateCoreToWalletUserAssetCompleted.reset()
     WalletUserAssetGroup.removeAllGroup() { [weak self] in
       self?.userAssetManager.migrateUserAssets(completion: {

--- a/Sources/BraveWallet/WalletUserAssetManager.swift
+++ b/Sources/BraveWallet/WalletUserAssetManager.swift
@@ -85,6 +85,7 @@ public class WalletUserAssetManager: WalletUserAssetManagerType {
   
   public func migrateUserAssets(for coin: BraveWallet.CoinType? = nil, completion: (() -> Void)? = nil) {
     guard !Preferences.Wallet.migrateCoreToWalletUserAssetCompleted.value else {
+      completion?()
       return
     }
     Task { @MainActor in


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
Restore a wallet should be considered as a fresh wallet restore meaning all user assets that we stored locally need to be wiped and new user assets migration should be preformed. 

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7785

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Please refer to the issue 

## Screenshot:
https://github.com/brave/brave-ios/assets/1187676/2b3ba605-8d50-4986-beb6-1969c1b63fbf

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
