### PR TITLE
Fix #7804: Fix a memory leak in `SettingsViewController` which could cause wallet creates duplicate auto-discovered assets

### DIFF
--- a/Sources/Brave/Frontend/Settings/SettingsViewController.swift
+++ b/Sources/Brave/Frontend/Settings/SettingsViewController.swift
@@ -275,7 +275,7 @@ class SettingsViewController: TableViewController {
     section.rows.append(
       Row(
         text: Strings.BraveNews.braveNews,
-        selection: {
+        selection: { [unowned self] in
           let controller = NewsSettingsViewController(dataSource: self.feedDataSource, openURL: { [weak self] url in
             guard let self else { return }
             self.dismiss(animated: true)

--- a/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -655,6 +655,9 @@ extension CryptoStore: BraveWalletBraveWalletServiceObserver {
   }
   
   public func onDiscoverAssetsCompleted(_ discoveredAssets: [BraveWallet.BlockchainToken]) {
+    // Failsafe incase two CryptoStore's are initialized (see brave-ios #7804) and asset
+    // migration is slow. Makes sure auto-discovered assets during asset migration to
+    // CoreData are added after.
     if !isUpdatingUserAssets {
       for asset in discoveredAssets {
         userAssetManager.addUserAsset(asset, completion: nil)

--- a/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -104,6 +104,7 @@ public class CryptoStore: ObservableObject {
   private let ipfsApi: IpfsAPI
   private let userAssetManager: WalletUserAssetManager
   private var isUpdatingUserAssets: Bool = false
+  private var autoDiscoveredAssets: [BraveWallet.BlockchainToken] = []
   
   public init(
     keyringService: BraveWalletKeyringService,
@@ -179,7 +180,11 @@ public class CryptoStore: ObservableObject {
     self.rpcService.add(self)
     self.walletService.add(self)
     
-    userAssetManager.migrateUserAssets { [weak self] in
+    Preferences.Wallet.migrateCoreToWalletUserAssetCompleted.observe(from: self)
+    
+    isUpdatingUserAssets = true
+    userAssetManager.migrateUserAssets() { [weak self] in
+      self?.isUpdatingUserAssets = false
       self?.updateAssets()
     }
   }
@@ -650,14 +655,31 @@ extension CryptoStore: BraveWalletBraveWalletServiceObserver {
   }
   
   public func onDiscoverAssetsCompleted(_ discoveredAssets: [BraveWallet.BlockchainToken]) {
-    for asset in discoveredAssets where userAssetManager.getUserAsset(asset) == nil {
-      userAssetManager.addUserAsset(asset, completion: nil)
-    }
-    if !discoveredAssets.isEmpty {
-      updateAssets()
+    if !isUpdatingUserAssets {
+      for asset in discoveredAssets {
+        userAssetManager.addUserAsset(asset, completion: nil)
+      }
+      if !discoveredAssets.isEmpty {
+        updateAssets()
+      }
+    } else {
+      autoDiscoveredAssets.append(contentsOf: discoveredAssets)
     }
   }
   
   public func onResetWallet() {
+  }
+}
+
+extension CryptoStore: PreferencesObserver {
+  public func preferencesDidChange(for key: String) {
+    // we are only observing `Preferences.Wallet.migrateCoreToWalletUserAssetCompleted`
+    if Preferences.Wallet.migrateCoreToWalletUserAssetCompleted.value, !autoDiscoveredAssets.isEmpty {
+      for asset in autoDiscoveredAssets {
+        userAssetManager.addUserAsset(asset, completion: nil)
+      }
+      autoDiscoveredAssets.removeAll()
+      updateAssets()
+    }
   }
 }

--- a/Sources/BraveWallet/WalletUserAssetManager.swift
+++ b/Sources/BraveWallet/WalletUserAssetManager.swift
@@ -68,6 +68,10 @@ public class WalletUserAssetManager: WalletUserAssetManagerType {
   }
   
   public func addUserAsset(_ asset: BraveWallet.BlockchainToken, completion: (() -> Void)?) {
+    guard WalletUserAsset.getUserAsset(asset: asset) == nil else {
+      completion?()
+      return
+    }
     WalletUserAsset.addUserAsset(asset: asset, completion: completion)
   }
   


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
`SettingsViewController` leaks so that it's `CryptoStore` would keep listening auto-discovered assets. This could cause race-condition when user restore a wallet again.
Some optimization added for user assets migration. We will not add auto-discovered assets until the initial migration is finished. 

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7804

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Please refer to the issue

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

https://github.com/brave/brave-ios/assets/1187676/85c83e48-35ce-49d9-9792-e5fbf59fc187



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
