### PR TITLE
Fix #7896: Whitelist Twitter/X.com for Playlist URL Bar Button

### DIFF
--- a/Sources/Shared/Extensions/URLExtensions.swift
+++ b/Sources/Shared/Extensions/URLExtensions.swift
@@ -418,7 +418,8 @@ extension URL {
       "rumble.com", "gorf.tv", "odysee.com", "brighteon.com",
       "lbry.tv", "luminarypodcasts.com", "marthastewart.com",
       "bbcgoodfood.com", "bt.com", "skysports.com", "sky.co.nz",
-      "kayosports.com.au", "listennotes.com", "vid.puffyan.us"
+      "kayosports.com.au", "listennotes.com", "vid.puffyan.us",
+      "twitter.com", "x.com"
     ])
 
     /// Additional sites for Japanese locale


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Playlist URL Bar Button will now show up on X.com or Twitter.com

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7896

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
- Visit a twitter page that has video
- The URL bar button should show to add the video to playlist.


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
