### PR TITLE
Fix #4923: Fix Recent Search Clear Button hard to tap

### DIFF
--- a/Sources/Brave/Frontend/Browser/Search/Recent Search/RecentSearchCell.swift
+++ b/Sources/Brave/Frontend/Browser/Search/Recent Search/RecentSearchCell.swift
@@ -23,11 +23,12 @@ class RecentSearchCell: UICollectionViewCell, CollectionViewReusable {
     $0.lineBreakMode = .byTruncatingMiddle
   }
 
-  private let openButton = UIButton().then {
+  private let openButton = BraveButton(type: .system).then {
     $0.setImage(UIImage(named: "recent-search-arrow", in: .module, compatibleWith: nil)!, for: .normal)
     $0.imageView?.contentMode = .scaleAspectFit
     $0.setContentHuggingPriority(.required, for: .horizontal)
     $0.setContentCompressionResistancePriority(.required, for: .horizontal)
+    $0.hitTestSlop = UIEdgeInsets(equalInset: -25.0)
   }
 
   override init(frame: CGRect) {

--- a/Sources/Brave/Frontend/Browser/Search/Recent Search/RecentSearchHeaderView.swift
+++ b/Sources/Brave/Frontend/Browser/Search/Recent Search/RecentSearchHeaderView.swift
@@ -209,4 +209,17 @@ class RecentSearchHeaderView: UICollectionReusableView {
 
     themeViews()
   }
+  
+  public override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+    let adjustedBounds = CGRect(x: hideClearButton.center.x,
+                                y: hideClearButton.center.y,
+                                width: 0.0,
+                                height: 0.0).inset(by: UIEdgeInsets(top: -25.0, left: -25.0, bottom: -5.0, right: -25.0))
+
+    if adjustedBounds.contains(point) {
+      return hideClearButton
+    }
+
+    return super.hitTest(point, with: event)
+  }
 }

--- a/Sources/Brave/Frontend/Browser/Search/Recent Search/RecentSearchHeaderView.swift
+++ b/Sources/Brave/Frontend/Browser/Search/Recent Search/RecentSearchHeaderView.swift
@@ -211,10 +211,7 @@ class RecentSearchHeaderView: UICollectionReusableView {
   }
   
   public override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
-    let adjustedBounds = CGRect(x: hideClearButton.center.x,
-                                y: hideClearButton.center.y,
-                                width: 0.0,
-                                height: 0.0).inset(by: UIEdgeInsets(top: -25.0, left: -25.0, bottom: -5.0, right: -25.0))
+    let adjustedBounds = hideClearButton.frame.inset(by: UIEdgeInsets(top: -25.0, left: -25.0, bottom: 0.0, right: -25.0))
 
     if adjustedBounds.contains(point) {
       return hideClearButton


### PR DESCRIPTION
## Summary of Changes
- Made the hit-test for recent searches clear button larger. `hitTestSlop` does NOT work for this as it's still clipped by the collection view header, so I calculate the hitTest on the header itself relative to the button.
- Button should be easier to press, and UI should update just fine after clearing recent searches.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #4923

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
