### PR TITLE
Fix #7796, Fix #6966: Use `webViewDidClose` to handle `window.close`

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -879,6 +879,12 @@ extension BrowserViewController: WKUIDelegate {
 
     return newTab.webView
   }
+  
+  public func webViewDidClose(_ webView: WKWebView) {
+    guard let tab = tabManager[webView] else { return }
+    tabManager.addTabToRecentlyClosed(tab)
+    tabManager.removeTab(tab)
+  }
 
   fileprivate func shouldDisplayJSAlertForWebView(_ webView: WKWebView) -> Bool {
     // Only display a JS Alert if we are selected and there isn't anything being shown


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #7796
This pull request fixes #6966

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
