### PR TITLE
Fix #7768: Add filter / search bar to Select a Token to Send

### DIFF
--- a/Sources/BraveWallet/Crypto/SelectAccountTokenView.swift
+++ b/Sources/BraveWallet/Crypto/SelectAccountTokenView.swift
@@ -48,6 +48,10 @@ struct SelectAccountTokenView: View {
       }
     }
     .listBackgroundColor(Color(UIColor.braveGroupedBackground))
+    .searchable(
+      text: $store.query,
+      placement: .navigationBarDrawer(displayMode: .always)
+    )
     .toolbar {
       ToolbarItemGroup(placement: .cancellationAction) {
         Button(action: { presentationMode.dismiss() }) {

--- a/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
@@ -131,7 +131,8 @@ public class SendTokenStore: ObservableObject {
     walletService: walletService,
     assetRatioService: assetRatioService,
     ipfsApi: ipfsApi,
-    userAssetManager: assetManager
+    userAssetManager: assetManager,
+    query: prefilledToken?.symbol
   )
 
   private let keyringService: BraveWalletKeyringService


### PR DESCRIPTION
## Summary of Changes
- Add search bar for filtering tokens by name or symbol in Select a Token to Send modal
- Pre-populate search filter with token symbol when opening send via asset details

This pull request fixes #7768

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Open Send, Select a Token to Send should open automatically
2. Enter search filter terms; results are matched against symbol or token name
3. Select a token and verify correct result is selected in Send view
4. Open Portfolio and open asset details for any asset
5. Tap `Send`
6. Verify token symbol is pre-populated in search, allowing user to select the account to send from (or network).


## Screenshots:

https://github.com/brave/brave-ios/assets/5314553/8d2f83d5-37d3-4b08-b4df-2c4a1fa315ef



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
