### PR TITLE
Fix #5357: Add back scale aspect fit to Favicons

### DIFF
--- a/Sources/Brave/Frontend/Browser/Tabs/TabTray/Views/TabTrayCell.swift
+++ b/Sources/Brave/Frontend/Browser/Tabs/TabTray/Views/TabTrayCell.swift
@@ -30,7 +30,9 @@ class TabCell: UICollectionViewCell {
     endPoint: CGPoint(x: 0, y: 1)
   )
   let titleLabel: UILabel
-  let favicon: UIImageView = UIImageView()
+  let favicon: UIImageView = UIImageView().then {
+    $0.contentMode = .scaleAspectFit
+  }
   let closeButton: UIButton
 
   var animator: SwipeAnimator!


### PR DESCRIPTION
## Summary of Changes
- Not sure if this was reverted or broke during a rebase somewhere, but adding `contentMode = .scaleAspectFit` so favicons don't stretch weirdly

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #5357

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes


## Screenshots:
<img width="277" alt="image" src="https://github.com/brave/brave-ios/assets/1530031/7f6d18f8-2ffb-4cea-be62-5b0b14f2c5da">



## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
