### PR TITLE
Fix #7836: Tabs Bar not updating when opening bulk bookmarks

### DIFF
--- a/Sources/Brave/Frontend/Browser/Tabs/TabBar/TabsBarViewController.swift
+++ b/Sources/Brave/Frontend/Browser/Tabs/TabBar/TabsBarViewController.swift
@@ -507,4 +507,9 @@ extension TabsBarViewController: TabManagerDelegate {
   func tabManagerDidRemoveAllTabs(_ tabManager: TabManager, toast: ButtonToast?) {
     updateData()
   }
+  
+  func tabManagerDidAddTabs(_ tabManager: TabManager) {
+    assert(Thread.current.isMainThread)
+    updateData()
+  }
 }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Update the tabs url when opening bulk tabs. Not exactly sure why this delegate was never implemented, but we either implement it or we call `selectTab` before `.isRestoring = false` instead of `isRestoring = false` then `selectTab`.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7836

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
