### PR TITLE
Fix #7823: Select Account not always showing checkmark

### DIFF
--- a/Sources/BraveWallet/Crypto/Accounts/AccountSelectionRootView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/AccountSelectionRootView.swift
@@ -43,7 +43,9 @@ struct AccountSelectionRootView: View {
         ForEach(allAccounts) { account in
           AccountListRowView(
             account: account,
-            isSelected: selectedAccounts.contains(account)
+            isSelected: selectedAccounts.contains(where: { selectedAccount in
+              selectedAccount.accountId == account.accountId
+            })
           ) {
             selectAccount(account)
           }


### PR DESCRIPTION
## Summary of Changes
- Bug in comparison to determine if an account is selected. Object instance was being compared instead of the account's id.

This pull request fixes #7823

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
  1. Open Wallet Panel and tap the blockie for the selected account
  2. In the `Select Account` modal, verify the checkmark is shown as expected. 
  3. Select a different account, then re-open `Select Account` and verify the checkmark is shown as expected.
  4. Add a new account, verify checkmark is shown as expected


## Screenshots:

https://github.com/brave/brave-ios/assets/5314553/0bffa362-6f70-4d15-8527-0900e91466bf


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
