### PR TITLE
Fix #7809: Filecoin basic support on iOS

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
@@ -604,7 +604,7 @@ extension Tab: BraveWalletKeyringServiceObserver {
       // check domain already has some permitted accounts for this Tab's URLOrigin
       let permissionRequestManager = WalletProviderPermissionRequestsManager.shared
       let allAccounts = await keyringService.allAccounts().accounts
-      for coin in WalletConstants.supportedCoinTypesForDapps {
+      for coin in WalletConstants.supportedCoinTypes.coins(.dapps) {
         let allAccountsForCoin = allAccounts.filter { $0.coin == coin }
         if permissionRequestManager.hasPendingRequest(for: origin, coinType: coin) {
           let pendingRequests = permissionRequestManager.pendingRequests(for: origin, coinType: coin)

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
@@ -604,7 +604,7 @@ extension Tab: BraveWalletKeyringServiceObserver {
       // check domain already has some permitted accounts for this Tab's URLOrigin
       let permissionRequestManager = WalletProviderPermissionRequestsManager.shared
       let allAccounts = await keyringService.allAccounts().accounts
-      for coin in WalletConstants.supportedCoinTypes {
+      for coin in WalletConstants.supportedCoinTypesForDapps {
         let allAccountsForCoin = allAccounts.filter { $0.coin == coin }
         if permissionRequestManager.hasPendingRequest(for: origin, coinType: coin) {
           let pendingRequests = permissionRequestManager.pendingRequests(for: origin, coinType: coin)

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
@@ -604,7 +604,7 @@ extension Tab: BraveWalletKeyringServiceObserver {
       // check domain already has some permitted accounts for this Tab's URLOrigin
       let permissionRequestManager = WalletProviderPermissionRequestsManager.shared
       let allAccounts = await keyringService.allAccounts().accounts
-      for coin in WalletConstants.supportedCoinTypes.coins(.dapps) {
+      for coin in WalletConstants.supportedCoinTypes(.dapps) {
         let allAccountsForCoin = allAccounts.filter { $0.coin == coin }
         if permissionRequestManager.hasPendingRequest(for: origin, coinType: coin) {
           let pendingRequests = permissionRequestManager.pendingRequests(for: origin, coinType: coin)

--- a/Sources/BraveWallet/Crypto/Accounts/AccountSelectionView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/AccountSelectionView.swift
@@ -11,6 +11,7 @@ import BraveUI
 /// Displays all accounts and will update the selected account to the account tapped on.
 struct AccountSelectionView: View {
   @ObservedObject var keyringStore: KeyringStore
+  var networkStore: NetworkStore
   let onDismiss: () -> Void
   
   @State private var isPresentingAddAccount: Bool = false
@@ -47,7 +48,10 @@ struct AccountSelectionView: View {
     }
     .sheet(isPresented: $isPresentingAddAccount) {
       NavigationView {
-        AddAccountView(keyringStore: keyringStore)
+        AddAccountView(
+          keyringStore: keyringStore,
+          networkStore: networkStore
+        )
       }
       .navigationViewStyle(.stack)
     }
@@ -60,10 +64,11 @@ struct AccountSelectionView_Previews: PreviewProvider {
     AccountSelectionView(
       keyringStore: {
         let store = KeyringStore.previewStoreWithWalletCreated
-        store.addPrimaryAccount("Account 2", coin: .eth, completion: nil)
-        store.addPrimaryAccount("Account 3", coin: .eth, completion: nil)
+        store.addPrimaryAccount("Account 2", coin: .eth, chainId: BraveWallet.MainnetChainId, completion: nil)
+        store.addPrimaryAccount("Account 3", coin: .eth, chainId: BraveWallet.MainnetChainId, completion: nil)
         return store
       }(),
+      networkStore: .previewStore,
       onDismiss: {}
     )
   }

--- a/Sources/BraveWallet/Crypto/Accounts/AccountTransactionListView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/AccountTransactionListView.swift
@@ -43,10 +43,17 @@ struct AccountTransactionListView: View {
               .contextMenu {
                 if !txSummary.txHash.isEmpty {
                   Button(action: {
-                    if let txNetwork = self.networkStore.allChains.first(where: { $0.chainId == txSummary.txInfo.chainId }),
-                       let baseURL = txNetwork.blockExplorerUrls.first.map(URL.init(string:)),
-                       let url = baseURL?.appendingPathComponent("tx/\(txSummary.txHash)") {
-                      openWalletURL(url)
+                    if let txNetwork = self.networkStore.allChains.first(where: { $0.chainId == txSummary.txInfo.chainId }) {
+                      if txNetwork.coin != .fil,
+                         let baseURL = txNetwork.blockExplorerUrls.first.map(URL.init(string:)),
+                         let url = baseURL?.appendingPathComponent("tx/\(txSummary.txHash)") {
+                        openWalletURL(url)
+                      } else if var urlComps = txNetwork.blockExplorerUrls.first.map(URLComponents.init(string:)) {
+                        urlComps?.queryItems = [URLQueryItem(name: "cid", value: txSummary.txHash)]
+                        if let url = urlComps?.url {
+                          openWalletURL(url)
+                        }
+                      }
                     }
                   }) {
                     Label(Strings.Wallet.viewOnBlockExplorer, systemImage: "arrow.up.forward.square")

--- a/Sources/BraveWallet/Crypto/Accounts/AccountTransactionListView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/AccountTransactionListView.swift
@@ -43,17 +43,9 @@ struct AccountTransactionListView: View {
               .contextMenu {
                 if !txSummary.txHash.isEmpty {
                   Button(action: {
-                    if let txNetwork = self.networkStore.allChains.first(where: { $0.chainId == txSummary.txInfo.chainId }) {
-                      if txNetwork.coin != .fil,
-                         let baseURL = txNetwork.blockExplorerUrls.first.map(URL.init(string:)),
-                         let url = baseURL?.appendingPathComponent("tx/\(txSummary.txHash)") {
-                        openWalletURL(url)
-                      } else if var urlComps = txNetwork.blockExplorerUrls.first.map(URLComponents.init(string:)) {
-                        urlComps?.queryItems = [URLQueryItem(name: "cid", value: txSummary.txHash)]
-                        if let url = urlComps?.url {
-                          openWalletURL(url)
-                        }
-                      }
+                    if let txNetwork = self.networkStore.allChains.first(where: { $0.chainId == txSummary.txInfo.chainId }),
+                       let url = txNetwork.txBlockExplorerLink(txHash: txSummary.txHash, for: txNetwork.coin) {
+                      openWalletURL(url)
                     }
                   }) {
                     Label(Strings.Wallet.viewOnBlockExplorer, systemImage: "arrow.up.forward.square")

--- a/Sources/BraveWallet/Crypto/Accounts/AccountsHeaderView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/AccountsHeaderView.swift
@@ -53,7 +53,10 @@ struct AccountsHeaderView: View {
           Color.clear
             .sheet(isPresented: $isPresentingAddAccount) {
               NavigationView {
-                AddAccountView(keyringStore: keyringStore)
+                AddAccountView(
+                  keyringStore: keyringStore,
+                  networkStore: networkStore
+                )
               }
               .navigationViewStyle(StackNavigationViewStyle())
             }

--- a/Sources/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
@@ -121,10 +121,17 @@ struct AccountActivityView: View {
               .contextMenu {
                 if !txSummary.txHash.isEmpty {
                   Button(action: {
-                    if let txNetwork = self.networkStore.allChains.first(where: { $0.chainId == txSummary.txInfo.chainId }),
-                       let baseURL = txNetwork.blockExplorerUrls.first.map(URL.init(string:)),
-                       let url = baseURL?.appendingPathComponent("tx/\(txSummary.txHash)") {
-                      openWalletURL(url)
+                    if let txNetwork = self.networkStore.allChains.first(where: { $0.chainId == txSummary.txInfo.chainId }) {
+                      if txNetwork.coin != .fil,
+                         let baseURL = txNetwork.blockExplorerUrls.first.map(URL.init(string:)),
+                         let url = baseURL?.appendingPathComponent("tx/\(txSummary.txHash)") {
+                        openWalletURL(url)
+                      } else if var urlComps = txNetwork.blockExplorerUrls.first.map(URLComponents.init(string:)) {
+                        urlComps?.queryItems = [URLQueryItem(name: "cid", value: txSummary.txHash)]
+                        if let url = urlComps?.url {
+                          openWalletURL(url)
+                        }
+                      }
                     }
                   }) {
                     Label(Strings.Wallet.viewOnBlockExplorer, systemImage: "arrow.up.forward.square")

--- a/Sources/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
@@ -121,17 +121,9 @@ struct AccountActivityView: View {
               .contextMenu {
                 if !txSummary.txHash.isEmpty {
                   Button(action: {
-                    if let txNetwork = self.networkStore.allChains.first(where: { $0.chainId == txSummary.txInfo.chainId }) {
-                      if txNetwork.coin != .fil,
-                         let baseURL = txNetwork.blockExplorerUrls.first.map(URL.init(string:)),
-                         let url = baseURL?.appendingPathComponent("tx/\(txSummary.txHash)") {
-                        openWalletURL(url)
-                      } else if var urlComps = txNetwork.blockExplorerUrls.first.map(URLComponents.init(string:)) {
-                        urlComps?.queryItems = [URLQueryItem(name: "cid", value: txSummary.txHash)]
-                        if let url = urlComps?.url {
-                          openWalletURL(url)
-                        }
-                      }
+                    if let txNetwork = self.networkStore.allChains.first(where: { $0.chainId == txSummary.txInfo.chainId }),
+                       let url = txNetwork.txBlockExplorerLink(txHash: txSummary.txHash, for: txNetwork.coin) {
+                      openWalletURL(url)
                     }
                   }) {
                     Label(Strings.Wallet.viewOnBlockExplorer, systemImage: "arrow.up.forward.square")

--- a/Sources/BraveWallet/Crypto/Accounts/Add/AddAccountView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/Add/AddAccountView.swift
@@ -91,7 +91,7 @@ struct AddAccountView: View {
   }
   
   private var showCoinSelection: Bool {
-    preSelectedCoin == nil && WalletConstants.supportedCoinTypes.count > 1
+    preSelectedCoin == nil && WalletConstants.supportedCoinTypes.coins().count > 1
   }
   
   private var navigationTitle: String {
@@ -103,7 +103,7 @@ struct AddAccountView: View {
   
   @ViewBuilder private var addAccountView: some View {
     List {
-      if selectedCoin == .fil && !allFilNetworks.isEmpty {
+      if (selectedCoin == .fil || preSelectedCoin == .fil) && !allFilNetworks.isEmpty {
         Picker(selection: $filNetwork) {
           ForEach(allFilNetworks) { network in
             Text(network.chainName)
@@ -111,9 +111,10 @@ struct AddAccountView: View {
               .tag(network)
           }
         } label: {
-          Text("Network")
+          Text(Strings.Wallet.transactionDetailsNetworkTitle)
             .foregroundColor(Color(.braveLabel))
         }
+        .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
       accountNameSection
       if isJSONImported {
@@ -151,7 +152,7 @@ struct AddAccountView: View {
           title: Text(Strings.Wallet.coinTypeSelectionHeader)
         )
       ) {
-        ForEach(Array(WalletConstants.supportedCoinTypes)) { coin in
+        ForEach(WalletConstants.supportedCoinTypes.coins().elements) { coin in
           NavigationLink(
             tag: coin,
             selection: $selectedCoin) {

--- a/Sources/BraveWallet/Crypto/Accounts/Add/AddAccountView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/Add/AddAccountView.swift
@@ -91,7 +91,7 @@ struct AddAccountView: View {
   }
   
   private var showCoinSelection: Bool {
-    preSelectedCoin == nil && WalletConstants.supportedCoinTypes.coins().count > 1
+    preSelectedCoin == nil && WalletConstants.supportedCoinTypes().count > 1
   }
   
   private var navigationTitle: String {
@@ -152,7 +152,7 @@ struct AddAccountView: View {
           title: Text(Strings.Wallet.coinTypeSelectionHeader)
         )
       ) {
-        ForEach(WalletConstants.supportedCoinTypes.coins().elements) { coin in
+        ForEach(WalletConstants.supportedCoinTypes().elements) { coin in
           NavigationLink(
             tag: coin,
             selection: $selectedCoin) {

--- a/Sources/BraveWallet/Crypto/Accounts/Details/AccountDetailsView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/Details/AccountDetailsView.swift
@@ -181,7 +181,7 @@ private struct AccountDetailsHeaderView: View {
 }
 
 #if DEBUG
-struct AccountDetailsViewController_Previews: PreviewProvider {
+struct AccountDetailsView_Previews: PreviewProvider {
   static var previews: some View {
     AccountDetailsView(
       keyringStore: .previewStoreWithWalletCreated,

--- a/Sources/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
+++ b/Sources/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
@@ -103,10 +103,17 @@ struct AssetDetailView: View {
             .contextMenu {
               if !txSummary.txHash.isEmpty {
                 Button(action: {
-                  if let txNetwork = self.networkStore.allChains.first(where: { $0.chainId == txSummary.txInfo.chainId }),
-                     let baseURL = txNetwork.blockExplorerUrls.first.map(URL.init(string:)),
-                     let url = baseURL?.appendingPathComponent("tx/\(txSummary.txHash)") {
-                    openWalletURL(url)
+                  if let txNetwork = self.networkStore.allChains.first(where: { $0.chainId == txSummary.txInfo.chainId }) {
+                    if txNetwork.coin != .fil,
+                       let baseURL = txNetwork.blockExplorerUrls.first.map(URL.init(string:)),
+                       let url = baseURL?.appendingPathComponent("tx/\(txSummary.txHash)") {
+                      openWalletURL(url)
+                    } else if var urlComps = txNetwork.blockExplorerUrls.first.map(URLComponents.init(string:)) {
+                      urlComps?.queryItems = [URLQueryItem(name: "cid", value: txSummary.txHash)]
+                      if let url = urlComps?.url {
+                        openWalletURL(url)
+                      }
+                    }
                   }
                 }) {
                   Label(Strings.Wallet.viewOnBlockExplorer, systemImage: "arrow.up.forward.square")

--- a/Sources/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
+++ b/Sources/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
@@ -211,7 +211,10 @@ struct AssetDetailView: View {
       Color.clear
         .sheet(isPresented: $isShowingAddAccount) {
           NavigationView {
-            AddAccountView(keyringStore: keyringStore)
+            AddAccountView(
+              keyringStore: keyringStore,
+              networkStore: networkStore
+            )
           }
           .navigationViewStyle(StackNavigationViewStyle())
         }

--- a/Sources/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
+++ b/Sources/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
@@ -103,17 +103,9 @@ struct AssetDetailView: View {
             .contextMenu {
               if !txSummary.txHash.isEmpty {
                 Button(action: {
-                  if let txNetwork = self.networkStore.allChains.first(where: { $0.chainId == txSummary.txInfo.chainId }) {
-                    if txNetwork.coin != .fil,
-                       let baseURL = txNetwork.blockExplorerUrls.first.map(URL.init(string:)),
-                       let url = baseURL?.appendingPathComponent("tx/\(txSummary.txHash)") {
-                      openWalletURL(url)
-                    } else if var urlComps = txNetwork.blockExplorerUrls.first.map(URLComponents.init(string:)) {
-                      urlComps?.queryItems = [URLQueryItem(name: "cid", value: txSummary.txHash)]
-                      if let url = urlComps?.url {
-                        openWalletURL(url)
-                      }
-                    }
+                  if let txNetwork = self.networkStore.allChains.first(where: { $0.chainId == txSummary.txInfo.chainId }),
+                     let url = txNetwork.txBlockExplorerLink(txHash: txSummary.txHash, for: txNetwork.coin) {
+                    openWalletURL(url)
                   }
                 }) {
                   Label(Strings.Wallet.viewOnBlockExplorer, systemImage: "arrow.up.forward.square")

--- a/Sources/BraveWallet/Crypto/BuySendSwap/AccountPicker.swift
+++ b/Sources/BraveWallet/Crypto/BuySendSwap/AccountPicker.swift
@@ -35,6 +35,7 @@ struct AccountPicker: View {
       NavigationView {
         AccountSelectionView(
           keyringStore: keyringStore,
+          networkStore: networkStore,
           onDismiss: { isPresentingPicker = false }
         )
       }

--- a/Sources/BraveWallet/Crypto/CryptoView.swift
+++ b/Sources/BraveWallet/Crypto/CryptoView.swift
@@ -120,6 +120,7 @@ public struct CryptoView: View {
               NavigationView {
                 AccountSelectionView(
                   keyringStore: keyringStore,
+                  networkStore: store.networkStore,
                   onDismiss: {
                     dismissAction()
                   }
@@ -212,6 +213,7 @@ public struct CryptoView: View {
               NavigationView {
                 AddAccountView(
                   keyringStore: keyringStore,
+                  networkStore: store.networkStore,
                   preSelectedCoin: request.coinType,
                   onCreate: {
                     // request is fullfilled.

--- a/Sources/BraveWallet/Crypto/NetworkSelectionView.swift
+++ b/Sources/BraveWallet/Crypto/NetworkSelectionView.swift
@@ -76,7 +76,11 @@ struct NetworkSelectionView: View {
           isPresented: $store.isPresentingAddAccount
         ) {
           NavigationView {
-            AddAccountView(keyringStore: keyringStore, preSelectedCoin: store.nextNetwork?.coin)
+            AddAccountView(
+              keyringStore: keyringStore,
+              networkStore: networkStore,
+              preSelectedCoin: store.nextNetwork?.coin
+            )
           }
           .navigationViewStyle(.stack)
           .onDisappear {

--- a/Sources/BraveWallet/Crypto/Stores/AccountActivityStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/AccountActivityStore.swift
@@ -78,8 +78,16 @@ class AccountActivityStore: ObservableObject {
       let coin = account.coin
       let networksForAccountCoin = await rpcService.allNetworks(coin)
         .filter { $0.chainId != BraveWallet.LocalhostChainId } // localhost not supported
+      let networksForAccount = networksForAccountCoin.filter { // .fil coin type has two different keyring ids
+        $0.supportedKeyrings.contains(account.keyringId.rawValue as NSNumber)
+      }
       
-      let allVisibleUserAssets = assetManager.getAllVisibleAssetsInNetworkAssets(networks: networksForAccountCoin)
+      struct NetworkAssets: Equatable {
+        let network: BraveWallet.NetworkInfo
+        let tokens: [BraveWallet.BlockchainToken]
+        let sortOrder: Int
+      }
+      let allVisibleUserAssets = assetManager.getAllVisibleAssetsInNetworkAssets(networks: networksForAccount)
       let allTokens = await blockchainRegistry.allTokens(in: networksForAccountCoin).flatMap(\.tokens)
       var updatedUserVisibleAssets: [AssetViewModel] = []
       var updatedUserVisibleNFTs: [NFTAssetViewModel] = []

--- a/Sources/BraveWallet/Crypto/Stores/AccountActivityStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/AccountActivityStore.swift
@@ -110,7 +110,7 @@ class AccountActivityStore: ObservableObject {
       self.userVisibleAssets = updatedUserVisibleAssets
       self.userVisibleNFTs = updatedUserVisibleNFTs
       
-      let keyringForAccount = await keyringService.keyringInfo(coin.keyringId)
+      let keyringForAccount = await keyringService.keyringInfo(account.keyringId)
       typealias TokenNetworkAccounts = (token: BraveWallet.BlockchainToken, network: BraveWallet.NetworkInfo, accounts: [BraveWallet.AccountInfo])
       let allTokenNetworkAccounts = allVisibleUserAssets.flatMap { networkAssets in
         networkAssets.tokens.map { token in

--- a/Sources/BraveWallet/Crypto/Stores/Address.swift
+++ b/Sources/BraveWallet/Crypto/Stores/Address.swift
@@ -4,6 +4,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import Foundation
+import BraveCore
 
 extension String {
   /// Truncates an address to only show the first 4 digits and last 4 digits
@@ -41,6 +42,16 @@ extension String {
     let hex = removingHexPrefix
     // Check the length and the rest of the char is a hex digit
     return hex.count == 40 && hex.allSatisfy(\.isHexDigit)
+  }
+  
+  /// Check if the string is a valid FIL address
+  var isFILAddress: Bool {
+    if starts(with: BraveWallet.FilecoinMainnet) || starts(with: BraveWallet.FilecoinTestnet) {// FIL address has to start with `f` or `t`
+      if count == 41 || count == 86 || count == 44 { // secp256k have 41 address length and BLS keys have 86 and FEVM f410 keys have 44
+        return true
+      }
+    }
+    return false
   }
   
   /// Strip prefix if it exists, ex. 'ethereum:'

--- a/Sources/BraveWallet/Crypto/Stores/AssetDetailStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/AssetDetailStore.swift
@@ -158,7 +158,8 @@ class AssetDetailStore: ObservableObject {
         self.isSwapSupported = await swapService.isSwapSupported(token.chainId)
         
         // fetch accounts
-        let keyring = await keyringService.keyringInfo(token.coin.keyringId)
+        let keyringId = BraveWallet.KeyringId.keyringId(for: token.coin, token.chainId)
+        let keyring = await keyringService.keyringInfo(keyringId)
         var updatedAccounts = keyring.accountInfos.map {
           AccountAssetViewModel(account: $0, decimalBalance: 0.0, balance: "", fiatBalance: "")
         }

--- a/Sources/BraveWallet/Crypto/Stores/AssetDetailStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/AssetDetailStore.swift
@@ -158,7 +158,7 @@ class AssetDetailStore: ObservableObject {
         self.isSwapSupported = await swapService.isSwapSupported(token.chainId)
         
         // fetch accounts
-        let keyringId = BraveWallet.KeyringId.keyringId(for: token.coin, token.chainId)
+        let keyringId = BraveWallet.KeyringId.keyringId(for: token.coin, on: token.chainId)
         let keyring = await keyringService.keyringInfo(keyringId)
         var updatedAccounts = keyring.accountInfos.map {
           AccountAssetViewModel(account: $0, decimalBalance: 0.0, balance: "", fiatBalance: "")

--- a/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -561,7 +561,7 @@ extension CryptoStore: BraveWalletKeyringServiceObserver {
   }
   public func keyringCreated(_ keyringId: BraveWallet.KeyringId) {
     Task { @MainActor [weak self] in
-      if let newCoin = WalletConstants.supportedCoinTypes.first(where: { $0.keyringId == keyringId }) {
+      if let newCoin = WalletConstants.supportedCoinTypes.first(where: { $0.keyringIds.contains(keyringId) }) {
         self?.userAssetManager.migrateUserAssets(for: newCoin, completion: {
           self?.updateAssets()
         })

--- a/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -410,9 +410,9 @@ public class CryptoStore: ObservableObject {
 
   @MainActor
   func fetchPendingTransactions() async -> [BraveWallet.TransactionInfo] {
-    let allKeyrings = await keyringService.keyrings(for: WalletConstants.supportedCoinTypes)
+    let allKeyrings = await keyringService.keyrings(for: WalletConstants.supportedCoinTypes.coins())
     var allNetworksForCoin: [BraveWallet.CoinType: [BraveWallet.NetworkInfo]] = [:]
-    for coin in WalletConstants.supportedCoinTypes {
+    for coin in WalletConstants.supportedCoinTypes.coins() {
       let allNetworks = await rpcService.allNetworks(coin)
       allNetworksForCoin[coin] = allNetworks
     }

--- a/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -560,13 +560,11 @@ extension CryptoStore: BraveWalletKeyringServiceObserver {
     rejectAllPendingWebpageRequests()
   }
   public func keyringCreated(_ keyringId: BraveWallet.KeyringId) {
-    Task { @MainActor [weak self] in
-      if let newCoin = WalletConstants.supportedCoinTypes.first(where: { $0.keyringIds.contains(keyringId) }) {
-        self?.userAssetManager.migrateUserAssets(for: newCoin, completion: {
-          self?.updateAssets()
-        })
-      }
-    }
+    // 1. We don't need to rely on this observer method to migrate user visible assets
+    // when user creates a new wallet, since in this case `CryptoStore` has not yet been initialized
+    // 2. We don't need to rely on this observer method to migrate user visible assets
+    // when user creates or imports a new account with a new keyring since any new
+    // supported coin type / keyring will be migrated inside `CryptoStore`'s init()
   }
   public func keyringRestored(_ keyringId: BraveWallet.KeyringId) {
     // This observer method will only get called when user restore a wallet

--- a/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -411,12 +411,12 @@ public class CryptoStore: ObservableObject {
   @MainActor
   func fetchPendingTransactions() async -> [BraveWallet.TransactionInfo] {
     let allKeyrings = await keyringService.keyrings(for: WalletConstants.supportedCoinTypes)
-    var allChainIdsForCoin: [BraveWallet.CoinType: [String]] = [:]
+    var allNetworksForCoin: [BraveWallet.CoinType: [BraveWallet.NetworkInfo]] = [:]
     for coin in WalletConstants.supportedCoinTypes {
       let allNetworks = await rpcService.allNetworks(coin)
-      allChainIdsForCoin[coin] = allNetworks.map(\.chainId)
+      allNetworksForCoin[coin] = allNetworks
     }
-    return await txService.pendingTransactions(chainIdsForCoin: allChainIdsForCoin, for: allKeyrings)
+    return await txService.pendingTransactions(networksForCoin: allNetworksForCoin, for: allKeyrings)
   }
 
   @MainActor

--- a/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -410,9 +410,9 @@ public class CryptoStore: ObservableObject {
 
   @MainActor
   func fetchPendingTransactions() async -> [BraveWallet.TransactionInfo] {
-    let allKeyrings = await keyringService.keyrings(for: WalletConstants.supportedCoinTypes.coins())
+    let allKeyrings = await keyringService.keyrings(for: WalletConstants.supportedCoinTypes())
     var allNetworksForCoin: [BraveWallet.CoinType: [BraveWallet.NetworkInfo]] = [:]
-    for coin in WalletConstants.supportedCoinTypes.coins() {
+    for coin in WalletConstants.supportedCoinTypes() {
       let allNetworks = await rpcService.allNetworks(coin)
       allNetworksForCoin[coin] = allNetworks
     }

--- a/Sources/BraveWallet/Crypto/Stores/KeyringStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/KeyringStore.swift
@@ -369,10 +369,17 @@ public class KeyringStore: ObservableObject {
     }
   }
 
-  func addPrimaryAccount(_ name: String, coin: BraveWallet.CoinType, completion: ((Bool) -> Void)? = nil) {
+  /// `chainId` is only for .fil or .btc coin type
+  /// correct `BraveWallet.KeyringId` will be returned from `keyringIdForNewAccount`
+  func addPrimaryAccount(
+    _ name: String,
+    coin: BraveWallet.CoinType,
+    chainId: String,
+    completion: ((Bool) -> Void)? = nil
+  ) {
     keyringService.addAccount(
       coin,
-      keyringId: coin.keyringId,
+      keyringId: BraveWallet.KeyringId.keyringId(for: coin, chainId),
       accountName: name
     ) { accountInfo in
       self.updateKeyringInfo()
@@ -380,18 +387,17 @@ public class KeyringStore: ObservableObject {
     }
   }
 
+  /// `chainId` is only for .fil or .btc coin type
   func addSecondaryAccount(
     _ name: String,
     coin: BraveWallet.CoinType,
+    chainId: String,
     privateKey: String,
     completion: ((BraveWallet.AccountInfo?) -> Void)? = nil
   ) {
     if coin == .fil {
-      rpcService.network(.fil, origin: nil) { [self] defaultNetwork in
-        let networkId = defaultNetwork.chainId.caseInsensitiveCompare(BraveWallet.FilecoinMainnet) == .orderedSame ? BraveWallet.FilecoinMainnet : BraveWallet.FilecoinTestnet
-        keyringService.importFilecoinAccount(name, privateKey: privateKey, network: networkId) { accountInfo in
-          completion?(accountInfo)
-        }
+      keyringService.importFilecoinAccount(name, privateKey: privateKey, network: chainId) { accountInfo in
+        completion?(accountInfo)
       }
     } else {
       keyringService.importAccount(name, privateKey: privateKey, coin: coin) { accountInfo in

--- a/Sources/BraveWallet/Crypto/Stores/KeyringStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/KeyringStore.swift
@@ -222,7 +222,7 @@ public class KeyringStore: ObservableObject {
     Task { @MainActor in // fetch all KeyringInfo for all coin types
       let selectedAccount = await keyringService.allAccounts().selectedAccount
       let selectedAccountAddress = selectedAccount?.address
-      let allKeyrings = await keyringService.keyrings(for: WalletConstants.supportedCoinTypes)
+      let allKeyrings = await keyringService.keyrings(for: WalletConstants.supportedCoinTypes.coins())
       if let defaultKeyring = allKeyrings.first(where: { $0.id == BraveWallet.KeyringId.default }) {
         self.defaultKeyring = defaultKeyring
         self.isDefaultKeyringLoaded = true
@@ -356,7 +356,7 @@ public class KeyringStore: ObservableObject {
         self.updateKeyringInfo()
         self.resetKeychainStoredPassword()
       }
-      for coin in WalletConstants.supportedCoinTypes {
+      for coin in WalletConstants.supportedCoinTypes.coins(.dapps) { // only coin types support dapps have permission management 
         Domain.clearAllWalletPermissions(for: coin)
       }
       Preferences.Wallet.sortOrderFilter.reset()
@@ -379,7 +379,7 @@ public class KeyringStore: ObservableObject {
   ) {
     keyringService.addAccount(
       coin,
-      keyringId: BraveWallet.KeyringId.keyringId(for: coin, chainId),
+      keyringId: BraveWallet.KeyringId.keyringId(for: coin, on: chainId),
       accountName: name
     ) { accountInfo in
       self.updateKeyringInfo()

--- a/Sources/BraveWallet/Crypto/Stores/KeyringStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/KeyringStore.swift
@@ -222,7 +222,7 @@ public class KeyringStore: ObservableObject {
     Task { @MainActor in // fetch all KeyringInfo for all coin types
       let selectedAccount = await keyringService.allAccounts().selectedAccount
       let selectedAccountAddress = selectedAccount?.address
-      let allKeyrings = await keyringService.keyrings(for: WalletConstants.supportedCoinTypes.coins())
+      let allKeyrings = await keyringService.keyrings(for: WalletConstants.supportedCoinTypes())
       if let defaultKeyring = allKeyrings.first(where: { $0.id == BraveWallet.KeyringId.default }) {
         self.defaultKeyring = defaultKeyring
         self.isDefaultKeyringLoaded = true
@@ -356,7 +356,7 @@ public class KeyringStore: ObservableObject {
         self.updateKeyringInfo()
         self.resetKeychainStoredPassword()
       }
-      for coin in WalletConstants.supportedCoinTypes.coins(.dapps) { // only coin types support dapps have permission management 
+      for coin in WalletConstants.supportedCoinTypes(.dapps) { // only coin types support dapps have permission management 
         Domain.clearAllWalletPermissions(for: coin)
       }
       Preferences.Wallet.sortOrderFilter.reset()

--- a/Sources/BraveWallet/Crypto/Stores/ManageSiteConnectionsStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/ManageSiteConnectionsStore.swift
@@ -41,7 +41,7 @@ class ManageSiteConnectionsStore: ObservableObject {
   /// Fetch all site connections with 1+ accounts connected
   func fetchSiteConnections() {
     var connections = [SiteConnection]()
-    for coin in WalletConstants.supportedCoinTypes {
+    for coin in WalletConstants.supportedCoinTypes.coins(.dapps) { // only coin types support dapps have site connection screen
       let domains = Domain.allDomainsWithWalletPermissions(for: coin)
       connections.append(contentsOf: domains.map {
         var connectedAddresses = [String]()

--- a/Sources/BraveWallet/Crypto/Stores/ManageSiteConnectionsStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/ManageSiteConnectionsStore.swift
@@ -41,7 +41,7 @@ class ManageSiteConnectionsStore: ObservableObject {
   /// Fetch all site connections with 1+ accounts connected
   func fetchSiteConnections() {
     var connections = [SiteConnection]()
-    for coin in WalletConstants.supportedCoinTypes.coins(.dapps) { // only coin types support dapps have site connection screen
+    for coin in WalletConstants.supportedCoinTypes(.dapps) { // only coin types support dapps have site connection screen
       let domains = Domain.allDomainsWithWalletPermissions(for: coin)
       connections.append(contentsOf: domains.map {
         var connectedAddresses = [String]()

--- a/Sources/BraveWallet/Crypto/Stores/NFTStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/NFTStore.swift
@@ -115,7 +115,7 @@ public class NFTStore: ObservableObject {
     self.updateTask = Task { @MainActor in
       self.allAccounts = await keyringService.allAccounts().accounts
         .filter { account in
-          WalletConstants.supportedCoinTypes.coins().contains(account.coin)
+          WalletConstants.supportedCoinTypes().contains(account.coin)
         }
       self.allNetworks = await rpcService.allNetworksForSupportedCoins()
       let filters = self.filters

--- a/Sources/BraveWallet/Crypto/Stores/NFTStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/NFTStore.swift
@@ -115,7 +115,7 @@ public class NFTStore: ObservableObject {
     self.updateTask = Task { @MainActor in
       self.allAccounts = await keyringService.allAccounts().accounts
         .filter { account in
-          WalletConstants.supportedCoinTypes.contains(account.coin)
+          WalletConstants.supportedCoinTypes.coins().contains(account.coin)
         }
       self.allNetworks = await rpcService.allNetworksForSupportedCoins()
       let filters = self.filters

--- a/Sources/BraveWallet/Crypto/Stores/NetworkStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/NetworkStore.swift
@@ -109,7 +109,7 @@ public class NetworkStore: ObservableObject {
     _ network: BraveWallet.NetworkInfo,
     isForOrigin: Bool
   ) async -> SetSelectedChainError? {
-    let keyringId = network.coin.keyringId
+    let keyringId = BraveWallet.KeyringId.keyringId(for: network.coin, network.chainId)
     let keyringInfo = await keyringService.keyringInfo(keyringId)
     if keyringInfo.accountInfos.isEmpty {
       // Need to prompt user to create new account via alert

--- a/Sources/BraveWallet/Crypto/Stores/NetworkStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/NetworkStore.swift
@@ -109,7 +109,7 @@ public class NetworkStore: ObservableObject {
     _ network: BraveWallet.NetworkInfo,
     isForOrigin: Bool
   ) async -> SetSelectedChainError? {
-    let keyringId = BraveWallet.KeyringId.keyringId(for: network.coin, network.chainId)
+    let keyringId = BraveWallet.KeyringId.keyringId(for: network.coin, on: network.chainId)
     let keyringInfo = await keyringService.keyringInfo(keyringId)
     if keyringInfo.accountInfos.isEmpty {
       // Need to prompt user to create new account via alert

--- a/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
@@ -334,7 +334,7 @@ public class PortfolioStore: ObservableObject {
       self.isLoadingBalances = true
       self.allAccounts = await keyringService.allAccounts().accounts
         .filter { account in
-          WalletConstants.supportedCoinTypes.coins().contains(account.coin)
+          WalletConstants.supportedCoinTypes().contains(account.coin)
         }
       self.allNetworks = await rpcService.allNetworksForSupportedCoins()
       let filters = self.filters

--- a/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
@@ -357,11 +357,7 @@ public class PortfolioStore: ObservableObject {
             network: networkAssets.network,
             accounts: selectedAccounts.filter {
               if token.coin == .fil {
-                if token.chainId == BraveWallet.FilecoinMainnet {
-                  return $0.keyringId == BraveWallet.KeyringId.filecoin
-                } else {
-                  return $0.keyringId == BraveWallet.KeyringId.filecoinTestnet
-                }
+                return $0.keyringId == BraveWallet.KeyringId.keyringId(for: token.coin, on: token.chainId)
               } else {
                 return $0.coin == token.coin
               }

--- a/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
@@ -334,7 +334,7 @@ public class PortfolioStore: ObservableObject {
       self.isLoadingBalances = true
       self.allAccounts = await keyringService.allAccounts().accounts
         .filter { account in
-          WalletConstants.supportedCoinTypes.contains(account.coin)
+          WalletConstants.supportedCoinTypes.coins().contains(account.coin)
         }
       self.allNetworks = await rpcService.allNetworksForSupportedCoins()
       let filters = self.filters

--- a/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
@@ -355,7 +355,17 @@ public class PortfolioStore: ObservableObject {
           TokenNetworkAccounts(
             token: token,
             network: networkAssets.network,
-            accounts: selectedAccounts.filter { $0.coin == token.coin }
+            accounts: selectedAccounts.filter {
+              if token.coin == .fil {
+                if token.chainId == BraveWallet.FilecoinMainnet {
+                  return $0.keyringId == BraveWallet.KeyringId.filecoin
+                } else {
+                  return $0.keyringId == BraveWallet.KeyringId.filecoinTestnet
+                }
+              } else {
+                return $0.coin == token.coin
+              }
+            }
           )
         }
       }
@@ -564,7 +574,7 @@ public class PortfolioStore: ObservableObject {
         })
     case let .account(account):
       return allVisibleUserAssets
-        .filter { $0.network.coin == account.coin }
+        .filter { $0.network.coin == account.coin && $0.network.supportedKeyrings.contains(account.accountId.keyringId.rawValue as NSNumber) }
         .flatMap { networkAssets in
           networkAssets.tokens.map { token in
             AssetViewModel(

--- a/Sources/BraveWallet/Crypto/Stores/SelectAccountTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SelectAccountTokenStore.swift
@@ -157,14 +157,18 @@ class SelectAccountTokenStore: ObservableObject {
     self.accountSections = allKeyrings.flatMap { keyring in
       let tokensForCoin = allVisibleUserAssets.filter { $0.coin == keyring.coin }
       return keyring.accountInfos.map { account in
-        let tokenBalances = tokensForCoin.map { token in
-          AccountSection.TokenBalance(
-            token: token,
-            network: allNetworks.first(where: { $0.chainId == token.chainId }) ?? .init(),
-            balance: cachedBalance(for: token, in: account),
-            price: cachedPrice(for: token, in: account),
-            nftMetadata: cachedMetadata(for: token)
-          )
+        let tokenBalances = tokensForCoin.compactMap { token in
+          let tokenNetwork = allNetworks.first(where: { $0.chainId == token.chainId }) ?? .init()
+          if tokenNetwork.supportedKeyrings.contains(keyring.id.rawValue as NSNumber) {
+            return AccountSection.TokenBalance(
+              token: token,
+              network: allNetworks.first(where: { $0.chainId == token.chainId }) ?? .init(),
+              balance: cachedBalance(for: token, in: account),
+              price: cachedPrice(for: token, in: account),
+              nftMetadata: cachedMetadata(for: token)
+            )
+          }
+          return nil
         }
         return AccountSection(
           account: account,
@@ -306,7 +310,7 @@ class SelectAccountTokenStore: ObservableObject {
 #if DEBUG
 extension SelectAccountTokenStore {
   func setupForTesting() {
-    allNetworks = [.mockMainnet, .mockGoerli, .mockSolana, .mockSolanaTestnet]
+    allNetworks = [.mockMainnet, .mockGoerli, .mockSolana, .mockSolanaTestnet, .mockFilecoinMainnet, .mockFilecoinTestnet]
   }
 }
 #endif

--- a/Sources/BraveWallet/Crypto/Stores/SelectAccountTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SelectAccountTokenStore.swift
@@ -143,7 +143,7 @@ class SelectAccountTokenStore: ObservableObject {
   }
   
   @MainActor func update() async {
-    let allKeyrings = await keyringService.keyrings(for: WalletConstants.supportedCoinTypes)
+    let allKeyrings = await keyringService.keyrings(for: WalletConstants.supportedCoinTypes.coins())
     let allNetworks = await rpcService.allNetworksForSupportedCoins()
     self.allNetworks = allNetworks
     // setup network filters if not currently setup

--- a/Sources/BraveWallet/Crypto/Stores/SelectAccountTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SelectAccountTokenStore.swift
@@ -143,7 +143,7 @@ class SelectAccountTokenStore: ObservableObject {
   }
   
   @MainActor func update() async {
-    let allKeyrings = await keyringService.keyrings(for: WalletConstants.supportedCoinTypes.coins())
+    let allKeyrings = await keyringService.keyrings(for: WalletConstants.supportedCoinTypes())
     let allNetworks = await rpcService.allNetworksForSupportedCoins()
     self.allNetworks = allNetworks
     // setup network filters if not currently setup

--- a/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
@@ -413,13 +413,7 @@ public class SendTokenStore: ObservableObject {
   }
   
   private func validateFilcoinSendAddress() {
-    if !sendAddress.hasPrefix(BraveWallet.FilecoinMainnet) && !sendAddress.hasPrefix(BraveWallet.FilecoinTestnet) {
-      addressError = .notFilAddress
-    } else if (sendAddress.count == 41 || sendAddress.count == 86 || sendAddress.count == 44) { // secp256k have 41 address length and BLS keys have 86 and FEVM f410 keys have 44
-      addressError = nil
-    } else {
-      addressError = .notFilAddress
-    }
+    addressError = sendAddress.isFILAddress ? nil : .notFilAddress
   }
   
   public func enableENSOffchainLookup() {

--- a/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
@@ -78,6 +78,7 @@ public class SendTokenStore: ObservableObject {
     case snsError(domain: String)
     case ensError(domain: String)
     case udError(domain: String)
+    case notFilAddress
 
     var errorDescription: String? {
       switch self {
@@ -99,6 +100,8 @@ public class SendTokenStore: ObservableObject {
         return String.localizedStringWithFormat(Strings.Wallet.sendErrorDomainNotRegistered, BraveWallet.CoinType.eth.localizedTitle)
       case .udError:
         return String.localizedStringWithFormat(Strings.Wallet.sendErrorDomainNotRegistered, BraveWallet.CoinType.eth.localizedTitle)
+      case .notFilAddress:
+        return Strings.Wallet.sendErrorInvalidRecipientAddress
       }
     }
     
@@ -311,7 +314,9 @@ public class SendTokenStore: ObservableObject {
         await validateEthereumSendAddress(fromAddress: selectedAccount.address)
       case .sol:
         await validateSolanaSendAddress(fromAddress: selectedAccount.address)
-      case .fil, .btc:
+      case .fil:
+        validateFilcoinSendAddress()
+      case .btc:
         break
       @unknown default:
         break
@@ -407,6 +412,16 @@ public class SendTokenStore: ObservableObject {
     addressError = nil
   }
   
+  private func validateFilcoinSendAddress() {
+    if !sendAddress.hasPrefix(BraveWallet.FilecoinMainnet) && !sendAddress.hasPrefix(BraveWallet.FilecoinTestnet) {
+      addressError = .notFilAddress
+    } else if (sendAddress.count == 41 || sendAddress.count == 86 || sendAddress.count == 44) { // secp256k have 41 address length and BLS keys have 86 and FEVM f410 keys have 44
+      addressError = nil
+    } else {
+      addressError = .notFilAddress
+    }
+  }
+  
   public func enableENSOffchainLookup() {
     Task { @MainActor in
       rpcService.setEnsOffchainLookupResolveMethod(.enabled)
@@ -488,6 +503,8 @@ public class SendTokenStore: ObservableObject {
         self.sendTokenOnEth(amount: amount, token: token, fromAddress: selectedAccount.address, completion: completion)
       case .sol:
         self.sendTokenOnSol(amount: amount, token: token, fromAddress: selectedAccount.address, completion: completion)
+      case .fil:
+        self.sendTokenOnFil(amount: amount, token: token, fromAddress: selectedAccount.address, completion: completion)
       default:
         completion(false, Strings.Wallet.internalErrorMessage)
       }
@@ -610,6 +627,34 @@ public class SendTokenStore: ObservableObject {
           }
         }
       }
+    }
+  }
+  
+  private func sendTokenOnFil(
+    amount: String,
+    token: BraveWallet.BlockchainToken,
+    fromAddress: String,
+    completion: @escaping (_ success: Bool, _ errMsg: String?) -> Void
+  ) {
+    let weiFormatter = WeiFormatter(decimalFormatStyle: .decimals(precision: Int(token.decimals)))
+    guard let weiString = weiFormatter.weiString(from: amount.normalizedDecimals, decimals: Int(token.decimals)) else {
+      completion(false, Strings.Wallet.internalErrorMessage)
+      return
+    }
+    
+    isMakingTx = true
+    let filTxData = BraveWallet.FilTxData(
+      nonce: "",
+      gasPremium: "",
+      gasFeeCap: "",
+      gasLimit: "",
+      maxFee: "0",
+      to: sendAddress,
+      value: weiString
+    )
+    self.txService.addUnapprovedTransaction(BraveWallet.TxDataUnion(filTxData: filTxData), from: fromAddress, origin: nil, groupId: nil) { success, txMetaId, errorMessage in
+      self.isMakingTx = false
+      completion(success, errorMessage)
     }
   }
   

--- a/Sources/BraveWallet/Crypto/Stores/SettingsStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SettingsStore.swift
@@ -121,7 +121,7 @@ public class SettingsStore: ObservableObject {
     walletService.reset()
     
     keychain.resetPasswordInKeychain(key: KeyringStore.passwordKeychainKey)
-    for coin in WalletConstants.supportedCoinTypes {
+    for coin in WalletConstants.supportedCoinTypes.coins() {
       Domain.clearAllWalletPermissions(for: coin)
       Preferences.Wallet.reset(for: coin)
     }

--- a/Sources/BraveWallet/Crypto/Stores/SettingsStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SettingsStore.swift
@@ -121,7 +121,7 @@ public class SettingsStore: ObservableObject {
     walletService.reset()
     
     keychain.resetPasswordInKeychain(key: KeyringStore.passwordKeychainKey)
-    for coin in WalletConstants.supportedCoinTypes.coins() {
+    for coin in WalletConstants.supportedCoinTypes() {
       Domain.clearAllWalletPermissions(for: coin)
       Preferences.Wallet.reset(for: coin)
     }

--- a/Sources/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
@@ -42,6 +42,12 @@ public class TransactionConfirmationStore: ObservableObject {
   @Published var transactionDetails: String = ""
   /// The gas esitimation for this eip1559 transaction
   @Published var eip1559GasEstimation: BraveWallet.GasEstimation1559?
+  /// The gas premium for filcoin transaction
+  @Published var filTxGasPremium: String?
+  /// The gas limit for filcoin transaction
+  @Published var filTxGasLimit: String?
+  /// The gas fee cap for filcoin transaction
+  @Published var filTxGasFeeCap: String?
   /// The origin info of this transaction
   @Published var originInfo: BraveWallet.OriginInfo?
   /// This is an id for the unppproved transaction that is currently displayed on screen
@@ -286,6 +292,10 @@ public class TransactionConfirmationStore: ObservableObject {
     isBalanceSufficient = true
     isSolTokenTransferWithAssociatedTokenAccountCreation = false
     isUnlimitedApprovalRequested = false
+    // Filecoin Tx
+    filTxGasPremium = nil
+    filTxGasLimit = nil
+    filTxGasFeeCap = nil
   }
   
   private var assetRatios: [String: Double] = [:]
@@ -534,6 +544,37 @@ public class TransactionConfirmationStore: ObservableObject {
           }
         }
       }
+    case let .filSend(details):
+      symbol = details.sendToken?.symbol ?? ""
+      value = details.sendAmount
+      fiat = details.sendFiat ?? ""
+    
+      filTxGasPremium = details.gasPremium
+      filTxGasLimit = details.gasLimit
+      filTxGasFeeCap = details.gasFeeCap
+      
+      if let gasFee = details.gasFee {
+        gasValue = gasFee.fee
+        gasFiat = gasFee.fiat
+        gasSymbol = activeParsedTransaction.networkSymbol
+        gasAssetRatio = assetRatios[activeParsedTransaction.networkSymbol.lowercased(), default: 0]
+        
+        if let gasBalance = gasTokenBalanceCache["\(network.nativeToken.symbol)\(activeParsedTransaction.fromAddress)"] {
+          if let gasValue = BDouble(gasFee.fee),
+             BDouble(gasBalance) > gasValue {
+            isBalanceSufficient = true
+          } else {
+            isBalanceSufficient = false
+          }
+        } else if shouldFetchGasTokenBalance {
+          if let account = keyring.accountInfos.first(where: { $0.address == activeParsedTransaction.fromAddress }) {
+            await fetchGasTokenBalance(token: network.nativeToken, account: account, network: network)
+          }
+        }
+      }
+      if let token = details.sendToken {
+        totalFiat = totalFiat(value: value, tokenAssetRatioId: token.assetRatioId, gasValue: gasValue, gasSymbol: gasSymbol, assetRatios: assetRatios, currencyFormatter: currencyFormatter)
+      }
     case .other:
       break
     }
@@ -557,12 +598,12 @@ public class TransactionConfirmationStore: ObservableObject {
   
   @MainActor private func fetchAllTransactions() async -> [BraveWallet.TransactionInfo] {
     let allKeyrings = await keyringService.keyrings(for: WalletConstants.supportedCoinTypes)
-    var allChainIdsForCoin: [BraveWallet.CoinType: [String]] = [:]
+    var allNetworksForCoin: [BraveWallet.CoinType: [BraveWallet.NetworkInfo]] = [:]
     for coin in WalletConstants.supportedCoinTypes {
       let allNetworks = await rpcService.allNetworks(coin)
-      allChainIdsForCoin[coin] = allNetworks.map(\.chainId)
+      allNetworksForCoin[coin] = allNetworks
     }
-    return await txService.pendingTransactions(chainIdsForCoin: allChainIdsForCoin, for: allKeyrings)
+    return await txService.pendingTransactions(networksForCoin: allNetworksForCoin, for: allKeyrings)
       .sorted(by: { $0.createdTime > $1.createdTime })
   }
 

--- a/Sources/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
@@ -218,7 +218,8 @@ public class TransactionConfirmationStore: ObservableObject {
       clearTrasactionInfoBeforeUpdate()
       
       let coin = transaction.coin
-      let keyring = await keyringService.keyringInfo(coin.keyringId)
+      let keyringId = BraveWallet.KeyringId.keyringId(for: transaction.coin, transaction.chainId)
+      let keyring = await keyringService.keyringInfo(keyringId)
       if !allNetworks.contains(where: { $0.chainId == transaction.chainId }) {
         allNetworks = await rpcService.allNetworksForSupportedCoins()
       }

--- a/Sources/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
@@ -224,7 +224,7 @@ public class TransactionConfirmationStore: ObservableObject {
       clearTrasactionInfoBeforeUpdate()
       
       let coin = transaction.coin
-      let keyringId = BraveWallet.KeyringId.keyringId(for: transaction.coin, transaction.chainId)
+      let keyringId = BraveWallet.KeyringId.keyringId(for: transaction.coin, on: transaction.chainId)
       let keyring = await keyringService.keyringInfo(keyringId)
       if !allNetworks.contains(where: { $0.chainId == transaction.chainId }) {
         allNetworks = await rpcService.allNetworksForSupportedCoins()
@@ -597,9 +597,9 @@ public class TransactionConfirmationStore: ObservableObject {
   }
   
   @MainActor private func fetchAllTransactions() async -> [BraveWallet.TransactionInfo] {
-    let allKeyrings = await keyringService.keyrings(for: WalletConstants.supportedCoinTypes)
+    let allKeyrings = await keyringService.keyrings(for: WalletConstants.supportedCoinTypes.coins())
     var allNetworksForCoin: [BraveWallet.CoinType: [BraveWallet.NetworkInfo]] = [:]
-    for coin in WalletConstants.supportedCoinTypes {
+    for coin in WalletConstants.supportedCoinTypes.coins() {
       let allNetworks = await rpcService.allNetworks(coin)
       allNetworksForCoin[coin] = allNetworks
     }

--- a/Sources/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
@@ -597,9 +597,9 @@ public class TransactionConfirmationStore: ObservableObject {
   }
   
   @MainActor private func fetchAllTransactions() async -> [BraveWallet.TransactionInfo] {
-    let allKeyrings = await keyringService.keyrings(for: WalletConstants.supportedCoinTypes.coins())
+    let allKeyrings = await keyringService.keyrings(for: WalletConstants.supportedCoinTypes())
     var allNetworksForCoin: [BraveWallet.CoinType: [BraveWallet.NetworkInfo]] = [:]
-    for coin in WalletConstants.supportedCoinTypes.coins() {
+    for coin in WalletConstants.supportedCoinTypes() {
       let allNetworks = await rpcService.allNetworks(coin)
       allNetworksForCoin[coin] = allNetworks
     }

--- a/Sources/BraveWallet/Crypto/Stores/TransactionDetailsStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/TransactionDetailsStore.swift
@@ -75,7 +75,8 @@ class TransactionDetailsStore: ObservableObject {
         return
       }
       self.network = network
-      let keyring = await keyringService.keyringInfo(coin.keyringId)
+      let keringId = BraveWallet.KeyringId.keyringId(for: coin, transaction.chainId)
+      let keyring = await keyringService.keyringInfo(keringId)
       var allTokens: [BraveWallet.BlockchainToken] = await blockchainRegistry.allTokens(network.chainId, coin: network.coin) + tokenInfoCache.map(\.value)
       let userVisibleTokens: [BraveWallet.BlockchainToken] = assetManager.getAllUserAssetsInNetworkAssets(networks: [network]).flatMap { $0.tokens }
       let unknownTokenContractAddresses = transaction.tokenContractAddresses

--- a/Sources/BraveWallet/Crypto/Stores/TransactionDetailsStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/TransactionDetailsStore.swift
@@ -168,6 +168,13 @@ class TransactionDetailsStore: ObservableObject {
       case let .solSwapTransaction(details):
         self.title = Strings.Wallet.solanaSwapTransactionTitle
         self.value = details.fromAmount
+      case let .filSend(details):
+        self.title = Strings.Wallet.sent
+        self.value = String(format: "%@ %@", details.sendAmount, details.sendToken?.symbol ?? "")
+        self.fiat = details.sendFiat
+        if let sendToken = details.sendToken, let tokenPrice = assetRatios[sendToken.assetRatioId.lowercased()] {
+          self.marketPrice = currencyFormatter.string(from: NSNumber(value: tokenPrice)) ?? "$0.00"
+        }
       case .other:
         break
       }

--- a/Sources/BraveWallet/Crypto/Stores/TransactionDetailsStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/TransactionDetailsStore.swift
@@ -75,7 +75,7 @@ class TransactionDetailsStore: ObservableObject {
         return
       }
       self.network = network
-      let keringId = BraveWallet.KeyringId.keyringId(for: coin, transaction.chainId)
+      let keringId = BraveWallet.KeyringId.keyringId(for: coin, on: transaction.chainId)
       let keyring = await keyringService.keyringInfo(keringId)
       var allTokens: [BraveWallet.BlockchainToken] = await blockchainRegistry.allTokens(network.chainId, coin: network.coin) + tokenInfoCache.map(\.value)
       let userVisibleTokens: [BraveWallet.BlockchainToken] = assetManager.getAllUserAssetsInNetworkAssets(networks: [network]).flatMap { $0.tokens }

--- a/Sources/BraveWallet/Crypto/Stores/TransactionsActivityStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/TransactionsActivityStore.swift
@@ -70,7 +70,7 @@ class TransactionsActivityStore: ObservableObject {
     updateTask?.cancel()
     updateTask = Task { @MainActor in
       let allKeyrings = await self.keyringService.keyrings(
-        for: WalletConstants.supportedCoinTypes
+        for: WalletConstants.supportedCoinTypes.coins()
       )
       let allAccountInfos = allKeyrings.flatMap(\.accountInfos)
       // setup network filters if not currently setup

--- a/Sources/BraveWallet/Crypto/Stores/TransactionsActivityStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/TransactionsActivityStore.swift
@@ -81,14 +81,10 @@ class TransactionsActivityStore: ObservableObject {
       }
       let networks = networkFilters.filter(\.isSelected).map(\.model)
       let networksForCoin: [BraveWallet.CoinType: [BraveWallet.NetworkInfo]] = Dictionary(grouping: networks, by: \.coin)
-      
-      let chainIdsForCoin = networksForCoin.mapValues { networks in
-        networks.map(\.chainId)
-      }
       let allNetworksAllCoins = networksForCoin.values.flatMap { $0 }
       
       let allTransactions = await txService.allTransactions(
-        chainIdsForCoin: chainIdsForCoin, for: allKeyrings
+        networksForCoin: networksForCoin, for: allKeyrings
       ).filter { $0.txStatus != .rejected }
       let userVisibleTokens = assetManager.getAllVisibleAssetsInNetworkAssets(networks: allNetworksAllCoins).flatMap(\.tokens)
       let allTokens = await blockchainRegistry.allTokens(

--- a/Sources/BraveWallet/Crypto/Stores/TransactionsActivityStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/TransactionsActivityStore.swift
@@ -70,7 +70,7 @@ class TransactionsActivityStore: ObservableObject {
     updateTask?.cancel()
     updateTask = Task { @MainActor in
       let allKeyrings = await self.keyringService.keyrings(
-        for: WalletConstants.supportedCoinTypes.coins()
+        for: WalletConstants.supportedCoinTypes()
       )
       let allAccountInfos = allKeyrings.flatMap(\.accountInfos)
       // setup network filters if not currently setup

--- a/Sources/BraveWallet/Crypto/Transaction Confirmations/PendingTransactionView.swift
+++ b/Sources/BraveWallet/Crypto/Transaction Confirmations/PendingTransactionView.swift
@@ -263,6 +263,47 @@ struct PendingTransactionView: View {
           switch viewMode {
           case .transaction:
             VStack(spacing: 0) {
+              if confirmationStore.activeParsedTransaction.coin == .fil {
+                if let gasLimit = confirmationStore.filTxGasLimit {
+                  HStack {
+                    Text("Gas Limit")
+                      .foregroundColor(Color(.bravePrimary))
+                    Spacer()
+                    Text("\(gasLimit) \(confirmationStore.gasSymbol)")
+                      .foregroundColor(Color(.bravePrimary))
+                      .multilineTextAlignment(.trailing)
+                  }
+                  .padding()
+                  .accessibilityElement(children: .contain)
+                  Divider()
+                }
+                if let gasPremium = confirmationStore.filTxGasPremium {
+                  HStack {
+                    Text("Gas Premium")
+                      .foregroundColor(Color(.bravePrimary))
+                    Spacer()
+                    Text("\(gasPremium) \(confirmationStore.gasSymbol)")
+                      .foregroundColor(Color(.bravePrimary))
+                      .multilineTextAlignment(.trailing)
+                  }
+                  .padding()
+                  .accessibilityElement(children: .contain)
+                  Divider()
+                }
+                if let gasFeeCap = confirmationStore.filTxGasFeeCap {
+                  HStack {
+                    Text("Gas Fee Cap")
+                      .foregroundColor(Color(.bravePrimary))
+                    Spacer()
+                    Text("\(gasFeeCap) \(confirmationStore.gasSymbol)")
+                      .foregroundColor(Color(.bravePrimary))
+                      .multilineTextAlignment(.trailing)
+                  }
+                  .padding()
+                  .accessibilityElement(children: .contain)
+                  Divider()
+                }
+              }
               HStack {
                 VStack(alignment: .leading) {
                   Text(confirmationStore.activeParsedTransaction.coin == .sol ? Strings.Wallet.transactionFee : Strings.Wallet.gasFee)
@@ -275,6 +316,7 @@ struct PendingTransactionView: View {
                 VStack(alignment: .trailing) {
                   Text("\(confirmationStore.gasValue) \(confirmationStore.gasSymbol)")
                     .foregroundColor(Color(.bravePrimary))
+                    .multilineTextAlignment(.trailing)
                   Text(confirmationStore.gasFiat)
                     .font(.footnote)
                 }
@@ -319,6 +361,7 @@ struct PendingTransactionView: View {
                       .foregroundColor(Color(.secondaryBraveLabel))
                     Text("\(confirmationStore.value) \(confirmationStore.symbol) + \(confirmationStore.gasValue) \(confirmationStore.gasSymbol)")
                       .foregroundColor(Color(.bravePrimary))
+                      .multilineTextAlignment(.trailing)
                     HStack(spacing: 4) {
                       if !confirmationStore.isBalanceSufficient {
                         Text(Strings.Wallet.insufficientBalance)

--- a/Sources/BraveWallet/Crypto/Transaction Confirmations/TransactionStatusView.swift
+++ b/Sources/BraveWallet/Crypto/Transaction Confirmations/TransactionStatusView.swift
@@ -40,10 +40,17 @@ struct TransactionStatusView: View {
           .buttonStyle(BraveFilledButtonStyle(size: .large))
           Button {
             if let tx = confirmationStore.allTxs.first(where: { $0.id == confirmationStore.activeTransactionId }),
-               let txNetwork = networkStore.allChains.first(where: { $0.chainId == tx.chainId }),
-               let baseURL = txNetwork.blockExplorerUrls.first.map(URL.init(string:)),
-               let url = baseURL?.appendingPathComponent("tx/\(tx.txHash)") {
-              openWalletURL(url)
+               let txNetwork = networkStore.allChains.first(where: { $0.chainId == tx.chainId }) {
+              if txNetwork.coin != .fil,
+                 let baseURL = txNetwork.blockExplorerUrls.first.map(URL.init(string:)),
+                 let url = baseURL?.appendingPathComponent("tx/\(tx.txHash)") {
+                openWalletURL(url)
+              } else if var urlComps = txNetwork.blockExplorerUrls.first.map(URLComponents.init(string:)) {
+                urlComps?.queryItems = [URLQueryItem(name: "cid", value: tx.txHash)]
+                if let url = urlComps?.url {
+                  openWalletURL(url)
+                }
+              }
             }
           } label: {
             HStack {

--- a/Sources/BraveWallet/Crypto/Transaction Confirmations/TransactionStatusView.swift
+++ b/Sources/BraveWallet/Crypto/Transaction Confirmations/TransactionStatusView.swift
@@ -40,17 +40,9 @@ struct TransactionStatusView: View {
           .buttonStyle(BraveFilledButtonStyle(size: .large))
           Button {
             if let tx = confirmationStore.allTxs.first(where: { $0.id == confirmationStore.activeTransactionId }),
-               let txNetwork = networkStore.allChains.first(where: { $0.chainId == tx.chainId }) {
-              if txNetwork.coin != .fil,
-                 let baseURL = txNetwork.blockExplorerUrls.first.map(URL.init(string:)),
-                 let url = baseURL?.appendingPathComponent("tx/\(tx.txHash)") {
-                openWalletURL(url)
-              } else if var urlComps = txNetwork.blockExplorerUrls.first.map(URLComponents.init(string:)) {
-                urlComps?.queryItems = [URLQueryItem(name: "cid", value: tx.txHash)]
-                if let url = urlComps?.url {
-                  openWalletURL(url)
-                }
-              }
+               let txNetwork = networkStore.allChains.first(where: { $0.chainId == tx.chainId }),
+               let url = txNetwork.txBlockExplorerLink(txHash: tx.txHash, for: txNetwork.coin) {
+              openWalletURL(url)
             }
           } label: {
             HStack {

--- a/Sources/BraveWallet/Crypto/Transactions/TransactionDetailsView.swift
+++ b/Sources/BraveWallet/Crypto/Transactions/TransactionDetailsView.swift
@@ -61,10 +61,17 @@ struct TransactionDetailsView: View {
           detailRow(title: Strings.Wallet.transactionDetailsDateTitle, value: dateFormatter.string(from: transactionDetailsStore.transaction.createdTime))
           if !transactionDetailsStore.transaction.txHash.isEmpty {
             Button(action: {
-              if let txNetwork = self.networkStore.allChains.first(where: { $0.chainId == transactionDetailsStore.transaction.chainId }),
-                 let baseURL = txNetwork.blockExplorerUrls.first.map(URL.init(string:)),
-                 let url = baseURL?.appendingPathComponent("tx/\(transactionDetailsStore.transaction.txHash)") {
-                openWalletURL(url)
+              if let txNetwork = self.networkStore.allChains.first(where: { $0.chainId == transactionDetailsStore.transaction.chainId }) {
+                if txNetwork.coin != .fil,
+                   let baseURL = txNetwork.blockExplorerUrls.first.map(URL.init(string:)),
+                   let url = baseURL?.appendingPathComponent("tx/\(transactionDetailsStore.transaction.txHash)") {
+                  openWalletURL(url)
+                } else if var urlComps = txNetwork.blockExplorerUrls.first.map(URLComponents.init(string:)) {
+                  urlComps?.queryItems = [URLQueryItem(name: "cid", value: transactionDetailsStore.transaction.txHash)]
+                  if let url = urlComps?.url {
+                    openWalletURL(url)
+                  }
+                }
               }
             }) {
               detailRow(title: Strings.Wallet.transactionDetailsTxHashTitle) {

--- a/Sources/BraveWallet/Crypto/Transactions/TransactionDetailsView.swift
+++ b/Sources/BraveWallet/Crypto/Transactions/TransactionDetailsView.swift
@@ -61,17 +61,9 @@ struct TransactionDetailsView: View {
           detailRow(title: Strings.Wallet.transactionDetailsDateTitle, value: dateFormatter.string(from: transactionDetailsStore.transaction.createdTime))
           if !transactionDetailsStore.transaction.txHash.isEmpty {
             Button(action: {
-              if let txNetwork = self.networkStore.allChains.first(where: { $0.chainId == transactionDetailsStore.transaction.chainId }) {
-                if txNetwork.coin != .fil,
-                   let baseURL = txNetwork.blockExplorerUrls.first.map(URL.init(string:)),
-                   let url = baseURL?.appendingPathComponent("tx/\(transactionDetailsStore.transaction.txHash)") {
-                  openWalletURL(url)
-                } else if var urlComps = txNetwork.blockExplorerUrls.first.map(URLComponents.init(string:)) {
-                  urlComps?.queryItems = [URLQueryItem(name: "cid", value: transactionDetailsStore.transaction.txHash)]
-                  if let url = urlComps?.url {
-                    openWalletURL(url)
-                  }
-                }
+              if let txNetwork = self.networkStore.allChains.first(where: { $0.chainId == transactionDetailsStore.transaction.chainId }),
+                 let url = txNetwork.txBlockExplorerLink(txHash: transactionDetailsStore.transaction.txHash, for: txNetwork.coin) {
+                openWalletURL(url)
               }
             }) {
               detailRow(title: Strings.Wallet.transactionDetailsTxHashTitle) {

--- a/Sources/BraveWallet/Crypto/Transactions/TransactionHeader.swift
+++ b/Sources/BraveWallet/Crypto/Transactions/TransactionHeader.swift
@@ -53,10 +53,12 @@ struct TransactionHeader: View {
                 AddressView(address: fromAccountAddress) {
                   Text(fromAccountName)
                 }
+                .frame(minWidth: 0, maxWidth: .infinity)
                 Image(systemName: "arrow.right")
                 AddressView(address: toAccountAddress) {
                   Text(toAccountName)
                 }
+                .frame(minWidth: 0, maxWidth: .infinity)
               }
             }
           }

--- a/Sources/BraveWallet/Crypto/Transactions/TransactionParser+TransactionSummary.swift
+++ b/Sources/BraveWallet/Crypto/Transactions/TransactionParser+TransactionSummary.swift
@@ -179,6 +179,17 @@ extension TransactionParser {
         gasFee: parsedTransaction.gasFee,
         networkSymbol: parsedTransaction.networkSymbol
       )
+    case let .filSend(details):
+      let title = String.localizedStringWithFormat(Strings.Wallet.transactionSendTitle, details.sendAmount, details.sendToken?.symbol ?? "", details.sendFiat ?? "")
+      return .init(
+        txInfo: transaction,
+        namedFromAddress: parsedTransaction.namedFromAddress,
+        toAddress: parsedTransaction.toAddress,
+        namedToAddress: parsedTransaction.namedToAddress,
+        title: title,
+        gasFee: details.gasFee,
+        networkSymbol: parsedTransaction.networkSymbol
+      )
     case .other:
       return .init(txInfo: .init(), namedFromAddress: "", toAddress: "", namedToAddress: "", title: "", gasFee: nil, networkSymbol: "")
     }

--- a/Sources/BraveWallet/Extensions/BraveWalletExtensions.swift
+++ b/Sources/BraveWallet/Extensions/BraveWalletExtensions.swift
@@ -104,18 +104,18 @@ extension BraveWallet.AccountId {
 }
 
 extension BraveWallet.CoinType {
-  public var keyringId: BraveWallet.KeyringId {
+  public var keyringIds: [BraveWallet.KeyringId] {
     switch self {
     case .eth:
-      return BraveWallet.KeyringId.default
+      return [.default]
     case .sol:
-      return BraveWallet.KeyringId.solana
+      return [.solana]
     case .fil:
-      return BraveWallet.KeyringId.filecoin
+      return [.filecoin, .filecoinTestnet]
     case .btc:
-      return BraveWallet.KeyringId.bitcoin84
+      return [.bitcoin84, .bitcoin84Testnet]
     @unknown default:
-      return BraveWallet.KeyringId.default
+      return [.default]
     }
   }
   
@@ -339,6 +339,23 @@ extension BraveWallet.OnRampProvider {
 extension BraveWallet.CoinMarket {
   static func abbreviateToBillion(input: Double) -> Double {
     input / 1000000000
+  }
+}
+
+extension BraveWallet.KeyringId {
+  static func keyringId(for coin: BraveWallet.CoinType, _ chainId: String) -> BraveWallet.KeyringId {
+    switch coin {
+    case .eth:
+      return .default
+    case .sol:
+      return .solana
+    case .fil:
+      return chainId == BraveWallet.FilecoinMainnet ? .filecoin : .filecoinTestnet
+    case.btc:
+      return chainId == BraveWallet.BitcoinMainnet ? .bitcoin84 : .bitcoin84Testnet
+    @unknown default:
+      return .default
+    }
   }
 }
 

--- a/Sources/BraveWallet/Extensions/BraveWalletExtensions.swift
+++ b/Sources/BraveWallet/Extensions/BraveWalletExtensions.swift
@@ -349,7 +349,7 @@ extension BraveWallet.CoinMarket {
 }
 
 extension BraveWallet.KeyringId {
-  static func keyringId(for coin: BraveWallet.CoinType, _ chainId: String) -> BraveWallet.KeyringId {
+  static func keyringId(for coin: BraveWallet.CoinType, on chainId: String) -> BraveWallet.KeyringId {
     switch coin {
     case .eth:
       return .default

--- a/Sources/BraveWallet/Extensions/BraveWalletExtensions.swift
+++ b/Sources/BraveWallet/Extensions/BraveWalletExtensions.swift
@@ -16,8 +16,14 @@ extension BraveWallet.TransactionInfo {
     }
   }
   var isEIP1559Transaction: Bool {
-    guard let ethTxData1559 = txDataUnion.ethTxData1559 else { return false }
-    return !ethTxData1559.maxPriorityFeePerGas.isEmpty && !ethTxData1559.maxFeePerGas.isEmpty
+    if coin == .eth {
+      guard let ethTxData1559 = txDataUnion.ethTxData1559 else { return false }
+      return !ethTxData1559.maxPriorityFeePerGas.isEmpty && !ethTxData1559.maxFeePerGas.isEmpty
+    } else if coin == .fil {
+      guard let filTxData = txDataUnion.filTxData else { return false }
+      return !filTxData.gasPremium.isEmpty && !filTxData.gasFeeCap.isEmpty
+    }
+    return false
   }
   var ethTxToAddress: String {
     // Eth transaction are all coming as `ethTxData1559`

--- a/Sources/BraveWallet/Extensions/BraveWalletExtensions.swift
+++ b/Sources/BraveWallet/Extensions/BraveWalletExtensions.swift
@@ -252,6 +252,18 @@ extension BraveWallet.NetworkInfo {
   var walletUserAssetGroupId: String {
     "\(coin.rawValue).\(chainId)"
   }
+  
+  /// Generate the link for a submitted transaction with given transaction hash and coin type. 
+  func txBlockExplorerLink(txHash: String, for coin: BraveWallet.CoinType) -> URL? {
+    if coin != .fil,
+       let baseURL = blockExplorerUrls.first.map(URL.init(string:)) {
+      return baseURL?.appendingPathComponent("tx/\(txHash)")
+    } else if var urlComps = blockExplorerUrls.first.map(URLComponents.init(string:)) {
+      urlComps?.queryItems = [URLQueryItem(name: "cid", value: txHash)]
+      return urlComps?.url
+    }
+    return nil
+  }
 }
 
 extension BraveWallet.BlockchainToken {

--- a/Sources/BraveWallet/Extensions/BraveWalletSwiftUIExtensions.swift
+++ b/Sources/BraveWallet/Extensions/BraveWalletSwiftUIExtensions.swift
@@ -23,6 +23,10 @@ extension BraveWallet.AccountInfo: Identifiable {
   public var coin: BraveWallet.CoinType {
     accountId.coin
   }
+  
+  public var keyringId: BraveWallet.KeyringId {
+    accountId.keyringId
+  }
 }
 
 extension BraveWallet.TransactionInfo: Identifiable {

--- a/Sources/BraveWallet/Extensions/KeyringServiceExtensions.swift
+++ b/Sources/BraveWallet/Extensions/KeyringServiceExtensions.swift
@@ -28,7 +28,11 @@ extension BraveWalletKeyringService {
           return partialResult + [prior]
         })
         .sorted(by: { lhs, rhs in
-          (lhs.coin ?? .eth).sortOrder < (rhs.coin ?? .eth).sortOrder
+          if lhs.coin == .fil && rhs.coin == .fil {
+            return lhs.id == BraveWallet.KeyringId.filecoin
+          } else {
+            return (lhs.coin ?? .eth).sortOrder < (rhs.coin ?? .eth).sortOrder
+          }
         })
       }
     )

--- a/Sources/BraveWallet/Extensions/KeyringServiceExtensions.swift
+++ b/Sources/BraveWallet/Extensions/KeyringServiceExtensions.swift
@@ -18,7 +18,7 @@ extension BraveWalletKeyringService {
       of: BraveWallet.KeyringInfo.self,
       returning: [BraveWallet.KeyringInfo].self,
       body: { @MainActor group in
-        let keyringIds: [BraveWallet.KeyringId] = coins.flatMap { $0.keyringIds }
+        let keyringIds: [BraveWallet.KeyringId] = coins.flatMap(\.keyringIds)
         for keyringId in keyringIds {
           group.addTask { @MainActor in
             await self.keyringInfo(keyringId)

--- a/Sources/BraveWallet/Extensions/RpcServiceExtensions.swift
+++ b/Sources/BraveWallet/Extensions/RpcServiceExtensions.swift
@@ -199,7 +199,24 @@ extension BraveWalletJsonRpcService {
           }
         }
       }
-    case .fil, .btc:
+    case .fil:
+      balance(accountAddress, coin: token.coin, chainId: network.chainId) { amount, status, _ in
+        guard status == .success && !amount.isEmpty else {
+          completion(nil)
+          return
+        }
+        let formatter = WeiFormatter(decimalFormatStyle: decimalFormatStyle)
+        if let valueString = formatter.decimalString(
+          for: "\(amount)",
+          radix: .decimal,
+          decimals: Int(token.decimals)
+        ) {
+          completion(BDouble(valueString))
+        } else {
+          completion(nil)
+        }
+      }
+    case .btc:
       completion(nil)
     @unknown default:
       completion(nil)

--- a/Sources/BraveWallet/Extensions/RpcServiceExtensions.swift
+++ b/Sources/BraveWallet/Extensions/RpcServiceExtensions.swift
@@ -295,7 +295,7 @@ extension BraveWalletJsonRpcService {
   /// Returns an array of all networks for the supported coin types. Result will exclude test networks if test networks is set to
   /// not shown in Wallet Settings
   @MainActor func allNetworksForSupportedCoins(respectTestnetPreference: Bool = true) async -> [BraveWallet.NetworkInfo] {
-    await allNetworks(for: WalletConstants.supportedCoinTypes.elements, respectTestnetPreference: respectTestnetPreference)
+    await allNetworks(for: WalletConstants.supportedCoinTypes.coins().elements, respectTestnetPreference: respectTestnetPreference)
   }
 
   /// Returns an array of all networks for givin coins. Result will exclude test networks if test networks is set to

--- a/Sources/BraveWallet/Extensions/RpcServiceExtensions.swift
+++ b/Sources/BraveWallet/Extensions/RpcServiceExtensions.swift
@@ -295,9 +295,15 @@ extension BraveWalletJsonRpcService {
   /// Returns an array of all networks for the supported coin types. Result will exclude test networks if test networks is set to
   /// not shown in Wallet Settings
   @MainActor func allNetworksForSupportedCoins(respectTestnetPreference: Bool = true) async -> [BraveWallet.NetworkInfo] {
+    await allNetworks(for: WalletConstants.supportedCoinTypes.elements, respectTestnetPreference: respectTestnetPreference)
+  }
+
+  /// Returns an array of all networks for givin coins. Result will exclude test networks if test networks is set to
+  /// not shown in Wallet Settings
+  @MainActor func allNetworks(for coins: [BraveWallet.CoinType], respectTestnetPreference: Bool = true) async -> [BraveWallet.NetworkInfo] {
     await withTaskGroup(of: [BraveWallet.NetworkInfo].self) { @MainActor [weak self] group -> [BraveWallet.NetworkInfo] in
       guard let self = self else { return [] }
-      for coinType in WalletConstants.supportedCoinTypes {
+      for coinType in coins {
         group.addTask { @MainActor in
           let chains = await self.allNetworks(coinType)
           return chains.filter { // localhost not supported

--- a/Sources/BraveWallet/Extensions/RpcServiceExtensions.swift
+++ b/Sources/BraveWallet/Extensions/RpcServiceExtensions.swift
@@ -295,7 +295,7 @@ extension BraveWalletJsonRpcService {
   /// Returns an array of all networks for the supported coin types. Result will exclude test networks if test networks is set to
   /// not shown in Wallet Settings
   @MainActor func allNetworksForSupportedCoins(respectTestnetPreference: Bool = true) async -> [BraveWallet.NetworkInfo] {
-    await allNetworks(for: WalletConstants.supportedCoinTypes.coins().elements, respectTestnetPreference: respectTestnetPreference)
+    await allNetworks(for: WalletConstants.supportedCoinTypes().elements, respectTestnetPreference: respectTestnetPreference)
   }
 
   /// Returns an array of all networks for givin coins. Result will exclude test networks if test networks is set to

--- a/Sources/BraveWallet/Extensions/RpcServiceExtensions.swift
+++ b/Sources/BraveWallet/Extensions/RpcServiceExtensions.swift
@@ -84,7 +84,24 @@ extension BraveWalletJsonRpcService {
           }
         }
       }
-    case .fil, .btc:
+    case .fil:
+      balance(account.address, coin: account.coin, chainId: network.chainId) { amount, status, _ in
+        guard status == .success && !amount.isEmpty else {
+          completion(nil)
+          return
+        }
+        let formatter = WeiFormatter(decimalFormatStyle: decimalFormatStyle)
+        if let valueString = formatter.decimalString(
+          for: "\(amount)",
+          radix: .decimal,
+          decimals: Int(token.decimals)
+        ) {
+          completion(Double(valueString))
+        } else {
+          completion(nil)
+        }
+      }
+    case .btc:
       completion(nil)
     @unknown default:
       completion(nil)

--- a/Sources/BraveWallet/Extensions/WalletTxServiceExtensions.swift
+++ b/Sources/BraveWallet/Extensions/WalletTxServiceExtensions.swift
@@ -10,16 +10,16 @@ extension BraveWalletTxService {
   
   // Fetches all pending transactions for all given keyrings
   func pendingTransactions(
-    chainIdsForCoin: [BraveWallet.CoinType: [String]],
+    networksForCoin: [BraveWallet.CoinType: [BraveWallet.NetworkInfo]],
     for keyrings: [BraveWallet.KeyringInfo]
   ) async -> [BraveWallet.TransactionInfo] {
-    await allTransactions(chainIdsForCoin: chainIdsForCoin, for: keyrings)
+    await allTransactions(networksForCoin: networksForCoin, for: keyrings)
       .filter { $0.txStatus == .unapproved }
   }
   
   // Fetches all transactions for all given keyrings
   func allTransactions(
-    chainIdsForCoin: [BraveWallet.CoinType: [String]],
+    networksForCoin: [BraveWallet.CoinType: [BraveWallet.NetworkInfo]],
     for keyrings: [BraveWallet.KeyringInfo]
   ) async -> [BraveWallet.TransactionInfo] {
     return await withTaskGroup(
@@ -27,13 +27,13 @@ extension BraveWalletTxService {
       body: { @MainActor group in
         for keyring in keyrings {
           guard let keyringCoin = keyring.coin,
-                let chainIdsForKeyringCoin = chainIdsForCoin[keyringCoin] else {
+                let networksForKeyringCoin = networksForCoin[keyringCoin] else {
             continue
           }
-          for chainId in chainIdsForKeyringCoin {
-            for info in keyring.accountInfos {
+          for info in keyring.accountInfos {
+            for network in networksForKeyringCoin where network.supportedKeyrings.contains(keyring.id.rawValue as NSNumber) {
               group.addTask { @MainActor in
-                await self.allTransactionInfo(info.coin, chainId: chainId, from: info.address)
+                await self.allTransactionInfo(info.coin, chainId: network.chainId, from: info.address)
               }
             }
           }
@@ -55,7 +55,7 @@ extension BraveWalletTxService {
     return await withTaskGroup(
       of: [BraveWallet.TransactionInfo].self,
       body: { @MainActor group in
-        for network in networks {
+        for network in networks where network.supportedKeyrings.contains(accountInfo.accountId.keyringId.rawValue as NSNumber) {
           group.addTask { @MainActor in
             await self.allTransactionInfo(accountInfo.coin, chainId: network.chainId, from: accountInfo.address)
           }

--- a/Sources/BraveWallet/Panels/Connect/EditSiteConnectionView.swift
+++ b/Sources/BraveWallet/Panels/Connect/EditSiteConnectionView.swift
@@ -205,8 +205,8 @@ struct EditSiteConnectionView_Previews: PreviewProvider {
     EditSiteConnectionView(
       keyringStore: {
         let store = KeyringStore.previewStoreWithWalletCreated
-        store.addPrimaryAccount("Account 2", coin: .eth, completion: nil)
-        store.addPrimaryAccount("Account 3", coin: .eth, completion: nil)
+        store.addPrimaryAccount("Account 2", coin: .eth, chainId: BraveWallet.MainnetChainId, completion: nil)
+        store.addPrimaryAccount("Account 3", coin: .eth, chainId: BraveWallet.MainnetChainId, completion: nil)
         return store
       }(),
       origin: .init(url: URL(string: "https://app.uniswap.org")!),

--- a/Sources/BraveWallet/Panels/Connect/NewSiteConnectionView.swift
+++ b/Sources/BraveWallet/Panels/Connect/NewSiteConnectionView.swift
@@ -256,8 +256,8 @@ struct NewSiteConnectionView_Previews: PreviewProvider {
       coin: .eth,
       keyringStore: {
         let store = KeyringStore.previewStoreWithWalletCreated
-        store.addPrimaryAccount("Account 2", coin: .eth, completion: nil)
-        store.addPrimaryAccount("Account 3", coin: .eth, completion: nil)
+        store.addPrimaryAccount("Account 2", coin: .eth, chainId: BraveWallet.MainnetChainId, completion: nil)
+        store.addPrimaryAccount("Account 3", coin: .eth, chainId: BraveWallet.MainnetChainId, completion: nil)
         return store
       }(),
       onConnect: { _ in },

--- a/Sources/BraveWallet/Panels/WalletPanelView.swift
+++ b/Sources/BraveWallet/Panels/WalletPanelView.swift
@@ -355,6 +355,8 @@ struct WalletPanelView: View {
         }
       }
       return true
+    } else if account.coin == .fil {
+      return true
     } else {
       return false
     }
@@ -518,7 +520,7 @@ struct WalletPanelView: View {
       }
     }
     .onAppear {
-      if let accountCreationRequest = WalletProviderAccountCreationRequestManager.shared.firstPendingRequest(for: origin, coinTypes: Array(WalletConstants.supportedCoinTypes)) {
+      if let accountCreationRequest = WalletProviderAccountCreationRequestManager.shared.firstPendingRequest(for: origin, coinTypes: WalletConstants.supportedCoinTypes.coins(.dapps).elements) {
         presentWalletWithContext(.createAccount(accountCreationRequest))
       } else if let request = WalletProviderPermissionRequestsManager.shared.firstPendingRequest(for: origin, coinTypes: [.eth, .sol]) {
         presentWalletWithContext(.requestPermissions(request, onPermittedAccountsUpdated: { accounts in

--- a/Sources/BraveWallet/Panels/WalletPanelView.swift
+++ b/Sources/BraveWallet/Panels/WalletPanelView.swift
@@ -520,7 +520,7 @@ struct WalletPanelView: View {
       }
     }
     .onAppear {
-      if let accountCreationRequest = WalletProviderAccountCreationRequestManager.shared.firstPendingRequest(for: origin, coinTypes: WalletConstants.supportedCoinTypes.coins(.dapps).elements) {
+      if let accountCreationRequest = WalletProviderAccountCreationRequestManager.shared.firstPendingRequest(for: origin, coinTypes: WalletConstants.supportedCoinTypes(.dapps).elements) {
         presentWalletWithContext(.createAccount(accountCreationRequest))
       } else if let request = WalletProviderPermissionRequestsManager.shared.firstPendingRequest(for: origin, coinTypes: [.eth, .sol]) {
         presentWalletWithContext(.requestPermissions(request, onPermittedAccountsUpdated: { accounts in

--- a/Sources/BraveWallet/Preview Content/MockContent.swift
+++ b/Sources/BraveWallet/Preview Content/MockContent.swift
@@ -134,6 +134,24 @@ extension BraveWallet.BlockchainToken {
     chainId: BraveWallet.SolanaMainnet,
     coin: .sol
   )
+  
+  static let mockFilToken: BraveWallet.BlockchainToken = .init(
+    contractAddress: "",
+    name: "Filcoin",
+    logo: "",
+    isErc20: false,
+    isErc721: false,
+    isErc1155: false,
+    isNft: false,
+    isSpam: false,
+    symbol: "FIL",
+    decimals: 18,
+    visible: false,
+    tokenId: "",
+    coingeckoId: "",
+    chainId: BraveWallet.FilecoinMainnet,
+    coin: .fil
+  )
 }
 
 extension BraveWallet.AccountInfo {
@@ -348,6 +366,36 @@ extension BraveWallet.TransactionInfo {
       effectiveRecipient: nil // Currently only available for ETH and FIL
     )
   }
+  /// Filecoin Unapproved Send
+  static let mockFilUnapprovedSend = BraveWallet.TransactionInfo(
+    id: UUID().uuidString,
+    fromAddress: "t165quq7gkjh6ebshr7qi2ud7vycel4m7x6dvfvgb",
+    from: BraveWallet.AccountInfo.mockFilAccount.accountId,
+    txHash: "",
+    txDataUnion:
+        .init(filTxData:
+            .init(nonce: "",
+                  gasPremium: "100911",
+                  gasFeeCap: "101965",
+                  gasLimit: "1527953",
+                  maxFee: "0",
+                  to: "t1xqhfiydm2yq6augugonr4zpdllh77iw53aexztb",
+                  value: "1000000000000000000"
+                 )
+        ),
+    txStatus: .unapproved,
+    txType: .other,
+    txParams: [],
+    txArgs: [
+    ],
+    createdTime: Date(timeIntervalSince1970: 1636399671), // Monday, November 8, 2021 7:27:51 PM
+    submittedTime: Date(timeIntervalSince1970: 1636399673), // Monday, November 8, 2021 7:27:53 PM
+    confirmedTime: Date(timeIntervalSince1970: 1636402508), // Monday, November 8, 2021 8:15:08 PM
+    originInfo: nil,
+    groupId: nil,
+    chainId: BraveWallet.FilecoinMainnet,
+    effectiveRecipient: nil
+  )
   static private func _transactionBase64ToData(_ base64String: String) -> [NSNumber] {
     guard let data = Data(base64Encoded: base64String) else { return [] }
     return Array(data).map(NSNumber.init(value:))

--- a/Sources/BraveWallet/Preview Content/MockJsonRpcService.swift
+++ b/Sources/BraveWallet/Preview Content/MockJsonRpcService.swift
@@ -358,6 +358,34 @@ extension BraveWallet.NetworkInfo {
     supportedKeyrings: [BraveWallet.KeyringId.solana.rawValue].map(NSNumber.init(value:)),
     isEip1559: false
   )
+  static let mockFilecoinMainnet: BraveWallet.NetworkInfo = .init(
+    chainId: BraveWallet.FilecoinMainnet,
+    chainName: "Filecoin Mainnet",
+    blockExplorerUrls: [""],
+    iconUrls: [],
+    activeRpcEndpointIndex: 0,
+    rpcEndpoints: [URL(string: "https://rpc.ankr.com/filecoin")!],
+    symbol: "FIL",
+    symbolName: "Filecoin",
+    decimals: 18,
+    coin: .fil,
+    supportedKeyrings: [BraveWallet.KeyringId.filecoin.rawValue].map(NSNumber.init(value:)),
+    isEip1559: true
+  )
+  static let mockFilecoinTestnet: BraveWallet.NetworkInfo = .init(
+    chainId: BraveWallet.FilecoinTestnet,
+    chainName: "Filecoin Testnet",
+    blockExplorerUrls: [""],
+    iconUrls: [],
+    activeRpcEndpointIndex: 0,
+    rpcEndpoints: [URL(string: "https://rpc.ankr.com/filecoin_testnet")!],
+    symbol: "FIL",
+    symbolName: "Filecoin",
+    decimals: 18,
+    coin: .fil,
+    supportedKeyrings: [BraveWallet.KeyringId.filecoinTestnet.rawValue].map(NSNumber.init(value:)),
+    isEip1559: true
+  )
 }
 
 #endif

--- a/Sources/BraveWallet/Preview Content/MockKeyringService.swift
+++ b/Sources/BraveWallet/Preview Content/MockKeyringService.swift
@@ -397,6 +397,20 @@ extension BraveWallet.AccountInfo {
     name: "Filecoin Account 1",
     hardware: nil
   )
+  
+  static let mockFilTestnetAccount: BraveWallet.AccountInfo = .init(
+    accountId: .init(
+      coin: .fil,
+      keyringId: BraveWallet.KeyringId.filecoinTestnet,
+      kind: .derived,
+      address: "mock_fil_testnet_id",
+      bitcoinAccountIndex: 0,
+      uniqueKey: "mock_fil_testnet_id"
+    ),
+    address: "mock_fil_testnet_id",
+    name: "Filecoin Testnet 1",
+    hardware: nil
+  )
 }
 
 extension BraveWallet.KeyringInfo {
@@ -422,5 +436,13 @@ extension BraveWallet.KeyringInfo {
     isLocked: false,
     isBackedUp: false,
     accountInfos: [.mockFilAccount]
+  )
+  
+  static let mockFilecoinTestnetKeyringInfo: BraveWallet.KeyringInfo = .init(
+    id: BraveWallet.KeyringId.filecoinTestnet,
+    isKeyringCreated: true,
+    isLocked: false,
+    isBackedUp: false,
+    accountInfos: [.mockFilTestnetAccount]
   )
 }

--- a/Sources/BraveWallet/Settings/Web3SettingsView.swift
+++ b/Sources/BraveWallet/Settings/Web3SettingsView.swift
@@ -253,7 +253,7 @@ private struct WalletSettingsView: View {
         .foregroundColor(Color(.secondaryBraveLabel))
     ) {
       Group {
-        ForEach(Array(WalletConstants.supportedCoinTypesForDapps)) { coin in
+        ForEach(WalletConstants.supportedCoinTypes.coins(.dapps)) { coin in
           NavigationLink(
             destination:
               DappsSettings(

--- a/Sources/BraveWallet/Settings/Web3SettingsView.swift
+++ b/Sources/BraveWallet/Settings/Web3SettingsView.swift
@@ -253,7 +253,7 @@ private struct WalletSettingsView: View {
         .foregroundColor(Color(.secondaryBraveLabel))
     ) {
       Group {
-        ForEach(Array(WalletConstants.supportedCoinTypes)) { coin in
+        ForEach(Array(WalletConstants.supportedCoinTypesForDapps)) { coin in
           NavigationLink(
             destination:
               DappsSettings(

--- a/Sources/BraveWallet/Settings/Web3SettingsView.swift
+++ b/Sources/BraveWallet/Settings/Web3SettingsView.swift
@@ -253,7 +253,7 @@ private struct WalletSettingsView: View {
         .foregroundColor(Color(.secondaryBraveLabel))
     ) {
       Group {
-        ForEach(WalletConstants.supportedCoinTypes.coins(.dapps)) { coin in
+        ForEach(WalletConstants.supportedCoinTypes(.dapps)) { coin in
           NavigationLink(
             destination:
               DappsSettings(

--- a/Sources/BraveWallet/WalletConstants.swift
+++ b/Sources/BraveWallet/WalletConstants.swift
@@ -77,14 +77,23 @@ public struct WalletConstants {
   ]
   
   /// The currently supported coin types in wallet
-  static var supportedCoinTypes: OrderedSet<BraveWallet.CoinType> {
-    return [.eth, .sol, .fil]
+  public struct SupportedCoinTypes {
+    public enum Mode {
+      case general
+      case dapps
+    }
+
+    public func coins(_ mode: Mode = .general) -> OrderedSet<BraveWallet.CoinType> {
+      switch mode {
+      case .general:
+        return [.eth, .sol, .fil]
+      case .dapps:
+        return [.eth, .sol]
+      }
+    }
   }
   
-  /// The currently supported coin types in dapps
-  public static var supportedCoinTypesForDapps: OrderedSet<BraveWallet.CoinType> {
-    return [.eth, .sol]
-  }
+  public static let supportedCoinTypes = SupportedCoinTypes()
   
   /// The supported Ethereum Name Service (ENS) extensions
   static let supportedENSExtensions = [".eth"]

--- a/Sources/BraveWallet/WalletConstants.swift
+++ b/Sources/BraveWallet/WalletConstants.swift
@@ -76,8 +76,13 @@ public struct WalletConstants {
     BraveWallet.FilecoinMainnet
   ]
   
-  /// The currently supported coin types.
-  public static var supportedCoinTypes: OrderedSet<BraveWallet.CoinType> {
+  /// The currently supported coin types in wallet
+  static var supportedCoinTypes: OrderedSet<BraveWallet.CoinType> {
+    return [.eth, .sol, .fil]
+  }
+  
+  /// The currently supported coin types in dapps
+  public static var supportedCoinTypesForDapps: OrderedSet<BraveWallet.CoinType> {
     return [.eth, .sol]
   }
   

--- a/Sources/BraveWallet/WalletConstants.swift
+++ b/Sources/BraveWallet/WalletConstants.swift
@@ -75,25 +75,21 @@ public struct WalletConstants {
     BraveWallet.MainnetChainId,
     BraveWallet.FilecoinMainnet
   ]
-  
-  /// The currently supported coin types in wallet
-  public struct SupportedCoinTypes {
-    public enum Mode {
-      case general
-      case dapps
-    }
-
-    public func coins(_ mode: Mode = .general) -> OrderedSet<BraveWallet.CoinType> {
-      switch mode {
-      case .general:
-        return [.eth, .sol, .fil]
-      case .dapps:
-        return [.eth, .sol]
-      }
-    }
+ 
+  public enum SupportedCoinTypesMode {
+    case general
+    case dapps
   }
   
-  public static let supportedCoinTypes = SupportedCoinTypes()
+  /// The currently supported coin types in wallet
+  public static func supportedCoinTypes(_ mode: SupportedCoinTypesMode = .general) -> OrderedSet<BraveWallet.CoinType> {
+    switch mode {
+    case .general:
+      return [.eth, .sol, .fil]
+    case .dapps:
+      return [.eth, .sol]
+    }
+  }
   
   /// The supported Ethereum Name Service (ENS) extensions
   static let supportedENSExtensions = [".eth"]

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -1976,6 +1976,13 @@ extension Strings {
       value: "Domain doesn\'t have a linked %@ address",
       comment: "An error that appears below the send crypto address text field, when the input `To` domain/url that we cannot resolve to a wallet address. The '%@' will be replaced with the coin type Ex. `Domain doesn\'t have a linked ETH address`"
     )
+    public static let sendErrorInvalidRecipientAddress = NSLocalizedString(
+      "wallet.sendErrorInvalidRecipientAddress",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Invalid recipient address",
+      comment: "An error that appears below the send crypto address text field, when the input `To` Filecoin address that is invalid"
+    )
     public static let customNetworkChainIdTitle = NSLocalizedString(
       "wallet.customNetworkChainIdTitle",
       tableName: "BraveWallet",

--- a/Sources/BraveWallet/WalletUserAssetManager.swift
+++ b/Sources/BraveWallet/WalletUserAssetManager.swift
@@ -7,6 +7,7 @@ import Foundation
 import Data
 import BraveCore
 import Preferences
+import CoreData
 
 public protocol WalletUserAssetManagerType: AnyObject {
   func getAllVisibleAssetsInNetworkAssets(networks: [BraveWallet.NetworkInfo]) -> [NetworkAssets]
@@ -87,19 +88,39 @@ public class WalletUserAssetManager: WalletUserAssetManagerType {
     WalletUserAssetGroup.removeGroup(groupId, completion: completion)
   }
   
-  public func migrateUserAssets(for coin: BraveWallet.CoinType? = nil, completion: (() -> Void)? = nil) {
-    guard !Preferences.Wallet.migrateCoreToWalletUserAssetCompleted.value else {
-      completion?()
-      return
+  public func migrateUserAssets(completion: (() -> Void)? = nil) {
+    Task { @MainActor in
+      if !Preferences.Wallet.migrateCoreToWalletUserAssetCompleted.value {
+        migrateUserAssets(for: Array(WalletConstants.supportedCoinTypes), completion: completion)
+      } else {
+        let allNetworks = await rpcService.allNetworksForSupportedCoins(respectTestnetPreference: false)
+        DataController.performOnMainContext { context in
+          let newCoins = self.allNewCoinsIntroduced(networks: allNetworks, context: context)
+          if !newCoins.isEmpty {
+            self.migrateUserAssets(for: newCoins, completion: completion)
+          } else {
+            completion?()
+          }
+        }
+      }
     }
+  }
+  
+  private func allNewCoinsIntroduced(networks: [BraveWallet.NetworkInfo], context: NSManagedObjectContext) -> [BraveWallet.CoinType] {
+    guard let assetGroupIds = WalletUserAssetGroup.getAllGroups(context: context)?.map({ group in
+      group.groupId
+    }) else { return WalletConstants.supportedCoinTypes.elements }
+    var newCoins: Set<BraveWallet.CoinType> = []
+    for network in networks where !assetGroupIds.contains("\(network.coin.rawValue).\(network.chainId)") {
+      newCoins.insert(network.coin)
+    }
+    return Array(newCoins)
+  }
+  
+  private func migrateUserAssets(for coins: [BraveWallet.CoinType], completion: (() -> Void)?) {
     Task { @MainActor in
       var fetchedUserAssets: [String: [BraveWallet.BlockchainToken]] = [:]
-      var networks: [BraveWallet.NetworkInfo] = []
-      if let coin = coin {
-        networks = await rpcService.allNetworks(coin)
-      } else {
-        networks = await rpcService.allNetworksForSupportedCoins(respectTestnetPreference: false)
-      }
+      let networks: [BraveWallet.NetworkInfo] = await rpcService.allNetworks(for: coins, respectTestnetPreference: false)
       let networkAssets = await walletService.allUserAssets(in: networks)
       for networkAsset in networkAssets {
         fetchedUserAssets["\(networkAsset.network.coin.rawValue).\(networkAsset.network.chainId)"] = networkAsset.tokens

--- a/Sources/BraveWallet/WalletUserAssetManager.swift
+++ b/Sources/BraveWallet/WalletUserAssetManager.swift
@@ -91,7 +91,7 @@ public class WalletUserAssetManager: WalletUserAssetManagerType {
   public func migrateUserAssets(completion: (() -> Void)? = nil) {
     Task { @MainActor in
       if !Preferences.Wallet.migrateCoreToWalletUserAssetCompleted.value {
-        migrateUserAssets(for: Array(WalletConstants.supportedCoinTypes.coins()), completion: completion)
+        migrateUserAssets(for: Array(WalletConstants.supportedCoinTypes()), completion: completion)
       } else {
         let allNetworks = await rpcService.allNetworksForSupportedCoins(respectTestnetPreference: false)
         DataController.performOnMainContext { context in
@@ -109,7 +109,7 @@ public class WalletUserAssetManager: WalletUserAssetManagerType {
   private func allNewCoinsIntroduced(networks: [BraveWallet.NetworkInfo], context: NSManagedObjectContext) -> [BraveWallet.CoinType] {
     guard let assetGroupIds = WalletUserAssetGroup.getAllGroups(context: context)?.map({ group in
       group.groupId
-    }) else { return WalletConstants.supportedCoinTypes.coins().elements }
+    }) else { return WalletConstants.supportedCoinTypes().elements }
     var newCoins: Set<BraveWallet.CoinType> = []
     for network in networks where !assetGroupIds.contains("\(network.coin.rawValue).\(network.chainId)") {
       newCoins.insert(network.coin)

--- a/Sources/BraveWallet/WalletUserAssetManager.swift
+++ b/Sources/BraveWallet/WalletUserAssetManager.swift
@@ -91,7 +91,7 @@ public class WalletUserAssetManager: WalletUserAssetManagerType {
   public func migrateUserAssets(completion: (() -> Void)? = nil) {
     Task { @MainActor in
       if !Preferences.Wallet.migrateCoreToWalletUserAssetCompleted.value {
-        migrateUserAssets(for: Array(WalletConstants.supportedCoinTypes), completion: completion)
+        migrateUserAssets(for: Array(WalletConstants.supportedCoinTypes.coins()), completion: completion)
       } else {
         let allNetworks = await rpcService.allNetworksForSupportedCoins(respectTestnetPreference: false)
         DataController.performOnMainContext { context in
@@ -109,7 +109,7 @@ public class WalletUserAssetManager: WalletUserAssetManagerType {
   private func allNewCoinsIntroduced(networks: [BraveWallet.NetworkInfo], context: NSManagedObjectContext) -> [BraveWallet.CoinType] {
     guard let assetGroupIds = WalletUserAssetGroup.getAllGroups(context: context)?.map({ group in
       group.groupId
-    }) else { return WalletConstants.supportedCoinTypes.elements }
+    }) else { return WalletConstants.supportedCoinTypes.coins().elements }
     var newCoins: Set<BraveWallet.CoinType> = []
     for network in networks where !assetGroupIds.contains("\(network.coin.rawValue).\(network.chainId)") {
       newCoins.insert(network.coin)

--- a/Tests/BraveWalletTests/AddressTests.swift
+++ b/Tests/BraveWalletTests/AddressTests.swift
@@ -86,4 +86,27 @@ class AddressTests: XCTestCase {
     XCTAssertNotEqual(address, result)
     XCTAssertEqual(zwspAddress, result)
   }
+  
+  func testIsFILAddress() {
+    let isMainnetAddressTrue = "f1ysqn2zflyeb1jqqi2bqbomgjtodunoplkfedbpa"
+    XCTAssertTrue(isMainnetAddressTrue.isFILAddress)
+    
+    let isTestnetAddressTrue = "t165quq7gkjh6ebshr7qi2ud7vycel4m7x6dvfvga"
+    XCTAssertTrue(isTestnetAddressTrue.isFILAddress)
+    
+    let isAddressFalseWrongPrefix = "a1ysqn2zflyeb1jqqi2bqbomgjtodunoplkfedbpa"
+    XCTAssertFalse(isAddressFalseWrongPrefix.isFILAddress)
+    
+    let isAddressFalseCorrentLength1 = "f1ysqn2zflyeb1jqqi2bqbomgjtodunoplkfedbpa"
+    XCTAssertTrue(isAddressFalseCorrentLength1.isFILAddress)
+    
+    let isAddressFalseCorrentLength2 = "f1ysqn2zflyeb1jqqi2bqbomgjtodunoplkfedbpa2ba"
+    XCTAssertTrue(isAddressFalseCorrentLength2.isFILAddress)
+    
+    let isAddressFalseCorrentLength3 = "f1ysqn2zflyeb1jqqi2bqbomgjtodunoplkfedbpaf1ysqn2zflyeb1jqqi2bqbomgjtodunoplkfedbpa1gdu"
+    XCTAssertTrue(isAddressFalseCorrentLength3.isFILAddress)
+    
+    let isAddressFalseWrongLength = "f1ysqn2zflyeb1jqqi2bqbomgjtodundbpa"
+    XCTAssertFalse(isAddressFalseWrongLength.isFILAddress)
+  }
 }

--- a/Tests/BraveWalletTests/KeyringStoreTests.swift
+++ b/Tests/BraveWalletTests/KeyringStoreTests.swift
@@ -26,6 +26,8 @@ class KeyringStoreTests: XCTestCase {
         completion(.mockSolanaKeyringInfo)
       case BraveWallet.KeyringId.filecoin:
         completion(.mockFilecoinKeyringInfo)
+      case BraveWallet.KeyringId.filecoinTestnet:
+        completion(.mockFilecoinTestnetKeyringInfo)
       default:
         completion(.init())
       }
@@ -66,14 +68,14 @@ class KeyringStoreTests: XCTestCase {
       rpcService: rpcService
     )
     
-    let expectedKeyrings = [BraveWallet.KeyringInfo.mockDefaultKeyringInfo, BraveWallet.KeyringInfo.mockSolanaKeyringInfo]
+    let expectedKeyrings = [BraveWallet.KeyringInfo.mockDefaultKeyringInfo, BraveWallet.KeyringInfo.mockSolanaKeyringInfo, BraveWallet.KeyringInfo.mockFilecoinKeyringInfo, BraveWallet.KeyringInfo.mockFilecoinTestnetKeyringInfo]
     
     let allTokensExpectation = expectation(description: "allKeyrings")
     store.$allKeyrings
       .dropFirst()
       .sink { allKeyrings in
         defer { allTokensExpectation.fulfill() }
-        XCTAssertEqual(allKeyrings.count, 2)
+        XCTAssertEqual(allKeyrings.count, 4)
         for keyring in allKeyrings {
           XCTAssertTrue(expectedKeyrings.contains(where: { $0.id == keyring.id }))
         }

--- a/Tests/BraveWalletTests/NFTStoreTests.swift
+++ b/Tests/BraveWalletTests/NFTStoreTests.swift
@@ -79,7 +79,7 @@ class NFTStoreTests: XCTestCase {
       case .sol:
         completion([solNetwork])
       case .fil:
-        XCTFail("Should not fetch filecoin network")
+        completion([.mockFilecoinTestnet])
       case .btc:
         XCTFail("Should not fetch btc network")
       @unknown default:

--- a/Tests/BraveWalletTests/NetworkStoreTests.swift
+++ b/Tests/BraveWalletTests/NetworkStoreTests.swift
@@ -25,12 +25,13 @@ import Preferences
     let currentChainId = currentNetwork.chainId
     let allNetworks: [BraveWallet.CoinType: [BraveWallet.NetworkInfo]] = [
       .eth: [.mockMainnet, .mockGoerli, .mockSepolia, .mockPolygon, .mockCustomNetwork],
-      .sol: [.mockSolana, .mockSolanaTestnet]
+      .sol: [.mockSolana, .mockSolanaTestnet],
+      .fil: [.mockFilecoinMainnet, .mockFilecoinTestnet]
     ]
     
     let keyringService = BraveWallet.TestKeyringService()
     keyringService._keyringInfo = { keyringId, completion in
-      let isEthereumKeyringId = keyringId == BraveWallet.CoinType.eth.keyringId
+      let isEthereumKeyringId = keyringId == BraveWallet.KeyringId.default
       let keyring: BraveWallet.KeyringInfo = .init(
         id: BraveWallet.KeyringId.default,
         isKeyringCreated: true,
@@ -151,6 +152,10 @@ import Preferences
     let error = await store.setSelectedChain(.mockSolana, isForOrigin: false)
     XCTAssertEqual(error, .selectedChainHasNoAccounts, "Expected chain has no accounts error")
     XCTAssertNotEqual(store.defaultSelectedChainId, BraveWallet.NetworkInfo.mockSolana.chainId)
+    
+    let selectFilecoinMainnetError = await store.setSelectedChain(.mockFilecoinMainnet, isForOrigin: false)
+    XCTAssertEqual(selectFilecoinMainnetError, .selectedChainHasNoAccounts, "Expected chain has no accounts error")
+    XCTAssertNotEqual(store.defaultSelectedChainId, BraveWallet.NetworkInfo.mockFilecoinMainnet.chainId)
   }
   
   func testUpdateChainList() async {
@@ -171,7 +176,9 @@ import Preferences
       .mockGoerli,
       .mockSepolia,
       .mockPolygon,
-      .mockCustomNetwork
+      .mockCustomNetwork,
+      .mockFilecoinMainnet,
+      .mockFilecoinTestnet
     ]
     
     let expectedCustomChains: [BraveWallet.NetworkInfo] = [
@@ -184,7 +191,10 @@ import Preferences
       .dropFirst()
       .sink { allChains in
         defer { allChainsExpectation.fulfill() }
-        XCTAssertEqual(allChains, expectedAllChains)
+        XCTAssertEqual(allChains.count, expectedAllChains.count)
+        for chain in allChains {
+          XCTAssertTrue(expectedAllChains.contains(chain))
+        }
       }
       .store(in: &cancellables)
     

--- a/Tests/BraveWalletTests/NetworkStoreTests.swift
+++ b/Tests/BraveWalletTests/NetworkStoreTests.swift
@@ -192,9 +192,7 @@ import Preferences
       .sink { allChains in
         defer { allChainsExpectation.fulfill() }
         XCTAssertEqual(allChains.count, expectedAllChains.count)
-        for chain in allChains {
-          XCTAssertTrue(expectedAllChains.contains(chain))
-        }
+        XCTAssertTrue(allChains.allSatisfy(expectedAllChains.contains(_:)))
       }
       .store(in: &cancellables)
     

--- a/Tests/BraveWalletTests/PortfolioStoreTests.swift
+++ b/Tests/BraveWalletTests/PortfolioStoreTests.swift
@@ -40,10 +40,19 @@ import Preferences
     $0.address = "mock_sol_id_2"
     $0.name = "Solana Account 2"
   }
+  let filAccount1: BraveWallet.AccountInfo = .mockFilAccount
+  let filAccount2 = (BraveWallet.AccountInfo.mockFilAccount.copy() as! BraveWallet.AccountInfo).then {
+    $0.address = "mock_fil_id_2"
+    $0.name = "Filecoin Account 2"
+  }
+  let filTestnetAccount: BraveWallet.AccountInfo = .mockFilTestnetAccount
+
   // Networks
   let ethNetwork: BraveWallet.NetworkInfo = .mockMainnet
   let goerliNetwork: BraveWallet.NetworkInfo = .mockGoerli
   let solNetwork: BraveWallet.NetworkInfo = .mockSolana
+  let filMainnet: BraveWallet.NetworkInfo = .mockFilecoinMainnet
+  let filTestnet: BraveWallet.NetworkInfo = .mockFilecoinTestnet
   // ETH Asset, balance, price, history
   let mockETHBalanceAccount1: Double = 0.896
   let mockETHPrice: String = "3059.99" // ETH value = $2741.75104
@@ -79,19 +88,53 @@ import Preferences
     .init(date: Date(), price: "250.00")
   ]
   
+  // FIL Asset, balance, price, history on filecoin mainnet
+  let mockFILBalanceAccount1: Double = 1
+  let mockFILPrice: String = "4.00" // FIL value on mainnet = $4.00
+  lazy var mockFILAssetPrice: BraveWallet.AssetPrice = .init(
+    fromAsset: "fil", toAsset: "usd",
+    price: mockFILPrice, assetTimeframeChange: "-57.23"
+  )
+  lazy var mockFILPriceHistory: [BraveWallet.AssetTimePrice] = [
+    .init(date: Date(timeIntervalSinceNow: -1000), price: "4.06"),
+    .init(date: Date(), price: mockFILPrice)
+  ]
+  // FIL Asset, balance on filecoin testnet
+  let mockFILBalanceTestnet: Double = 100 // FIL value on testnet = $400.00
+  
   var totalBalance: String {
     let totalEthBalanceValue: Double = (Double(mockETHAssetPrice.price) ?? 0) * mockETHBalanceAccount1
     var totalUSDCBalanceValue: Double = 0
     totalUSDCBalanceValue += (Double(mockUSDCAssetPrice.price) ?? 0) * mockUSDCBalanceAccount1
     totalUSDCBalanceValue += (Double(mockUSDCAssetPrice.price) ?? 0) * mockUSDCBalanceAccount2
     let totalSolBalanceValue: Double = (Double(mockSOLAssetPrice.price) ?? 0) * mockSOLBalance
-    let totalBalanceValue = totalEthBalanceValue + totalSolBalanceValue + totalUSDCBalanceValue
+    let totalFilBalanceValue: Double = (Double(mockFILAssetPrice.price) ?? 0) * mockFILBalanceAccount1
+    let totalBalanceValue = totalEthBalanceValue + totalSolBalanceValue + totalUSDCBalanceValue + totalFilBalanceValue
     return currencyFormatter.string(from: NSNumber(value: totalBalanceValue)) ?? ""
   }
   
   private func setupStore() -> PortfolioStore {
     let mockSOLLamportBalance: UInt64 = 3876535000 // ~3.8765 SOL
     let formatter = WeiFormatter(decimalFormatStyle: .decimals(precision: 18))
+    
+    // config filecoin on mainnet
+    let mockFilAccountInfos: [BraveWallet.AccountInfo] = [filAccount1, filAccount2]
+    let mockFilUserAssets: [BraveWallet.BlockchainToken] = [
+      BraveWallet.NetworkInfo.mockFilecoinMainnet.nativeToken.copy(asVisibleAsset: true)
+    ]
+    let mockFilBalanceInWei = formatter.weiString(
+      from: mockFILBalanceAccount1,
+      radix: .decimal,
+      decimals: Int(BraveWallet.BlockchainToken.mockFilToken.decimals)
+    ) ?? ""
+    // config filecoin on testnet
+    let mockFilTestnetAccountInfos: [BraveWallet.AccountInfo] = [filTestnetAccount]
+    let mockFilTestnetBalanceInWei = formatter.weiString(
+      from: mockFILBalanceTestnet,
+      radix: .decimal,
+      decimals: Int(BraveWallet.BlockchainToken.mockFilToken.decimals)
+    ) ?? ""
+    
     // config Solana
     let mockSolAccountInfos: [BraveWallet.AccountInfo] = [solAccount1, solAccount2]
     let mockSolUserAssets: [BraveWallet.BlockchainToken] = [
@@ -125,6 +168,10 @@ import Preferences
       goerliNetwork.nativeToken.copy(asVisibleAsset: true)
     ]
     
+    let mockFilTestnetUserAssets: [BraveWallet.BlockchainToken] = [
+      filTestnet.nativeToken.copy(asVisibleAsset: true)
+    ]
+    
     let ethKeyring: BraveWallet.KeyringInfo = .init(
       id: BraveWallet.KeyringId.default,
       isKeyringCreated: true,
@@ -139,6 +186,20 @@ import Preferences
       isBackedUp: true,
       accountInfos: mockSolAccountInfos
     )
+    let filKeyring: BraveWallet.KeyringInfo = .init(
+      id: .filecoin,
+      isKeyringCreated: true,
+      isLocked: false,
+      isBackedUp: true,
+      accountInfos: mockFilAccountInfos
+    )
+    let filTestnetKeyring: BraveWallet.KeyringInfo = .init(
+      id: .filecoinTestnet,
+      isKeyringCreated: true,
+      isLocked: false,
+      isBackedUp: true,
+      accountInfos: mockFilTestnetAccountInfos
+    )
     
     // setup test services
     let keyringService = BraveWallet.TestKeyringService()
@@ -149,7 +210,7 @@ import Preferences
     }
     keyringService._allAccounts = {
       $0(.init(
-        accounts: ethKeyring.accountInfos + solKeyring.accountInfos,
+        accounts: ethKeyring.accountInfos + solKeyring.accountInfos + filKeyring.accountInfos + filTestnetKeyring.accountInfos,
         selectedAccount: ethKeyring.accountInfos.first,
         ethDappSelectedAccount: ethKeyring.accountInfos.first,
         solDappSelectedAccount: solKeyring.accountInfos.first
@@ -164,19 +225,31 @@ import Preferences
       case .sol:
         completion([self.solNetwork])
       case .fil:
-        XCTFail("Should not fetch filecoin network")
+        completion([self.filMainnet, self.filTestnet])
       case .btc:
         XCTFail("Should not fetch bitcoin network")
       @unknown default:
         XCTFail("Should not fetch unknown network")
       }
     }
-    rpcService._balance = { accountAddress, _, chainId, completion in
-      // eth mainnet balance
-      if chainId == self.ethNetwork.chainId, accountAddress == self.ethAccount1.address {
-        completion(ethBalanceWei, .success, "")
-      } else {
-        completion("", .success, "")
+    rpcService._balance = { accountAddress, coin, chainId, completion in
+      // eth balance
+      if coin == .eth {
+        if chainId == self.ethNetwork.chainId, accountAddress == self.ethAccount1.address {
+          completion(ethBalanceWei, .success, "")
+        } else {
+          completion("", .success, "")
+        }
+      } else { // .fil
+        if chainId == self.filMainnet.chainId {
+          if accountAddress == self.filAccount1.address {
+            completion(mockFilBalanceInWei, .success, "")
+          } else {
+            completion("", .success, "")
+          }
+        } else {
+          completion(mockFilTestnetBalanceInWei, .success, "")
+        }
       }
     }
     rpcService._erc20TokenBalance = { contractAddress, accountAddress, _, completion in
@@ -200,7 +273,7 @@ import Preferences
     walletService._defaultBaseCurrency = { $0(CurrencyCode.usd.code) }
     let assetRatioService = BraveWallet.TestAssetRatioService()
     assetRatioService._price = { priceIds, _, _, completion in
-      completion(true, [self.mockETHAssetPrice, self.mockUSDCAssetPrice, self.mockSOLAssetPrice])
+      completion(true, [self.mockETHAssetPrice, self.mockUSDCAssetPrice, self.mockSOLAssetPrice, self.mockFILAssetPrice])
     }
     assetRatioService._priceHistory = { priceId, _, _, completion in
       switch priceId {
@@ -210,6 +283,8 @@ import Preferences
         completion(true, self.mockETHPriceHistory)
       case BraveWallet.BlockchainToken.mockUSDCToken.assetRatioId:
         completion(true, self.mockUSDCPriceHistory)
+      case "fil":
+        completion(true, self.mockFILPriceHistory) // for both mainnet and testnet
       default:
         completion(false, [])
       }
@@ -220,7 +295,9 @@ import Preferences
       [
         NetworkAssets(network: .mockMainnet, tokens: mockEthUserAssets.filter({ $0.visible == true }), sortOrder: 0),
         NetworkAssets(network: .mockSolana, tokens: mockSolUserAssets.filter({ $0.visible == true }), sortOrder: 1),
-        NetworkAssets(network: .mockGoerli, tokens: mockEthGoerliUserAssets.filter({ $0.visible == true }), sortOrder: 2)
+        NetworkAssets(network: .mockGoerli, tokens: mockEthGoerliUserAssets.filter({ $0.visible == true }), sortOrder: 2),
+        NetworkAssets(network: .mockFilecoinMainnet, tokens: mockFilUserAssets.filter({ $0.visible == true }), sortOrder: 3),
+        NetworkAssets(network: .mockFilecoinTestnet, tokens: mockFilTestnetUserAssets.filter({ $0.visible == true }), sortOrder: 4)
       ].filter { networkAsset in networks.contains(where: { $0 == networkAsset.network }) }
     }
     return PortfolioStore(
@@ -248,6 +325,7 @@ import Preferences
       .sink { assetGroups in
         defer { assetGroupsExpectation.fulfill() }
         XCTAssertEqual(assetGroups.count, 2) // empty (no balance, price, history), populated
+        
         guard let lastUpdatedAssetGroups = assetGroups.last else {
           XCTFail("Unexpected test result")
           return
@@ -257,8 +335,9 @@ import Preferences
           XCTFail("Unexpected test result")
           return
         }
-        // ETH on Ethereum mainnet, SOL on Solana mainnet, USDC on Ethereum mainnet, ETH on Goerli
-        XCTAssertEqual(group.assets.count, 3)
+        
+        // ETH on Ethereum mainnet, SOL on Solana mainnet, USDC on Ethereum mainnet, ETH on Goerli, FIL on Filecoin mainnet, FIL on Filecoin testnet
+        XCTAssertEqual(group.assets.count, 4)
         // ETH Mainnet (value ~= $2741.7510399999996)
         XCTAssertEqual(group.assets[safe: 0]?.token.symbol,
                        BraveWallet.BlockchainToken.previewToken.symbol)
@@ -268,6 +347,7 @@ import Preferences
                        self.mockETHPriceHistory)
         XCTAssertEqual(group.assets[safe: 0]?.quantity,
                        String(format: "%.04f", self.mockETHBalanceAccount1))
+        
         // SOL (value = $775.3)
         XCTAssertEqual(group.assets[safe: 1]?.token.symbol,
                        BraveWallet.BlockchainToken.mockSolToken.symbol)
@@ -277,19 +357,33 @@ import Preferences
                        self.mockSOLPriceHistory)
         XCTAssertEqual(group.assets[safe: 1]?.quantity,
                        String(format: "%.04f", self.mockSOLBalance))
-        // USDC (value $0.04)
+        
+        // FIL (value $4.00) on mainnet
         XCTAssertEqual(group.assets[safe: 2]?.token.symbol,
-                       BraveWallet.BlockchainToken.mockUSDCToken.symbol)
+                       BraveWallet.BlockchainToken.mockFilToken.symbol)
         XCTAssertEqual(group.assets[safe: 2]?.price,
-                       self.mockUSDCAssetPrice.price)
+                       self.mockFILAssetPrice.price)
         XCTAssertEqual(group.assets[safe: 2]?.history,
-                       self.mockUSDCPriceHistory)
+                       self.mockFILPriceHistory)
         XCTAssertEqual(group.assets[safe: 2]?.quantity,
+                       String(format: "%.04f", self.mockFILBalanceAccount1))
+        
+        // USDC (value $0.04)
+        XCTAssertEqual(group.assets[safe: 3]?.token.symbol,
+                       BraveWallet.BlockchainToken.mockUSDCToken.symbol)
+        XCTAssertEqual(group.assets[safe: 3]?.price,
+                       self.mockUSDCAssetPrice.price)
+        XCTAssertEqual(group.assets[safe: 3]?.history,
+                       self.mockUSDCPriceHistory)
+        XCTAssertEqual(group.assets[safe: 3]?.quantity,
                        String(format: "%.04f", self.mockUSDCBalanceAccount1 + self.mockUSDCBalanceAccount2))
+        
         // ETH Goerli (value = 0), hidden because test networks not selected by default
-        XCTAssertNil(group.assets[safe: 3])
+        // FIL Testnet (value = $400.00), hidden because test networks not selected by default
+        XCTAssertNil(group.assets[safe: 4])
       }
       .store(in: &cancellables)
+
     
     // test that `update()` will assign new value to `balance` publisher
     let balanceExpectation = expectation(description: "update-balance")
@@ -338,8 +432,8 @@ import Preferences
           XCTFail("Unexpected test result")
           return
         }
-        // USDC on Ethereum mainnet, SOL on Solana mainnet, ETH on Ethereum mainnet
-        XCTAssertEqual(group.assets.count, 4)
+        // USDC on Ethereum mainnet, SOL on Solana mainnet, ETH on Ethereum mainnet, FIL on Filecoin mainnet and FIL on Filecoin testnet
+        XCTAssertEqual(group.assets.count, 6)
         // ETH Goerli (value = $0)
         XCTAssertEqual(group.assets[safe: 0]?.token.symbol,
                        BraveWallet.BlockchainToken.previewToken.symbol)
@@ -349,15 +443,25 @@ import Preferences
                        BraveWallet.BlockchainToken.mockUSDCToken.symbol)
         XCTAssertEqual(group.assets[safe: 1]?.quantity,
                        String(format: "%.04f", self.mockUSDCBalanceAccount1 + self.mockUSDCBalanceAccount2))
-        // SOL (value = $775.3)
+        // FIL (value = $4.00) on filecoin mainnet
         XCTAssertEqual(group.assets[safe: 2]?.token.symbol,
-                       BraveWallet.BlockchainToken.mockSolToken.symbol)
+                       BraveWallet.BlockchainToken.mockFilToken.symbol)
         XCTAssertEqual(group.assets[safe: 2]?.quantity,
+                       String(format: "%.04f", self.mockFILBalanceAccount1))
+        // FIL (value = $400.00) on filecoin testnet
+        XCTAssertEqual(group.assets[safe: 3]?.token.symbol,
+                       BraveWallet.BlockchainToken.mockFilToken.symbol)
+        XCTAssertEqual(group.assets[safe: 3]?.quantity,
+                       String(format: "%.04f", self.mockFILBalanceTestnet))
+        // SOL (value = $775.3)
+        XCTAssertEqual(group.assets[safe: 4]?.token.symbol,
+                       BraveWallet.BlockchainToken.mockSolToken.symbol)
+        XCTAssertEqual(group.assets[safe: 4]?.quantity,
                        String(format: "%.04f", self.mockSOLBalance))
         // ETH Mainnet (value ~= $2741.7510399999996)
-        XCTAssertEqual(group.assets[safe: 3]?.token.symbol,
+        XCTAssertEqual(group.assets[safe: 5]?.token.symbol,
                        BraveWallet.BlockchainToken.previewToken.symbol)
-        XCTAssertEqual(group.assets[safe: 3]?.quantity,
+        XCTAssertEqual(group.assets[safe: 5]?.quantity,
                        String(format: "%.04f", self.mockETHBalanceAccount1))
       }.store(in: &cancellables)
 
@@ -368,10 +472,10 @@ import Preferences
       isHidingSmallBalances: store.filters.isHidingSmallBalances,
       isHidingUnownedNFTs: store.filters.isHidingUnownedNFTs,
       isShowingNFTNetworkLogo: store.filters.isShowingNFTNetworkLogo,
-      accounts: [ethAccount1, ethAccount2, solAccount1, solAccount2].map {
+      accounts: [ethAccount1, ethAccount2, solAccount1, solAccount2, filAccount1, filAccount2, filTestnetAccount].map {
         .init(isSelected: true, model: $0)
       },
-      networks: [ethNetwork, goerliNetwork, solNetwork].map {
+      networks: [ethNetwork, goerliNetwork, solNetwork, filMainnet, filTestnet].map {
         .init(isSelected: true, model: $0)
       }
     ))
@@ -399,8 +503,8 @@ import Preferences
           XCTFail("Unexpected test result")
           return
         }
-        // ETH on Ethereum mainnet, SOL on Solana mainnet
-        XCTAssertEqual(group.assets.count, 2) // USDC, ETH Goerli hidden for small balance
+        // ETH on Ethereum mainnet, SOL on Solana mainnet, FIL on Filecoin mainnet and testnet
+        XCTAssertEqual(group.assets.count, 4) // USDC, ETH Goerli hidden for small balance
         // ETH Mainnet (value ~= $2741.7510399999996)
         XCTAssertEqual(group.assets[safe: 0]?.token.symbol,
                        BraveWallet.BlockchainToken.previewToken.symbol)
@@ -411,8 +515,18 @@ import Preferences
                        BraveWallet.BlockchainToken.mockSolToken.symbol)
         XCTAssertEqual(group.assets[safe: 1]?.quantity,
                        String(format: "%.04f", self.mockSOLBalance))
+        // FIL (value = $400) on Filecoin testnet
+        XCTAssertEqual(group.assets[safe: 2]?.token.symbol,
+                       BraveWallet.BlockchainToken.mockFilToken.symbol)
+        XCTAssertEqual(group.assets[safe: 2]?.quantity,
+                       String(format: "%.04f", self.mockFILBalanceTestnet))
+        // FIL (value = $4) on Filecoin mainnet
+        XCTAssertEqual(group.assets[safe: 3]?.token.symbol,
+                       BraveWallet.BlockchainToken.mockFilToken.symbol)
+        XCTAssertEqual(group.assets[safe: 3]?.quantity,
+                       String(format: "%.04f", self.mockFILBalanceAccount1))
         // USDC (value = $0.04), hidden
-        XCTAssertNil(group.assets[safe: 2])
+        XCTAssertNil(group.assets[safe: 4])
       }.store(in: &cancellables)
     store.saveFilters(.init(
       groupBy: store.filters.groupBy,
@@ -420,10 +534,10 @@ import Preferences
       isHidingSmallBalances: true,
       isHidingUnownedNFTs: store.filters.isHidingUnownedNFTs,
       isShowingNFTNetworkLogo: store.filters.isShowingNFTNetworkLogo,
-      accounts: [ethAccount1, ethAccount2, solAccount1, solAccount2].map {
+      accounts: [ethAccount1, ethAccount2, solAccount1, solAccount2, filAccount1, filAccount2, filTestnetAccount].map {
         .init(isSelected: true, model: $0)
       },
-      networks: [ethNetwork, goerliNetwork, solNetwork].map {
+      networks: [ethNetwork, goerliNetwork, solNetwork, filMainnet, filTestnet].map {
         .init(isSelected: true, model: $0)
       }
     ))
@@ -451,8 +565,8 @@ import Preferences
           XCTFail("Unexpected test result")
           return
         }
-        // ETH on Ethereum mainnet, SOL on Solana mainnet, USDC on Ethereum mainnet, ETH on Goerli
-        XCTAssertEqual(group.assets.count, 4)
+        // ETH on Ethereum mainnet, SOL on Solana mainnet, USDC on Ethereum mainnet, ETH on Goerli, FIL on mainnet and testnet
+        XCTAssertEqual(group.assets.count, 6)
         // ETH Mainnet (value ~= $2741.7510399999996)
         XCTAssertEqual(group.assets[safe: 0]?.token.symbol,
                        BraveWallet.BlockchainToken.previewToken.symbol)
@@ -463,15 +577,25 @@ import Preferences
                        BraveWallet.BlockchainToken.mockSolToken.symbol)
         XCTAssertEqual(group.assets[safe: 1]?.quantity,
                        String(format: "%.04f", self.mockSOLBalance))
-        // USDC (value = $0.03, ethAccount2 hidden!)
+        // FIL (value = $400) on testnet
         XCTAssertEqual(group.assets[safe: 2]?.token.symbol,
-                       BraveWallet.BlockchainToken.mockUSDCToken.symbol)
+                       BraveWallet.BlockchainToken.mockFilToken.symbol)
         XCTAssertEqual(group.assets[safe: 2]?.quantity,
+                       String(format: "%.04f", self.mockFILBalanceTestnet))
+        // FIL (value = $4) on mainnet
+        XCTAssertEqual(group.assets[safe: 3]?.token.symbol,
+                       BraveWallet.BlockchainToken.mockFilToken.symbol)
+        XCTAssertEqual(group.assets[safe: 3]?.quantity,
+                       String(format: "%.04f", self.mockFILBalanceAccount1))
+        // USDC (value = $0.03, ethAccount2 hidden!)
+        XCTAssertEqual(group.assets[safe: 4]?.token.symbol,
+                       BraveWallet.BlockchainToken.mockUSDCToken.symbol)
+        XCTAssertEqual(group.assets[safe: 4]?.quantity,
                        String(format: "%.04f", self.mockUSDCBalanceAccount1)) // verify account 2 hidden
         // ETH Goerli (value = $0)
-        XCTAssertEqual(group.assets[safe: 03]?.token.symbol,
+        XCTAssertEqual(group.assets[safe: 5]?.token.symbol,
                        self.goerliNetwork.nativeToken.symbol)
-        XCTAssertEqual(group.assets[safe: 3]?.quantity, String(format: "%.04f", 0))
+        XCTAssertEqual(group.assets[safe: 5]?.quantity, String(format: "%.04f", 0))
       }.store(in: &cancellables)
     store.saveFilters(.init(
       groupBy: store.filters.groupBy,
@@ -479,10 +603,10 @@ import Preferences
       isHidingSmallBalances: false,
       isHidingUnownedNFTs: store.filters.isHidingUnownedNFTs,
       isShowingNFTNetworkLogo: store.filters.isShowingNFTNetworkLogo,
-      accounts: [ethAccount1, ethAccount2, solAccount1, solAccount2].map { // deselect ethAccount2
+      accounts: [ethAccount1, ethAccount2, solAccount1, solAccount2, filAccount1, filAccount2, filTestnetAccount].map { // deselect ethAccount2
         .init(isSelected: $0 != ethAccount2, model: $0)
       },
-      networks: [ethNetwork, goerliNetwork, solNetwork].map {
+      networks: [ethNetwork, goerliNetwork, solNetwork, filMainnet, filTestnet].map {
         .init(isSelected: true, model: $0)
       }
     ))
@@ -510,24 +634,34 @@ import Preferences
           XCTFail("Unexpected test result")
           return
         }
-        // ETH on Ethereum mainnet, USDC on Ethereum mainnet, ETH on Goerli
-        XCTAssertEqual(group.assets.count, 3)
+        // ETH on Ethereum mainnet, USDC on Ethereum mainnet, ETH on Goerli, FIL on mainnet and testnet
+        XCTAssertEqual(group.assets.count, 5)
         // ETH Mainnet (value ~= $2741.7510399999996)
         XCTAssertEqual(group.assets[safe: 0]?.token.symbol,
                        BraveWallet.BlockchainToken.previewToken.symbol)
         XCTAssertEqual(group.assets[safe: 0]?.quantity,
                        String(format: "%.04f", self.mockETHBalanceAccount1))
-        // USDC (value = $0.04)
+        // FIL (value = $400) on testnet
         XCTAssertEqual(group.assets[safe: 1]?.token.symbol,
-                       BraveWallet.BlockchainToken.mockUSDCToken.symbol)
+                       BraveWallet.BlockchainToken.mockFilToken.symbol)
         XCTAssertEqual(group.assets[safe: 1]?.quantity,
+                       String(format: "%.04f", self.mockFILBalanceTestnet))
+        // FIL (value = $4) on mainnet
+        XCTAssertEqual(group.assets[safe: 2]?.token.symbol,
+                       BraveWallet.BlockchainToken.mockFilToken.symbol)
+        XCTAssertEqual(group.assets[safe: 2]?.quantity,
+                       String(format: "%.04f", self.mockFILBalanceAccount1))
+        // USDC (value = $0.04)
+        XCTAssertEqual(group.assets[safe: 3]?.token.symbol,
+                       BraveWallet.BlockchainToken.mockUSDCToken.symbol)
+        XCTAssertEqual(group.assets[safe: 3]?.quantity,
                        String(format: "%.04f", self.mockUSDCBalanceAccount1 + self.mockUSDCBalanceAccount2))
         // ETH Goerli (value = $0)
-        XCTAssertEqual(group.assets[safe: 2]?.token.symbol,
+        XCTAssertEqual(group.assets[safe: 4]?.token.symbol,
                        self.goerliNetwork.nativeToken.symbol)
-        XCTAssertEqual(group.assets[safe: 2]?.quantity, String(format: "%.04f", 0))
+        XCTAssertEqual(group.assets[safe: 4]?.quantity, String(format: "%.04f", 0))
         // SOL (value = $0, SOL networks hidden)
-        XCTAssertNil(group.assets[safe: 3])
+        XCTAssertNil(group.assets[safe: 5])
       }.store(in: &cancellables)
     store.saveFilters(.init(
       groupBy: store.filters.groupBy,
@@ -535,11 +669,11 @@ import Preferences
       isHidingSmallBalances: false,
       isHidingUnownedNFTs: store.filters.isHidingUnownedNFTs,
       isShowingNFTNetworkLogo: store.filters.isShowingNFTNetworkLogo,
-      accounts: [ethAccount1, ethAccount2, solAccount1, solAccount2].map {
+      accounts: [ethAccount1, ethAccount2, solAccount1, solAccount2, filAccount1, filAccount2, filTestnetAccount].map {
         .init(isSelected: true, model: $0)
       },
-      networks: [ethNetwork, goerliNetwork, solNetwork].map { // only select Ethereum networks
-        .init(isSelected: $0.coin == .eth, model: $0)
+      networks: [ethNetwork, goerliNetwork, solNetwork, filMainnet, filTestnet].map { // only select Ethereum networks
+        .init(isSelected: $0.coin == .eth || $0.coin == .fil, model: $0)
       }
     ))
     await fulfillment(of: [networksExpectation], timeout: 1)
@@ -563,11 +697,14 @@ import Preferences
           return
         }
         // grouping by .account; 1 for each of the 4 accounts
-        XCTAssertEqual(lastUpdatedAssetGroups.count, 4)
+        XCTAssertEqual(lastUpdatedAssetGroups.count, 7)
         guard let ethAccount1Group = lastUpdatedAssetGroups[safe: 0],
               let solAccount1Group = lastUpdatedAssetGroups[safe: 1],
-              let ethAccount2Group = lastUpdatedAssetGroups[safe: 2],
-              let solAccount2Group = lastUpdatedAssetGroups[safe: 3] else {
+              let filTestnetAccountGroup = lastUpdatedAssetGroups[safe: 2],
+              let filAccount1Group = lastUpdatedAssetGroups[safe: 3],
+              let ethAccount2Group = lastUpdatedAssetGroups[safe: 4],
+              let solAccount2Group = lastUpdatedAssetGroups[safe: 5],
+              let filAccount2Group = lastUpdatedAssetGroups[safe: 6] else {
           XCTFail("Unexpected test result")
           return
         }
@@ -596,6 +733,22 @@ import Preferences
         XCTAssertEqual(solAccount1Group.assets[safe: 0]?.quantity,
                        String(format: "%.04f", self.mockSOLBalance))
         
+        XCTAssertEqual(filTestnetAccountGroup.groupType, .account(self.filTestnetAccount))
+        XCTAssertEqual(filTestnetAccountGroup.assets.count, 1)
+        // FIL (value = $400)
+        XCTAssertEqual(filTestnetAccountGroup.assets[safe: 0]?.token.symbol,
+                       BraveWallet.BlockchainToken.mockFilToken.symbol)
+        XCTAssertEqual(filTestnetAccountGroup.assets[safe: 0]?.quantity,
+                       String(format: "%.04f", self.mockFILBalanceTestnet))
+        
+        XCTAssertEqual(filAccount1Group.groupType, .account(self.filAccount1))
+        XCTAssertEqual(filAccount1Group.assets.count, 1)
+        // FIL (value = $4)
+        XCTAssertEqual(filAccount1Group.assets[safe: 0]?.token.symbol,
+                       BraveWallet.BlockchainToken.mockFilToken.symbol)
+        XCTAssertEqual(filAccount1Group.assets[safe: 0]?.quantity,
+                       String(format: "%.04f", self.mockFILBalanceAccount1))
+        
         XCTAssertEqual(ethAccount2Group.groupType, .account(self.ethAccount2))
         XCTAssertEqual(ethAccount2Group.assets.count, 3) // ETH Mainnet, USDC, ETH Goerli
         // USDC (value $0.01)
@@ -618,6 +771,13 @@ import Preferences
         XCTAssertEqual(solAccount2Group.assets[safe: 0]?.token.symbol,
                        BraveWallet.BlockchainToken.mockSolToken.symbol)
         XCTAssertEqual(solAccount2Group.assets[safe: 0]?.quantity, String(format: "%.04f", 0))
+        
+        XCTAssertEqual(filAccount2Group.groupType, .account(self.filAccount2))
+        XCTAssertEqual(filAccount2Group.assets.count, 1)
+        // FIL (value = $0)
+        XCTAssertEqual(filAccount2Group.assets[safe: 0]?.token.symbol,
+                       BraveWallet.BlockchainToken.mockFilToken.symbol)
+        XCTAssertEqual(filAccount2Group.assets[safe: 0]?.quantity, String(format: "%.04f", 0))
       }
       .store(in: &cancellables)
     store.saveFilters(.init(
@@ -626,10 +786,10 @@ import Preferences
       isHidingSmallBalances: store.filters.isHidingSmallBalances,
       isHidingUnownedNFTs: store.filters.isHidingUnownedNFTs,
       isShowingNFTNetworkLogo: store.filters.isShowingNFTNetworkLogo,
-      accounts: [ethAccount1, ethAccount2, solAccount1, solAccount2].map {
+      accounts: [ethAccount1, ethAccount2, solAccount1, solAccount2, filAccount1, filAccount2, filTestnetAccount].map {
         .init(isSelected: true, model: $0)
       },
-      networks: [ethNetwork, goerliNetwork, solNetwork].map {
+      networks: [ethNetwork, goerliNetwork, solNetwork, filMainnet, filTestnet].map {
         .init(isSelected: true, model: $0)
       }
     ))
@@ -648,9 +808,11 @@ import Preferences
           return
         }
         // grouping by .account; 1 for each of the 2 accounts selected accounts
-        XCTAssertEqual(lastUpdatedAssetGroups.count, 2)
+        XCTAssertEqual(lastUpdatedAssetGroups.count, 4)
         guard let ethAccount1Group = lastUpdatedAssetGroups[safe: 0],
-              let solAccountGroup = lastUpdatedAssetGroups[safe: 1] else {
+              let solAccountGroup = lastUpdatedAssetGroups[safe: 1],
+              let filTestnetAccountGroup = lastUpdatedAssetGroups[safe: 2],
+              let filAccount1Group = lastUpdatedAssetGroups[safe: 3] else {
           XCTFail("Unexpected test result")
           return
         }
@@ -671,9 +833,27 @@ import Preferences
                        BraveWallet.BlockchainToken.mockSolToken.symbol)
         XCTAssertEqual(solAccountGroup.assets[safe: 0]?.quantity,
                        String(format: "%.04f", self.mockSOLBalance))
-        // ethAccount2 hidden as it's de-selected, solAccount2 hidden for small balance
-        XCTAssertNil(lastUpdatedAssetGroups[safe: 2])
-        XCTAssertNil(lastUpdatedAssetGroups[safe: 3])
+        
+        XCTAssertEqual(filTestnetAccountGroup.groupType, .account(self.filTestnetAccount))
+        XCTAssertEqual(filTestnetAccountGroup.assets.count, 1)
+        // FIL (value = $400)
+        XCTAssertEqual(filTestnetAccountGroup.assets[safe: 0]?.token.symbol,
+                       BraveWallet.BlockchainToken.mockFilToken.symbol)
+        XCTAssertEqual(filTestnetAccountGroup.assets[safe: 0]?.quantity,
+                       String(format: "%.04f", self.mockFILBalanceTestnet))
+        
+        XCTAssertEqual(filAccount1Group.groupType, .account(self.filAccount1))
+        XCTAssertEqual(filAccount1Group.assets.count, 1)
+        // FIL (value = $4)
+        XCTAssertEqual(filAccount1Group.assets[safe: 0]?.token.symbol,
+                       BraveWallet.BlockchainToken.mockFilToken.symbol)
+        XCTAssertEqual(filAccount1Group.assets[safe: 0]?.quantity,
+                       String(format: "%.04f", self.mockFILBalanceAccount1))
+        
+        // ethAccount2 hidden as it's de-selected, solAccount2 hidden for small balance, filAccount2 hidden for small balance
+        XCTAssertNil(lastUpdatedAssetGroups[safe: 4])
+        XCTAssertNil(lastUpdatedAssetGroups[safe: 5])
+        XCTAssertNil(lastUpdatedAssetGroups[safe: 6])
       }
       .store(in: &cancellables)
     store.saveFilters(.init(
@@ -682,10 +862,10 @@ import Preferences
       isHidingSmallBalances: true,
       isHidingUnownedNFTs: store.filters.isHidingUnownedNFTs,
       isShowingNFTNetworkLogo: store.filters.isShowingNFTNetworkLogo,
-      accounts: [ethAccount1, ethAccount2, solAccount1, solAccount2].map {
+      accounts: [ethAccount1, ethAccount2, solAccount1, solAccount2, filAccount1, filAccount2, filTestnetAccount].map {
         .init(isSelected: $0 != ethAccount2, model: $0)
       },
-      networks: [ethNetwork, goerliNetwork, solNetwork].map {
+      networks: [ethNetwork, goerliNetwork, solNetwork, filMainnet, filTestnet].map {
         .init(isSelected: true, model: $0)
       }
     ))
@@ -709,11 +889,13 @@ import Preferences
           XCTFail("Unexpected test result")
           return
         }
-        // grouping by .network; 1 for each of the 2 networks, with Goerli group hidden due to 0 balance.
-        XCTAssertEqual(lastUpdatedAssetGroups.count, 3)
+        // grouping by .network; 1 for each of the 2 networks
+        XCTAssertEqual(lastUpdatedAssetGroups.count, 5)
         guard let ethMainnetGroup = lastUpdatedAssetGroups[safe: 0],
               let solMainnetGroup = lastUpdatedAssetGroups[safe: 1],
-              let ethGoerliGroup = lastUpdatedAssetGroups[safe: 2] else {
+              let filTestnetGroup = lastUpdatedAssetGroups[safe: 2],
+              let filMainnetGroup = lastUpdatedAssetGroups[safe: 3],
+              let ethGoerliGroup = lastUpdatedAssetGroups[safe: 4] else {
           XCTFail("Unexpected test result")
           return
         }
@@ -738,6 +920,22 @@ import Preferences
         XCTAssertEqual(solMainnetGroup.assets[safe: 0]?.quantity,
                        String(format: "%.04f", self.mockSOLBalance))
         
+        XCTAssertEqual(filTestnetGroup.groupType, .network(.mockFilecoinTestnet))
+        XCTAssertEqual(filTestnetGroup.assets.count, 1) // FIL on testnet
+        // FIL (value = $400)
+        XCTAssertEqual(filTestnetGroup.assets[safe: 0]?.token.symbol,
+                       BraveWallet.BlockchainToken.mockFilToken.symbol)
+        XCTAssertEqual(filTestnetGroup.assets[safe: 0]?.quantity,
+                       String(format: "%.04f", self.mockFILBalanceTestnet))
+        
+        XCTAssertEqual(filMainnetGroup.groupType, .network(.mockFilecoinMainnet))
+        XCTAssertEqual(filMainnetGroup.assets.count, 1) // FIL on mainnet
+        // FIL (value = $4)
+        XCTAssertEqual(filMainnetGroup.assets[safe: 0]?.token.symbol,
+                       BraveWallet.BlockchainToken.mockFilToken.symbol)
+        XCTAssertEqual(filMainnetGroup.assets[safe: 0]?.quantity,
+                       String(format: "%.04f", self.mockFILBalanceAccount1))
+        
         XCTAssertEqual(ethGoerliGroup.groupType, .network(.mockGoerli))
         XCTAssertEqual(ethGoerliGroup.assets.count, 1) // ETH Goerli
         // ETH Goerli (value = $0)
@@ -752,10 +950,10 @@ import Preferences
       isHidingSmallBalances: store.filters.isHidingSmallBalances,
       isHidingUnownedNFTs: store.filters.isHidingUnownedNFTs,
       isShowingNFTNetworkLogo: store.filters.isShowingNFTNetworkLogo,
-      accounts: [ethAccount1, ethAccount2, solAccount1, solAccount2].map {
+      accounts: [ethAccount1, ethAccount2, solAccount1, solAccount2, filAccount1, filAccount2, filTestnetAccount].map {
         .init(isSelected: true, model: $0)
       },
-      networks: [ethNetwork, goerliNetwork, solNetwork].map {
+      networks: [ethNetwork, goerliNetwork, solNetwork, filMainnet, filTestnet].map {
         .init(isSelected: true, model: $0)
       }
     ))
@@ -773,9 +971,11 @@ import Preferences
           XCTFail("Unexpected test result")
           return
         }
-        // grouping by .network; 1 group for Solana network
-        XCTAssertEqual(lastUpdatedAssetGroups.count, 1)
-        guard let solMainnetGroup = lastUpdatedAssetGroups[safe: 0] else {
+        // grouping by .network; 1 group for Solana network, 1 group for Filecoin mainnet, 1 group for Filecoin testnet
+        XCTAssertEqual(lastUpdatedAssetGroups.count, 3)
+        guard let solMainnetGroup = lastUpdatedAssetGroups[safe: 0],
+              let filTestnetGroup = lastUpdatedAssetGroups[safe: 1],
+              let filMainnetGroup = lastUpdatedAssetGroups[safe: 2]  else {
           XCTFail("Unexpected test result")
           return
         }
@@ -786,10 +986,26 @@ import Preferences
                        BraveWallet.BlockchainToken.mockSolToken.symbol)
         XCTAssertEqual(solMainnetGroup.assets[safe: 0]?.quantity,
                        String(format: "%.04f", self.mockSOLBalance))
+        
+        XCTAssertEqual(filTestnetGroup.groupType, .network(.mockFilecoinTestnet))
+        XCTAssertEqual(filTestnetGroup.assets.count, 1) // FIL
+        // FIL (value = $400)
+        XCTAssertEqual(filTestnetGroup.assets[safe: 0]?.token.symbol,
+                       BraveWallet.BlockchainToken.mockFilToken.symbol)
+        XCTAssertEqual(filTestnetGroup.assets[safe: 0]?.quantity,
+                       String(format: "%.04f", self.mockFILBalanceTestnet))
+        
+        XCTAssertEqual(filMainnetGroup.groupType, .network(.mockFilecoinMainnet))
+        XCTAssertEqual(filMainnetGroup.assets.count, 1) // FIL
+        // FIL (value = $4)
+        XCTAssertEqual(filMainnetGroup.assets[safe: 0]?.token.symbol,
+                       BraveWallet.BlockchainToken.mockFilToken.symbol)
+        XCTAssertEqual(filMainnetGroup.assets[safe: 0]?.quantity,
+                       String(format: "%.04f", self.mockFILBalanceAccount1))
         // eth mainnet group hidden as network de-selected
-        XCTAssertNil(lastUpdatedAssetGroups[safe: 1])
+        XCTAssertNil(lastUpdatedAssetGroups[safe: 3])
         // goerli network group hidden for small balance
-        XCTAssertNil(lastUpdatedAssetGroups[safe: 2])
+        XCTAssertNil(lastUpdatedAssetGroups[safe: 4])
       }
       .store(in: &cancellables)
     store.saveFilters(.init(
@@ -798,10 +1014,10 @@ import Preferences
       isHidingSmallBalances: true,
       isHidingUnownedNFTs: store.filters.isHidingUnownedNFTs,
       isShowingNFTNetworkLogo: store.filters.isShowingNFTNetworkLogo,
-      accounts: [ethAccount1, ethAccount2, solAccount1, solAccount2].map {
+      accounts: [ethAccount1, ethAccount2, solAccount1, solAccount2, filAccount1, filAccount2, filTestnetAccount].map {
         .init(isSelected: true, model: $0)
       },
-      networks: [ethNetwork, goerliNetwork, solNetwork].map { // hide ethNetwork
+      networks: [ethNetwork, goerliNetwork, solNetwork, filMainnet, filTestnet].map { // hide ethNetwork
         .init(isSelected: $0 != ethNetwork, model: $0)
       }
     ))

--- a/Tests/BraveWalletTests/PortfolioStoreTests.swift
+++ b/Tests/BraveWalletTests/PortfolioStoreTests.swift
@@ -293,11 +293,11 @@ import Preferences
     let mockAssetManager = TestableWalletUserAssetManager()
     mockAssetManager._getAllVisibleAssetsInNetworkAssets = { networks in
       [
-        NetworkAssets(network: .mockMainnet, tokens: mockEthUserAssets.filter({ $0.visible == true }), sortOrder: 0),
-        NetworkAssets(network: .mockSolana, tokens: mockSolUserAssets.filter({ $0.visible == true }), sortOrder: 1),
-        NetworkAssets(network: .mockGoerli, tokens: mockEthGoerliUserAssets.filter({ $0.visible == true }), sortOrder: 2),
-        NetworkAssets(network: .mockFilecoinMainnet, tokens: mockFilUserAssets.filter({ $0.visible == true }), sortOrder: 3),
-        NetworkAssets(network: .mockFilecoinTestnet, tokens: mockFilTestnetUserAssets.filter({ $0.visible == true }), sortOrder: 4)
+        NetworkAssets(network: .mockMainnet, tokens: mockEthUserAssets.filter(\.visible), sortOrder: 0),
+        NetworkAssets(network: .mockSolana, tokens: mockSolUserAssets.filter(\.visible), sortOrder: 1),
+        NetworkAssets(network: .mockGoerli, tokens: mockEthGoerliUserAssets.filter(\.visible), sortOrder: 2),
+        NetworkAssets(network: .mockFilecoinMainnet, tokens: mockFilUserAssets.filter(\.visible), sortOrder: 3),
+        NetworkAssets(network: .mockFilecoinTestnet, tokens: mockFilTestnetUserAssets.filter(\.visible), sortOrder: 4)
       ].filter { networkAsset in networks.contains(where: { $0 == networkAsset.network }) }
     }
     return PortfolioStore(

--- a/Tests/BraveWalletTests/SelectAccountTokenStoreTests.swift
+++ b/Tests/BraveWalletTests/SelectAccountTokenStoreTests.swift
@@ -139,7 +139,8 @@ import Preferences
     
     let keyringService = BraveWallet.TestKeyringService()
     keyringService._keyringInfo = { keyringId, completion in
-      if keyringId == BraveWallet.KeyringId.default {
+      switch keyringId {
+      case .default:
         let keyring: BraveWallet.KeyringInfo = .init(
           id: BraveWallet.KeyringId.default,
           isKeyringCreated: true,
@@ -148,7 +149,7 @@ import Preferences
           accountInfos: [.mockEthAccount, self.mockEthAccount2]
         )
         completion(keyring)
-      } else if keyringId == BraveWallet.KeyringId.solana {
+      case .solana:
         let keyring: BraveWallet.KeyringInfo = .init(
           id: BraveWallet.KeyringId.solana,
           isKeyringCreated: true,
@@ -157,10 +158,12 @@ import Preferences
           accountInfos: [.mockSolAccount]
         )
         completion(keyring)
-      } else if keyringId == BraveWallet.KeyringId.filecoin {
+      case .filecoin:
         completion(.mockFilecoinKeyringInfo)
-      } else {
+      case .filecoinTestnet:
         completion(.mockFilecoinTestnetKeyringInfo)
+      default:
+        completion(.mockDefaultKeyringInfo)
       }
     }
     let rpcService = BraveWallet.TestJsonRpcService()

--- a/Tests/BraveWalletTests/SendTokenStoreTests.swift
+++ b/Tests/BraveWalletTests/SendTokenStoreTests.swift
@@ -534,6 +534,33 @@ class SendTokenStoreTests: XCTestCase {
     }
   }
   
+  /// Test making a FIL Send transaction on filecoin mainnet
+  func testMakeSendFILTransaction() {
+    let (keyringService, rpcService, walletService, ethTxManagerProxy, solTxManagerProxy, mockAssetManager) = setupServices()
+    let store = SendTokenStore(
+      keyringService: keyringService,
+      rpcService: rpcService,
+      walletService: walletService,
+      txService: MockTxService(),
+      blockchainRegistry: MockBlockchainRegistry(),
+      assetRatioService: MockAssetRatioService(),
+      ethTxManagerProxy: ethTxManagerProxy,
+      solTxManagerProxy: solTxManagerProxy,
+      prefilledToken: .previewToken,
+      ipfsApi: TestIpfsAPI(),
+      userAssetManager: mockAssetManager
+    )
+    store.selectedSendToken = .mockFilToken
+    let ex = expectation(description: "send-fil-transaction")
+    store.sendToken(amount: "1") { success, _ in
+      defer { ex.fulfill() }
+      XCTAssertTrue(success)
+    }
+    waitForExpectations(timeout: 3) { error in
+      XCTAssertNil(error)
+    }
+  }
+
   /// Test Solana System Program transaction is created with correct lamports value for the `mockSolToken` (9 decimals)
   func testSendSolAmount() {
     let mockBalance: UInt64 = 47
@@ -1017,7 +1044,9 @@ class SendTokenStoreTests: XCTestCase {
     store.$resolvedAddress
       .dropFirst(3) // Initial value, reset to nil in `sendAddress` didSet, reset to nil in `validateEthereumSendAddress`
       .sink { resolvedAddress in
-        defer { resolvedAddressExpectation.fulfill() }
+        defer {
+          resolvedAddressExpectation.fulfill()
+        }
         XCTAssertEqual(resolvedAddress, expectedAddress)
       }.store(in: &cancellables)
     store.sendAddress = domain
@@ -1482,28 +1511,50 @@ class SendTokenStoreTests: XCTestCase {
     await fulfillment(of: [didSelectSendTokenExpectation, setSelectedAccountExpectation, setNetworkExpectation], timeout: 1)
   }
 
-  /// Test `didSelect(account:token:)` with a new token that is on a different coin type (ex. Ethereum -> Solana).
+  /// Test `didSelect(account:token:)` with a new token that is on a different coin type (ex. Ethereum -> Solana, Solana -> Filecoin).
   @MainActor func testDidSelectCoinTypeSwitch() async {
     let solMainnet: BraveWallet.BlockchainToken = BraveWallet.NetworkInfo.mockSolana.nativeToken
       .copy(asVisibleAsset: true)
+    let filTokenMainnet: BraveWallet.BlockchainToken = .mockFilToken.copy(asVisibleAsset: true)
     var selectedNetwork: BraveWallet.NetworkInfo = .mockGoerli
-    let allNetworks: [BraveWallet.NetworkInfo] = [.mockGoerli, .mockSolana]
+    var selectedNetworkToBe: BraveWallet.NetworkInfo = .mockSolana
+    var selectedAccount: BraveWallet.AccountInfo = account
+    let allNetworks: [BraveWallet.NetworkInfo] = [.mockGoerli, .mockSolana, .mockFilecoinMainnet]
     let (keyringService, rpcService, walletService, ethTxManagerProxy, solTxManagerProxy, mockAssetManager) = setupServices(
-      selectedAccount: account,
-      userAssets: [.mockGoerli: [usdcGoerli], .mockSolana: [solMainnet]],
+      selectedAccount: selectedAccount,
+      userAssets: [.mockGoerli: [usdcGoerli], .mockSolana: [solMainnet], .mockFilecoinMainnet: [filTokenMainnet]],
       selectedCoin: .eth,
       allNetworks: allNetworks
     )
+    
+    let didSelectSendFilTokenExpectation = expectation(description: "didSelectSendFilTokenExpectation")
+    let setSelectedFilAccountExpectation = expectation(description: "setSelectedFilAccountExpectation")
+    let setFilNetworkExpectation = expectation(description: "setFilNetworkExpectation")
+    
+    let didSelectSendTokenExpectation = expectation(description: "didSelectSendTokenExpectation")
     let setSelectedAccountExpectation = expectation(description: "setSelectedAccountExpectation")
+    let setNetworkExpectation = expectation(description: "setNetworkExpectation")
+    
     keyringService._setSelectedAccount = { accountId, completion in
-      defer { setSelectedAccountExpectation.fulfill() }
-      XCTAssertEqual(accountId.address, BraveWallet.AccountInfo.mockSolAccount.address)
+      defer {
+        if accountId.coin == .sol {
+          setSelectedAccountExpectation.fulfill()
+        } else {
+          setSelectedFilAccountExpectation.fulfill()
+        }
+      }
+      XCTAssertEqual(accountId.address, selectedAccount.address)
       completion(true)
     }
-    let setNetworkExpectation = expectation(description: "setNetworkExpectation")
     rpcService._setNetwork = { chainId, coin, origin, completion in
-      defer { setNetworkExpectation.fulfill() }
-      XCTAssertEqual(chainId, solMainnet.chainId)
+      defer {
+        if coin == .sol {
+          setNetworkExpectation.fulfill()
+        } else {
+          setFilNetworkExpectation.fulfill()
+        }
+      }
+      XCTAssertEqual(chainId, selectedNetworkToBe.chainId)
       selectedNetwork = allNetworks.first(where: { $0.chainId == chainId }) ?? selectedNetwork
       completion(true)
     }
@@ -1536,15 +1587,34 @@ class SendTokenStoreTests: XCTestCase {
     await fulfillment(of: [sendTokenExpectation], timeout: 1)
     cancellables.removeAll()
     
-    let didSelectSendTokenExpectation = expectation(description: "didSelectSendTokenExpectation")
+    // select solana mainnet
+    selectedAccount = .mockSolAccount
     store.$selectedSendToken
       .dropFirst()
       .sink { selectedSendToken in
-        defer { didSelectSendTokenExpectation.fulfill() }
+        defer {
+          didSelectSendTokenExpectation.fulfill()
+        }
         XCTAssertEqual(selectedSendToken, solMainnet)
       }
       .store(in: &cancellables)
     store.didSelect(account: .mockSolAccount, token: solMainnet)
     await fulfillment(of: [didSelectSendTokenExpectation, setSelectedAccountExpectation, setNetworkExpectation], timeout: 1)
+    cancellables.removeAll()
+    
+    // select filecoin mainnet
+    selectedAccount = .mockFilAccount
+    selectedNetworkToBe = .mockFilecoinMainnet
+    store.$selectedSendToken
+      .dropFirst()
+      .sink { selectedSendToken in
+        defer {
+          didSelectSendFilTokenExpectation.fulfill()
+        }
+        XCTAssertEqual(selectedSendToken, filTokenMainnet)
+      }
+      .store(in: &cancellables)
+    store.didSelect(account: .mockFilAccount, token: filTokenMainnet)
+    await fulfillment(of: [didSelectSendFilTokenExpectation, setSelectedFilAccountExpectation, setFilNetworkExpectation], timeout: 1)
   }
 }

--- a/Tests/BraveWalletTests/SendTokenStoreTests.swift
+++ b/Tests/BraveWalletTests/SendTokenStoreTests.swift
@@ -7,9 +7,17 @@ import XCTest
 import Combine
 import BraveCore
 import BigNumber
+import Preferences
 @testable import BraveWallet
 
 class SendTokenStoreTests: XCTestCase {
+  override func setUp() {
+    Preferences.Wallet.showTestNetworks.value = true
+  }
+  override func tearDown() {
+    Preferences.Wallet.showTestNetworks.reset()
+  }
+  
   private var cancellables: Set<AnyCancellable> = []
   private let batSymbol = "BAT"
   

--- a/Tests/BraveWalletTests/TransactionConfirmationStoreTests.swift
+++ b/Tests/BraveWalletTests/TransactionConfirmationStoreTests.swift
@@ -23,13 +23,15 @@ import Preferences
   private func setupStore(
     selectedNetworkForCoinType: [BraveWallet.CoinType: BraveWallet.NetworkInfo] = [
       .eth : BraveWallet.NetworkInfo.mockMainnet,
-      .sol : BraveWallet.NetworkInfo.mockSolana
+      .sol : BraveWallet.NetworkInfo.mockSolana,
+      .fil : BraveWallet.NetworkInfo.mockFilecoinMainnet
     ],
     allNetworksForCoinType: [BraveWallet.CoinType: [BraveWallet.NetworkInfo]] = [
       .eth: [.mockMainnet, .mockGoerli],
-      .sol: [.mockSolana, .mockSolanaTestnet]
+      .sol: [.mockSolana, .mockSolanaTestnet],
+      .fil: [.mockFilecoinMainnet, .mockFilecoinTestnet]
     ],
-    accountInfos: [BraveWallet.AccountInfo] = [.mockEthAccount, .mockSolAccount],
+    accountInfos: [BraveWallet.AccountInfo] = [.mockEthAccount, .mockSolAccount, .mockFilAccount],
     allTokens: [BraveWallet.BlockchainToken] = [],
     transactions: [BraveWallet.TransactionInfo] = [],
     gasEstimation: BraveWallet.GasEstimation1559 = .init(),
@@ -38,12 +40,14 @@ import Preferences
   ) -> TransactionConfirmationStore {
     let mockEthAssetPrice: BraveWallet.AssetPrice = .init(fromAsset: "eth", toAsset: "usd", price: "3059.99", assetTimeframeChange: "-57.23")
     let mockSolAssetPrice: BraveWallet.AssetPrice = .init(fromAsset: "sol", toAsset: "usd", price: "39.57", assetTimeframeChange: "-57.23")
+    let mockFilAssetPrice: BraveWallet.AssetPrice = .init(fromAsset: "fil", toAsset: "usd", price: "4.0", assetTimeframeChange: "-57.23")
     let formatter = WeiFormatter(decimalFormatStyle: .decimals(precision: 18))
     let mockBalanceWei = formatter.weiString(from: 0.0896, radix: .hex, decimals: 18) ?? ""
+    let mockFILBalanceWei = formatter.weiString(from: 1, decimals: 18) ?? ""
     // setup test services
     let assetRatioService = BraveWallet.TestAssetRatioService()
     assetRatioService._price = { _, _, _, completion in
-      completion(true, [mockEthAssetPrice, mockSolAssetPrice])
+      completion(true, [mockEthAssetPrice, mockSolAssetPrice, mockFilAssetPrice])
     }
     let rpcService = BraveWallet.TestJsonRpcService()
     rpcService._chainIdForOrigin = { coin, origin, completion in
@@ -55,8 +59,12 @@ import Preferences
     rpcService._allNetworks = { coin, completion in
       completion(allNetworksForCoinType[coin] ?? [])
     }
-    rpcService._balance = { _, _, _, completion in
-      completion(mockBalanceWei, .success, "")
+    rpcService._balance = { _, coin, _, completion in
+      if coin == .eth {
+        completion(mockBalanceWei, .success, "")
+      } else { // .fil
+        completion(mockFILBalanceWei, .success, "")
+      }
     }
     rpcService._erc20TokenAllowance = { _, _, _, _, completion in
       completion("16345785d8a0000", .success, "") // 0.1000
@@ -110,8 +118,10 @@ import Preferences
         accountInfos: [])
       if id == BraveWallet.KeyringId.default {
         keyring.accountInfos = accountInfos.filter { $0.coin == .eth }
-      } else {
+      } else if id == .solana {
         keyring.accountInfos = accountInfos.filter { $0.coin == .sol }
+      } else {
+        keyring.accountInfos = accountInfos.filter { $0.coin == .fil }
       }
       completion(keyring)
     }
@@ -324,8 +334,10 @@ import Preferences
     solanaSendCopy.chainId = BraveWallet.SolanaMainnet
     let solanaSPLSendCopy = BraveWallet.TransactionInfo.previewConfirmedSolTokenTransfer.copy() as! BraveWallet.TransactionInfo
     solanaSPLSendCopy.chainId = BraveWallet.SolanaTestnet
+    let filecoinSendCopy = BraveWallet.TransactionInfo.mockFilUnapprovedSend.copy() as! BraveWallet.TransactionInfo
+    filecoinSendCopy.chainId = BraveWallet.FilecoinMainnet
     let pendingTransactions: [BraveWallet.TransactionInfo] = [
-      sendCopy, swapCopy, solanaSendCopy, solanaSPLSendCopy
+      sendCopy, swapCopy, solanaSendCopy, solanaSPLSendCopy, filecoinSendCopy
     ].enumerated().map { (index, tx) in
       tx.txStatus = .unapproved
       // transactions sorted by created time, make sure they are in-order
@@ -339,28 +351,30 @@ import Preferences
     )
     let networkExpectation = expectation(description: "network-expectation")
     store.$network
-      .dropFirst(6) // `network` is assigned multiple times during setup
-      .collect(4) // collect all transactions
+      .dropFirst(7) // `network` is assigned multiple times during setup
+      .collect(5) // collect all transactions
       .sink { networks in
         defer { networkExpectation.fulfill() }
-        XCTAssertEqual(networks.count, 4)
-        XCTAssertEqual(networks[safe: 0], BraveWallet.NetworkInfo.mockSolanaTestnet)
-        XCTAssertEqual(networks[safe: 1], BraveWallet.NetworkInfo.mockSolana)
-        XCTAssertEqual(networks[safe: 2], BraveWallet.NetworkInfo.mockMainnet)
-        XCTAssertEqual(networks[safe: 3], BraveWallet.NetworkInfo.mockGoerli)
+        XCTAssertEqual(networks.count, 5)
+        XCTAssertEqual(networks[safe: 0], BraveWallet.NetworkInfo.mockFilecoinMainnet)
+        XCTAssertEqual(networks[safe: 1], BraveWallet.NetworkInfo.mockSolanaTestnet)
+        XCTAssertEqual(networks[safe: 2], BraveWallet.NetworkInfo.mockSolana)
+        XCTAssertEqual(networks[safe: 3], BraveWallet.NetworkInfo.mockMainnet)
+        XCTAssertEqual(networks[safe: 4], BraveWallet.NetworkInfo.mockGoerli)
       }
       .store(in: &cancellables)
     let activeTransactionIdExpectation = expectation(description: "activeTransactionId-expectation")
     store.$activeTransactionId
       .dropFirst()
-      .collect(4) // collect all transactions
+      .collect(5) // collect all transactions
       .sink { activeTransactionIds in
         defer { activeTransactionIdExpectation.fulfill() }
-        XCTAssertEqual(activeTransactionIds.count, 4)
-        XCTAssertEqual(activeTransactionIds[safe: 0], pendingTransactions[safe: 3]?.id)
-        XCTAssertEqual(activeTransactionIds[safe: 1], pendingTransactions[safe: 2]?.id)
-        XCTAssertEqual(activeTransactionIds[safe: 2], pendingTransactions[safe: 1]?.id)
-        XCTAssertEqual(activeTransactionIds[safe: 3], pendingTransactions[safe: 0]?.id)
+        XCTAssertEqual(activeTransactionIds.count, 5)
+        XCTAssertEqual(activeTransactionIds[safe: 0], pendingTransactions[safe: 4]?.id)
+        XCTAssertEqual(activeTransactionIds[safe: 1], pendingTransactions[safe: 3]?.id)
+        XCTAssertEqual(activeTransactionIds[safe: 2], pendingTransactions[safe: 2]?.id)
+        XCTAssertEqual(activeTransactionIds[safe: 3], pendingTransactions[safe: 1]?.id)
+        XCTAssertEqual(activeTransactionIds[safe: 4], pendingTransactions[safe: 0]?.id)
       }
       .store(in: &cancellables)
     
@@ -368,6 +382,7 @@ import Preferences
     store.nextTransaction() // `swapCopy` on Ethereum Mainnet
     store.nextTransaction() // `solanaSendCopy` on Solana Mainnet
     store.nextTransaction() // `solanaSPLSendCopy` on Solana Testnet
+    store.nextTransaction() // `filecoinSendCopy` on filecoin mainnet
     await fulfillment(of: [networkExpectation, activeTransactionIdExpectation], timeout: 1)
   }
   
@@ -494,6 +509,55 @@ import Preferences
       }
     )
     await fulfillment(of: [editExpectation], timeout: 1)
+  }
+  
+  func testPrepareFilSend() async {
+    let mockAllTokens: [BraveWallet.BlockchainToken] = [.mockFilToken]
+    let mockTransaction: BraveWallet.TransactionInfo = .mockFilUnapprovedSend
+    let mockTransactions: [BraveWallet.TransactionInfo] = [mockTransaction].map { tx in
+      tx.txStatus = .unapproved
+      return tx
+    }
+    let store = setupStore(
+      accountInfos: [.mockFilAccount],
+      allTokens: mockAllTokens,
+      transactions: mockTransactions
+    )
+    let prepareExpectation = expectation(description: "prepare")
+    await store.prepare()
+    store.$activeTransactionId
+      .sink { id in
+        defer { prepareExpectation.fulfill() }
+        XCTAssertEqual(id, mockTransaction.id)
+      }
+      .store(in: &cancellables)
+    store.$gasValue
+      .dropFirst()
+      .sink { value in
+        XCTAssertEqual(value, "0.000000155797727645")
+      }
+      .store(in: &cancellables)
+    store.$gasSymbol
+      .dropFirst()
+      .sink { value in
+        XCTAssertEqual(value, BraveWallet.BlockchainToken.mockFilToken.symbol)
+      }
+      .store(in: &cancellables)
+    store.$symbol
+      .dropFirst()
+      .sink { value in
+        XCTAssertEqual(value, BraveWallet.BlockchainToken.mockFilToken.symbol)
+      }
+      .store(in: &cancellables)
+    store.$value
+      .dropFirst()
+      .sink { value in
+        XCTAssertEqual(value, "1")
+      }
+      .store(in: &cancellables)
+    
+    await fulfillment(of: [prepareExpectation], timeout: 1)
+    
   }
 }
 

--- a/Tests/BraveWalletTests/TransactionsActivityStoreTests.swift
+++ b/Tests/BraveWalletTests/TransactionsActivityStoreTests.swift
@@ -52,15 +52,16 @@ class TransactionsActivityStoreTests: XCTestCase {
     let keyringService = BraveWallet.TestKeyringService()
     keyringService._addObserver = { _ in }
     keyringService._keyringInfo = { keyringId, completion in
-      if keyringId == BraveWallet.KeyringId.default {
+      switch keyringId {
+      case .default:
         completion(.mockDefaultKeyringInfo)
-      } else if keyringId == .solana {
+      case .solana:
         completion(.mockSolanaKeyringInfo)
-      } else if keyringId == .filecoin {
+      case .filecoin:
         completion(.mockFilecoinKeyringInfo)
-      } else if keyringId == .filecoinTestnet {
+      case .filecoinTestnet:
         completion(.mockFilecoinTestnetKeyringInfo)
-      } else {
+      default:
         completion(.mockDefaultKeyringInfo)
       }
     }

--- a/Tests/BraveWalletTests/TransactionsActivityStoreTests.swift
+++ b/Tests/BraveWalletTests/TransactionsActivityStoreTests.swift
@@ -22,7 +22,8 @@ class TransactionsActivityStoreTests: XCTestCase {
   
   let networks: [BraveWallet.CoinType: [BraveWallet.NetworkInfo]] = [
     .eth: [.mockMainnet],
-    .sol: [.mockSolana]
+    .sol: [.mockSolana],
+    .fil: [.mockFilecoinMainnet, .mockFilecoinTestnet]
   ]
   let visibleAssetsForCoins: [BraveWallet.CoinType: [BraveWallet.BlockchainToken]] = [
     .eth: [
@@ -32,14 +33,19 @@ class TransactionsActivityStoreTests: XCTestCase {
     .sol: [
       BraveWallet.NetworkInfo.mockSolana.nativeToken.copy(asVisibleAsset: true),
       .mockSolanaNFTToken.copy(asVisibleAsset: true),
-      .mockSpdToken.copy(asVisibleAsset: true)]
+      .mockSpdToken.copy(asVisibleAsset: true)],
+    .fil: [
+      BraveWallet.NetworkInfo.mockFilecoinMainnet.nativeToken.copy(asVisibleAsset: true),
+      BraveWallet.NetworkInfo.mockFilecoinTestnet.nativeToken.copy(asVisibleAsset: true)]
   ]
   let tokenRegistry: [BraveWallet.CoinType: [BraveWallet.BlockchainToken]] = [:]
   let mockAssetPrices: [BraveWallet.AssetPrice] = [
     .init(fromAsset: "eth", toAsset: "usd", price: "3059.99", assetTimeframeChange: "-57.23"),
     .init(fromAsset: "usdc", toAsset: "usd", price: "1.00", assetTimeframeChange: "-57.23"),
     .init(fromAsset: "sol", toAsset: "usd", price: "2.00", assetTimeframeChange: "-57.23"),
-    .init(fromAsset: "spd", toAsset: "usd", price: "0.50", assetTimeframeChange: "-57.23")
+    .init(fromAsset: "spd", toAsset: "usd", price: "0.50", assetTimeframeChange: "-57.23"),
+    .init(fromAsset: BraveWallet.BlockchainToken.mockFilToken.assetRatioId.lowercased(),
+          toAsset: "usd", price: "4.00", assetTimeframeChange: "-57.23")
   ]
   
   func testUpdate() {
@@ -48,8 +54,14 @@ class TransactionsActivityStoreTests: XCTestCase {
     keyringService._keyringInfo = { keyringId, completion in
       if keyringId == BraveWallet.KeyringId.default {
         completion(.mockDefaultKeyringInfo)
-      } else {
+      } else if keyringId == .solana {
         completion(.mockSolanaKeyringInfo)
+      } else if keyringId == .filecoin {
+        completion(.mockFilecoinKeyringInfo)
+      } else if keyringId == .filecoinTestnet {
+        completion(.mockFilecoinTestnetKeyringInfo)
+      } else {
+        completion(.mockDefaultKeyringInfo)
       }
     }
     
@@ -57,8 +69,10 @@ class TransactionsActivityStoreTests: XCTestCase {
     rpcService._allNetworks = { coin, completion in
       if coin == .sol {
         completion([.mockSolana, .mockSolanaTestnet])
-      } else {
+      } else if coin == .eth {
         completion([.mockMainnet, .mockGoerli])
+      } else { // .fil
+        completion([.mockFilecoinMainnet, .mockFilecoinTestnet])
       }
     }
     
@@ -83,7 +97,10 @@ class TransactionsActivityStoreTests: XCTestCase {
     let solSendTxCopy = BraveWallet.TransactionInfo.previewConfirmedSolSystemTransfer.copy() as! BraveWallet.TransactionInfo // default in mainnet
     let solTestnetSendTxCopy = BraveWallet.TransactionInfo.previewConfirmedSolTokenTransfer.copy() as! BraveWallet.TransactionInfo
     solTestnetSendTxCopy.chainId = BraveWallet.SolanaTestnet
-    let mockTxs: [BraveWallet.TransactionInfo] = [ethSendTxCopy, goerliSwapTxCopy, solSendTxCopy, solTestnetSendTxCopy].enumerated().map { (index, tx) in
+    let filSendTxCopy = BraveWallet.TransactionInfo.mockFilUnapprovedSend.copy() as! BraveWallet.TransactionInfo
+    let filTestnetSendTxCopy = BraveWallet.TransactionInfo.mockFilUnapprovedSend.copy() as! BraveWallet.TransactionInfo
+    filTestnetSendTxCopy.chainId = BraveWallet.FilecoinTestnet
+    let mockTxs: [BraveWallet.TransactionInfo] = [ethSendTxCopy, goerliSwapTxCopy, solSendTxCopy, solTestnetSendTxCopy, filSendTxCopy, filTestnetSendTxCopy].enumerated().map { (index, tx) in
       tx.txStatus = .unapproved
       // transactions sorted by created time, make sure they are in-order
       tx.createdTime = firstTransactionDate.addingTimeInterval(TimeInterval(index))
@@ -95,8 +112,10 @@ class TransactionsActivityStoreTests: XCTestCase {
     txService._allTransactionInfo = { coin, chainId, address, completion in
       if coin == .eth {
         completion([ethSendTxCopy, goerliSwapTxCopy].filter({ $0.chainId == chainId }))
-      } else {
+      } else if coin == .sol {
         completion([solSendTxCopy, solTestnetSendTxCopy].filter({ $0.chainId == chainId }))
+      } else { // .fil
+        completion([filSendTxCopy, filTestnetSendTxCopy].filter({ $0.chainId == chainId }))
       }
     }
     
@@ -144,28 +163,37 @@ class TransactionsActivityStoreTests: XCTestCase {
         XCTAssertEqual(transactionSummariesWithoutPrices.map(\.txInfo.txHash), expectedSortedOrder.map(\.txHash))
         XCTAssertEqual(transactionSummariesWithPrices.map(\.txInfo.txHash), expectedSortedOrder.map(\.txHash))
         // verify they are populated with correct tx (summaries are tested in `TransactionParserTests`)
+        XCTAssertEqual(transactionSummariesWithoutPrices[safe: 0]?.txInfo, filTestnetSendTxCopy)
+        XCTAssertEqual(transactionSummariesWithoutPrices[safe: 0]?.txInfo.chainId, filTestnetSendTxCopy.chainId)
+        XCTAssertEqual(transactionSummariesWithPrices[safe: 0]?.txInfo, filTestnetSendTxCopy)
+
+        XCTAssertEqual(transactionSummariesWithoutPrices[safe: 1]?.txInfo, filSendTxCopy)
+        XCTAssertEqual(transactionSummariesWithoutPrices[safe: 1]?.txInfo.chainId, filSendTxCopy.chainId)
+        XCTAssertEqual(transactionSummariesWithPrices[safe: 1]?.txInfo, filSendTxCopy)
+
+        XCTAssertEqual(transactionSummariesWithoutPrices[safe: 2]?.txInfo, solTestnetSendTxCopy)
+        XCTAssertEqual(transactionSummariesWithoutPrices[safe: 2]?.txInfo.chainId, solTestnetSendTxCopy.chainId)
+        XCTAssertEqual(transactionSummariesWithPrices[safe: 2]?.txInfo, solTestnetSendTxCopy)
         
-        XCTAssertEqual(transactionSummariesWithoutPrices[safe: 0]?.txInfo, solTestnetSendTxCopy)
-        XCTAssertEqual(transactionSummariesWithoutPrices[safe: 0]?.txInfo.chainId, solTestnetSendTxCopy.chainId)
-        XCTAssertEqual(transactionSummariesWithPrices[safe: 0]?.txInfo, solTestnetSendTxCopy)
+        XCTAssertEqual(transactionSummariesWithoutPrices[safe: 3]?.txInfo, solSendTxCopy)
+        XCTAssertEqual(transactionSummariesWithoutPrices[safe: 3]?.txInfo.chainId, solSendTxCopy.chainId)
+        XCTAssertEqual(transactionSummariesWithPrices[safe: 3]?.txInfo, solSendTxCopy)
         
-        XCTAssertEqual(transactionSummariesWithoutPrices[safe: 1]?.txInfo, solSendTxCopy)
-        XCTAssertEqual(transactionSummariesWithoutPrices[safe: 1]?.txInfo.chainId, solSendTxCopy.chainId)
-        XCTAssertEqual(transactionSummariesWithPrices[safe: 1]?.txInfo, solSendTxCopy)
+        XCTAssertEqual(transactionSummariesWithoutPrices[safe: 4]?.txInfo, goerliSwapTxCopy)
+        XCTAssertEqual(transactionSummariesWithoutPrices[safe: 4]?.txInfo.chainId, goerliSwapTxCopy.chainId)
+        XCTAssertEqual(transactionSummariesWithPrices[safe: 4]?.txInfo, goerliSwapTxCopy)
         
-        XCTAssertEqual(transactionSummariesWithoutPrices[safe: 2]?.txInfo, goerliSwapTxCopy)
-        XCTAssertEqual(transactionSummariesWithoutPrices[safe: 2]?.txInfo.chainId, goerliSwapTxCopy.chainId)
-        XCTAssertEqual(transactionSummariesWithPrices[safe: 2]?.txInfo, goerliSwapTxCopy)
-        
-        XCTAssertEqual(transactionSummariesWithoutPrices[safe: 3]?.txInfo, ethSendTxCopy)
-        XCTAssertEqual(transactionSummariesWithoutPrices[safe: 3]?.txInfo.chainId, ethSendTxCopy.chainId)
-        XCTAssertEqual(transactionSummariesWithPrices[safe: 3]?.txInfo, ethSendTxCopy)
+        XCTAssertEqual(transactionSummariesWithoutPrices[safe: 5]?.txInfo, ethSendTxCopy)
+        XCTAssertEqual(transactionSummariesWithoutPrices[safe: 5]?.txInfo.chainId, ethSendTxCopy.chainId)
+        XCTAssertEqual(transactionSummariesWithPrices[safe: 5]?.txInfo, ethSendTxCopy)
         
         // verify gas fee fiat
-        XCTAssertEqual(transactionSummariesWithPrices[safe: 0]?.gasFee?.fiat, "$0.000000002")
-        XCTAssertEqual(transactionSummariesWithPrices[safe: 1]?.gasFee?.fiat, "$0.000000002")
-        XCTAssertEqual(transactionSummariesWithPrices[safe: 2]?.gasFee?.fiat, "$255.03792654")
-        XCTAssertEqual(transactionSummariesWithPrices[safe: 3]?.gasFee?.fiat, "$10.41008598" )
+        XCTAssertEqual(transactionSummariesWithPrices[safe: 0]?.gasFee?.fiat, "$0.0000006232")
+        XCTAssertEqual(transactionSummariesWithPrices[safe: 1]?.gasFee?.fiat, "$0.0000006232")
+        XCTAssertEqual(transactionSummariesWithPrices[safe: 2]?.gasFee?.fiat, "$0.000000002")
+        XCTAssertEqual(transactionSummariesWithPrices[safe: 3]?.gasFee?.fiat, "$0.000000002")
+        XCTAssertEqual(transactionSummariesWithPrices[safe: 4]?.gasFee?.fiat, "$255.03792654")
+        XCTAssertEqual(transactionSummariesWithPrices[safe: 5]?.gasFee?.fiat, "$10.41008598" )
       }
       .store(in: &cancellables)
     

--- a/Tests/BraveWalletTests/UserAssetsStoreTests.swift
+++ b/Tests/BraveWalletTests/UserAssetsStoreTests.swift
@@ -15,11 +15,13 @@ class UserAssetsStoreTests: XCTestCase {
   
   let networks: [BraveWallet.CoinType: [BraveWallet.NetworkInfo]] = [
     .eth: [.mockMainnet],
-    .sol: [.mockSolana]
+    .sol: [.mockSolana],
+    .fil: [.mockFilecoinMainnet]
   ]
   let tokenRegistry: [BraveWallet.CoinType: [BraveWallet.BlockchainToken]] = [
     .eth: [.mockUSDCToken],
-    .sol: [.mockSpdToken]
+    .sol: [.mockSpdToken],
+    .fil: [.mockFilToken]
   ]
   
   private func setupServices() -> (BraveWallet.TestKeyringService, BraveWallet.TestJsonRpcService, BraveWallet.TestBlockchainRegistry, BraveWallet.TestAssetRatioService) {
@@ -73,6 +75,15 @@ class UserAssetsStoreTests: XCTestCase {
               ],
               sortOrder: 1)
           )
+        } else if network.chainId == BraveWallet.FilecoinMainnet {
+          result.append(
+            NetworkAssets(
+              network: .mockFilecoinMainnet,
+              tokens: [
+                BraveWallet.NetworkInfo.mockFilecoinMainnet.nativeToken.copy(asVisibleAsset: true)
+              ],
+              sortOrder: 1)
+          )
         }
       }
       return result
@@ -92,7 +103,7 @@ class UserAssetsStoreTests: XCTestCase {
       .dropFirst()
       .sink { assetStores in
         defer { assetStoresException.fulfill() }
-        XCTAssertEqual(assetStores.count, 6)
+        XCTAssertEqual(assetStores.count, 7)
         
         XCTAssertEqual(assetStores[0].token.symbol, BraveWallet.NetworkInfo.mockSolana.nativeToken.symbol)
         XCTAssertTrue(assetStores[0].token.visible)
@@ -117,6 +128,10 @@ class UserAssetsStoreTests: XCTestCase {
         XCTAssertEqual(assetStores[5].token.symbol, BraveWallet.BlockchainToken.mockUSDCToken.symbol)
         XCTAssertFalse(assetStores[5].token.visible)
         XCTAssertEqual(assetStores[5].network, BraveWallet.NetworkInfo.mockMainnet)
+        
+        XCTAssertEqual(assetStores[6].token.symbol, BraveWallet.BlockchainToken.mockFilToken.symbol)
+        XCTAssertTrue(assetStores[6].token.visible)
+        XCTAssertEqual(assetStores[6].network, BraveWallet.NetworkInfo.mockFilecoinMainnet)
       }
       .store(in: &cancellables)
     
@@ -153,6 +168,15 @@ class UserAssetsStoreTests: XCTestCase {
                 BraveWallet.NetworkInfo.mockSolana.nativeToken.copy(asVisibleAsset: true),
                 .mockSolanaNFTToken.copy(asVisibleAsset: true),
                 .mockSpdToken
+              ],
+              sortOrder: 1)
+          )
+        } else if network.chainId == BraveWallet.FilecoinMainnet {
+          result.append(
+            NetworkAssets(
+              network: .mockFilecoinMainnet,
+              tokens: [
+                BraveWallet.NetworkInfo.mockFilecoinMainnet.nativeToken.copy(asVisibleAsset: true)
               ],
               sortOrder: 1)
           )


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
Wallet is now support a new coin type `.fil`
This includes
- create filecoin account
- edit filecoin account
- remove secondary filecoin account
- filecoin mainnet and testnet working in network selection and portfolio 
- filecoin account list and account details 
- `FIL` send transaction and its related screen 

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7809

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
1. Once you upgrade to 1.58, you should see FIL on filecoin mainnet on Portfolio (If you set to show test networks from settings, you should see FIL on filecoin testnet on Portfolio as well)
2. You should be able to create Filecoin account in both mainnet and testnet by selecting Filecoin in coin selection screen, and choose network in the next screen. 
3. Once the account has been created, go to the account detail screen, check if correct FIL is displayed in the screen(Filecoin Mainnet Account should only display FIL on mainnet and Filecoin Testnet Account should only display FIL on testnet)
4. FIL on Mainnet should be available in Buy. Verify you can correctly go to the buy page with the supported provider(s)
5. FIL on Mainnet and Testnet should be available in Send. Verify correct confirmation screen shows up and tx can be submitted and confirm on chain by checking tx summary in Activity/Account Activity and tx details screen.
6. FIL mainnet or testnet can be select in Swap but not available state should be shown
7. Verify Portfolio grouping/sorting is still working with FIL 

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->
![Simulator Screenshot - iPhone 14 Pro - 2023-08-21 at 22 25 26](https://github.com/brave/brave-ios/assets/1187676/deb88e37-2ac0-4cdc-827e-0e60b2db1d84) | ![Simulator Screenshot - iPhone 14 Pro - 2023-08-21 at 22 24 56](https://github.com/brave/brave-ios/assets/1187676/1d0cc61a-9697-4dca-b78b-bd1291712531) | ![Simulator Screenshot - iPhone 14 Pro - 2023-08-21 at 22 26 16](https://github.com/brave/brave-ios/assets/1187676/1f1c65d2-f45b-4ac8-ab42-7c84790ee5a4)
--|--|--
![Simulator Screenshot - iPhone 14 Pro - 2023-08-21 at 22 26 29](https://github.com/brave/brave-ios/assets/1187676/0ed97c96-263b-4d02-a916-7b92ffe940c3) | ![Simulator Screenshot - iPhone 14 Pro - 2023-08-21 at 22 26 33](https://github.com/brave/brave-ios/assets/1187676/6ff5d238-3f90-425a-a191-660ff3bbff8c) | ![Simulator Screenshot - iPhone 14 Pro - 2023-08-21 at 22 26 41](https://github.com/brave/brave-ios/assets/1187676/84ec4317-5b84-4929-b1c8-2323770caa75)
![Simulator Screenshot - iPhone 14 Pro - 2023-08-21 at 22 28 58](https://github.com/brave/brave-ios/assets/1187676/1388124c-c137-4c0d-b882-d350a458c53e) | ![Simulator Screenshot - iPhone 14 Pro - 2023-08-21 at 22 29 10](https://github.com/brave/brave-ios/assets/1187676/41ef44f6-43e9-42ae-9c24-8479e0aa35e5) | ![simulator_screenshot_F4CAE4B8-DC33-4FF0-90FF-13F7FC928DF2](https://github.com/brave/brave-ios/assets/1187676/4efff58e-68bb-4702-bafd-7aca842d3175)

https://github.com/brave/brave-ios/assets/1187676/ae3e76f0-3d4b-43ea-83ce-53f54eb09ad2


## Reviewer Checklist:


- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
