### PR TITLE
Fix #7658: Fix playlist shared folders to skip over videos that can't load

### DIFF
--- a/Sources/Brave/Frontend/Browser/Playlist/PlaylistSharedFolder.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/PlaylistSharedFolder.swift
@@ -8,6 +8,7 @@ import UIKit
 import Data
 import CoreData
 import CodableHelpers
+import OSLog
 
 struct PlaylistSharedFolderModel: Decodable {
   let version: String
@@ -200,8 +201,12 @@ struct PlaylistSharedFolderNetwork {
       }
       
       var result = [PlaylistInfo]()
-      for try await value in group {
-        result.append(value)
+      while let task = await group.nextResult() {
+        do {
+          try result.append(task.get())
+        } catch {
+          Logger.module.error("Error fetching media item info: \(error)")
+        }
       }
       return result
     }

--- a/Sources/Data/models/PlaylistInfo.swift
+++ b/Sources/Data/models/PlaylistInfo.swift
@@ -74,7 +74,7 @@ public struct PlaylistInfo: Codable, Identifiable, Hashable, Equatable {
   public init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     self.name = try container.decode(String.self, forKey: .name)
-    let src = try container.decode(String.self, forKey: .src)
+    let src = try container.decodeIfPresent(String.self, forKey: .src) ?? ""
     self.pageSrc = try container.decode(String.self, forKey: .pageSrc)
     self.pageTitle = try container.decode(String.self, forKey: .pageTitle)
     self.mimeType = try container.decodeIfPresent(String.self, forKey: .mimeType) ?? ""


### PR DESCRIPTION
## Summary of Changes
- Fix playlist shared folders throwing an exception because a video was made private.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7658

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
