### PR TITLE
Fix #7849: Update Sync Local Authentication Logic

### DIFF
--- a/Sources/Brave/Frontend/Browser/Tabs/TabTray/TabTrayController.swift
+++ b/Sources/Brave/Frontend/Browser/Tabs/TabTray/TabTrayController.swift
@@ -698,10 +698,9 @@ class TabTrayController: AuthenticationController {
         syncAPI: braveCore.syncAPI,
         syncProfileService: braveCore.syncProfileService,
         tabManager: tabManager,
-        windowProtection: windowProtection,
-        requiresAuthentication: true)
+        windowProtection: windowProtection)
       
-        syncSettingsScreen.syncStatusDelegate = self
+        syncSettingsScreen.syncStatusDelegate = self 
       
         openInsideSettingsNavigation(with: syncSettingsScreen)
       default:

--- a/Sources/Brave/Frontend/Settings/SettingsViewController.swift
+++ b/Sources/Brave/Frontend/Settings/SettingsViewController.swift
@@ -332,8 +332,7 @@ class SettingsViewController: TableViewController {
                 syncProfileService:
                   syncProfileServices,
                 tabManager: tabManager,
-                windowProtection: windowProtection,
-                requiresAuthentication: true)
+                windowProtection: windowProtection)
 
               self.navigationController?
                 .pushViewController(syncSettingsViewController, animated: true)

