### PR TITLE
Fix #7822: Fix Block scripts to work on all frames

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -400,7 +400,13 @@ extension BrowserViewController: WKNavigationDelegate {
         // Load rule lists
         let ruleLists = await ContentBlockerManager.shared.ruleLists(for: domainForShields)
         tab?.contentBlocker.set(ruleLists: ruleLists)
-        
+      }
+      
+      let documentTargetURL: URL? = navigationAction.request.mainDocumentURL ??
+                                    navigationAction.targetFrame?.request.mainDocumentURL ??
+                                    url   // Should be the same as the sourceFrame URL
+      if let documentTargetURL = documentTargetURL {
+        let domainForShields = Domain.getOrCreate(forUrl: documentTargetURL, persistent: !isPrivateBrowsing)
         let isScriptsEnabled = !domainForShields.isShieldExpected(.NoScript, considerAllShieldsOption: true)
         preferences.allowsContentJavaScript = isScriptsEnabled
       }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- We have a condition for adblocking to work on main-frame targets only. However, the logic for block scripts was also bundled under the same conditions.
- This PR fixes it, to block regardless of frame.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7822

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
-- See the ticket.


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
