### PR TITLE
[v1.58] Fix #7818, #7807: Mojo Origin Cleanup, AccountId for Transaction refactor, and BraveCore v1.58.77 bump

### DIFF
--- a/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -28,8 +28,8 @@ extension PendingRequest: Identifiable {
     case let .switchChain(chainRequest): return "switchChain-\(chainRequest.chainId)"
     case let .addSuggestedToken(tokenRequest): return "addSuggestedToken-\(tokenRequest.token.id)"
     case let .signMessage(signRequests): return "signMessage-\(signRequests.map(\.id))"
-    case let .getEncryptionPublicKey(request): return "getEncryptionPublicKey-\(request.address)-\(request.originInfo.origin)"
-    case let .decrypt(request): return "decrypt-\(request.address)-\(request.originInfo.origin)"
+    case let .getEncryptionPublicKey(request): return "getEncryptionPublicKey-\(request.address)-\(request.requestId)"
+    case let .decrypt(request): return "decrypt-\(request.address)-\(request.requestId)"
     case let .signTransaction(requests): return "signTransaction-\(requests.map(\.id))"
     case let .signAllTransactions(requests): return "signAllTransactions-\(requests.map(\.id))"
     }
@@ -37,12 +37,12 @@ extension PendingRequest: Identifiable {
 }
 
 enum WebpageRequestResponse: Equatable {
-  case switchChain(approved: Bool, originInfo: BraveWallet.OriginInfo)
+  case switchChain(approved: Bool, requestId: String)
   case addNetwork(approved: Bool, chainId: String)
   case addSuggestedToken(approved: Bool, token: BraveWallet.BlockchainToken)
   case signMessage(approved: Bool, id: Int32)
-  case getEncryptionPublicKey(approved: Bool, originInfo: BraveWallet.OriginInfo)
-  case decrypt(approved: Bool, originInfo: BraveWallet.OriginInfo)
+  case getEncryptionPublicKey(approved: Bool, requestId: String)
+  case decrypt(approved: Bool, requestId: String)
   case signTransaction(approved: Bool, id: Int32)
   case signAllTransactions(approved: Bool, id: Int32)
 }
