### PR TITLE
Fix #7897: Clearing Out Data From Recently Closed Tabs

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+TabManagerDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+TabManagerDelegate.swift
@@ -312,14 +312,21 @@ extension BrowserViewController: TabManagerDelegate {
             // After opening the Recently Closed in a new tab delete it from list
             RecentlyClosed.remove(with: recentlyClosed.url)
           }
+
+          recentlyClosedTabsView.onClearAllRecentlyClosed = { [weak self] in
+            // After clearing tabs need to remove button actions from the tab bar controls
+            guard let self = self else { return }
+
+            DispatchQueue.main.async {
+              self.updateToolbarUsingTabManager(tabManager)
+            }
+          }
           
           self.present(UIHostingController(rootView: recentlyClosedTabsView), animated: true)
         })
-      
-      recentlyClosedMenuChildren.append(viewRecentlyClosedTabs)
-      
       // Fetch last item in Recently Closed
       if let recentlyClosedTab = RecentlyClosed.all().first {
+        recentlyClosedMenuChildren.append(viewRecentlyClosedTabs)
         let reopenLastClosedTab = UIAction(
           title: Strings.RecentlyClosed.recentlyClosedReOpenLastActionTitle,
           image: UIImage(braveSystemNamed: "leo.browser.mobile-tab-ntp"),

--- a/Sources/Brave/Frontend/Browser/Tabs/RecentlyClosedTabs/RecentlyClosedTabsView.swift
+++ b/Sources/Brave/Frontend/Browser/Tabs/RecentlyClosedTabs/RecentlyClosedTabsView.swift
@@ -19,6 +19,7 @@ struct RecentlyClosedTabsView: View {
   
   @State private var showClearDataPrompt: Bool = false
   var onRecentlyClosedSelected: ((RecentlyClosed) -> Void)?
+  var onClearAllRecentlyClosed: (() -> Void)?
   
   private let tabManager: TabManager?
 
@@ -30,13 +31,14 @@ struct RecentlyClosedTabsView: View {
     .foregroundColor(Color(.braveBlurpleTint))
     .actionSheet(isPresented: $showClearDataPrompt) {
       .init(title: Text(Strings.RecentlyClosed.recentlyClosedClearActionConfirmation),
-        buttons: [
-          .destructive(Text(Strings.RecentlyClosed.recentlyClosedClearActionTitle), action: {
-            RecentlyClosed.removeAll()
-            dismissView()
-          }),
-          .cancel()
-        ]
+            buttons: [
+              .destructive(Text(Strings.RecentlyClosed.recentlyClosedClearActionTitle), action: {
+                RecentlyClosed.removeAll()
+                onClearAllRecentlyClosed?()
+                dismissView()
+              }),
+              .cancel()
+            ]
       )
     }
   }


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #7897. When clearing recently closed tabs, data was being persisted. 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
