### PR TITLE
[v1.58] Fix #7637: Allow users to choose which SOL account to connect

### DIFF
--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Paged/WalletEthereumProviderScript.js
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Paged/WalletEthereumProviderScript.js
@@ -3,7 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-window.__firefox__.execute(function($) {
+window.__firefox__.execute(function($, $Object) {
   
 if (window.isSecureContext) {
   function post(method, payload) {
@@ -30,7 +30,7 @@ if (window.isSecureContext) {
     }));
   }
   
-  Object.defineProperty(window, 'ethereum', {
+  const provider = {
     value: {
       chainId: undefined,
       networkVersion: undefined,
@@ -93,7 +93,9 @@ if (window.isSecureContext) {
         return post('isUnlocked', {})
       }),
     }
-  });
+  };
+  $Object.defineProperty(window, 'ethereum', provider);
+  $Object.defineProperty(window, 'braveEthereum', provider);
 }
   
 });

--- a/Sources/BraveWallet/Panels/Connect/NewSiteConnectionView.swift
+++ b/Sources/BraveWallet/Panels/Connect/NewSiteConnectionView.swift
@@ -96,10 +96,18 @@ public struct NewSiteConnectionView: View {
         Section {
           ForEach(accountInfos) { account in
             Button {
-              if selectedAccounts.contains(account.id) {
-                selectedAccounts.remove(account.id)
-              } else {
-                selectedAccounts.insert(account.id)
+              switch coin {
+              case .eth:
+                if selectedAccounts.contains(account.id) {
+                  selectedAccounts.remove(account.id)
+                } else {
+                  selectedAccounts.insert(account.id)
+                }
+              case .sol:
+                // only allow selecting one Solana account at a time
+                selectedAccounts = .init(arrayLiteral: account.id)
+              default:
+                break // not supported
               }
             } label: {
               HStack {


### PR DESCRIPTION
## Summary of Changes
- Allow user to choose which Solana account to connect, but only allow one at a time.
- Fixes v1.58 ethereum dapps missing `emit` function. Core script was changed to use `window.braveEthereum` instead of `window.ethereum` with [Add support for EIP-6963](https://github.com/brave/brave-ios/issues/7779) in core.

This pull request fixes #7637

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Setup wallet to have two Solana accounts and select Account 1
2. Navigate to [Test DApp Site](https://pwgoom.csb.app/)
3. Tap "Connect" and we should see two accounts to choose after unlock.
4. Verify you are only able to select 1 account at a time to connect.
5. Choose Account 2 and approve
6. Check the wallet panel, verify the selected account is Account 2 and it is connected
2. Tap "Disconnect" on the Test DApp Site and changed selected account to account 1 in panel
3. Prompt should only show account 1 because Account 2 is already permitted
4. Tap Account 1 and reject the request
5. The Test DApp site should still shows disconnected.
7. Navigate to any Ethereum DApp and verify you are still able to connect more than 1 account at the same time.


## Screenshots:

https://github.com/brave/brave-ios/assets/5314553/a5a15dc0-5d9e-4d48-9b76-6772224453ef



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
