### PR TITLE
Fix #7932: Update list of known supported Brave News languages/locales

### DIFF
--- a/Sources/BraveNews/Composer/FeedDataSource.swift
+++ b/Sources/BraveNews/Composer/FeedDataSource.swift
@@ -177,6 +177,8 @@ public class FeedDataSource: ObservableObject {
   public static let supportedLanguages = [
     "en",
     "ja",
+    "de",
+    "fr",
   ]
   
   /// A list of known supported locales
@@ -184,10 +186,14 @@ public class FeedDataSource: ObservableObject {
     "en_US",
     "en_CA",
     "en_UK",
+    "en_AU",
+    "en_IN",
     "ja_JP",
     "es_ES",
     "es_MX",
     "pt_BR",
+    "de_DE",
+    "fr_FR",
   ]
 
   private struct NewsBucket {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes #7932 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

- Verify that Brave News opt-in card appears when your locale is set to french or german

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
