### PR TITLE
Fix #5357: Add brave-favicon for NTP

### DIFF
--- a/Sources/Brave/Frontend/Browser/Tab.swift
+++ b/Sources/Brave/Frontend/Browser/Tab.swift
@@ -538,7 +538,11 @@ class Tab: NSObject {
   }
 
   var displayFavicon: Favicon? {
-    if let url = url, InternalURL(url)?.isAboutHomeURL == true { return nil }
+    if let url = url, InternalURL(url)?.isAboutHomeURL == true {
+      return Favicon(image: UIImage(sharedNamed: "brave.logo"),
+                     isMonogramImage: false,
+                     backgroundColor: .clear)
+    }
     return favicon
   }
 

--- a/Sources/Brave/Frontend/Browser/Tabs/TabTray/Views/TabTrayCell.swift
+++ b/Sources/Brave/Frontend/Browser/Tabs/TabTray/Views/TabTrayCell.swift
@@ -56,7 +56,7 @@ class TabCell: UICollectionViewCell {
     }
 
     titleLabel.text = tab.displayTitle
-    favicon.image = Favicon.defaultImage
+    favicon.image = tab.displayFavicon?.image ?? Favicon.defaultImage
 
     if !tab.displayTitle.isEmpty {
       accessibilityLabel = tab.displayTitle


### PR DESCRIPTION
## Summary of Changes
- Add the brave-logo as the favicon on NTP but not on sites that are missing a favicon (shows a globe)

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5357

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
