### PR TITLE
Fix #7860: Default Browser Prompt NTP - Logic Change

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController.swift
@@ -3162,6 +3162,9 @@ extension BrowserViewController {
   }
 
   public func handleNavigationPath(path: NavigationPath) {
+    // Remove Default Browser Callout if an external url is triggered
+    Preferences.General.defaultBrowserCalloutDismissed.value = true
+    
     executeAfterSetup {
       NavigationPath.handle(nav: path, with: self)
     }

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Callout.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Callout.swift
@@ -268,7 +268,7 @@ extension BrowserViewController {
       return false
     }
 
-    if presentedViewController != nil || !FullScreenCalloutManager.shouldShowDefaultBrowserCallout(calloutType: calloutType) {
+    if presentedViewController != nil || !FullScreenCalloutManager.shouldShowCallout(calloutType: calloutType) {
       return false
     }
     

--- a/Sources/Brave/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
+++ b/Sources/Brave/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
@@ -201,6 +201,10 @@ class NewTabPageViewController: UIViewController {
 
     // This is a one-off view, adding it to the NTP only if necessary.
     if NTPDefaultBrowserCalloutProvider.shouldShowCallout {
+      // Never show Default Browser Notification over an NPT SI
+      if let ntpBackground = background.currentBackground, case .sponsoredImage = ntpBackground {
+        return
+      }
       sections.insert(NTPDefaultBrowserCalloutProvider(), at: 0)
     }
 

--- a/Sources/Onboarding/ProductNotifications/FullScreenCalloutManager.swift
+++ b/Sources/Onboarding/ProductNotifications/FullScreenCalloutManager.swift
@@ -61,7 +61,7 @@ public enum FullScreenCalloutType: CaseIterable {
 public struct FullScreenCalloutManager {
   /// It determines whether we should show show the designated callout or not and sets corresponding preferences accordingly.
   /// Returns true if the callout should be shown.
-  public static func shouldShowDefaultBrowserCallout(calloutType: FullScreenCalloutType) -> Bool {
+  public static func shouldShowCallout(calloutType: FullScreenCalloutType) -> Bool {
     guard Preferences.Onboarding.isNewRetentionUser.value == true,
       let appRetentionLaunchDate = Preferences.DAU.appRetentionLaunchDate.value,
       !calloutType.preferenceValue.value


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7860

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

Check If Default Browser Prompt logic supports the changes

- Don't show if one external url is opened(via mail app, notes, other apps...)
- Don't show for 7 days after install
- Never show over an NPT SI
- Stop showing it after 14 days since install

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
