### PR TITLE
Fix #7813: Localize folder item count text.

### DIFF
--- a/Sources/Brave/Frontend/Browser/Playlist/Browser/PlaylistChangeFoldersView.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/Browser/PlaylistChangeFoldersView.swift
@@ -104,7 +104,7 @@ struct PlaylistChangeFoldersView: View {
     }
   
   private func folderCountLabel(_ count: Int) -> String {
-    String(format: count == 1 ? Strings.PlayList.folderItemCountSingular : Strings.PlayList.folderItemCountPlural, count)
+    String.localizedStringWithFormat(count == 1 ? Strings.PlayList.folderItemCountSingular : Strings.PlayList.folderItemCountPlural, count)
   }
 }
 

--- a/Sources/Brave/Frontend/Browser/Playlist/Browser/PlaylistChangeFoldersView.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/Browser/PlaylistChangeFoldersView.swift
@@ -48,7 +48,7 @@ struct PlaylistChangeFoldersView: View {
                 VStack(alignment: .leading) {
                   Text(folder.title ?? "")
                     .foregroundColor(Color(.braveLabel))
-                  Text("\(folder.playlistItems?.count ?? 0) items")
+                  Text(folderCountLabel(folder.playlistItems?.count ?? 0))
                     .foregroundColor(Color(.secondaryBraveLabel))
                     .font(.subheadline)
                 }
@@ -102,6 +102,10 @@ struct PlaylistChangeFoldersView: View {
         }
       }
     }
+  
+  private func folderCountLabel(_ count: Int) -> String {
+    String(format: count == 1 ? Strings.PlayList.folderItemCountSingular : Strings.PlayList.folderItemCountPlural, count)
+  }
 }
 
 private struct CreateFolderView: View {

--- a/Sources/BraveStrings/BraveStrings.swift
+++ b/Sources/BraveStrings/BraveStrings.swift
@@ -1918,6 +1918,16 @@ extension Strings {
       NSLocalizedString("playlist.playlistAlreadyShowingBody", tableName: "BraveShared", bundle: .module,
         value: "Playlist is already active on another window",
         comment: "Playlist alert message when playlist is already showing on a different window")
+    
+    public static let folderItemCountSingular =
+      NSLocalizedString("playlist.foldersCountSingular", tableName: "BraveShared", bundle: .module,
+        value: "%d item",
+        comment: "Title for when there's a single item inside of a folder")
+    
+    public static let folderItemCountPlural =
+      NSLocalizedString("playlist.folderItemCountPlural", tableName: "BraveShared", bundle: .module,
+        value: "%d items",
+        comment: "Number of items in the playlsit folder. Example: '10 items'")
   }
 
   public struct PlaylistFolders {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7813 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
