### PR TITLE
Fix #7642: Move reload long press action to UIContext menu action.

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController.swift
@@ -59,8 +59,6 @@ public class BrowserViewController: UIViewController {
 
     let toolBarInteraction = UIContextMenuInteraction(delegate: self)
     topToolbar.locationView.addInteraction(toolBarInteraction)
-    let reloadInteraction = UIContextMenuInteraction(delegate: self)
-    topToolbar.locationView.reloadButton.addInteraction(reloadInteraction)
     return topToolbar
   }()
   

--- a/Sources/Brave/Frontend/Browser/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController.swift
@@ -59,6 +59,8 @@ public class BrowserViewController: UIViewController {
 
     let toolBarInteraction = UIContextMenuInteraction(delegate: self)
     topToolbar.locationView.addInteraction(toolBarInteraction)
+    let reloadInteraction = UIContextMenuInteraction(delegate: self)
+    topToolbar.locationView.reloadButton.addInteraction(reloadInteraction)
     return topToolbar
   }()
   

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
@@ -29,14 +29,6 @@ extension BrowserViewController {
     self.topToolbar.locationView.rewardsButton.iconState = Preferences.Rewards.rewardsToggledOnce.value ? (rewards.isEnabled || rewards.isCreatingWallet ? .enabled : .disabled) : .initial
   }
 
-  func showRewardsDebugSettings() {
-    if AppConstants.buildChannel.isPublic { return }
-
-    let settings = RewardsDebugSettingsViewController(rewards: rewards)
-    let container = UINavigationController(rootViewController: settings)
-    present(container, animated: true)
-  }
-
   func showBraveRewardsPanel() {
     if !Preferences.FullScreenCallout.rewardsCalloutCompleted.value,
       Preferences.Onboarding.isNewRetentionUser.value == true,

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
@@ -956,8 +956,6 @@ extension BrowserViewController: UIContextMenuInteractionDelegate {
         pasteMenuChildren.reverse()
       }
       
-      var copyMenu: UIMenu?
-      
       let copyAction = UIAction(
         title: Strings.copyAddressTitle,
         image: UIImage(systemName: "doc.on.doc"),
@@ -967,7 +965,7 @@ extension BrowserViewController: UIContextMenuInteractionDelegate {
           }
         })
 
-      copyMenu = UIMenu(options: .displayInline, children: [copyAction])
+      let copyMenu = UIMenu(options: .displayInline, children: [copyAction])
       
       if UIPasteboard.general.hasStrings || UIPasteboard.general.hasURLs {
         let pasteMenu = UIMenu(options: .displayInline, children: pasteMenuChildren)

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
@@ -932,8 +932,6 @@ extension BrowserViewController: UIContextMenuInteractionDelegate {
   
   private var reloadButtonMenuConfiguration: UIContextMenuConfiguration {
     let configuration =  UIContextMenuConfiguration(identifier: nil, previewProvider: nil) { [unowned self] _ in
-      var actionMenu: [UIMenu] = []
-      
       let tab = tabManager.selectedTab
       
       let title = tab?.isDesktopSite == true ? Strings.appMenuViewMobileSiteTitleString : Strings.appMenuViewDesktopSiteTitleString
@@ -948,10 +946,7 @@ extension BrowserViewController: UIContextMenuInteractionDelegate {
         })
 
       let copyMenu = UIMenu(title: "", options: .displayInline, children: [copyAction])
-      
-      actionMenu = [copyMenu]
-      
-      return UIMenu(title: "", identifier: nil, children: actionMenu)
+      return UIMenu(children: [copyMenu])
     }
     
     return configuration
@@ -994,10 +989,10 @@ extension BrowserViewController: UIContextMenuInteractionDelegate {
           }
         })
 
-      let copyMenu = UIMenu(title: "", options: .displayInline, children: [copyAction])
+      let copyMenu = UIMenu(options: .displayInline, children: [copyAction])
       
       if UIPasteboard.general.hasStrings || UIPasteboard.general.hasURLs {
-        let pasteMenu = UIMenu(title: "", options: .displayInline, children: pasteMenuChildren)
+        let pasteMenu = UIMenu(options: .displayInline, children: pasteMenuChildren)
         
         actionMenu = [pasteMenu, copyMenu]
         
@@ -1008,7 +1003,7 @@ extension BrowserViewController: UIContextMenuInteractionDelegate {
         actionMenu = [copyMenu]
       }
 
-      return UIMenu(title: "", identifier: nil, children: actionMenu)
+      return UIMenu(children: actionMenu)
     }
     
     return configuration

