### PR TITLE
Fix #7790: Add content insets to vpn promo settings header.

### DIFF
--- a/Sources/BraveVPN/EnableVPNSettingHeader.swift
+++ b/Sources/BraveVPN/EnableVPNSettingHeader.swift
@@ -48,6 +48,7 @@ public class EnableVPNSettingHeader: UIView {
     }()
 
     $0.setTitle(title, for: .normal)
+    $0.contentEdgeInsets = .init(top: 0, left: 8, bottom: 0, right: 8)
     $0.backgroundColor = .braveBlurpleTint
     $0.titleLabel?.font = UIFont.systemFont(ofSize: 16, weight: .semibold)
     $0.setTitleColor(.white, for: .normal)


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7790 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