--- a/Sources/Brave/Frontend/Sync/SyncSettingsTableViewController.swift
+++ b/Sources/Brave/Frontend/Sync/SyncSettingsTableViewController.swift
@@ -264,7 +264,6 @@ class SyncSettingsTableViewController: SyncViewController, UITableViewDelegate, 
 
   @objc private func didToggleSyncType(_ toggle: UISwitch) {
     let toggleExistingStatus = !toggle.isOn
-    toggle.setOn(toggleExistingStatus, animated: false)
     
     askForAuthentication() { [weak self] status, error in
       guard let self = self, status else {

--- a/Sources/Brave/Frontend/Sync/SyncSettingsTableViewController.swift
+++ b/Sources/Brave/Frontend/Sync/SyncSettingsTableViewController.swift
@@ -84,14 +84,18 @@ class SyncSettingsTableViewController: SyncViewController, UITableViewDelegate, 
        syncAPI: BraveSyncAPI,
        syncProfileService: BraveSyncProfileServiceIOS,
        tabManager: TabManager,
-       windowProtection: WindowProtection?,
-       requiresAuthentication: Bool) {
+       windowProtection: WindowProtection?) {
     self.isModallyPresented = isModallyPresented
     self.syncAPI = syncAPI
     self.syncProfileService = syncProfileService
     self.tabManager = tabManager
     
-    super.init(windowProtection: windowProtection, requiresAuthentication: requiresAuthentication, isModallyPresented: isModallyPresented)
+    // Local Authentication (Biometric - Pincode) needed only for actions
+    // Enabling - disabling password sync and add new device
+    super.init(windowProtection: windowProtection,
+               requiresAuthentication: false,
+               isModallyPresented: isModallyPresented,
+               dismissPresenter: false)
   }
 
   required init?(coder: NSCoder) {
@@ -259,25 +263,37 @@ class SyncSettingsTableViewController: SyncViewController, UITableViewDelegate, 
   }
 
   @objc private func didToggleSyncType(_ toggle: UISwitch) {
-    switch toggle.tag {
-    case SyncDataTypes.bookmarks.rawValue:
-      Preferences.Chromium.syncBookmarksEnabled.value = toggle.isOn
-    case SyncDataTypes.history.rawValue:
-      Preferences.Chromium.syncHistoryEnabled.value = toggle.isOn
-    case SyncDataTypes.passwords.rawValue:
-      Preferences.Chromium.syncPasswordsEnabled.value = toggle.isOn
-    case SyncDataTypes.openTabs.rawValue:
-      Preferences.Chromium.syncOpenTabsEnabled.value = toggle.isOn
-      
-      // Sync Regular Tabs when open tabs are enabled
-      if Preferences.Chromium.syncOpenTabsEnabled.value {
-        tabManager.addRegularTabsToSyncChain()
+    let toggleExistingStatus = !toggle.isOn
+    toggle.setOn(toggleExistingStatus, animated: false)
+    
+    askForAuthentication() { [weak self] status, error in
+      guard let self = self, status else {
+        toggle.setOn(toggleExistingStatus, animated: false)
+        return
       }
-    default:
-      return
-    }
+      
+      toggle.setOn(!toggleExistingStatus, animated: false)
 
-    syncAPI.enableSyncTypes(syncProfileService: syncProfileService)
+      switch toggle.tag {
+      case SyncDataTypes.bookmarks.rawValue:
+        Preferences.Chromium.syncBookmarksEnabled.value = !toggleExistingStatus
+      case SyncDataTypes.history.rawValue:
+        Preferences.Chromium.syncHistoryEnabled.value = !toggleExistingStatus
+      case SyncDataTypes.passwords.rawValue:
+        Preferences.Chromium.syncPasswordsEnabled.value = !toggleExistingStatus
+      case SyncDataTypes.openTabs.rawValue:
+        Preferences.Chromium.syncOpenTabsEnabled.value = !toggleExistingStatus
+        
+        // Sync Regular Tabs when open tabs are enabled
+        if Preferences.Chromium.syncOpenTabsEnabled.value {
+          tabManager.addRegularTabsToSyncChain()
+        }
+      default:
+        return
+      }
+
+      syncAPI.enableSyncTypes(syncProfileService: syncProfileService)
+    }
   }
   
   /// Update visibility of view shown when no devices returned for sync session
@@ -307,11 +323,15 @@ class SyncSettingsTableViewController: SyncViewController, UITableViewDelegate, 
 
   @objc
   private func onSyncInternalsTapped() {
-    let syncInternalsController = syncAPI.createSyncInternalsController().then {
-      $0.title = Strings.braveSyncInternalsTitle
+    askForAuthentication() { [weak self] status, error in
+      guard let self = self, status else { return }
+      
+      let syncInternalsController = syncAPI.createSyncInternalsController().then {
+        $0.title = Strings.braveSyncInternalsTitle
+      }
+      
+      self.navigationController?.pushViewController(syncInternalsController, animated: true)
     }
-
-    navigationController?.pushViewController(syncInternalsController, animated: true)
   }
 }
 
@@ -559,16 +579,21 @@ extension SyncSettingsTableViewController {
   }
 
   private func addAnotherDevice() {
-    let view = SyncSelectDeviceTypeViewController()
-
-    view.syncInitHandler = { title, type in
-      let view = SyncAddDeviceViewController(title: title, type: type, syncAPI: self.syncAPI)
-      view.addDeviceHandler = {
-        self.navigationController?.popToViewController(self, animated: true)
+    askForAuthentication() { [weak self] status, error in
+      guard let self = self, status else { return }
+      
+      let view = SyncSelectDeviceTypeViewController()
+      
+      view.syncInitHandler = { title, type in
+        let view = SyncAddDeviceViewController(title: title, type: type, syncAPI: self.syncAPI)
+        view.addDeviceHandler = {
+          self.navigationController?.popToViewController(self, animated: true)
+        }
+        self.navigationController?.pushViewController(view, animated: true)
       }
+      
       self.navigationController?.pushViewController(view, animated: true)
     }
-    navigationController?.pushViewController(view, animated: true)
   }
 }
 

--- a/Sources/Brave/Frontend/Sync/SyncSettingsTableViewController.swift
+++ b/Sources/Brave/Frontend/Sync/SyncSettingsTableViewController.swift
@@ -273,22 +273,25 @@ class SyncSettingsTableViewController: SyncViewController, UITableViewDelegate, 
       
       toggle.setOn(!toggleExistingStatus, animated: false)
 
-      switch toggle.tag {
-      case SyncDataTypes.bookmarks.rawValue:
+      guard let syncDataType = SyncDataTypes(rawValue: toggle.tag) else {
+         Logger.module.error("Invalid Sync DataType")
+         return
+      }
+      
+      switch syncDataType {
+      case .bookmarks:
         Preferences.Chromium.syncBookmarksEnabled.value = !toggleExistingStatus
-      case SyncDataTypes.history.rawValue:
+      case .history:
         Preferences.Chromium.syncHistoryEnabled.value = !toggleExistingStatus
-      case SyncDataTypes.passwords.rawValue:
+      case .passwords:
         Preferences.Chromium.syncPasswordsEnabled.value = !toggleExistingStatus
-      case SyncDataTypes.openTabs.rawValue:
+      case .openTabs:
         Preferences.Chromium.syncOpenTabsEnabled.value = !toggleExistingStatus
         
         // Sync Regular Tabs when open tabs are enabled
         if Preferences.Chromium.syncOpenTabsEnabled.value {
           tabManager.addRegularTabsToSyncChain()
         }
-      default:
-        return
       }
 
       syncAPI.enableSyncTypes(syncProfileService: syncProfileService)
@@ -325,7 +328,7 @@ class SyncSettingsTableViewController: SyncViewController, UITableViewDelegate, 
     askForAuthentication() { [weak self] status, error in
       guard let self = self, status else { return }
       
-      let syncInternalsController = syncAPI.createSyncInternalsController().then {
+      let syncInternalsController = self.syncAPI.createSyncInternalsController().then {
         $0.title = Strings.braveSyncInternalsTitle
       }
       

--- a/Sources/Brave/Frontend/Sync/SyncViewController.swift
+++ b/Sources/Brave/Frontend/Sync/SyncViewController.swift
@@ -10,22 +10,35 @@ import Combine
 class SyncViewController: AuthenticationController {
 
   private let isModallyPresented: Bool
+  private let dismissPresenter: Bool
   private var localAuthObservers = Set<AnyCancellable>()
 
   // MARK: Lifecycle
-
+  
+  /// Constructor for Sync View Controller that enables
+  /// functionality related with local authentication and internet connection
+  /// - Parameters:
+  ///   - windowProtection: WindowProtection for passcode window functionality
+  ///   - requiresAuthentication: Boolean determines viewing the screen requires local auth
+  ///   - isAuthenticationCancellable: Determines if the niometric authentication has cancel function
+  ///   - isModallyPresented: Checks  if view controller presented modally in order to determine dismiss type
+  ///   - dismissPresenter: Boolean that determines cancel functionality dismisses the presented controller
   init(windowProtection: WindowProtection? = nil,
        requiresAuthentication: Bool = false,
        isAuthenticationCancellable: Bool = true,
-       isModallyPresented: Bool = false) {
+       isModallyPresented: Bool = false,
+       dismissPresenter: Bool = true) {
     self.isModallyPresented = isModallyPresented
+    self.dismissPresenter = dismissPresenter
     super.init(windowProtection: windowProtection, requiresAuthentication: requiresAuthentication)
     
     windowProtection?.isCancellable = isAuthenticationCancellable
     
     windowProtection?.cancelPressed
       .sink { [weak self] _ in
-        self?.dismissSyncController()
+        if dismissPresenter {
+          self?.dismissSyncController()
+        }
       }.store(in: &localAuthObservers)
   }
 

--- a/Sources/Brave/Frontend/Widgets/LoadingViewController.swift
+++ b/Sources/Brave/Frontend/Widgets/LoadingViewController.swift
@@ -38,7 +38,7 @@ public class AuthenticationController: LoadingViewController {
   enum AuthViewType {
     case sync, tabTray
     
-    var description: String {
+    var detailText: String {
       switch self {
       case .sync:
         return Strings.Sync.syncSetPasscodeAlertDescription
@@ -99,7 +99,7 @@ public class AuthenticationController: LoadingViewController {
   func showSetPasscodeError(viewType: AuthViewType, completion: @escaping (() -> Void)) {
     let alert = UIAlertController(
       title: Strings.Sync.syncSetPasscodeAlertTitle,
-      message: viewType.description,
+      message: viewType.detailText,
       preferredStyle: .alert)
 
     alert.addAction(

--- a/Sources/Brave/Frontend/Widgets/LoadingViewController.swift
+++ b/Sources/Brave/Frontend/Widgets/LoadingViewController.swift
@@ -37,6 +37,15 @@ public class LoadingViewController: UIViewController {
 public class AuthenticationController: LoadingViewController {
   enum AuthViewType {
     case sync, tabTray
+    
+    var description: String {
+      switch self {
+      case .sync:
+        return Strings.Sync.syncSetPasscodeAlertDescription
+      case .tabTray:
+        return Strings.Privacy.tabTraySetPasscodeAlertDescription
+      }
+    }
   }
   
   let windowProtection: WindowProtection?
@@ -90,7 +99,7 @@ public class AuthenticationController: LoadingViewController {
   func showSetPasscodeError(viewType: AuthViewType, completion: @escaping (() -> Void)) {
     let alert = UIAlertController(
       title: Strings.Sync.syncSetPasscodeAlertTitle,
-      message: viewType == .sync ? Strings.Sync.syncSetPasscodeAlertDescription : Strings.Privacy.tabTraySetPasscodeAlertDescription,
+      message: viewType.description,
       preferredStyle: .alert)
 
     alert.addAction(

--- a/Sources/BraveStrings/BraveStrings.swift
+++ b/Sources/BraveStrings/BraveStrings.swift
@@ -3286,7 +3286,7 @@ extension Strings {
         "login.syncSetPasscodeAlertDescription",
         tableName: "BraveShared",
         bundle: .module,
-        value: "To setup sync chain or see settings, you must first set a passcode on your device.",
+        value: "To add a device to sync chain or toggle password sync, you must first set a passcode on your device.",
         comment: "The message displayed in alert when a user needs to set a passcode")
   }
 }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request is changing the criteria for Sync Local Authentication Logic criterias.

Previous version has to authenticate user if user is viewing sync setting or creating a sync chain. 

New criteria suggests  

1. Ask for authentication when user toggle password-sync option or wants to add a device to sync
2. If no auth enabled at all you are not allowed to disable or enable password sync
3. If no auth set up when you tap on the password sync toggle show user an alert that they need to enable pincode/faceid.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7849

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan _ Screenshots::

Test 1 

-Create a or join a Sync Chain
-Disable PIN Code entirely
-Try to toggle password sync

![test662](https://github.com/brave/brave-ios/assets/6643505/96339033-519a-4fca-9fa5-941ecb908183)


Test 2 

-Create a or join a Sync Chain
-Disable FaceID - Touch ID but do not disable Pincode
-Check adding device and toggling password logic (this should include cancel)
-Enable Face ID or Touch Id again
-Check adding device and toggling password logic (this should include also cancel functionality)



https://github.com/brave/brave-ios/assets/6643505/e87facf4-0f82-4a20-8ba1-d82b4c7c8655



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