--- a/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
+++ b/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
@@ -12,23 +12,17 @@ import DesignSystem
 
 protocol TabLocationViewDelegate {
   func tabLocationViewDidTapLocation(_ tabLocationView: TabLocationView)
-  func tabLocationViewDidLongPressLocation(_ tabLocationView: TabLocationView)
   func tabLocationViewDidTapReaderMode(_ tabLocationView: TabLocationView)
   func tabLocationViewDidBeginDragInteraction(_ tabLocationView: TabLocationView)
   func tabLocationViewDidTapPlaylist(_ tabLocationView: TabLocationView)
   func tabLocationViewDidTapPlaylistMenuAction(_ tabLocationView: TabLocationView, action: PlaylistURLBarButton.MenuAction)
   func tabLocationViewDidTapLockImageView(_ tabLocationView: TabLocationView)
   func tabLocationViewDidTapReload(_ tabLocationView: TabLocationView)
-  func tabLocationViewDidLongPressReload(_ tabLocationView: TabLocationView, from button: UIButton)
   func tabLocationViewDidTapStop(_ tabLocationView: TabLocationView)
   func tabLocationViewDidTapVoiceSearch(_ tabLocationView: TabLocationView)
   func tabLocationViewDidTapShieldsButton(_ urlBar: TabLocationView)
   func tabLocationViewDidTapRewardsButton(_ urlBar: TabLocationView)
-  func tabLocationViewDidLongPressRewardsButton(_ urlBar: TabLocationView)
   func tabLocationViewDidTapWalletButton(_ urlBar: TabLocationView)
-  
-  /// - returns: whether the long-press was handled by the delegate; i.e. return `false` when the conditions for even starting handling long-press were not satisfied
-  @discardableResult func tabLocationViewDidLongPressReaderMode(_ tabLocationView: TabLocationView) -> Bool
 }
 
 private struct TabLocationViewUX {
@@ -41,8 +35,6 @@ private struct TabLocationViewUX {
 
 class TabLocationView: UIView {
   var delegate: TabLocationViewDelegate?
-  var longPressRecognizer: UILongPressGestureRecognizer!
-  var tapRecognizer: UITapGestureRecognizer!
   var contentView: UIStackView!
   private var tabObservers: TabObservers!
   private var privateModeCancellable: AnyCancellable?
@@ -169,13 +161,11 @@ class TabLocationView: UIView {
   private(set) lazy var readerModeButton: ReaderModeButton = {
     let readerModeButton = ReaderModeButton(frame: .zero)
     readerModeButton.addTarget(self, action: #selector(didTapReaderModeButton), for: .touchUpInside)
-    readerModeButton.addGestureRecognizer(UILongPressGestureRecognizer(target: self, action: #selector(didLongPressReaderModeButton)))
     readerModeButton.isAccessibilityElement = true
     readerModeButton.isHidden = true
     readerModeButton.imageView?.contentMode = .scaleAspectFit
     readerModeButton.accessibilityLabel = Strings.tabToolbarReaderViewButtonAccessibilityLabel
     readerModeButton.accessibilityIdentifier = "TabLocationView.readerModeButton"
-    readerModeButton.accessibilityCustomActions = [UIAccessibilityCustomAction(name: Strings.tabToolbarReaderViewButtonTitle, target: self, selector: #selector(didLongPressReaderModeCustomAction))]
     readerModeButton.unselectedTintColor = .braveLabel
     readerModeButton.selectedTintColor = .braveBlurpleTint
     return readerModeButton
@@ -196,14 +186,14 @@ class TabLocationView: UIView {
     $0.addTarget(self, action: #selector(didTapWalletButton), for: .touchUpInside)
   }
   
+  let reloadButtonAccessibilityIdentifier = "TabToolbar.stopReloadButton"
+  
   lazy var reloadButton = ToolbarButton().then {
-    $0.accessibilityIdentifier = "TabToolbar.stopReloadButton"
+    $0.accessibilityIdentifier = reloadButtonAccessibilityIdentifier
     $0.isAccessibilityElement = true
     $0.accessibilityLabel = Strings.tabToolbarReloadButtonAccessibilityLabel
     $0.setImage(UIImage(braveSystemNamed: "leo.browser.refresh", compatibleWith: nil), for: .normal)
     $0.tintColor = .braveLabel
-    let longPressGestureStopReloadButton = UILongPressGestureRecognizer(target: self, action: #selector(didLongPressStopReloadButton(_:)))
-    $0.addGestureRecognizer(longPressGestureStopReloadButton)
     $0.addTarget(self, action: #selector(didTapStopReloadButton), for: .touchUpInside)
   }
   
@@ -231,8 +221,6 @@ class TabLocationView: UIView {
   lazy var rewardsButton: RewardsButton = {
     let button = RewardsButton()
     button.addTarget(self, action: #selector(didTapBraveRewardsButton), for: .touchUpInside)
-    let longPressGestureRewardsButton = UILongPressGestureRecognizer(target: self, action: #selector(didLongPressRewardsButton(_:)))
-    button.addGestureRecognizer(longPressGestureRewardsButton)
     return button
   }()
 
@@ -260,14 +248,7 @@ class TabLocationView: UIView {
 
     tabObservers = registerFor(.didChangeContentBlocking, .didGainFocus, queue: .main)
 
-    longPressRecognizer = UILongPressGestureRecognizer(target: self, action: #selector(didLongPressLocationBar))
-    longPressRecognizer.delegate = self
-
-    tapRecognizer = UITapGestureRecognizer(target: self, action: #selector(didTapLocationBar))
-    tapRecognizer.delegate = self
-
-    addGestureRecognizer(longPressRecognizer)
-    addGestureRecognizer(tapRecognizer)
+    addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(didTapLocationBar)))
     
     var optionSubviews: [UIView] = [readerModeButton, walletButton, playlistButton]
     if isVoiceSearchAvailable {
@@ -387,36 +368,6 @@ class TabLocationView: UIView {
     reloadButton.isHidden = url == nil
     voiceSearchButton.isHidden = (url != nil) || !isVoiceSearchAvailable
   }
-
-  // MARK: Long Press Actions
-
-  @objc func didLongPressReaderModeButton(_ recognizer: UILongPressGestureRecognizer) {
-    if recognizer.state == .began {
-      delegate?.tabLocationViewDidLongPressReaderMode(self)
-    }
-  }
-  
-  @objc func didLongPressLocationBar(_ recognizer: UITapGestureRecognizer) {
-    if recognizer.state == .began {
-      delegate?.tabLocationViewDidLongPressLocation(self)
-    }
-  }
-  
-  @objc func didLongPressStopReloadButton(_ recognizer: UILongPressGestureRecognizer) {
-    if recognizer.state == .began && !loading {
-      delegate?.tabLocationViewDidLongPressReload(self, from: reloadButton)
-    }
-  }
-  
-  @objc func didLongPressReaderModeCustomAction() -> Bool {
-    return delegate?.tabLocationViewDidLongPressReaderMode(self) ?? false
-  }
-  
-  @objc func didLongPressRewardsButton(_ gesture: UILongPressGestureRecognizer) {
-    if gesture.state == .began {
-      delegate?.tabLocationViewDidLongPressRewardsButton(self)
-    }
-  }
   
   // MARK: Tap Actions
   
@@ -460,27 +411,6 @@ class TabLocationView: UIView {
   
   @objc func didTapWalletButton() {
     delegate?.tabLocationViewDidTapWalletButton(self)
-  }
-}
-
-// MARK: - UIGestureRecognizerDelegate
-
-extension TabLocationView: UIGestureRecognizerDelegate {
-  func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
-    // When long pressing a button make sure the textfield's long press gesture is not triggered
-    return !(otherGestureRecognizer.view is UIButton)
-  }
-
-  func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldBeRequiredToFailBy otherGestureRecognizer: UIGestureRecognizer) -> Bool {
-    // If the longPressRecognizer is active, fail the tap recognizer to avoid conflicts.
-    return gestureRecognizer == longPressRecognizer && otherGestureRecognizer == tapRecognizer
-  }
-
-  func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
-    if gestureRecognizer == tapRecognizer && touch.view == tabOptionsStackView {
-      return false
-    }
-    return true
   }
 }
 

--- a/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
+++ b/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
@@ -186,10 +186,8 @@ class TabLocationView: UIView {
     $0.addTarget(self, action: #selector(didTapWalletButton), for: .touchUpInside)
   }
   
-  let reloadButtonAccessibilityIdentifier = "TabToolbar.stopReloadButton"
-  
   lazy var reloadButton = ToolbarButton().then {
-    $0.accessibilityIdentifier = reloadButtonAccessibilityIdentifier
+    $0.accessibilityIdentifier = "TabToolbar.stopReloadButton"
     $0.isAccessibilityElement = true
     $0.accessibilityLabel = Strings.tabToolbarReloadButtonAccessibilityLabel
     $0.setImage(UIImage(braveSystemNamed: "leo.browser.refresh", compatibleWith: nil), for: .normal)

--- a/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
+++ b/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
@@ -15,13 +15,10 @@ import BraveCore
 protocol TopToolbarDelegate: AnyObject {
   func topToolbarDidPressTabs(_ topToolbar: TopToolbarView)
   func topToolbarDidPressReaderMode(_ topToolbar: TopToolbarView)
-  // Returns whether the long-press was handled by the delegate; i.e. return `false` when the conditions for even starting handling long-press were not satisfied
-  func topToolbarDidLongPressReaderMode(_ topToolbar: TopToolbarView) -> Bool
   func topToolbarDidPressPlaylistButton(_ urlBar: TopToolbarView)
   func topToolbarDidPressPlaylistMenuAction(_ urlBar: TopToolbarView, action: PlaylistURLBarButton.MenuAction)
   func topToolbarDidEnterOverlayMode(_ topToolbar: TopToolbarView)
   func topToolbarDidLeaveOverlayMode(_ topToolbar: TopToolbarView)
-  func topToolbarDidLongPressLocation(_ topToolbar: TopToolbarView)
   func topToolbarDidPressScrollToTop(_ topToolbar: TopToolbarView)
   func topToolbar(_ topToolbar: TopToolbarView, didEnterText text: String)
   func topToolbar(_ topToolbar: TopToolbarView, didSubmitText text: String)
@@ -31,9 +28,7 @@ protocol TopToolbarDelegate: AnyObject {
   func topToolbarDidTapBookmarkButton(_ topToolbar: TopToolbarView)
   func topToolbarDidTapBraveShieldsButton(_ topToolbar: TopToolbarView)
   func topToolbarDidTapBraveRewardsButton(_ topToolbar: TopToolbarView)
-  func topToolbarDidLongPressBraveRewardsButton(_ topToolbar: TopToolbarView)
   func topToolbarDidTapMenuButton(_ topToolbar: TopToolbarView)
-  func topToolbarDidLongPressReloadButton(_ urlBar: TopToolbarView, from button: UIButton)
   func topToolbarDidPressVoiceSearchButton(_ urlBar: TopToolbarView)
   func topToolbarDidPressStop(_ urlBar: TopToolbarView)
   func topToolbarDidPressReload(_ urlBar: TopToolbarView)
@@ -725,14 +720,6 @@ extension TopToolbarView: TabLocationViewDelegate {
     delegate?.topToolbarDidTapBraveRewardsButton(self)
   }
 
-  func tabLocationViewDidLongPressRewardsButton(_ urlBar: TabLocationView) {
-    delegate?.topToolbarDidLongPressBraveRewardsButton(self)
-  }
-
-  func tabLocationViewDidLongPressReaderMode(_ tabLocationView: TabLocationView) -> Bool {
-    return delegate?.topToolbarDidLongPressReaderMode(self) ?? false
-  }
-
   func tabLocationViewDidTapLocation(_ tabLocationView: TabLocationView) {
     guard let (locationText, isSearchQuery) = delegate?.topToolbarDisplayTextForURL(locationView.url as URL?) else { return }
     
@@ -745,10 +732,6 @@ extension TopToolbarView: TabLocationViewDelegate {
     enterOverlayMode(overlayText, pasted: false, search: isSearchQuery)
   }
 
-  func tabLocationViewDidLongPressLocation(_ tabLocationView: TabLocationView) {
-    delegate?.topToolbarDidLongPressLocation(self)
-  }
-
   func tabLocationViewDidTapLockImageView(_ tabLocationView: TabLocationView) {
     delegate?.topToolbarDidPressLockImageView(self)
   }
@@ -759,10 +742,6 @@ extension TopToolbarView: TabLocationViewDelegate {
 
   func tabLocationViewDidTapStop(_ tabLocationView: TabLocationView) {
     delegate?.topToolbarDidPressStop(self)
-  }
-
-  func tabLocationViewDidLongPressReload(_ tabLocationView: TabLocationView, from button: UIButton) {
-    delegate?.topToolbarDidLongPressReloadButton(self, from: button)
   }
   
   func tabLocationViewDidTapVoiceSearch(_ tabLocationView: TabLocationView) {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
I also cleaned up other long press actions

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7642 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
