### PR TITLE
Fix #7907: Crash when downloading images in Wallet with invalid URL

### DIFF
--- a/Sources/BraveWallet/Extensions/WebImageDownloaderExtensions.swift
+++ b/Sources/BraveWallet/Extensions/WebImageDownloaderExtensions.swift
@@ -8,6 +8,7 @@ import BraveUI
 
 extension BraveCore.WebImageDownloader: WebImageDownloaderType {
   @MainActor public func downloadImage(url: URL) async -> UIImage? {
+    guard url.isWebPage() else { return nil }
     return await withCheckedContinuation { continuation in
       downloadImage(url) { image, _, _ in
         continuation.resume(returning: image)


### PR DESCRIPTION
## Summary of Changes
- Validate image url is a web page url before passing to `WebImageDownloader` from core. Resolves crashes on iOS until https://github.com/brave/brave-browser/issues/32419 is resolved.

This pull request fixes #7907

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Open Swap and change network to Polygon
2. Verify no crash when AAVE token is displayed (should be default `to` token)
3. Open Portfolio and tap Edit User Assets button
4. Optional: change network filters to only have Polygon selected
5. Scroll to bottom of the list
6. Verify no crash when AAVE token is displayed/used


## Screenshots:

https://github.com/brave/brave-ios/assets/5314553/5c499762-0ab6-4e28-a0e4-4002ab6451a1


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
