### PR TITLE
Fix #7901: Remove `ZIPFoundation` dep and fix rewards internals sharing

### DIFF
--- a/App/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -168,15 +168,6 @@
         "revision" : "16e6409ee82e1b81390bdffbf217b9c08ab32784",
         "version" : "0.5.0"
       }
-    },
-    {
-      "identity" : "zipfoundation",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/weichsel/ZIPFoundation",
-      "state" : {
-        "revision" : "f6a22e7da26314b38bf9befce34ae8e4b2543090",
-        "version" : "0.9.15"
-      }
     }
   ],
   "version" : 2

--- a/Package.swift
+++ b/Package.swift
@@ -44,7 +44,6 @@ var package = Package(
     .plugin(name: "LeoAssetsPlugin", targets: ["LeoAssetsPlugin"])
   ],
   dependencies: [
-    .package(url: "https://github.com/weichsel/ZIPFoundation", from: "0.9.15"),
     .package(url: "https://github.com/SnapKit/SnapKit", from: "5.0.1"),
     .package(url: "https://github.com/cezheng/Fuzi", from: "3.1.3"),
     .package(url: "https://github.com/SwiftyJSON/SwiftyJSON", from: "5.0.0"),
@@ -355,7 +354,6 @@ var braveTarget: PackageDescription.Target = .target(
     "Fuzi",
     "SnapKit",
     "Static",
-    "ZIPFoundation",
     "SDWebImage",
     "Then",
     "SwiftKeychainWrapper",

--- a/Sources/Brave/Assets/About/Licenses.html
+++ b/Sources/Brave/Assets/About/Licenses.html
@@ -844,38 +844,6 @@ limitations under the License.</p>
 <p class="center">-</p>
 
 <div>
-<input id="ac-ZIPFoundation" name="accordion-1" type="checkbox" />
-<label for="ac-ZIPFoundation"><h2>ZIP Foundation</h2></label>
-<article>
-<p class="link"><a href="https://github.com/weichsel/ZIPFoundation">github.com/weichsel/ZIPFoundation</a></p>
-<div class="text">
-<p>MIT License</p>
-
-<p>Copyright (c) 2017-2020 Thomas Zoechling (https://www.peakstep.com)</p>
-
-<p>Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:</p>
-
-<p>The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.</p>
-
-<p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.</p>
-</div>
-</article>
-</div>
-<p class="center">-</p>
-
-<div>
     <input id="ac-FeedKit" name="accordion-1" type="checkbox" />
     <label for="ac-FeedKit"><h2>ZIP Foundation</h2></label>
     <article>

--- a/Sources/Brave/Frontend/Settings/Debug/Rewards Internals/RewardsInternalsViewController.swift
+++ b/Sources/Brave/Frontend/Settings/Debug/Rewards Internals/RewardsInternalsViewController.swift
@@ -108,34 +108,32 @@ class RewardsInternalsViewController: TableViewController {
 struct RewardsInternalsBasicInfoGenerator: RewardsInternalsFileGenerator {
   func generateFiles(at path: String, using builder: RewardsInternalsSharableBuilder, completion: @escaping (Error?) -> Void) {
     // Only 1 file to make here
-    var internals: BraveCore.BraveRewards.RewardsInternalsInfo?
-    builder.ledger.rewardsInternalInfo { info in
-      internals = info
-    }
-    guard let info = internals else {
-      completion(RewardsInternalsSharableError.rewardsInternalsUnavailable)
-      return
-    }
-
-    let data: [String: Any] = [
-      "Rewards Profile Info": [
-        "Key Info Seed": "\(info.isKeyInfoSeedValid ? "Valid" : "Invalid")",
-        "Rewards Payment ID": info.paymentId,
-        "Rewards Profile Creation Date": builder.dateFormatter.string(from: Date(timeIntervalSince1970: TimeInterval(info.bootStamp))),
-      ],
-      "Device Info": [
-        "DeviceCheck Status": DCDevice.current.isSupported ? "Supported" : "Not supported",
-        "DeviceCheck Enrollment State": DeviceCheckClient.isDeviceEnrolled() ? "Enrolled" : "Not enrolled",
-        "OS": "\(UIDevice.current.systemName) \(UIDevice.current.systemVersion)",
-        "Model": UIDevice.current.model,
-      ],
-    ]
-
-    do {
-      try builder.writeJSON(from: data, named: "basic", at: path)
-      completion(nil)
-    } catch {
-      completion(error)
+    builder.ledger.rewardsInternalInfo { internals in
+      guard let info = internals else {
+        completion(RewardsInternalsSharableError.rewardsInternalsUnavailable)
+        return
+      }
+      
+      let data: [String: Any] = [
+        "Rewards Profile Info": [
+          "Key Info Seed": "\(info.isKeyInfoSeedValid ? "Valid" : "Invalid")",
+          "Rewards Payment ID": info.paymentId,
+          "Rewards Profile Creation Date": builder.dateFormatter.string(from: Date(timeIntervalSince1970: TimeInterval(info.bootStamp))),
+        ],
+        "Device Info": [
+          "DeviceCheck Status": DCDevice.current.isSupported ? "Supported" : "Not supported",
+          "DeviceCheck Enrollment State": DeviceCheckClient.isDeviceEnrolled() ? "Enrolled" : "Not enrolled",
+          "OS": "\(UIDevice.current.systemName) \(UIDevice.current.systemVersion)",
+          "Model": UIDevice.current.model,
+        ],
+      ]
+      
+      do {
+        try builder.writeJSON(from: data, named: "basic", at: path)
+        completion(nil)
+      } catch {
+        completion(error)
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #7901

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

- Visit Rewards Internals and tap the share button. It should still share a zip file with a JSON file inside of it

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
