### PR TITLE
Fix #7828: Adding Issue Category Separately to VPN Contact Form

### DIFF
--- a/Sources/Brave/Frontend/Settings/SettingsViewController.swift
+++ b/Sources/Brave/Frontend/Settings/SettingsViewController.swift
@@ -565,18 +565,25 @@ class SettingsViewController: TableViewController {
       selection: { [unowned self] in
 
         let vc = { () -> UIViewController? in
-          switch BraveVPN.vpnState {
-          case .notPurchased, .expired:
-            return BraveVPN.vpnState.enableVPNDestinationVC
-          case .purchased:
-            let vc = BraveVPNSettingsViewController()
-            vc.openURL = { [unowned self] url in
-              self.settingsDelegate?.settingsOpenURLInNewTab(url)
-              self.dismiss(animated: true)
-            }
-
-            return vc
+          let vc = BraveVPNSettingsViewController()
+          vc.openURL = { [unowned self] url in
+            self.settingsDelegate?.settingsOpenURLInNewTab(url)
+            self.dismiss(animated: true)
           }
+          return vc
+          
+//          switch BraveVPN.vpnState {
+//          case .notPurchased, .expired:
+//            return BraveVPN.vpnState.enableVPNDestinationVC
+//          case .purchased:
+//            let vc = BraveVPNSettingsViewController()
+//            vc.openURL = { [unowned self] url in
+//              self.settingsDelegate?.settingsOpenURLInNewTab(url)
+//              self.dismiss(animated: true)
+//            }
+//
+//            return vc
+//          }
         }()
 
         guard let vcToShow = vc else { return }

--- a/Sources/Brave/Frontend/Settings/SettingsViewController.swift
+++ b/Sources/Brave/Frontend/Settings/SettingsViewController.swift
@@ -565,25 +565,18 @@ class SettingsViewController: TableViewController {
       selection: { [unowned self] in
 
         let vc = { () -> UIViewController? in
-          let vc = BraveVPNSettingsViewController()
-          vc.openURL = { [unowned self] url in
-            self.settingsDelegate?.settingsOpenURLInNewTab(url)
-            self.dismiss(animated: true)
+          switch BraveVPN.vpnState {
+          case .notPurchased, .expired:
+            return BraveVPN.vpnState.enableVPNDestinationVC
+          case .purchased:
+            let vc = BraveVPNSettingsViewController()
+            vc.openURL = { [unowned self] url in
+              self.settingsDelegate?.settingsOpenURLInNewTab(url)
+              self.dismiss(animated: true)
+            }
+
+            return vc
           }
-          return vc
-          
-//          switch BraveVPN.vpnState {
-//          case .notPurchased, .expired:
-//            return BraveVPN.vpnState.enableVPNDestinationVC
-//          case .purchased:
-//            let vc = BraveVPNSettingsViewController()
-//            vc.openURL = { [unowned self] url in
-//              self.settingsDelegate?.settingsOpenURLInNewTab(url)
-//              self.dismiss(animated: true)
-//            }
-//
-//            return vc
-//          }
         }()
 
         guard let vcToShow = vc else { return }

--- a/Sources/BraveStrings/BraveStrings.swift
+++ b/Sources/BraveStrings/BraveStrings.swift
@@ -2883,6 +2883,11 @@ extension Strings {
       NSLocalizedString("vpn.contactFormIssue", tableName: "BraveShared", bundle: .module,
         value: "Issue",
         comment: "Specific issue field for customer support contact form.")
+    
+    public static let contactFormIssueDescription =
+      NSLocalizedString("vpn.contactFormIssueDescription", tableName: "BraveShared", bundle: .module,
+        value: "Please choose the cetagory that describes the issue.",
+        comment: "Description used for specific issue field for customer support contact form.")
 
     public static let contactFormFooterSharedWithGuardian =
       NSLocalizedString("vpn.contactFormFooterSharedWithGuardian", tableName: "BraveShared", bundle: .module,

--- a/Sources/BraveVPN/BraveVPNContactFormViewController.swift
+++ b/Sources/BraveVPN/BraveVPNContactFormViewController.swift
@@ -223,6 +223,8 @@ class BraveVPNContactFormViewController: TableViewController {
         
           let optionsVC =
             OptionSelectionViewController<IssueType>(
+              headerText: Strings.VPN.contactFormIssue,
+              footerText: Strings.VPN.contactFormIssueDescription,
               options: IssueType.allCases,
               optionChanged: optionChanged)
 
@@ -255,7 +257,12 @@ class BraveVPNContactFormViewController: TableViewController {
       $0.setToRecipients([self.supportEmail])
     }
 
-    mail.setSubject(Strings.VPN.contactFormTitle)
+    var formTitle = Strings.VPN.contactFormTitle
+    if let issue = contactForm.issue {
+      formTitle += " + \(issue)"
+    }
+    
+    mail.setSubject(formTitle)
     mail.setMessageBody(self.composeEmailBody(with: self.contactForm), isHTML: false)
     present(mail, animated: true)
   }
@@ -282,10 +289,18 @@ class BraveVPNContactFormViewController: TableViewController {
   }
 
   private func composeEmailBody(with contactForm: ContactForm) -> String {
-    var body = "\n\n"
+    var body = "\n"
 
     body.append(contentsOf: "#### \(Strings.VPN.contactFormDoNotEditText) ####\n\n")
 
+    body.append(Strings.VPN.contactFormPlatform)
+    body.append("\n\(UIDevice.current.systemName)\n\n")
+
+    if let issue = contactForm.issue {
+      body.append(Strings.VPN.contactFormIssue)
+      body.append("\n\(issue)\n\n")
+    }
+    
     if let hostname = contactForm.hostname {
       body.append(Strings.VPN.contactFormHostname)
       body.append("\n\(hostname)\n\n")
@@ -305,10 +320,7 @@ class BraveVPNContactFormViewController: TableViewController {
       body.append(Strings.VPN.contactFormAppVersion)
       body.append("\n\(appVersion)\n\n")
     }
-      
-    body.append(Strings.VPN.contactFormPlatform)
-    body.append("\n\(UIDevice.current.systemName)\n\n")
-
+    
     if let timezone = contactForm.timezone {
       body.append(Strings.VPN.contactFormTimezone)
       body.append("\n\(timezone)\n\n")
@@ -335,11 +347,6 @@ class BraveVPNContactFormViewController: TableViewController {
       }
 
       body.append("\n")
-    }
-
-    if let issue = contactForm.issue {
-      body.append(Strings.VPN.contactFormIssue)
-      body.append("\n\(issue)\n\n")
     }
 
     if let receipt = contactForm.receipt {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

Adding issue selector as mandatory for support, check the ticket for implementation details.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7828

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Go Settings
2. Press Brave Firewall + VPN
3. Press Contact Technical Support
4. Choose (toggle) categories which are necessary
5. Click Continue to Email
6. Issue Selection screen presented
7. Select a issue
8. User email should be presented with necessary Issue in subject and body for the email

## Screenshots:

![supportmeialtest13211](https://github.com/brave/brave-ios/assets/6643505/49091412-a596-429a-afec-c1d787819421)



https://github.com/brave/brave-ios/assets/6643505/812de48b-3c27-4100-bfee-a4a7250fc891



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
