### PR TITLE
Fix iOS for recent `AdblockEngine` changes

### DIFF
--- a/App/iOS/Delegates/AppDelegate.swift
+++ b/App/iOS/Delegates/AppDelegate.swift
@@ -255,9 +255,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     // Override point for customization after application launch.
     var shouldPerformAdditionalDelegateHandling = true
-
-    // TODO: Adblock fixup for v1.58.62
-//    AdblockEngine.setDomainResolver(AdblockEngine.defaultDomainResolver)
+    AdblockEngine.setDomainResolver()
 
     UIView.applyAppearanceDefaults()
 

--- a/Sources/Brave/WebFilters/AdBlockEngineManager.swift
+++ b/Sources/Brave/WebFilters/AdBlockEngineManager.swift
@@ -179,11 +179,22 @@ public actor AdBlockEngineManager: Sendable {
       $0.order < $1.order
     })
     
-    let results = await AdblockEngine.createEngines(from: resourcesWithVersion)
+    let results = await CachedAdBlockEngine.createEngines(from: resourcesWithVersion)
+    
+    let validEngines = results.compactMap { result in
+      do {
+        return try result.get()
+      } catch {
+        ContentBlockerManager.log.error("Failed to compile engine: \(String(describing: error))")
+        return nil
+      }
+    }
+    
     self.compiledResources = Set(resourcesWithVersion)
-    await stats.set(engines: results.engines)
+    await stats.set(engines: validEngines)
+    
     #if DEBUG
-    debug(compiledResults: results.compileResults)
+    ContentBlockerManager.log.error("Recompiled engines")
     #endif
   }
   
@@ -203,61 +214,3 @@ public actor AdBlockEngineManager: Sendable {
     enabledResources.insert(resource)
   }
 }
-
-#if DEBUG
-private extension AdBlockEngineManager {
-  /// A method that logs info on the given resources
-  func debug(compiledResults: [ResourceWithVersion: Result<Void, Error>]) {
-    log.debug("Loaded \(compiledResults.count) (total) engine resources:")
-    
-    compiledResults.sorted(by: { $0.key.order < $1.key.order })
-      .forEach { (resourceWithVersion, compileResult) in
-        let resultString: String
-        
-        switch compileResult {
-        case .success:
-          resultString = "✔︎"
-        case .failure(let error):
-          resultString = "\(error)"
-        }
-        
-        let sourceDebugString = [
-          "", resourceWithVersion.debugDescription,
-          "\(resultString)",
-        ].joined(separator: " ")
-        
-        log.debug("\(sourceDebugString)")
-      }
-  }
-}
-
-extension AdBlockEngineManager.ResourceWithVersion: CustomDebugStringConvertible {
-  public var debugDescription: String {
-    return [
-      "#\(order)",
-      "\(resource.source.debugDescription).\(resource.type.debugDescription)",
-      "v\(version ?? "nil")",
-    ].joined(separator: " ")
-  }
-}
-
-extension AdBlockEngineManager.Source: CustomDebugStringConvertible {
-  public var debugDescription: String {
-    switch self {
-    case .filterList(let uuid): return "filterList(\(uuid))"
-    case .filterListURL(let uuid): return "filterListURL(\(uuid))"
-    case .adBlock: return "adBlock"
-    }
-  }
-}
-
-extension AdBlockEngineManager.ResourceType: CustomDebugStringConvertible {
-  public var debugDescription: String {
-    switch self {
-    case .dat: return "dat"
-    case .jsonResources: return "jsonResources"
-    case .ruleList: return "ruleList"
-    }
-  }
-}
-#endif

