### PR TITLE
Fix #7911: Switches to private tab mode when using biometric authentication in sync flow

### DIFF
--- a/Sources/Brave/Frontend/Browser/Tabs/TabTray/TabTrayController.swift
+++ b/Sources/Brave/Frontend/Browser/Tabs/TabTray/TabTrayController.swift
@@ -311,8 +311,8 @@ class TabTrayController: AuthenticationController {
     }.store(in: &localAuthObservers)
     
     windowProtection?.finalizedAuthentication
-      .sink { [weak self] success in
-        if success {
+      .sink { [weak self] success, viewType in
+        if success, viewType == .tabTray {
           self?.toggleModeChanger()
         }
         self?.navigationController?.popViewController(animated: true)

--- a/Sources/Brave/Frontend/Browser/Tabs/TabTray/Views/TabSyncCustomView.swift
+++ b/Sources/Brave/Frontend/Browser/Tabs/TabTray/Views/TabSyncCustomView.swift
@@ -7,7 +7,7 @@ import UIKit
 import BraveUI
 import BraveStrings
 
-protocol TabSyncHeaderViewDelegate {
+protocol TabSyncHeaderViewDelegate: AnyObject {
   func toggleSection(_ header: TabSyncHeaderView, section: Int)
   func hideForNow(_ header: TabSyncHeaderView, section: Int)
   func openAll(_ header: TabSyncHeaderView, section: Int)
@@ -21,7 +21,7 @@ class TabSyncHeaderView: UITableViewHeaderFooterView, TableViewReusable {
     static let iconSize = 20.0
   }
   
-  var delegate: TabSyncHeaderViewDelegate?
+  weak var delegate: TabSyncHeaderViewDelegate?
   var section = 0
   var isCollapsed = false {
     didSet {
@@ -184,7 +184,7 @@ class TabSyncTableViewCell: UITableViewCell, TableViewReusable {
     static let imageSize = 32.0
   }
   
-  var delegate: TabSyncHeaderViewDelegate?
+  weak var delegate: TabSyncHeaderViewDelegate?
   
   let imageIconView = UIImageView().then {
     $0.contentMode = .scaleAspectFit

--- a/Sources/Brave/Frontend/Login/LoginAuthViewController.swift
+++ b/Sources/Brave/Frontend/Login/LoginAuthViewController.swift
@@ -74,7 +74,7 @@ class LoginAuthViewController: UITableViewController {
         completion?(false, .passcodeNotSet)
       }
     } else {
-      windowProtection.presentAuthenticationForViewController(determineLockWithPasscode: false) { status, error in
+      windowProtection.presentAuthenticationForViewController(determineLockWithPasscode: false, viewType: .passwords) { status, error in
         completion?(status, error)
       }
     }

--- a/Sources/Brave/Frontend/Passcode/WindowProtection.swift
+++ b/Sources/Brave/Frontend/Passcode/WindowProtection.swift
@@ -127,13 +127,13 @@ public class WindowProtection {
   }
   
   private let onCancelPressed = PassthroughSubject<Void, Never>()
-  private let didFinalizeAuthentication = PassthroughSubject<Bool, Never>()
+  private let didFinalizeAuthentication = PassthroughSubject<(Bool, AuthViewType), Never>()
 
   var cancelPressed: AnyPublisher<Void, Never> {
     onCancelPressed.eraseToAnyPublisher()
   }
   
-  var finalizedAuthentication: AnyPublisher<Bool, Never> {
+  var finalizedAuthentication: AnyPublisher<(Bool, AuthViewType), Never> {
     didFinalizeAuthentication.eraseToAnyPublisher()
   }
     
@@ -196,19 +196,19 @@ public class WindowProtection {
       let isLocked = Preferences.Privacy.lockWithPasscode.value
       isVisible = isLocked
       if isLocked {
-        presentLocalAuthentication() { status, error in
+        presentLocalAuthentication(viewType: viewType) { status, error in
           completion?(status, error)
         }
       }
     } else {
       isVisible = true
-      presentLocalAuthentication() { status, error in
+      presentLocalAuthentication(viewType: viewType) { status, error in
         completion?(status, error)
       }
     }
   }
 
-  private func presentLocalAuthentication(completion: ((Bool, LAError.Code?) -> Void)? = nil) {
+  private func presentLocalAuthentication(viewType: AuthViewType = .general, completion: ((Bool, LAError.Code?) -> Void)? = nil) {
     if !context.canEvaluatePolicy(.deviceOwnerAuthentication, error: nil) {
       completion?(false, .passcodeNotSet)
       return
@@ -239,7 +239,7 @@ public class WindowProtection {
           }
         }
         
-        self.didFinalizeAuthentication.send(success)
+        self.didFinalizeAuthentication.send((success, viewType))
       }
     }
   }

--- a/Sources/Brave/Frontend/Passcode/WindowProtection.swift
+++ b/Sources/Brave/Frontend/Passcode/WindowProtection.swift
@@ -12,6 +12,10 @@ import Preferences
 import BraveUI
 import os.log
 
+public enum AuthViewType {
+  case general, sync, tabTray, passwords
+}
+
 public class WindowProtection {
 
   private class LockedViewController: UIViewController {
@@ -178,7 +182,7 @@ public class WindowProtection {
     isVisible = false
   }
 
-  private func updateVisibleStatusForForeground(_ determineLockWithPasscode: Bool = true, completion: ((Bool, LAError.Code?) -> Void)? = nil) {
+  private func updateVisibleStatusForForeground(_ determineLockWithPasscode: Bool = true, viewType: AuthViewType = .general, completion: ((Bool, LAError.Code?) -> Void)? = nil) {
     var error: NSError?
     if !context.canEvaluatePolicy(.deviceOwnerAuthentication, error: &error),
       (error as? LAError)?.code == .passcodeNotSet {
@@ -240,13 +244,13 @@ public class WindowProtection {
     }
   }
 
-  func presentAuthenticationForViewController(determineLockWithPasscode: Bool = true, completion: ((Bool, LAError.Code?) -> Void)? = nil) {
+  func presentAuthenticationForViewController(determineLockWithPasscode: Bool = true, viewType: AuthViewType, completion: ((Bool, LAError.Code?) -> Void)? = nil) {
     if isVisible {
       return
     }
 
     context = LAContext()
-    updateVisibleStatusForForeground(determineLockWithPasscode) { status, error in
+    updateVisibleStatusForForeground(determineLockWithPasscode, viewType: viewType) { status, error in
       completion?(status, error)
     }
   }

--- a/Sources/Brave/Frontend/Widgets/LoadingViewController.swift
+++ b/Sources/Brave/Frontend/Widgets/LoadingViewController.swift
@@ -35,19 +35,6 @@ public class LoadingViewController: UIViewController {
 }
 
 public class AuthenticationController: LoadingViewController {
-  enum AuthViewType {
-    case sync, tabTray
-    
-    var detailText: String {
-      switch self {
-      case .sync:
-        return Strings.Sync.syncSetPasscodeAlertDescription
-      case .tabTray:
-        return Strings.Privacy.tabTraySetPasscodeAlertDescription
-      }
-    }
-  }
-  
   let windowProtection: WindowProtection?
   let requiresAuthentication: Bool
   
@@ -88,7 +75,7 @@ public class AuthenticationController: LoadingViewController {
       }
     } else {
       windowProtection.presentAuthenticationForViewController(
-        determineLockWithPasscode: false) { status, error in
+        determineLockWithPasscode: false, viewType: viewType) { status, error in
           completion?(status, error)
       }
     }
@@ -97,9 +84,20 @@ public class AuthenticationController: LoadingViewController {
   /// An alert presenter for passcode error to warn user to setup passcode to use feature
   /// - Parameter completion: block after Ok button is pressed
   func showSetPasscodeError(viewType: AuthViewType, completion: @escaping (() -> Void)) {
+    var alertMessage: String?
+    
+    switch viewType {
+    case .sync:
+      alertMessage = Strings.Sync.syncSetPasscodeAlertDescription
+    case .tabTray:
+      alertMessage = Strings.Privacy.tabTraySetPasscodeAlertDescription
+    default:
+      alertMessage = nil
+    }
+    
     let alert = UIAlertController(
       title: Strings.Sync.syncSetPasscodeAlertTitle,
-      message: viewType.detailText,
+      message: alertMessage,
       preferredStyle: .alert)
 
     alert.addAction(


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->


## Summary of Changes

Fixing the memory leak that cause Tab Tray not deinitialize which cause observer in Tab Tray to activate when it should not. View type to local authentication to determine certain cases of causing different behaviour

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7911

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

1. Install 1.57.x or upgrade from 1.56.x (doesn't matter)
2. Join sync chain
3. Enable open tabs in sync settings on both clients
4. Open tab view - Tabs from Other Devices
5. Open sync settings again and select Add New Device which user will have to use PIN/Face ID to authenticate now when adding new device (new in 1.57.x)
6. Complete auth but do not add device
7. Observe

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


https://github.com/brave/brave-ios/assets/6643505/56eaa251-adeb-48cd-8c63-0b42c338cefa



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
