### PR TITLE
Fix #7717: Match color on reader mode bar to private/night mode

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+ReaderMode.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+ReaderMode.swift
@@ -111,7 +111,7 @@ extension BrowserViewController {
 
   func showReaderModeBar(animated: Bool) {
     if self.readerModeBar == nil {
-      let readerModeBar = ReaderModeBarView(frame: CGRect.zero)
+      let readerModeBar = ReaderModeBarView(privateBrowsingManager: tabManager.privateBrowsingManager)
       readerModeBar.delegate = self
       view.insertSubview(readerModeBar, aboveSubview: webViewContainer)
       self.readerModeBar = readerModeBar


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #7717 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Screenshots:

| Night Mode | Private Mode | 
| --- | --- |
| ![Simulator Screenshot - iPhone 14 Pro - 2023-08-23 at 16 33 36](https://github.com/brave/brave-ios/assets/529104/9c2cc28c-c80c-495b-9aa4-8e7992d47006) | ![Simulator Screenshot - iPhone 14 Pro - 2023-08-23 at 16 33 25](https://github.com/brave/brave-ios/assets/529104/9722f912-a7a1-49ba-839b-e8e8219efca4) |

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