--- a/Sources/Brave/WebFilters/FilterListCustomURLDownloader.swift
+++ b/Sources/Brave/WebFilters/FilterListCustomURLDownloader.swift
@@ -66,18 +66,15 @@ actor FilterListCustomURLDownloader: ObservableObject {
   private func handle(downloadResult: ResourceDownloader<DownloadResource>.DownloadResult, for filterListCustomURL: FilterListCustomURL) async {
     let uuid = await filterListCustomURL.setting.uuid
     
-    /*
-     // TODO: Adblock fixup for v1.58.62
     // Compile this rule list if we haven't already or if the file has been modified
     if downloadResult.isModified {
       do {
         let filterSet = try String(contentsOf: downloadResult.fileURL, encoding: .utf8)
-        var truncated: Bool = false
-        let jsonRules = AdblockEngine.contentBlockerRules(fromFilterSet: filterSet, truncated: &truncated)
+        let result = try AdblockEngine.contentBlockerRules(fromFilterSet: filterSet)
         let type = ContentBlockerManager.BlocklistType.customFilterList(uuid: uuid)
         
         try await ContentBlockerManager.shared.compile(
-          encodedContentRuleList: jsonRules,
+          encodedContentRuleList: result.rulesJSON,
           for: type,
           options: .all
         )
@@ -91,7 +88,6 @@ actor FilterListCustomURLDownloader: ObservableObject {
         )
       }
     }
-     */
       
     // Add/remove the resource depending on if it is enabled/disabled
     if await filterListCustomURL.setting.isEnabled {

--- a/Tests/ClientTests/AdblockRustTests.swift
+++ b/Tests/ClientTests/AdblockRustTests.swift
@@ -7,10 +7,8 @@ import BraveCore
 @testable import Brave
 
 class AdblockRustTests: XCTestCase {
-  // TODO: Adblock fixup for v1.58.62
-  /*
   // Taken from adblock-rust-ffi TestBasics()
-  func testBasicBlocking() {
+  func testBasicBlocking() throws {
     let rules =
       """
           -advertisement-icon.
@@ -20,8 +18,8 @@ class AdblockRustTests: XCTestCase {
           @@good-advertisement
       """
 
-    let engine = AdblockEngine(rules: rules)
-    AdblockEngine.setDomainResolver(AdblockEngine.defaultDomainResolver)
+    AdblockEngine.setDomainResolver()
+    let engine = try AdblockEngine(rules: rules)
 
     XCTAssertTrue(engine.shouldBlock(
       requestURL: URL(string: "http://example.com/-advertisement-icon.")!,
@@ -44,5 +42,4 @@ class AdblockRustTests: XCTestCase {
       isAggressive: true
     ))
   }
-   */
 }

--- a/Tests/ClientTests/Web Filters/AdBlockEngineManagerTests.swift
+++ b/Tests/ClientTests/Web Filters/AdBlockEngineManagerTests.swift
@@ -50,9 +50,7 @@ class AdBlockEngineManagerTests: XCTestCase {
     let expectation = expectation(description: "Compiled engine resources")
     let stats = AdBlockStats()
     let engineManager = AdBlockEngineManager(stats: stats)
-    
-    // TODO: Adblock fixup for v1.58.62
-//    AdblockEngine.setDomainResolver(AdblockEngine.defaultDomainResolver)
+    AdblockEngine.setDomainResolver()
     
     Task.detached {
       for (index, (source, url)) in filterListURLs.enumerated() {
@@ -113,8 +111,6 @@ class AdBlockEngineManagerTests: XCTestCase {
   }
   
   func testPerformance() throws {
-    // TODO: Adblock fixup for v1.58.62
-//    AdblockEngine.setDomainResolver(AdblockEngine.defaultDomainResolver)
     // Given
     // Ad block data and an engine manager
     let sampleAdBlockDatURL = Bundle.module.url(forResource: "rs-ABPFilterParserData", withExtension: "dat")!


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
Fix iOS with the latest AdblockEngine changes on brave-core

Note: to simplify this, I removed some logging that was mostly helpful for me. Any errors are still logged.

Note: 
## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
1. Test cosmetic filtering (i.e. https://dev-pages.brave.software/filtering/cosmetic-filtering.html)
2. Test trackers-blocking (i.e. https://test-pages.privacytests.org/tracking_content.html)
3. Test scriplets (i.e. https://dev-pages.brave.software/filtering/scriptlets.html)
4. Test YouTube (not exactly related to the changes but it provides a good performance test)

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->
N/A

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
