### PR TITLE
[No Bug]: Disconnect before showing VPN buy screen

### DIFF
--- a/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/VPNMenuButton.swift
+++ b/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/VPNMenuButton.swift
@@ -58,6 +58,10 @@ struct VPNMenuButton: View {
     }
     switch BraveVPN.vpnState {
     case .notPurchased, .expired:
+      // Expired Subcriptions can cause glitch because of connect on demand
+      // Disconnect VPN before showing Purchase
+      BraveVPN.disconnect(skipChecks: true)
+
       guard let vc = vpnState.enableVPNDestinationVC else { return }
       displayVPNDestination(vc)
     case .purchased:

--- a/Sources/BraveVPN/BraveVPN.swift
+++ b/Sources/BraveVPN/BraveVPN.swift
@@ -354,7 +354,12 @@ public class BraveVPN {
 
   /// Disconnects the vpn.
   /// The vpn must be configured prior to that otherwise it does nothing.
-  public static func disconnect() {
+  public static func disconnect(skipChecks: Bool = false) {
+    if skipChecks {
+      helper.disconnectVPN()
+      return
+    }
+    
     if reconnectPending {
       logAndStoreError("Can't disconnect the vpn while reconnect is still pending.")
       return


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

Call Disconnect VPN before showing VPN purchase screen in order to prevent a problem where user has invalid subscription and connect on demand is triggering toggle.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #N/A

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
N/A

## Screenshots:
N/A


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
