### PR TITLE
Fix #7844: Fix bug where backgroundView on stats is invisible

### DIFF
--- a/Sources/Brave/Frontend/Browser/New Tab Page/Sections/StatsSectionProvider.swift
+++ b/Sources/Brave/Frontend/Browser/New Tab Page/Sections/StatsSectionProvider.swift
@@ -175,16 +175,11 @@ class BraveShieldStatsView: SpringButton {
   
   var isPrivateBrowsing: Bool = false {
     didSet {
-      if oldValue == isPrivateBrowsing {
+      if backgroundView.superview != nil {
         return
       }
 
-      if isPrivateBrowsing {
-        backgroundView.removeFromSuperview()
-        topStackView.arrangedSubviews.forEach {
-          $0.removeFromSuperview()
-        }
-      } else if Preferences.NewTabPage.showNewTabPrivacyHub.value {
+      if !isPrivateBrowsing && Preferences.NewTabPage.showNewTabPrivacyHub.value {
         backgroundView.backgroundColor = .init(white: 0, alpha: 0.25)
         backgroundView.layer.cornerRadius = 12
         backgroundView.layer.cornerCurve = .continuous


### PR DESCRIPTION
## Summary of Changes
- Fix background view not showing due to private-browsing condition returning early.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7844

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