@@ -471,8 +471,8 @@ public class CryptoStore: ObservableObject {
     completion: ((_ error: String?) -> Void)? = nil
   ) {
     switch response {
-    case let .switchChain(approved, originInfo):
-      rpcService.notifySwitchChainRequestProcessed(approved, origin: originInfo.origin)
+    case let .switchChain(approved, requestId):
+      rpcService.notifySwitchChainRequestProcessed(requestId, approved: approved)
     case let .addNetwork(approved, chainId):
       // for add network request, approval requires network call so we must
       // wait for `onAddEthereumChainRequestCompleted` to know success/failure
@@ -494,10 +494,10 @@ public class CryptoStore: ObservableObject {
       walletService.notifyAddSuggestTokenRequestsProcessed(approved, contractAddresses: [token.contractAddress])
     case let .signMessage(approved, id):
       walletService.notifySignMessageRequestProcessed(approved, id: id, signature: nil, error: nil)
-    case let .getEncryptionPublicKey(approved, originInfo):
-      walletService.notifyGetPublicKeyRequestProcessed(approved, origin: originInfo.origin)
-    case let .decrypt(approved, originInfo):
-      walletService.notifyDecryptRequestProcessed(approved, origin: originInfo.origin)
+    case let .getEncryptionPublicKey(approved, requestId):
+      walletService.notifyGetPublicKeyRequestProcessed(requestId, approved: approved)
+    case let .decrypt(approved, requestId):
+      walletService.notifyDecryptRequestProcessed(requestId, approved: approved)
     case let .signTransaction(approved, id):
       walletService.notifySignTransactionRequestProcessed(approved, id: id, signature: nil, error: nil)
     case let .signAllTransactions(approved, id):
@@ -519,7 +519,7 @@ public class CryptoStore: ObservableObject {
       }
       let pendingSwitchChainRequests = await rpcService.pendingSwitchChainRequests()
       pendingSwitchChainRequests.forEach {
-        handleWebpageRequestResponse(.switchChain(approved: false, originInfo: $0.originInfo))
+        handleWebpageRequestResponse(.switchChain(approved: false, requestId: $0.requestId))
       }
       let pendingAddSuggestedTokenRequets = await walletService.pendingAddSuggestTokenRequests()
       pendingAddSuggestedTokenRequets.forEach {
@@ -527,11 +527,11 @@ public class CryptoStore: ObservableObject {
       }
       let pendingGetEncryptionPublicKeyRequests = await walletService.pendingGetEncryptionPublicKeyRequests()
       pendingGetEncryptionPublicKeyRequests.forEach {
-        handleWebpageRequestResponse(.getEncryptionPublicKey(approved: false, originInfo: $0.originInfo))
+        handleWebpageRequestResponse(.getEncryptionPublicKey(approved: false, requestId: $0.requestId))
       }
       let pendingDecryptRequests = await walletService.pendingDecryptRequests()
       pendingDecryptRequests.forEach {
-        handleWebpageRequestResponse(.decrypt(approved: false, originInfo: $0.originInfo))
+        handleWebpageRequestResponse(.decrypt(approved: false, requestId: $0.requestId))
       }
     }
   }

--- a/Sources/BraveWallet/Crypto/Transaction Confirmations/PendingTransactionView.swift
+++ b/Sources/BraveWallet/Crypto/Transaction Confirmations/PendingTransactionView.swift
@@ -97,7 +97,7 @@ struct PendingTransactionView: View {
               .frame(maxWidth: .infinity, maxHeight: .infinity)
               .background(Color(.braveDisabled))
           } else {
-            if let url = originInfo.origin.url {
+            if let url = URL(string: originInfo.originSpec) {
               FaviconReader(url: url) { image in
                 if let image = image {
                   Image(uiImage: image)
@@ -113,7 +113,8 @@ struct PendingTransactionView: View {
         }
         .frame(width: min(faviconSize, maxFaviconSize), height: min(faviconSize, maxFaviconSize))
         .clipShape(RoundedRectangle(cornerRadius: 4, style: .continuous))
-        Text(urlOrigin: originInfo.origin)
+
+        Text(originInfo: originInfo)
           .font(.subheadline)
           .foregroundColor(Color(.braveLabel))
           .multilineTextAlignment(.center)

--- a/Sources/BraveWallet/Crypto/Transaction Confirmations/SwapTransactionConfirmationView.swift
+++ b/Sources/BraveWallet/Crypto/Transaction Confirmations/SwapTransactionConfirmationView.swift
@@ -44,13 +44,13 @@ struct SwapTransactionConfirmationView: View {
     VStack {
       if let originInfo = parsedTransaction?.transaction.originInfo {
         Group {
-          if originInfo.origin == WalletConstants.braveWalletOrigin {
+          if originInfo.isBraveWalletOrigin {
             Image(uiImage: UIImage(sharedNamed: "brave.logo")!)
               .resizable()
               .aspectRatio(contentMode: .fit)
               .foregroundColor(Color(.braveOrange))
           } else {
-            originInfo.origin.url.map { url in
+            if let url = URL(string: originInfo.originSpec) {
               FaviconReader(url: url) { image in
                 if let image = image {
                   Image(uiImage: image)
@@ -67,7 +67,8 @@ struct SwapTransactionConfirmationView: View {
           }
         }
         .frame(width: min(faviconSize, maxFaviconSize), height: min(faviconSize, maxFaviconSize))
-        Text(urlOrigin: originInfo.origin)
+        
+        Text(originInfo: originInfo)
           .foregroundColor(Color(.braveLabel))
           .font(.subheadline)
           .multilineTextAlignment(.center)
@@ -252,8 +253,7 @@ struct SwapTransactionConfirmationView_Previews: PreviewProvider {
   static var transaction: BraveWallet.TransactionInfo {
     let transaction: BraveWallet.TransactionInfo = .init()
     transaction.originInfo = .init(
-      origin: WalletConstants.braveWalletOrigin,
-      originSpec: "brave://wallet",
+      originSpec: WalletConstants.braveWalletOriginSpec,
       eTldPlusOne: ""
     )
     return transaction

--- a/Sources/BraveWallet/Crypto/Transactions/TransactionHeader.swift
+++ b/Sources/BraveWallet/Crypto/Transactions/TransactionHeader.swift
@@ -72,7 +72,7 @@ struct TransactionHeader: View {
         ))
       )
       if let originInfo = originInfo {
-        Text(urlOrigin: originInfo.origin)
+        Text(originInfo: originInfo)
           .foregroundColor(Color(.braveLabel))
           .font(.subheadline)
           .multilineTextAlignment(.center)

--- a/Sources/BraveWallet/Extensions/BraveWalletExtensions.swift
+++ b/Sources/BraveWallet/Extensions/BraveWalletExtensions.swift
@@ -88,7 +88,7 @@ extension BraveWallet.TransactionInfo {
 extension BraveWallet.OriginInfo {
   /// If the current OriginInfo matches the Brave Wallet origin
   var isBraveWalletOrigin: Bool {
-    origin == WalletConstants.braveWalletOrigin
+    originSpec == WalletConstants.braveWalletOriginSpec
   }
 }
 

--- a/Sources/BraveWallet/Extensions/BraveWalletSwiftUIExtensions.swift
+++ b/Sources/BraveWallet/Extensions/BraveWalletSwiftUIExtensions.swift
@@ -140,7 +140,7 @@ extension BraveWallet.NetworkInfo: Identifiable {
 extension BraveWallet.SignMessageRequest {
   static var previewRequest: BraveWallet.SignMessageRequest {
     .init(
-      originInfo: .init(origin: .init(url: URL(string: "https://app.uniswap.org")!), originSpec: "", eTldPlusOne: "uniswap.org"),
+      originInfo: .init(originSpec: "https://app.uniswap.org", eTldPlusOne: "uniswap.org"),
       id: 1,
       address: "",
       domain: "example.com",

--- a/Sources/BraveWallet/Extensions/Text+URLOrigin.swift
+++ b/Sources/BraveWallet/Extensions/Text+URLOrigin.swift
@@ -25,4 +25,28 @@ extension Text {
       }
     }
   }
+  
+  /// Creates a text view that displays a BraveWallet.OriginInfo, bolding the eTLD+1.
+  init(originInfo: BraveWallet.OriginInfo) {
+    // Internal Transaction from Brave:
+    // originInfo.eTldPlusOne=""
+    // originInfo.originSpec="chrome://wallet"
+    // From Uniswap:
+    // originInfo.eTldPlusOne="uniswap.org"
+    // originInfo.originSpec="https://app.uniswap.org"
+    if originInfo.isBraveWalletOrigin {
+      self = Text(Strings.Wallet.braveWallet)
+    } else {
+      let origin = originInfo.originSpec
+      let eTldPlusOne = originInfo.eTldPlusOne
+      if let range = origin.range(of: eTldPlusOne) {
+        let originStart = origin[origin.startIndex..<range.lowerBound]
+        let etldPlusOne = origin[range.lowerBound..<range.upperBound]
+        let originEnd = origin[range.upperBound...]
+        self = Text(String(originStart).zwspOutput) + Text(etldPlusOne).bold() + Text(String(originEnd).zwspOutput)
+      } else {
+        self = Text(origin)
+      }
+    }
+  }
 }

--- a/Sources/BraveWallet/Panels/Add Suggested Token/AddSuggestedTokenView.swift
+++ b/Sources/BraveWallet/Panels/Add Suggested Token/AddSuggestedTokenView.swift
@@ -28,7 +28,7 @@ struct AddSuggestedTokenView: View {
           Text(Strings.Wallet.addSuggestedTokenSubtitle)
             .font(.headline)
             .foregroundColor(Color(.bravePrimary))
-          Text(urlOrigin: originInfo.origin)
+          Text(originInfo: originInfo)
             .font(.footnote)
             .foregroundColor(Color(.braveLabel))
         }
@@ -145,8 +145,7 @@ struct AddSuggestedTokenView_Previews: PreviewProvider {
     AddSuggestedTokenView(
       token: .previewToken,
       originInfo: .init(
-        origin: .init(url: URL(string: "https://app.uniswap.org")!),
-        originSpec: "",
+        originSpec: "https://app.uniswap.org",
         eTldPlusOne: "uniswap.org"
       ),
       cryptoStore: .previewStore,

--- a/Sources/BraveWallet/Panels/Encryption/EncryptionView.swift
+++ b/Sources/BraveWallet/Panels/Encryption/EncryptionView.swift
@@ -81,7 +81,7 @@ struct EncryptionView: View {
                 .foregroundColor(Color(.secondaryBraveLabel))
             }
           }
-          Text(urlOrigin: request.originInfo.origin)
+          Text(originInfo: request.originInfo)
             .font(.caption)
             .foregroundColor(Color(.braveLabel))
             .multilineTextAlignment(.center)
@@ -96,13 +96,13 @@ struct EncryptionView: View {
       Group {
         if case .getEncryptionPublicKey = request {
           ScrollView {
-            Text(urlOrigin: request.originInfo.origin) + Text(" \(Strings.Wallet.getEncryptionPublicKeyRequestMessage)")
+            Text(originInfo: request.originInfo) + Text(" \(Strings.Wallet.getEncryptionPublicKeyRequestMessage)")
           }
           .padding(20)
         } else if case let .decrypt(decryptRequest) = request {
           ScrollView {
             SensitiveTextView(
-              text: decryptRequest.unsafeMessage ?? "",
+              text: decryptRequest.unsafeMessage,
               isCopyEnabled: false,
               isShowingText: $isShowingDecryptMessage
             )
@@ -222,9 +222,9 @@ struct EncryptionView: View {
   private func handleAction(approved: Bool) {
     switch request {
     case .getEncryptionPublicKey(let request):
-      cryptoStore.handleWebpageRequestResponse(.getEncryptionPublicKey(approved: approved, originInfo: request.originInfo))
+      cryptoStore.handleWebpageRequestResponse(.getEncryptionPublicKey(approved: approved, requestId: request.requestId))
     case .decrypt(let request):
-      cryptoStore.handleWebpageRequestResponse(.decrypt(approved: approved, originInfo: request.originInfo))
+      cryptoStore.handleWebpageRequestResponse(.decrypt(approved: approved, requestId: request.requestId))
     }
     onDismiss()
   }
@@ -235,19 +235,20 @@ struct EncryptionView_Previews: PreviewProvider {
   static var previews: some View {
     let address = BraveWallet.AccountInfo.previewAccount.address
     let originInfo = BraveWallet.OriginInfo(
-      origin: .init(url: URL(string: "https://brave.com")!),
-      originSpec: "",
+      originSpec: WalletConstants.braveWalletOriginSpec,
       eTldPlusOne: ""
     )
     let requests: [EncryptionView.EncryptionType] = [
       .getEncryptionPublicKey(
         .init(
+          requestId: UUID().uuidString,
           originInfo: originInfo,
           address: address
         )
       ),
       .decrypt(
         .init(
+          requestId: UUID().uuidString,
           originInfo: originInfo,
           address: address,
           unsafeMessage: "Secret message"

--- a/Sources/BraveWallet/Panels/RequestContainerView.swift
+++ b/Sources/BraveWallet/Panels/RequestContainerView.swift
@@ -37,8 +37,7 @@ struct RequestContainerView<DismissContent: ToolbarContent>: View {
             )
           case .switchChain(let request):
             SuggestedNetworkView(
-              mode: .switchNetworks(chainId: request.chainId),
-              originInfo: request.originInfo,
+              mode: .switchNetworks(request),
               cryptoStore: cryptoStore,
               keyringStore: keyringStore,
               networkStore: cryptoStore.networkStore,
@@ -46,8 +45,7 @@ struct RequestContainerView<DismissContent: ToolbarContent>: View {
             )
           case .addChain(let request):
             SuggestedNetworkView(
-              mode: .addNetwork(request.networkInfo),
-              originInfo: request.originInfo,
+              mode: .addNetwork(request),
               cryptoStore: cryptoStore,
               keyringStore: keyringStore,
               networkStore: cryptoStore.networkStore,

--- a/Sources/BraveWallet/Panels/Sign Transaction/SignTransactionView.swift
+++ b/Sources/BraveWallet/Panels/Sign Transaction/SignTransactionView.swift
@@ -161,7 +161,7 @@ struct SignTransactionView: View {
             }
             .foregroundColor(Color(.bravePrimary))
             .font(.callout)
-            Text(urlOrigin: currentRequest.originInfo.origin)
+            Text(originInfo: currentRequest.originInfo)
               .foregroundColor(Color(.braveLabel))
               .font(.subheadline)
               .multilineTextAlignment(.center)

--- a/Sources/BraveWallet/Panels/Signature Request/SignatureRequestView.swift
+++ b/Sources/BraveWallet/Panels/Signature Request/SignatureRequestView.swift
@@ -180,7 +180,7 @@ struct SignatureRequestView: View {
                   .foregroundColor(Color(.secondaryBraveLabel))
               }
             }
-            Text(urlOrigin: currentRequest.originInfo.origin)
+            Text(originInfo: currentRequest.originInfo)
               .font(.caption)
               .foregroundColor(Color(.braveLabel))
               .multilineTextAlignment(.center)

--- a/Sources/BraveWallet/Preview Content/MockBlockchainRegistry.swift
+++ b/Sources/BraveWallet/Preview Content/MockBlockchainRegistry.swift
@@ -71,4 +71,8 @@ class MockBlockchainRegistry: BraveWalletBlockchainRegistry {
   func topDapps(_ chainId: String, coin: BraveWallet.CoinType, completion: @escaping ([BraveWallet.Dapp]) -> Void) {
     completion([])
   }
+  
+  func coingeckoId(_ chainId: String, contractAddress: String, completion: @escaping (String?) -> Void) {
+    completion(nil)
+  }
 }

--- a/Sources/BraveWallet/Preview Content/MockBraveWalletService.swift
+++ b/Sources/BraveWallet/Preview Content/MockBraveWalletService.swift
@@ -124,14 +124,14 @@ class MockBraveWalletService: BraveWalletBraveWalletService {
     completion("", "")
   }
   
-  func notifyGetPublicKeyRequestProcessed(_ approved: Bool, origin: URLOrigin) {
+  func notifyGetPublicKeyRequestProcessed(_ requestId: String, approved: Bool) {
   }
   
   func pendingGetEncryptionPublicKeyRequests() async -> [BraveWallet.GetEncryptionPublicKeyRequest] {
     return []
   }
   
-  func notifyDecryptRequestProcessed(_ approved: Bool, origin: URLOrigin) {
+  func notifyDecryptRequestProcessed(_ requestId: String, approved: Bool) {
   }
   
   func pendingDecryptRequests() async -> [BraveWallet.DecryptRequest] {
@@ -150,15 +150,15 @@ class MockBraveWalletService: BraveWalletBraveWalletService {
     self.coin = coin
   }
   
-  func addPermission(_ accountId: BraveWallet.AccountId, origin: URLOrigin, completion: @escaping (Bool) -> Void) {
+  func addPermission(_ accountId: BraveWallet.AccountId, completion: @escaping (Bool) -> Void) {
     completion(false)
   }
   
-  func hasPermission(_ accountId: BraveWallet.AccountId, origin: URLOrigin, completion: @escaping (Bool, Bool) -> Void) {
-    completion(false, false)
+  func hasPermission(_ accounts: [BraveWallet.AccountId], completion: @escaping (Bool, [BraveWallet.AccountId]) -> Void) {
+    completion(false, [])
   }
   
-  func resetPermission(_ accountId: BraveWallet.AccountId, origin: URLOrigin, completion: @escaping (Bool) -> Void) {
+  func resetPermission(_ accountId: BraveWallet.AccountId, completion: @escaping (Bool) -> Void) {
     completion(false)
   }
   
@@ -196,7 +196,7 @@ class MockBraveWalletService: BraveWalletBraveWalletService {
     completion([])
   }
 
-  func isPermissionDenied(_ coin: BraveWallet.CoinType, origin: URLOrigin, completion: @escaping (Bool) -> Void) {
+  func isPermissionDenied(_ coin: BraveWallet.CoinType, completion: @escaping (Bool) -> Void) {
     completion(false)
   }
 

--- a/Sources/BraveWallet/Preview Content/MockContent.swift
+++ b/Sources/BraveWallet/Preview Content/MockContent.swift
@@ -158,7 +158,8 @@ extension BraveWallet.TransactionInfo {
   static var previewConfirmedSend: BraveWallet.TransactionInfo {
     BraveWallet.TransactionInfo(
       id: "fce43e63-1f68-4685-9d40-035f13250a4c",
-      fromAddress: "0x879240B2D6179E9EC40BC2AFFF9E9EC40BC2AFFF",
+      fromAddress: BraveWallet.AccountInfo.previewAccount.accountId.address,
+      from: BraveWallet.AccountInfo.previewAccount.accountId,
       txHash: "0x46fbd9d5ed775b9e5836aacaf0ed7a78bf5f5a4da451f23238c6123ed0fd51bf",
       txDataUnion: .init(
         ethTxData1559: .init(
@@ -194,7 +195,8 @@ extension BraveWallet.TransactionInfo {
   static var previewConfirmedSwap: BraveWallet.TransactionInfo {
     BraveWallet.TransactionInfo(
       id: "2531db97-6d1d-4906-a1b2-f829c41f489e",
-      fromAddress: "0x879240B2D6179E9EC40BC2AFFF9E9EC40BC2AFFF",
+      fromAddress: BraveWallet.AccountInfo.previewAccount.accountId.address,
+      from: BraveWallet.AccountInfo.previewAccount.accountId,
       txHash: "0xe21f7110753a8a42793c0b6c0c649aac1545488e57a3f57541b9f199d6b2be11",
       txDataUnion: .init(
         ethTxData1559: .init(
@@ -234,7 +236,8 @@ extension BraveWallet.TransactionInfo {
   static var previewConfirmedERC20Approve: BraveWallet.TransactionInfo {
     BraveWallet.TransactionInfo(
       id: "19819c05-612a-47c5-84b0-e95045d15b37",
-      fromAddress: "0x879240B2D6179E9EC40BC2AFFF9E9EC40BC2AFFF",
+      fromAddress: BraveWallet.AccountInfo.previewAccount.accountId.address,
+      from: BraveWallet.AccountInfo.previewAccount.accountId,
       txHash: "0x46d0ecf2ec9829d451154767c98ae372413bac809c25b16d1946aba100663e4b",
       txDataUnion: .init(
         ethTxData1559: .init(
@@ -271,13 +274,14 @@ extension BraveWallet.TransactionInfo {
   static var previewConfirmedSolSystemTransfer: BraveWallet.TransactionInfo {
     BraveWallet.TransactionInfo(
       id: "3d3c7715-f5f2-4f70-ab97-7fb8d3b2a3cd",
-      fromAddress: "6WRQXT2wMAkSjTjGQSqfEnuqgnqskTp5FnT28tScDsAd",
+      fromAddress: BraveWallet.AccountInfo.mockSolAccount.accountId.address,
+      from: BraveWallet.AccountInfo.mockSolAccount.accountId,
       txHash: "2rbyfcSQ9xCem4wtpjMYD4u6PdKE9YcBurCHDgkMcAaBMh8CirQvuLYtj8AyaYu62ekwWKM1UDZ2VLRB4uN96Fcu",
       txDataUnion: .init(
         solanaTxData: .init(
           recentBlockhash: "",
           lastValidBlockHeight: 0,
-          feePayer: "6WRQXT2wMAkSjTjGQSqfEnuqgnqskTp5FnT28tScDsAd",
+          feePayer: BraveWallet.AccountInfo.mockSolAccount.accountId.address,
           toWalletAddress: "FoVyVfWMwoK7QgS4fcULpPSdLEp2PB5aj5ATs8VhPEv2",
           splTokenMintAddress: "",
           lamports: UInt64(100000000),
@@ -309,13 +313,14 @@ extension BraveWallet.TransactionInfo {
   static var previewConfirmedSolTokenTransfer: BraveWallet.TransactionInfo {
     BraveWallet.TransactionInfo(
       id: "12345675-f5f2-4f70-ab97-7fb8d3b2a3cd",
-      fromAddress: "6WRQXT2wMAkSjTjGQSqfEnuqgnqskTp5FnT28tScDsAd",
+      fromAddress: BraveWallet.AccountInfo.mockSolAccount.accountId.address,
+      from: BraveWallet.AccountInfo.mockSolAccount.accountId,
       txHash: "",
       txDataUnion: .init(
         solanaTxData: .init(
           recentBlockhash: "",
           lastValidBlockHeight: 0,
-          feePayer: "6WRQXT2wMAkSjTjGQSqfEnuqgnqskTp5FnT28tScDsAd",
+          feePayer: BraveWallet.AccountInfo.mockSolAccount.accountId.address,
           toWalletAddress: "FoVyVfWMwoK7QgS4fcULpPSdLEp2PB5aj5ATs8VhPEv2",
           splTokenMintAddress: "0x1111111111222222222233333333334444444444",
           lamports: UInt64(0),

--- a/Sources/BraveWallet/Preview Content/MockJsonRpcService.swift
+++ b/Sources/BraveWallet/Preview Content/MockJsonRpcService.swift
@@ -133,7 +133,7 @@ class MockJsonRpcService: BraveWalletJsonRpcService {
   func addEthereumChainRequestCompleted(_ chainId: String, approved: Bool) {
   }
   
-  func notifySwitchChainRequestProcessed(_ approved: Bool, origin: URLOrigin) {
+  func notifySwitchChainRequestProcessed(_ requestId: String, approved: Bool) {
   }
   
   func setCustomNetworkForTesting(_ chainId: String, coin: BraveWallet.CoinType, providerUrl: URL) {

--- a/Sources/BraveWallet/WalletConstants.swift
+++ b/Sources/BraveWallet/WalletConstants.swift
@@ -20,8 +20,11 @@ public struct WalletConstants {
   /// The wei value used for unlimited allowance in an ERC 20 transaction.
   static let MAX_UINT256 = "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
   
-  /// The origin used for transactions/requests from Brave Wallet.
+  /// The `URLOrigin` used for transactions/requests from Brave Wallet.
   static let braveWalletOrigin: URLOrigin = .init(url: URL(string: "chrome://wallet")!)
+  
+  /// The `OriginInfo.originSpec` used for transactions/requests from Brave Wallet.
+  static let braveWalletOriginSpec = "chrome://wallet"
   
   /// The url to Brave Help Center for Wallet.
   static let braveWalletSupportURL = URL(string: "https://support.brave.com/hc/en-us/categories/360001059151-Brave-Wallet")!

--- a/Tests/BraveWalletTests/TransactionConfirmationStoreTests.swift
+++ b/Tests/BraveWalletTests/TransactionConfirmationStoreTests.swift
@@ -53,6 +53,12 @@ import BraveCore
     rpcService._erc20TokenAllowance = { _, _, _, _, completion in
       completion("16345785d8a0000", .success, "") // 0.1000
     }
+    rpcService._solanaBalance = { accountAddress, chainId, completion in
+      completion(0, .success, "")
+    }
+    rpcService._splTokenAccountBalance = { _, tokenMintAddress, _, completion in
+      completion("", UInt8(0), "", .success, "")
+    }
     let txService = BraveWallet.TestTxService()
     txService._addObserver = { _ in }
     txService._allTransactionInfo = { coin, chainId, address, completion in

--- a/Tests/BraveWalletTests/TransactionParserTests.swift
+++ b/Tests/BraveWalletTests/TransactionParserTests.swift
@@ -34,10 +34,22 @@ class TransactionParserTests: XCTestCase {
   
   private let currencyFormatter: NumberFormatter = .usdCurrencyFormatter
   private let accountInfos: [BraveWallet.AccountInfo] = [
-    .init(address: "0x1234567890123456789012345678901234567890", name: "Ethereum Account 1"),
-    .init(address: "0x0987654321098765432109876543210987654321", name: "Ethereum Account 2"),
-    .init(address: "0xaaaaaaaaaabbbbbbbbbbccccccccccdddddddddd", name: "Solana Account 1", coin: .sol),
-    .init(address: "0xeeeeeeeeeeffffffffff11111111112222222222", name: "Solana Account 2", coin: .sol)
+    BraveWallet.AccountInfo.previewAccount,
+    (BraveWallet.AccountInfo.previewAccount.copy() as! BraveWallet.AccountInfo).then {
+      $0.name = "Ethereum Account 2"
+      $0.address = "0x0987654321098765432109876543210987654321"
+      $0.accountId.address = "0x0987654321098765432109876543210987654321"
+    },
+    (BraveWallet.AccountInfo.mockSolAccount.copy() as! BraveWallet.AccountInfo).then {
+      $0.name = "Solana Account 1"
+      $0.address = "0xaaaaaaaaaabbbbbbbbbbccccccccccdddddddddd"
+      $0.accountId.address = "0xaaaaaaaaaabbbbbbbbbbccccccccccdddddddddd"
+    },
+    (BraveWallet.AccountInfo.mockSolAccount.copy() as! BraveWallet.AccountInfo).then {
+      $0.name = "Solana Account 2"
+      $0.address = "0xeeeeeeeeeeffffffffff11111111112222222222"
+      $0.accountId.address = "0xeeeeeeeeeeffffffffff11111111112222222222"
+    }
   ]
   private let tokens: [BraveWallet.BlockchainToken] = [
     .previewToken, .previewDaiToken, .mockUSDCToken, .mockSolToken, .mockSpdToken, .mockSolanaNFTToken
@@ -79,7 +91,8 @@ class TransactionParserTests: XCTestCase {
     )
     let transaction = BraveWallet.TransactionInfo(
       id: "1",
-      fromAddress: "0x1234567890123456789012345678901234567890",
+      fromAddress: accountInfos[0].accountId.address,
+      from: accountInfos[0].accountId,
       txHash: "0xaaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffff1234",
       txDataUnion: .init(ethTxData1559: transactionData),
       txStatus: .confirmed,
@@ -97,8 +110,8 @@ class TransactionParserTests: XCTestCase {
     
     let expectedParsedTransaction = ParsedTransaction(
       transaction: transaction,
-      namedFromAddress: "Ethereum Account 1",
-      fromAddress: "0x1234567890123456789012345678901234567890",
+      namedFromAddress: accountInfos[0].name,
+      fromAddress: accountInfos[0].address,
       namedToAddress: "Ethereum Account 2",
       toAddress: "0x0987654321098765432109876543210987654321",
       networkSymbol: "ETH",
@@ -174,7 +187,8 @@ class TransactionParserTests: XCTestCase {
     )
     let transaction = BraveWallet.TransactionInfo(
       id: "2",
-      fromAddress: "0x1234567890123456789012345678901234567890",
+      fromAddress: accountInfos[0].address,
+      from: accountInfos[0].accountId,
       txHash: "0xaaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffff1234",
       txDataUnion: .init(ethTxData1559: transactionData),
       txStatus: .confirmed,
@@ -192,8 +206,8 @@ class TransactionParserTests: XCTestCase {
     
     let expectedParsedTransaction = ParsedTransaction(
       transaction: transaction,
-      namedFromAddress: "Ethereum Account 1",
-      fromAddress: "0x1234567890123456789012345678901234567890",
+      namedFromAddress: accountInfos[0].name,
+      fromAddress: accountInfos[0].address,
       namedToAddress: "Ethereum Account 2",
       toAddress: "0x0987654321098765432109876543210987654321",
       networkSymbol: "ETH",
@@ -256,7 +270,8 @@ class TransactionParserTests: XCTestCase {
     )
     let transaction = BraveWallet.TransactionInfo(
       id: "3",
-      fromAddress: "0x1234567890123456789012345678901234567890",
+      fromAddress: accountInfos[0].address,
+      from: accountInfos[0].accountId,
       txHash: "0xaaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffff1234",
       txDataUnion: .init(ethTxData1559: transactionData),
       txStatus: .confirmed,
@@ -278,8 +293,8 @@ class TransactionParserTests: XCTestCase {
     
     let expectedParsedTransaction = ParsedTransaction(
       transaction: transaction,
-      namedFromAddress: "Ethereum Account 1",
-      fromAddress: "0x1234567890123456789012345678901234567890",
+      namedFromAddress: accountInfos[0].name,
+      fromAddress: accountInfos[0].address,
       namedToAddress: "0x Exchange Proxy",
       toAddress: "0xDef1C0ded9bec7F1a1670819833240f027b25EfF",
       networkSymbol: "ETH",
@@ -346,7 +361,8 @@ class TransactionParserTests: XCTestCase {
     )
     let transaction = BraveWallet.TransactionInfo(
       id: "3",
-      fromAddress: "0x1234567890123456789012345678901234567890",
+      fromAddress: accountInfos[0].address,
+      from: accountInfos[0].accountId,
       txHash: "0xaaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffff1234",
       txDataUnion: .init(ethTxData1559: transactionData),
       txStatus: .confirmed,
@@ -368,8 +384,8 @@ class TransactionParserTests: XCTestCase {
     
     let expectedParsedTransaction = ParsedTransaction(
       transaction: transaction,
-      namedFromAddress: "Ethereum Account 1",
-      fromAddress: "0x1234567890123456789012345678901234567890",
+      namedFromAddress: accountInfos[0].name,
+      fromAddress: accountInfos[0].address,
       namedToAddress: "0x Exchange Proxy",
       toAddress: "0xDef1C0ded9bec7F1a1670819833240f027b25EfF",
       networkSymbol: "ETH",
@@ -436,7 +452,8 @@ class TransactionParserTests: XCTestCase {
     )
     let transaction = BraveWallet.TransactionInfo(
       id: "4",
-      fromAddress: "0x1234567890123456789012345678901234567890",
+      fromAddress: accountInfos[0].address,
+      from: accountInfos[0].accountId,
       txHash: "0xaaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffff1234",
       txDataUnion: .init(ethTxData1559: transactionData),
       txStatus: .confirmed,
@@ -454,8 +471,8 @@ class TransactionParserTests: XCTestCase {
     
     let expectedParsedTransaction = ParsedTransaction(
       transaction: transaction,
-      namedFromAddress: "Ethereum Account 1",
-      fromAddress: "0x1234567890123456789012345678901234567890",
+      namedFromAddress: accountInfos[0].name,
+      fromAddress: accountInfos[0].address,
       namedToAddress: BraveWallet.BlockchainToken.previewDaiToken.contractAddress.truncatedAddress,
       toAddress: BraveWallet.BlockchainToken.previewDaiToken.contractAddress,
       networkSymbol: "ETH",
@@ -520,7 +537,8 @@ class TransactionParserTests: XCTestCase {
     )
     let transaction = BraveWallet.TransactionInfo(
       id: "5",
-      fromAddress: "0x1234567890123456789012345678901234567890",
+      fromAddress: accountInfos[0].address,
+      from: accountInfos[0].accountId,
       txHash: "0xaaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffff1234",
       txDataUnion: .init(ethTxData1559: transactionData),
       txStatus: .confirmed,
@@ -538,8 +556,8 @@ class TransactionParserTests: XCTestCase {
     
     let expectedParsedTransaction = ParsedTransaction(
       transaction: transaction,
-      namedFromAddress: "Ethereum Account 1",
-      fromAddress: "0x1234567890123456789012345678901234567890",
+      namedFromAddress: accountInfos[0].name,
+      fromAddress: accountInfos[0].address,
       namedToAddress: BraveWallet.BlockchainToken.previewDaiToken.contractAddress.truncatedAddress,
       toAddress: BraveWallet.BlockchainToken.previewDaiToken.contractAddress,
       networkSymbol: "ETH",
@@ -604,7 +622,8 @@ class TransactionParserTests: XCTestCase {
     )
     let transaction = BraveWallet.TransactionInfo(
       id: "6",
-      fromAddress: "0x1234567890123456789012345678901234567890",
+      fromAddress: accountInfos[0].address,
+      from: accountInfos[0].accountId,
       txHash: "0xaaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffff1234",
       txDataUnion: .init(ethTxData1559: transactionData),
       txStatus: .confirmed,
@@ -626,8 +645,8 @@ class TransactionParserTests: XCTestCase {
     
     let expectedParsedTransaction = ParsedTransaction(
       transaction: transaction,
-      namedFromAddress: "Ethereum Account 1",
-      fromAddress: "0x1234567890123456789012345678901234567890",
+      namedFromAddress: accountInfos[0].name,
+      fromAddress: accountInfos[0].address,
       namedToAddress: "Ethereum Account 2",
       toAddress: "0x0987654321098765432109876543210987654321",
       networkSymbol: "ETH",
@@ -668,8 +687,8 @@ class TransactionParserTests: XCTestCase {
     let transactionData: BraveWallet.SolanaTxData = .init(
       recentBlockhash: "",
       lastValidBlockHeight: 0,
-      feePayer: "0xaaaaaaaaaabbbbbbbbbbccccccccccdddddddddd",
-      toWalletAddress: "0xeeeeeeeeeeffffffffff11111111112222222222",
+      feePayer: accountInfos[2].accountId.address,
+      toWalletAddress: accountInfos[3].accountId.address,
       splTokenMintAddress: "",
       lamports: 100000000,
       amount: 0,
@@ -692,7 +711,8 @@ class TransactionParserTests: XCTestCase {
     )
     let transaction = BraveWallet.TransactionInfo(
       id: "7",
-      fromAddress: "0xaaaaaaaaaabbbbbbbbbbccccccccccdddddddddd",
+      fromAddress: accountInfos[2].accountId.address,
+      from: accountInfos[2].accountId,
       txHash: "0xaaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffff1234",
       txDataUnion: .init(solanaTxData: transactionData),
       txStatus: .confirmed,
@@ -710,10 +730,10 @@ class TransactionParserTests: XCTestCase {
     )
     let expectedParsedTransaction = ParsedTransaction(
       transaction: transaction,
-      namedFromAddress: "Solana Account 1",
-      fromAddress: "0xaaaaaaaaaabbbbbbbbbbccccccccccdddddddddd",
-      namedToAddress: "Solana Account 2",
-      toAddress: "0xeeeeeeeeeeffffffffff11111111112222222222",
+      namedFromAddress: accountInfos[2].name,
+      fromAddress: accountInfos[2].accountId.address,
+      namedToAddress: accountInfos[3].name,
+      toAddress: accountInfos[3].accountId.address,
       networkSymbol: "SOL",
       details: .solSystemTransfer(
         .init(
@@ -765,8 +785,8 @@ class TransactionParserTests: XCTestCase {
     let transactionData: BraveWallet.SolanaTxData = .init(
       recentBlockhash: "",
       lastValidBlockHeight: 0,
-      feePayer: "0xaaaaaaaaaabbbbbbbbbbccccccccccdddddddddd",
-      toWalletAddress: "0xeeeeeeeeeeffffffffff11111111112222222222",
+      feePayer: accountInfos[2].accountId.address,
+      toWalletAddress: accountInfos[3].accountId.address,
       splTokenMintAddress: BraveWallet.BlockchainToken.mockSpdToken.contractAddress,
       lamports: 0,
       amount: 43210000,
@@ -789,7 +809,8 @@ class TransactionParserTests: XCTestCase {
     )
     let transaction = BraveWallet.TransactionInfo(
       id: "7",
-      fromAddress: "0xaaaaaaaaaabbbbbbbbbbccccccccccdddddddddd",
+      fromAddress: accountInfos[2].accountId.address,
+      from: accountInfos[2].accountId,
       txHash: "0xaaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffff1234",
       txDataUnion: .init(solanaTxData: transactionData),
       txStatus: .confirmed,
@@ -807,10 +828,10 @@ class TransactionParserTests: XCTestCase {
     )
     let expectedParsedTransaction = ParsedTransaction(
       transaction: transaction,
-      namedFromAddress: "Solana Account 1",
-      fromAddress: "0xaaaaaaaaaabbbbbbbbbbccccccccccdddddddddd",
-      namedToAddress: "Solana Account 2",
-      toAddress: "0xeeeeeeeeeeffffffffff11111111112222222222",
+      namedFromAddress: accountInfos[2].name,
+      fromAddress: accountInfos[2].accountId.address,
+      namedToAddress: accountInfos[3].name,
+      toAddress: accountInfos[3].accountId.address,
       networkSymbol: "SOL",
       details: .solSplTokenTransfer(
         .init(
@@ -849,8 +870,8 @@ class TransactionParserTests: XCTestCase {
     let transactionData: BraveWallet.SolanaTxData = .init(
       recentBlockhash: "",
       lastValidBlockHeight: 0,
-      feePayer: "0xaaaaaaaaaabbbbbbbbbbccccccccccdddddddddd",
-      toWalletAddress: "0xeeeeeeeeeeffffffffff11111111112222222222",
+      feePayer: accountInfos[2].accountId.address,
+      toWalletAddress: accountInfos[3].accountId.address,
       splTokenMintAddress: BraveWallet.BlockchainToken.mockSolanaNFTToken.contractAddress,
       lamports: 0,
       amount: 1,
@@ -873,7 +894,8 @@ class TransactionParserTests: XCTestCase {
     )
     let transaction = BraveWallet.TransactionInfo(
       id: "7",
-      fromAddress: "0xaaaaaaaaaabbbbbbbbbbccccccccccdddddddddd",
+      fromAddress: accountInfos[2].accountId.address,
+      from: accountInfos[2].accountId,
       txHash: "0xaaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffff1234",
       txDataUnion: .init(solanaTxData: transactionData),
       txStatus: .confirmed,
@@ -891,10 +913,10 @@ class TransactionParserTests: XCTestCase {
     )
     let expectedParsedTransaction = ParsedTransaction(
       transaction: transaction,
-      namedFromAddress: "Solana Account 1",
-      fromAddress: "0xaaaaaaaaaabbbbbbbbbbccccccccccdddddddddd",
-      namedToAddress: "Solana Account 2",
-      toAddress: "0xeeeeeeeeeeffffffffff11111111112222222222",
+      namedFromAddress: accountInfos[2].name,
+      fromAddress: accountInfos[2].accountId.address,
+      namedToAddress: accountInfos[3].name,
+      toAddress: accountInfos[3].accountId.address,
       networkSymbol: "SOL",
       details: .solSplTokenTransfer(
         .init(

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@mozilla/readability": "^0.4.2",
-        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.58.63/brave-core-ios-1.58.63.tgz",
+        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.58.77/brave-core-ios-1.58.77.tgz",
         "leo-sf-symbols": "github:brave/leo-sf-symbols#60a41d77d4e58bd48284848a04ad3f9b79bf7daa",
         "page-metadata-parser": "^1.1.3",
         "webpack-cli": "^4.8.0"
@@ -356,9 +356,9 @@
       }
     },
     "node_modules/brave-core-ios": {
-      "version": "1.58.63",
-      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.58.63/brave-core-ios-1.58.63.tgz",
-      "integrity": "sha512-9BR0yGcuOB/axccwE4oRRH+cQTSTbZd4CmGznYg8Mf7cqL4UVeT2bqCnoo6Bg5vir7BU3w0rSie8JIHikfZctA==",
+      "version": "1.58.77",
+      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.58.77/brave-core-ios-1.58.77.tgz",
+      "integrity": "sha512-/L9etEIS9PH3gnIqe+/3STbvoO/rtaN4bIMJUQ570dh+BlPWpZ8kaJ6YlWeN548hCOv8zp8gxfmjm093jyYQzg==",
       "license": "ISC"
     },
     "node_modules/browserslist": {
@@ -1738,8 +1738,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-browser/releases/download/v1.58.63/brave-core-ios-1.58.63.tgz",
-      "integrity": "sha512-9BR0yGcuOB/axccwE4oRRH+cQTSTbZd4CmGznYg8Mf7cqL4UVeT2bqCnoo6Bg5vir7BU3w0rSie8JIHikfZctA=="
+      "version": "https://github.com/brave/brave-browser/releases/download/v1.58.77/brave-core-ios-1.58.77.tgz",
+      "integrity": "sha512-/L9etEIS9PH3gnIqe+/3STbvoO/rtaN4bIMJUQ570dh+BlPWpZ8kaJ6YlWeN548hCOv8zp8gxfmjm093jyYQzg=="
     },
     "browserslist": {
       "version": "4.17.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "license": "MPL-2.0",
   "dependencies": {
     "@mozilla/readability": "^0.4.2",
-    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.58.63/brave-core-ios-1.58.63.tgz",
+    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.58.77/brave-core-ios-1.58.77.tgz",
     "leo-sf-symbols": "github:brave/leo-sf-symbols#60a41d77d4e58bd48284848a04ad3f9b79bf7daa",
     "page-metadata-parser": "^1.1.3",
     "webpack-cli": "^4.8.0"


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #7818, fixes #7807

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Verify origin (and Favicon when displayed on that view) displays as expected for Get Encryption Public Key request, Decrypt request, Switch Chain request.
2. Verify Get Encryption Public Key request, Decrypt request, Switch Chain request can all be approved & cancelled.
3. Verify ERC20 approve transaction confirmation header shows BraveWallet when created from native wallet, origin + favicon from dApp.
4. Verify creating & submitting/approving (test networks are fine) Solana & Ethereum transaction


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
