### PR TITLE
Fix #7846: Ensure Ads enabled pref is updated correctly when disabling

### DIFF
--- a/Sources/Brave/Frontend/Rewards/BraveRewards.swift
+++ b/Sources/Brave/Frontend/Rewards/BraveRewards.swift
@@ -132,6 +132,7 @@ public class BraveRewards: NSObject {
         }
         self.reportLastAdsUsageP3A()
         if !newValue {
+          self.ads.isEnabled = newValue
           self.proposeAdsShutdown()
         } else {
           self.fetchWalletAndInitializeAds(toggleAds: true)


### PR DESCRIPTION
This was moved in a 1.57 core bump for the enabling path but missed for the disabling path

## Summary of Changes

This pull request fixes #7846 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
