### PR TITLE
Fix #7819: Resetting Speech Recognizer properly after valid search conditions

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
@@ -598,6 +598,8 @@ extension BrowserViewController: TopToolbarDelegate {
       if let query = searchQuery {
         self.submitSearchText(query)
       }
+      
+      self.speechRecognizer.clearSearch()
     }
   }
 

--- a/Sources/Brave/Frontend/Browser/Search/Voice Search/SpeechRecognizer.swift
+++ b/Sources/Brave/Frontend/Browser/Search/Voice Search/SpeechRecognizer.swift
@@ -203,9 +203,13 @@ class SpeechRecognizer: ObservableObject {
     }
   }
   
-  nonisolated private func clearSearch() {
+  nonisolated func clearSearch() {
     Task { @MainActor in
+      transcript = " "
+      transcriptedIcon = "leo.microphone"
       finalizedRecognition = (false, "")
+      animationType = .pulse(scale: 1)
+      isSilent = true
     }
   }
   


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7819
This pull request fixes #7686 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
sanity check for multiple searches

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
