### PR TITLE
Fix #7857: Fix migration of screenshot data when there's thousands of tabs

### DIFF
--- a/Sources/Brave/Migration/Migration.swift
+++ b/Sources/Brave/Migration/Migration.swift
@@ -148,18 +148,6 @@ public class Migration {
                                                                    pageIndex: UInt(currentPage),
                                                                    isPrivateBrowsing: isPrivate)
         
-        var screenshot = Data()
-        if let imageStore = diskImageStore, let screenshotUUID = oldTab.screenshotUUID {
-          do {
-            let image = try imageStore.getSynchronously(screenshotUUID)
-            if let data = image.jpegData(compressionQuality: CGFloat(UIConstants.screenshotQuality)) {
-              screenshot = data
-            }
-          } catch {
-            Logger.module.error("Failed to migrate screenshot for Tab: \(error)")
-          }
-        }
-        
         // Create SessionTab and associate it with a SessionWindow
         // Tabs currently do not have groups, so sessionTabGroup is nil by default
         _ = SessionTab(context: context,
@@ -170,7 +158,7 @@ public class Migration {
                        isPrivate: isPrivate,
                        isSelected: oldTab.isSelected,
                        lastUpdated: oldTab.lastUpdate ?? .now,
-                       screenshotData: screenshot,
+                       screenshotData: Data(),  // Do not migrate screenshot data
                        title: tabTitle,
                        url: url,
                        tabId: tabId)


### PR DESCRIPTION
## Summary of Changes
- Remove migration of screenshot data when migrating thousands of tabs

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7857

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
Test on dev channel only, use exact builds mentioned in the test plan, it's a very specific crash.
1. Install `1.50 (23.8.8.15)`
2. 3dot menu scroll down to 'Add 1000 tabs button'. Test with 1000 or 2000 tabs
3. Upgrade to `1.51 (23.8.10.16)`
4. Verify that this build loads without issues.

As an additional test you can test upgrade scenario from 1.56 to 1.57, also with 1000-2000 tabs. Keep in mind we consider capping the number of created tabs to 500 in the future

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
