### PR TITLE
Fix #7876: Replace Rewards ads usage P3A question

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController.swift
@@ -450,6 +450,7 @@ public class BrowserViewController: UIViewController {
     Preferences.Playlist.enablePlaylistMenuBadge.observe(from: self)
     Preferences.Playlist.enablePlaylistURLBarButton.observe(from: self)
     Preferences.Playlist.syncSharedFoldersAutomatically.observe(from: self)
+    Preferences.NewTabPage.backgroundSponsoredImages.observe(from: self)
     ShieldPreferences.blockAdsAndTrackingLevelRaw.observe(from: self)
     
     pageZoomListener = NotificationCenter.default.addObserver(forName: PageZoomView.notificationName, object: nil, queue: .main) { [weak self] _ in
@@ -464,6 +465,7 @@ public class BrowserViewController: UIViewController {
       guard let self = self else { return }
       self.updateRewardsButtonState()
       self.setupAdsNotificationHandler()
+      self.recordAdsUsageType()
     }
     Preferences.Playlist.webMediaSourceCompatibility.observe(from: self)
     Preferences.PrivacyReports.captureShieldsData.observe(from: self)
@@ -551,6 +553,7 @@ public class BrowserViewController: UIViewController {
     recordAccessibilityDocumentsDirectorySizeP3A()
     recordTimeBasedNumberReaderModeUsedP3A(activated: false)
     PlaylistP3A.recordHistogram()
+    recordAdsUsageType()
     
     // Revised Review Handling
     AppReviewManager.shared.handleAppReview(for: .revisedCrossPlatform, using: self)
@@ -3145,6 +3148,8 @@ extension BrowserViewController: PreferencesObserver {
       updateURLBarWalletButton()
     case Preferences.Playlist.syncSharedFoldersAutomatically.key:
       syncPlaylistFolders()
+    case Preferences.NewTabPage.backgroundSponsoredImages.key:
+      recordAdsUsageType()
     default:
       Logger.module.debug("Received a preference change for an unknown key: \(key, privacy: .public) on \(type(of: self), privacy: .public)")
       break

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+P3A.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+P3A.swift
@@ -181,6 +181,24 @@ extension BrowserViewController {
       value: storage.combinedValue
     )
   }
+  
+  func recordAdsUsageType() {
+    enum Answer: Int, CaseIterable {
+      case none = 0
+      case ntpOnly = 1
+      case pushOnly = 2
+      case ntpAndPush = 3
+    }
+    var answer: Answer = .none
+    if rewards.ads.isEnabled && Preferences.NewTabPage.backgroundSponsoredImages.value {
+      answer = .ntpAndPush
+    } else if rewards.ads.isEnabled {
+      answer = .pushOnly
+    } else if Preferences.NewTabPage.backgroundSponsoredImages.value {
+      answer = .ntpOnly
+    }
+    UmaHistogramEnumeration("Brave.Rewards.AdTypesEnabled", sample: answer)
+  }
 }
 
 extension P3AFeatureUsage {


### PR DESCRIPTION
This removes the `Brave.Rewards.AdsEnabledDuration` question and answers the new `Brave.Rewards.AdTypesEnabled` question

## Summary of Changes

This pull request fixes #7876 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

- Fresh Installs should no longer report `Brave.Rewards.AdsEnabledDuration`
- Verify that `Brave.Rewards.AdTypesEnabled` sends correct answers for ads/NTP-SI settings

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
