### PR TITLE
Fix #6577: Hide Active NTP when backgrounding the app in private mode

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController.swift
@@ -719,6 +719,7 @@ public class BrowserViewController: UIViewController {
     if let tab = tabManager.selectedTab, tab.isPrivate {
       webViewContainerBackdrop.alpha = 1
       webViewContainer.alpha = 0
+      activeNewTabPageViewController?.view.alpha = 0
       header.contentView.alpha = 0
       presentedViewController?.popoverPresentationController?.containerView?.alpha = 0
       presentedViewController?.view.alpha = 0
@@ -748,6 +749,7 @@ public class BrowserViewController: UIViewController {
       animations: {
         self.webViewContainer.alpha = 1
         self.header.contentView.alpha = 1
+        self.activeNewTabPageViewController?.view.alpha = 1
         self.presentedViewController?.popoverPresentationController?.containerView?.alpha = 1
         self.presentedViewController?.view.alpha = 1
         self.view.backgroundColor = .clear


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #6577 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

- Enter Private Mode and make a new tab
- Verify background the app will hide the new tab page

## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
