### PR TITLE
Fix #7832: Restored but unopened tabs not added to Recently Closed Tabs

### DIFF
--- a/Sources/Brave/Frontend/Browser/TabManager.swift
+++ b/Sources/Brave/Frontend/Browser/TabManager.swift
@@ -1127,9 +1127,9 @@ class TabManager: NSObject {
     }
 
     // NTP should not be passed as Recently Closed item
-    var recentlyClosedURL  = tab.url ?? SessionTab.from(tabId: tab.id)?.url
+    let recentlyClosedURL  = tab.url ?? SessionTab.from(tabId: tab.id)?.url
 
-    guard let tabUrl = recentlyClosedURL, InternalURL(tabUrl)?.isAboutHomeURL == false else {
+    guard let tabUrl = recentlyClosedURL, tabUrl.isWebPage() else {
       return nil
     }
       

--- a/Sources/Brave/Frontend/Browser/TabManager.swift
+++ b/Sources/Brave/Frontend/Browser/TabManager.swift
@@ -1127,13 +1127,12 @@ class TabManager: NSObject {
     }
 
     // NTP should not be passed as Recently Closed item
-    guard let tabUrl = tab.url,
-          let interactionState = tab.webView?.sessionData else { return nil }
-      
-    if InternalURL(tabUrl)?.isAboutHomeURL == true {
+    var recentlyClosedURL  = tab.url ?? SessionTab.from(tabId: tab.id)?.url
+
+    guard let tabUrl = recentlyClosedURL, InternalURL(tabUrl)?.isAboutHomeURL == false else {
       return nil
     }
-    
+      
     // Convert any internal URLs to their real URL for the Recently Closed item
     var fetchedTabURL = tabUrl
     if let url = InternalURL(fetchedTabURL),
@@ -1144,7 +1143,7 @@ class TabManager: NSObject {
     return SavedRecentlyClosed(
       url: fetchedTabURL,
       title: tab.displayTitle,
-      interactionState: interactionState,
+      interactionState: tab.webView?.sessionData,
       order: -1)
   }
 }

--- a/Sources/Data/models/RecentlyClosed.swift
+++ b/Sources/Data/models/RecentlyClosed.swift
@@ -12,10 +12,10 @@ public struct SavedRecentlyClosed {
   public let url: String
   public let title: String
   public let dateAdded: Date
-  public let interactionState: Data
+  public let interactionState: Data?
   public let index: Int32
 
-  public init(url: URL, title: String, dateAdded: Date = .now, interactionState: Data, order: Int32) {
+  public init(url: URL, title: String, dateAdded: Date = .now, interactionState: Data?, order: Int32) {
     self.url = url.absoluteString
     self.title = title
     self.dateAdded = dateAdded


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

Adding session tab url fetch and nullable interaction state

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7832

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

1. Open 2 or more tabs
2. Fully quit Brave from app switcher
3. Open Brave
4. Tap and hold on tab tray button and tap Recently Closed Tabs
5. Clear list if not empty (not required, but easier to see bug)
6. Tap and hold on tab button, tap Close All n Tabs
7. Tap and hold on tab tray button and tap Recently Closed Tabs

## Screenshots:


https://github.com/brave/brave-ios/assets/6643505/9b2507a6-8283-403f-ab54-85abf3bf286c



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
