### PR TITLE
Fix #7873: Skip old reddit redirect when loading new reddit media page

### DIFF
--- a/Tests/ClientTests/Web Filters/WebsiteRedirectsTests.swift
+++ b/Tests/ClientTests/Web Filters/WebsiteRedirectsTests.swift
@@ -74,6 +74,11 @@ class WebsiteRedirectsTests: XCTestCase {
     
     XCTAssertEqual(WebsiteRedirects.redirect(
       for: try url("https://www.reddit.com/r/brave")), try url("https://old.reddit.com/r/brave"))
+    
+    // Skip media redirect
+    
+    XCTAssertNil(WebsiteRedirects.redirect(
+      for: try url("https://reddit.com/media?url=https%3A%2F%2Fi.redd.it%2Fimageid.jpg")))
   }
   
   func testNpr() throws {


### PR DESCRIPTION
`i.redd.it/{id}` now redirects to a new media viewer page instead of viewing the content directly, and that media page is located at `reddit.com/media?url={iredditurl}`. If we attempt to redirect this URL to `old.reddit.com`, it will be treated as a post lookup instead of the media viewer, and end up on a random /r/funny post from years ago

## Summary of Changes

This pull request fixes #7873

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
