### PR TITLE
Ref #4879: VPN churn improvements - VerifyReceiptData fields with isBillingRetry

### DIFF
--- a/App/Client.xcodeproj/Brave.xctestplan
+++ b/App/Client.xcodeproj/Brave.xctestplan
@@ -116,6 +116,13 @@
         "identifier" : "PrivateCDNTests",
         "name" : "PrivateCDNTests"
       }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:..",
+        "identifier" : "BraveVPNTests",
+        "name" : "BraveVPNTests"
+      }
     }
   ],
   "version" : 1

--- a/Package.swift
+++ b/Package.swift
@@ -291,6 +291,10 @@ var package = Package(
       dependencies: ["BraveShared", "Preferences"]
     ),
     .testTarget(
+      name: "BraveVPNTests",
+      dependencies: ["BraveVPN", "BraveShared", "GuardianConnect"]
+    ),
+    .testTarget(
       name: "BraveWalletTests",
       dependencies: [
         "BraveWallet",

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Callout.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Callout.swift
@@ -260,6 +260,7 @@ extension BrowserViewController {
   private func presentVPNUpdateBillingCallout(skipSafeGuards: Bool = false) {
     if !skipSafeGuards {
       // TODO: Condition
+      return
     }
     
     presentVPNChurnPromoCallout(for: .updateBillingExpired) {

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Callout.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Callout.swift
@@ -17,8 +17,19 @@ import SafariServices
 // MARK: - Callouts
 
 extension BrowserViewController {
-  
-  // Priority: P3A - Bottom Bar - VPN - Default Browser - Rewards - Cookie Notification - Link Receipt
+  /*
+   Check FullScreenCalloutType to make alterations to pirotiry of pop-over variation
+   
+   Priority:
+   - P3A
+   - VPN Update Billing
+   - Bottom Bar
+   - VPN Promotion
+   - Default Browser
+   - Rewards
+   - Cookie Notification
+   - VPN Link Receipt
+  */
   func presentFullScreenCallouts() {
     for type in FullScreenCalloutType.allCases {
       presentScreenCallout(for: type)
@@ -34,6 +45,8 @@ extension BrowserViewController {
     switch type {
     case .p3a:
       presentP3AScreenCallout()
+    case .vpnUpdateBilling:
+      presentVPNUpdateBillingCallout(skipSafeGuards: skipSafeGuards)
     case .bottomBar:
       presentBottomBarCallout(skipSafeGuards: skipSafeGuards)
     case .defaultBrowser:
@@ -244,11 +257,23 @@ extension BrowserViewController {
     present(popup, animated: false)
   }
   
-  private func presentVPNChurnPromoCallout(for type: VPNChurnPromoType) {
+  private func presentVPNUpdateBillingCallout(skipSafeGuards: Bool = false) {
+    if !skipSafeGuards {
+      // TODO: Condition
+    }
+    
+    presentVPNChurnPromoCallout(for: .updateBillingExpired) {
+      // TODO: Action
+    }
+  }
+  
+  // MARK: Helper Methods for Presentation
+
+  private func presentVPNChurnPromoCallout(for type: VPNChurnPromoType, completion: @escaping () -> Void) {
     var vpnChurnPromoView = VPNChurnPromoView(churnPromoType: type)
    
     vpnChurnPromoView.renewAction = {
-      // TODO: Action
+      completion()
     }
     
     let popup = PopupViewController(rootView: vpnChurnPromoView, isDismissable: true)

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Callout.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Callout.swift
@@ -18,7 +18,7 @@ import SafariServices
 
 extension BrowserViewController {
   /*
-   Check FullScreenCalloutType to make alterations to pirotiry of pop-over variation
+   Check FullScreenCalloutType to make alterations to priority of pop-over variation
    
    Priority:
    - P3A

--- a/Sources/Brave/Frontend/Settings/RetentionPreferencesDebugMenuViewController.swift
+++ b/Sources/Brave/Frontend/Settings/RetentionPreferencesDebugMenuViewController.swift
@@ -129,18 +129,18 @@ class RetentionPreferencesDebugMenuViewController: TableViewController {
         .boolRow(
           title: "VPN Callout Shown",
           detailText: "Flag determining if VPN callout is shown to user.",
-          toggleValue: Preferences.FullScreenCallout.vpnCalloutCompleted.value,
+          toggleValue: Preferences.FullScreenCallout.vpnPromotionCalloutCompleted.value,
           valueChange: {
             if $0 {
               let status = $0
-              Preferences.FullScreenCallout.vpnCalloutCompleted.value = status
+              Preferences.FullScreenCallout.vpnPromotionCalloutCompleted.value = status
             }
           },
           cellReuseId: "VPNCalloutCell"),
         .boolRow(
           title: "Rewards Callout Shown",
           detailText: "Flag determining if Rewards callout is shown to user.",
-          toggleValue: Preferences.FullScreenCallout.vpnCalloutCompleted.value,
+          toggleValue: Preferences.FullScreenCallout.vpnPromotionCalloutCompleted.value,
           valueChange: {
             if $0 {
               let status = $0

--- a/Sources/BraveVPN/BraveVPN.swift
+++ b/Sources/BraveVPN/BraveVPN.swift
@@ -13,6 +13,21 @@ import os.log
 
 /// A static class to handle all things related to the Brave VPN service.
 public class BraveVPN {
+  
+  public struct ReceiptResponse {
+    enum Status {
+      case active, expired, retryPeriod
+    }
+    
+    enum ExpirationIntent: Int {
+      case none, cancelled, billingError, priceIncreaseConsent, notAvailable, unknown
+    }
+    
+    var receiptStatus: Status
+    var expirationReason: ExpirationIntent = .none
+    var autoRenewEnabled: Bool = false
+  }
+  
   private static let housekeepingApi = GRDHousekeepingAPI()
   private static let helper = GRDVPNHelper.sharedInstance()
   private static let serverManager = GRDServerManager()
@@ -80,9 +95,8 @@ public class BraveVPN {
       return
     }
     
-    // We validate the current receipt at the start to know if the subscription has expirerd.
-    BraveVPN.validateReceipt() { expired in
-      if expired == true {
+    BraveVPN.validateReceiptData() { receiptResponse in
+      if receiptResponse?.receiptStatus == .expired {
         clearConfiguration()
         logAndStoreError("Receipt expired")
         return
@@ -155,6 +169,81 @@ public class BraveVPN {
       
       GRDSubscriptionManager.setIsPayingUser(true)
       receiptHasExpired?(false)
+    }
+  }
+  
+  /// Connects to Guardian's server to validate locally stored receipt.
+  /// Returns true if the receipt expired, false if not or nil if expiration status can't be determined.
+  public static func validateReceiptData(receiptResponse: ((ReceiptResponse?) -> Void)? = nil) {
+    guard let receipt = receipt,
+    let bundleId = Bundle.main.bundleIdentifier else {
+      receiptResponse?(nil)
+      return
+    }
+    
+    if Preferences.VPN.skusCredential.value != nil {
+      // Receipt verification applies to Apple's IAP only,
+      // if we detect Brave's SKU token we should not look at Apple's receipt.
+      return
+    }
+    
+    housekeepingApi.verifyReceiptData(receipt, bundleId: bundleId) { response, error in
+      if let error = error {
+        // Error while fetching receipt response, the variations of error can be listed
+        // No App Store receipt data present
+        // Failed to retrieve receipt data from server
+        // Failed to decode JSON response data
+        receiptResponse?(nil)
+        logAndStoreError("Call for receipt verification failed: \(error.localizedDescription)")
+        return
+      }
+      
+      guard let response = response else {
+        receiptResponse?(nil)
+        logAndStoreError("Receipt verification response is empty")
+        return
+      }
+      
+      let receiptResponseItem = GRDIAPReceiptResponse(withReceiptResponse: response)
+      
+      print("receiptResponse \(receiptResponseItem)")
+      
+      guard let newestReceiptLineItem = receiptResponseItem.lineItems.sorted(by: { $0.expiresDate > $1.expiresDate }).first else {
+        Preferences.VPN.expirationDate.value = Date(timeIntervalSince1970: 1)
+
+        receiptResponse?(ReceiptResponse(receiptStatus: .expired))
+        logAndStoreError("VPN Subscription LineItems are empty subscription expired", printToConsole: false)
+        return
+      }
+      
+      let lineItemMetaData =  receiptResponseItem.lineItemsMetadata.first(
+        where: { Int($0.originalTransactionId) ?? 00 == newestReceiptLineItem.originalTransactionId })
+      
+      Preferences.VPN.expirationDate.value = newestReceiptLineItem.expiresDate
+      Preferences.VPN.freeTrialUsed.value = !newestReceiptLineItem.isTrialPeriod
+      
+      populateRegionDataIfNecessary()
+      GRDSubscriptionManager.setIsPayingUser(true)
+      
+      guard let metadata = lineItemMetaData else {
+        receiptResponse?(ReceiptResponse(receiptStatus: .active))
+        return
+      }
+      
+      var receiptStatus: ReceiptResponse.Status = .active
+      // Expiration Intent is unsigned
+      let expirationIntent = ReceiptResponse.ExpirationIntent(rawValue: Int(metadata.expirationIntent)) ?? .none
+      // 0 is for turned off renewal, 1 is subscription renewal
+      let autoRenewEnabled: Bool = metadata.autoRenewStatus == 1
+
+      if lineItemMetaData?.isInBillingRetryPeriod == true {
+        receiptStatus = .retryPeriod
+      }
+
+      receiptResponse?(ReceiptResponse(
+        receiptStatus: receiptStatus,
+        expirationReason: expirationIntent,
+        autoRenewEnabled: autoRenewEnabled))
     }
   }
 

--- a/Sources/Onboarding/OnboardingPreferences.swift
+++ b/Sources/Onboarding/OnboardingPreferences.swift
@@ -49,8 +49,8 @@ extension Preferences {
       key: "fullScreenCallout.full-screen-bottom-bar-callout-completed",
       default: false)
     
-    /// Whether the vpn callout is shown.
-    public static let vpnCalloutCompleted = Option<Bool>(
+    /// Whether the vpn promotion callout is shown.
+    public static let vpnPromotionCalloutCompleted = Option<Bool>(
       key: "fullScreenCallout.full-screen-vpn-callout-completed",
       default: false)
     
@@ -67,6 +67,11 @@ extension Preferences {
     /// Whether the omnibox callout is shown.
     public static let omniboxCalloutCompleted = Option<Bool>(
       key: "fullScreenCallout.full-screen-omnibox-callout-completed",
+      default: false)
+    
+    /// Whether the vpn promotion callout is shown.
+    public static let vpnUpdateBillingCalloutCompleted = Option<Bool>(
+      key: "fullScreenCallout.full-screen-vpn-billing-callout-completed",
       default: false)
   }
 }

--- a/Sources/Onboarding/ProductNotifications/FullScreenCalloutManager.swift
+++ b/Sources/Onboarding/ProductNotifications/FullScreenCalloutManager.swift
@@ -9,17 +9,31 @@ import Preferences
 import Growth
 
 public enum FullScreenCalloutType: CaseIterable {
-  case bottomBar, p3a, rewards, defaultBrowser, blockCookieConsentNotices, vpnPromotion, vpnLinkReceipt
+  /*
+   The order will effect the priority
+   
+   Priority:
+   - P3A
+   - VPN Update Billing
+   - Bottom Bar
+   - VPN Promotion
+   - Default Browser
+   - Rewards
+   - Cookie Notification
+   - VPN Link Receipt
+  */
+  case p3a, vpnUpdateBilling, bottomBar, vpnPromotion, defaultBrowser, rewards, blockCookieConsentNotices, vpnLinkReceipt
 
   /// The number of days passed to show certain type of callout
   var period: Int {
     switch self {
-    case .bottomBar: return 0
     case .p3a: return 0
-    case .rewards: return 8
-    case .defaultBrowser: return 10
-    case .blockCookieConsentNotices: return 0
+    case .vpnUpdateBilling: return 0
+    case .bottomBar: return 0
     case .vpnPromotion: return 4
+    case .defaultBrowser: return 10
+    case .rewards: return 8
+    case .blockCookieConsentNotices: return 0
     case .vpnLinkReceipt: return 0
     }
   }
@@ -27,18 +41,20 @@ public enum FullScreenCalloutType: CaseIterable {
   /// The preference value stored for complete state
   public var preferenceValue: Preferences.Option<Bool> {
     switch self {
-    case .bottomBar:
-      return Preferences.FullScreenCallout.bottomBarCalloutCompleted
     case .p3a:
       return Preferences.Onboarding.p3aOnboardingShown
-    case .rewards:
-      return Preferences.FullScreenCallout.rewardsCalloutCompleted
+    case .vpnUpdateBilling:
+      return Preferences.FullScreenCallout.vpnUpdateBillingCalloutCompleted
+    case .bottomBar:
+      return Preferences.FullScreenCallout.bottomBarCalloutCompleted
+    case .vpnPromotion:
+      return Preferences.FullScreenCallout.vpnPromotionCalloutCompleted
     case .defaultBrowser:
       return Preferences.DefaultBrowserIntro.completed
+    case .rewards:
+      return Preferences.FullScreenCallout.rewardsCalloutCompleted
     case .blockCookieConsentNotices:
       return Preferences.FullScreenCallout.blockCookieConsentNoticesCalloutCompleted
-    case .vpnPromotion:
-      return Preferences.FullScreenCallout.vpnCalloutCompleted
     case .vpnLinkReceipt:
       return Preferences.Onboarding.vpnLinkReceiptShown
     }

--- a/Tests/BraveVPNTests/BraveVPNTests.swift
+++ b/Tests/BraveVPNTests/BraveVPNTests.swift
@@ -12,79 +12,146 @@ import GuardianConnect
 class BraveVPNTests: XCTestCase {
 
   override func setUp() {
-//    subject = ["line-items": ["quantity": "1",
-//                              "expires_date": "2023-07-27 22:19:43 Etc/GMT",
-//                              "expires_date_pst": "2023-07-27 15:19:43 America/Los_Angeles",
-//                              "is_in_intro_offer_period": "false",
-//                              "purchase_date_ms": "1690492783000",
-//                              "transaction_id": "2000000377681042",
-//                              "is_trial_period": "false",
-//                              "original_transaction_id": "2000000159090000",
-//                              "in_app_ownership_type": "PURCHASED",
-//                              "original_purchase_date_pst": "2022-09-20 08:12:56 America/Los_Angeles",
-//                              "product_id": "bravevpn.yearly",
-//                              "purchase_date": "2023-07-27 21:19:43 Etc/GMT",
-//                              "subscription_group_identifier": "20621968",
-//                              "original_purchase_date_ms": "1663686776000",
-//                              "web_order_line_item_id": "2000000032896443",
-//                              "expires_date_ms": "1690496383000",
-//                              "purchase_date_pst": "2023-07-27 14:19:43 America/Los_Angeles",
-//                              "original_purchase_date": "2022-09-20 15:12:56 Etc/GMT"],
-//               "line-items-metadata": ["product_id": "bravevpn.yearly",
-//                                       "original_transaction_id": "2000000159090000",
-//                                       "auto_renew_product_id": "bravevpn.yearly",
-//                                       "auto_renew_status": "1"]
-//               ]
-    
-    let lineItem: NSDictionary = ["quantity": "1",
-                        "expires_date": "2023-07-27 22:19:43 Etc/GMT",
-                        "expires_date_pst": "2023-07-27 15:19:43 America/Los_Angeles",
-                        "is_in_intro_offer_period": "false",
-                        "purchase_date_ms": "1690492783000",
-                        "transaction_id": "2000000377681042",
-                        "is_trial_period": "false",
-                        "original_transaction_id": "2000000159090000",
-                        "in_app_ownership_type": "PURCHASED",
-                        "original_purchase_date_pst": "2022-09-20 08:12:56 America/Los_Angeles",
-                        "product_id": "bravevpn.yearly",
-                        "purchase_date": "2023-07-27 21:19:43 Etc/GMT",
-                        "subscription_group_identifier": "20621968",
-                        "original_purchase_date_ms": "1663686776000",
-                        "web_order_line_item_id": "2000000032896443",
-                        "expires_date_ms": "1690496383000",
-                        "purchase_date_pst": "2023-07-27 14:19:43 America/Los_Angeles",
-                        "original_purchase_date": "2022-09-20 15:12:56 Etc/GMT"]
-    
-    let lineItemMetaData: NSDictionary = ["product_id": "bravevpn.yearly",
-                                          "original_transaction_id": "2000000159090000",
-                                          "auto_renew_product_id": "bravevpn.yearly",
-                                          "auto_renew_status": "1"]
-    
-    let receiptLineItem: GRDReceiptLineItem = GRDReceiptLineItem(dictionary: lineItem as! [AnyHashable: Any])
-    let receiptLineItemMetaData: GRDReceiptLineItemMetadata = GRDReceiptLineItemMetadata(dictionary: lineItemMetaData as! [AnyHashable: Any])
-    
-    let receiptResponse = GRDIAPReceiptResponse(withReceiptResponse: ["":""])
-    receiptResponse.lineItems = [receiptLineItem]
-    receiptResponse.lineItemsMetadata = [receiptLineItemMetaData]
 
-    subject = receiptResponse
+    let lineItemPurchasedNotInTrial: NSDictionary = [
+      "quantity": "1",
+      "expires_date": "2024-07-27 22:19:43 Etc/GMT",
+      "expires_date_pst": "2024-07-27 15:19:43 America/Los_Angeles",
+      "is_in_intro_offer_period": "false",
+      "purchase_date_ms": "1690492783000",
+      "transaction_id": "2000000377681042",
+      "is_trial_period": "false",
+      "original_transaction_id": "2000000159090000",
+      "in_app_ownership_type": "PURCHASED",
+      "original_purchase_date_pst": "2022-09-20 08:12:56 America/Los_Angeles",
+      "product_id": "bravevpn.yearly",
+      "purchase_date": "2024-07-27 22:19:43 Etc/GMT",
+      "subscription_group_identifier": "20621968",
+      "original_purchase_date_ms": "1663686776000",
+      "expires_date_ms": "1690496383000",
+      "purchase_date_pst": "2023-07-27 14:19:43 America/Los_Angeles",
+      "original_purchase_date": "2022-09-20 15:12:56 Etc/GMT"]
+    
+    let lineItemPurchasedInTrial: NSDictionary = [
+      "quantity": "1",
+      "expires_date": "2024-07-27 22:19:43 Etc/GMT",
+      "expires_date_pst": "2024-07-27 15:19:43 America/Los_Angeles",
+      "is_in_intro_offer_period": "false",
+      "purchase_date_ms": "1690492783000",
+      "transaction_id": "2000000377681042",
+      "is_trial_period": "true",
+      "original_transaction_id": "2000000159090000",
+      "in_app_ownership_type": "PURCHASED",
+      "original_purchase_date_pst": "2022-09-20 08:12:56 America/Los_Angeles",
+      "product_id": "bravevpn.yearly",
+      "purchase_date": "2024-07-27 22:19:43 Etc/GMT",
+      "subscription_group_identifier": "20621968",
+      "original_purchase_date_ms": "1663686776000",
+      "web_order_line_item_id": "2000000032896443",
+      "expires_date_ms": "1690496383000",
+      "purchase_date_pst": "2023-07-27 14:19:43 America/Los_Angeles",
+      "original_purchase_date": "2022-09-20 15:12:56 Etc/GMT"]
+    
+    let lineItemMetaDataAutoRenewEnabled: NSDictionary = [
+      "product_id": "bravevpn.yearly",
+      "original_transaction_id": "2000000159090000",
+      "auto_renew_product_id": "bravevpn.yearly",
+      "auto_renew_status": "1"]
+    
+    let lineItemMetaDataAutoRenewCanceled: NSDictionary = [
+      "product_id": "bravevpn.yearly",
+      "original_transaction_id": "2000000159090000",
+      "auto_renew_product_id": "bravevpn.yearly",
+      "auto_renew_status": "0"]
+    
+    let lineItemMetaDataIsInRetryPeriod: NSDictionary = [
+      "product_id": "bravevpn.yearly",
+      "original_transaction_id": "2000000159090000",
+      "auto_renew_product_id": "bravevpn.yearly",
+      "auto_renew_status": "0",
+      "is_in_billing_retry_period": "true"]
+    
+
+    subjectActivePeriodRenewableNotInTrial = generateReceiptResponse(using: lineItemPurchasedNotInTrial, metaData: lineItemMetaDataAutoRenewEnabled)
+    subjectActivePeriodRenewableInTrial = generateReceiptResponse(using: lineItemPurchasedInTrial, metaData: lineItemMetaDataAutoRenewEnabled)
+    subjectActivePeriodNotRenewable = generateReceiptResponse(using: lineItemPurchasedNotInTrial, metaData: lineItemMetaDataAutoRenewCanceled)
+    subjectRetryPeriod = generateReceiptResponse(using: lineItemPurchasedNotInTrial, metaData: lineItemMetaDataIsInRetryPeriod)
+    subjectExpiredPeriod = generateReceiptResponse(using: nil, metaData: lineItemMetaDataAutoRenewCanceled)
   }
 
   override func tearDown() {
-    subject = nil
-
+    subjectActivePeriodRenewableNotInTrial = nil
+    subjectActivePeriodRenewableInTrial = nil
+    subjectActivePeriodNotRenewable = nil
+    subjectRetryPeriod = nil
+    subjectExpiredPeriod = nil
+    
     super.tearDown()
   }
 
-  func testAutoRenewEnabled() {
-    print("Test")
-
-    let processedLineItem = BraveVPN.processReceiptResponse(receiptResponseItem: subject)
+  func testSubscriptionActiveAutoRenewEnabledNotInTrial() {
+    let processedLineItem = BraveVPN.processReceiptResponse(receiptResponseItem: subjectActivePeriodRenewableNotInTrial)
     
-    XCTAssertTrue(processedLineItem.response.status == .active)
-
+    XCTAssertTrue(processedLineItem.status == .active)
+    XCTAssertTrue(processedLineItem.autoRenewEnabled)
+    XCTAssertFalse(processedLineItem.isInTrialPeriod)
+  }
+  
+  func testSubscriptionActiveAutoRenewEnabledInTrial() {
+    let processedLineItem = BraveVPN.processReceiptResponse(receiptResponseItem: subjectActivePeriodRenewableInTrial)
+    
+    XCTAssertTrue(processedLineItem.status == .active)
+    XCTAssertTrue(processedLineItem.autoRenewEnabled)
+    XCTAssertTrue(processedLineItem.isInTrialPeriod)
+  }
+  
+  func testSubscriptionActiveAutoRenewDisabled() {
+    let processedLineItem = BraveVPN.processReceiptResponse(receiptResponseItem: subjectActivePeriodNotRenewable)
+    
+    XCTAssertTrue(processedLineItem.status == .active)
+    XCTAssertFalse(processedLineItem.autoRenewEnabled)
+  }
+  
+  func testSubscriptionIsInRetryPeriod() {
+    let processedLineItem = BraveVPN.processReceiptResponse(receiptResponseItem: subjectRetryPeriod)
+    
+    XCTAssertTrue(processedLineItem.status == .retryPeriod)
+    XCTAssertFalse(processedLineItem.autoRenewEnabled)
+    XCTAssertFalse(processedLineItem.isInTrialPeriod)
+  }
+  
+  func testSubscriptionExpiredPeriod() {
+    let processedLineItem = BraveVPN.processReceiptResponse(receiptResponseItem: subjectExpiredPeriod)
+    
+    XCTAssertTrue(processedLineItem.status == .expired)
+    XCTAssertFalse(processedLineItem.autoRenewEnabled)
+    XCTAssertFalse(processedLineItem.isInTrialPeriod)
+  }
+  
+  private func generateReceiptResponse(using lineItem: NSDictionary?, metaData: NSDictionary)-> GRDIAPReceiptResponse {
+    var receiptLineItem: GRDReceiptLineItem?
+    
+    if let lineItem = lineItem {
+      receiptLineItem = GRDReceiptLineItem(
+        dictionary: lineItem as! [AnyHashable: Any])
+    }
+    let receiptLineItemMetaData: GRDReceiptLineItemMetadata = GRDReceiptLineItemMetadata(
+      dictionary: metaData as! [AnyHashable: Any])
+    
+    let receiptResponse = GRDIAPReceiptResponse(withReceiptResponse: ["":""])
+    if let receiptLineItem = receiptLineItem {
+      receiptResponse.lineItems = [receiptLineItem]
+    } else {
+      receiptResponse.lineItems = []
+    }
+    receiptResponse.lineItemsMetadata = [receiptLineItemMetaData]
+    
+    return receiptResponse
   }
 
-
-  private var subject: GRDIAPReceiptResponse!
+  private var subjectActivePeriodRenewableNotInTrial: GRDIAPReceiptResponse!
+  private var subjectActivePeriodRenewableInTrial: GRDIAPReceiptResponse!
+  private var subjectActivePeriodNotRenewable: GRDIAPReceiptResponse!
+  private var subjectRetryPeriod: GRDIAPReceiptResponse!
+  private var subjectExpiredPeriod: GRDIAPReceiptResponse!
 }

--- a/Tests/BraveVPNTests/BraveVPNTests.swift
+++ b/Tests/BraveVPNTests/BraveVPNTests.swift
@@ -1,0 +1,90 @@
+// Copyright 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+@testable import BraveVPN
+import BraveShared
+import XCTest
+import GuardianConnect
+
+class BraveVPNTests: XCTestCase {
+
+  override func setUp() {
+//    subject = ["line-items": ["quantity": "1",
+//                              "expires_date": "2023-07-27 22:19:43 Etc/GMT",
+//                              "expires_date_pst": "2023-07-27 15:19:43 America/Los_Angeles",
+//                              "is_in_intro_offer_period": "false",
+//                              "purchase_date_ms": "1690492783000",
+//                              "transaction_id": "2000000377681042",
+//                              "is_trial_period": "false",
+//                              "original_transaction_id": "2000000159090000",
+//                              "in_app_ownership_type": "PURCHASED",
+//                              "original_purchase_date_pst": "2022-09-20 08:12:56 America/Los_Angeles",
+//                              "product_id": "bravevpn.yearly",
+//                              "purchase_date": "2023-07-27 21:19:43 Etc/GMT",
+//                              "subscription_group_identifier": "20621968",
+//                              "original_purchase_date_ms": "1663686776000",
+//                              "web_order_line_item_id": "2000000032896443",
+//                              "expires_date_ms": "1690496383000",
+//                              "purchase_date_pst": "2023-07-27 14:19:43 America/Los_Angeles",
+//                              "original_purchase_date": "2022-09-20 15:12:56 Etc/GMT"],
+//               "line-items-metadata": ["product_id": "bravevpn.yearly",
+//                                       "original_transaction_id": "2000000159090000",
+//                                       "auto_renew_product_id": "bravevpn.yearly",
+//                                       "auto_renew_status": "1"]
+//               ]
+    
+    let lineItem: NSDictionary = ["quantity": "1",
+                        "expires_date": "2023-07-27 22:19:43 Etc/GMT",
+                        "expires_date_pst": "2023-07-27 15:19:43 America/Los_Angeles",
+                        "is_in_intro_offer_period": "false",
+                        "purchase_date_ms": "1690492783000",
+                        "transaction_id": "2000000377681042",
+                        "is_trial_period": "false",
+                        "original_transaction_id": "2000000159090000",
+                        "in_app_ownership_type": "PURCHASED",
+                        "original_purchase_date_pst": "2022-09-20 08:12:56 America/Los_Angeles",
+                        "product_id": "bravevpn.yearly",
+                        "purchase_date": "2023-07-27 21:19:43 Etc/GMT",
+                        "subscription_group_identifier": "20621968",
+                        "original_purchase_date_ms": "1663686776000",
+                        "web_order_line_item_id": "2000000032896443",
+                        "expires_date_ms": "1690496383000",
+                        "purchase_date_pst": "2023-07-27 14:19:43 America/Los_Angeles",
+                        "original_purchase_date": "2022-09-20 15:12:56 Etc/GMT"]
+    
+    let lineItemMetaData: NSDictionary = ["product_id": "bravevpn.yearly",
+                                          "original_transaction_id": "2000000159090000",
+                                          "auto_renew_product_id": "bravevpn.yearly",
+                                          "auto_renew_status": "1"]
+    
+    let receiptLineItem: GRDReceiptLineItem = GRDReceiptLineItem(dictionary: lineItem as! [AnyHashable: Any])
+    let receiptLineItemMetaData: GRDReceiptLineItemMetadata = GRDReceiptLineItemMetadata(dictionary: lineItemMetaData as! [AnyHashable: Any])
+    
+    let receiptResponse = GRDIAPReceiptResponse(withReceiptResponse: ["":""])
+    receiptResponse.lineItems = [receiptLineItem]
+    receiptResponse.lineItemsMetadata = [receiptLineItemMetaData]
+
+    subject = receiptResponse
+  }
+
+  override func tearDown() {
+    subject = nil
+
+    super.tearDown()
+  }
+
+  func testAutoRenewEnabled() {
+    print("Test")
+
+    let processedLineItem = BraveVPN.processReceiptResponse(receiptResponseItem: subject)
+    
+    XCTAssertTrue(processedLineItem.response.status == .active)
+
+  }
+
+
+  private var subject: GRDIAPReceiptResponse!
+}


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

Second part Pr for VPN Churn improvement. After https://github.com/brave/brave-ios/pull/7670 added Pop-over types and new style of displaying the pop-overs.

This PR is adding fixes for proper priority for Callouts and method for displaying update billing pop over.

In addition main part is implementation of `verifyReceiptData` function which is right now only used in AppLaunch which can retrieve all details of receipt.

The tests are added for receipt field different variation.

There will be a 3 rd Pr after this to combine menu changes and popover UX depending on this PR. But this Pr can be merged when review is finished and application works as expected with the change of verifyReceipt data functions

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4879

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
N/A


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
