### PR TITLE
No Bug: Remove duplicated localized strings

### DIFF
--- a/Sources/BraveStrings/BraveStrings.swift
+++ b/Sources/BraveStrings/BraveStrings.swift
@@ -3379,7 +3379,7 @@ extension Strings {
         comment: "")
     public static let persistentPrivateBrowsingDescription =
       NSLocalizedString(
-        "tabs.settings.persistentPrivateBrowsingTitle", tableName: "BraveShared", bundle: .module,
+        "tabs.settings.persistentPrivateBrowsingDescription", tableName: "BraveShared", bundle: .module,
         value: "Keep private browsing tabs open when you close the app, ensuring private browsing sessions continue seamlessly.",
         comment: "")
   }

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -731,7 +731,7 @@ extension Strings {
       comment: "The subtitle of the last step of creating a new wallet."
     )
     public static let onboardingCompletedButtonTitle = NSLocalizedString(
-      "wallet.onbordingCompletedTitle",
+      "wallet.onboardingCompletedButtonTitle",
       tableName: "BraveWallet",
       bundle: .module,
       value: "Go to my portfolio",
@@ -1067,7 +1067,7 @@ extension Strings {
       comment: "The title shown when a user is asked if they would like to setup biometric unlock. `%@` will be replaced with the biometric type name of the current device."
     )
     public static let biometricsSetupSubTitle = NSLocalizedString(
-      "wallet.biometricsSetupTitle",
+      "wallet.biometricsSetupSubTitle",
       tableName: "BraveWallet",
       bundle: .module,
       value: "Would you like to use %@ to unlock Brave Wallet?",


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
