### PR TITLE
Fix #7831: Fixed PopoverController not deallocating

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Onboarding.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Onboarding.swift
@@ -221,11 +221,11 @@ extension BrowserViewController {
       didDismiss()
     }
 
-    borderView.didClickBorderedArea = {
+    borderView.didClickBorderedArea = { [weak popover] in
       maskShape.removeFromSuperlayer()
       borderView.removeFromSuperview()
         
-      popover.dismissPopover() {
+      popover?.dismissPopover() {
         didClickBorderedArea()
       }
     }

--- a/Sources/Brave/Frontend/Browser/Playlist/Browser/BrowserViewController+Playlist.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/Browser/BrowserViewController+Playlist.swift
@@ -223,7 +223,7 @@ extension BrowserViewController: PlaylistScriptHandlerDelegate, PlaylistFolderSh
         DispatchQueue.main.async {
           let model = OnboardingPlaylistModel()
           let popover = PopoverController(content: OnboardingPlaylistView(model: model))
-          popover.previewForOrigin = .init(view: self.topToolbar.locationView.playlistButton, action: { popover in
+          popover.previewForOrigin = .init(view: self.topToolbar.locationView.playlistButton, action: { [weak tab] popover in
             guard let item = tab?.playlistItem else {
               popover.dismissPopover()
               return
@@ -236,8 +236,8 @@ extension BrowserViewController: PlaylistScriptHandlerDelegate, PlaylistFolderSh
           })
           popover.present(from: self.topToolbar.locationView.playlistButton, on: self)
 
-          model.onboardingCompleted = {
-            popover.dismissPopover()
+          model.onboardingCompleted = { [weak tab, weak popover] in
+            popover?.dismissPopover()
             self.openPlaylist(tab: tab, item: tab?.playlistItem)
           }
         }


### PR DESCRIPTION
## Summary of Changes
- Fixed PopoverController not deallocating due to cyclical references capturing its model and model capturing popover.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7831

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

1. FRESH install
2. Go to Youtube.
3. Paste: https://www.youtube.com/watch?v=YlpN3S16ZAs
4. Wait for Popover/onboarding to show up and DISMISS it.
5. PLAY the video so you can hear audio.
6. Open Settings -> Media
7. Enable Background Play.
8. Page refreshes automatically.
9. PLAY the video so you can hear audio.
10. Close the tab.
11. Continues playing.

With this PR, audio should no longer play when the tab is closed.


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
