### PR TITLE
Missing self in closures

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+TabManagerDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+TabManagerDelegate.swift
@@ -301,7 +301,7 @@ extension BrowserViewController: TabManagerDelegate {
         handler: UIAction.deferredActionHandler { [weak self] _ in
           guard let self = self else { return }
           
-          if privateBrowsingManager.isPrivateBrowsing {
+          if self.privateBrowsingManager.isPrivateBrowsing {
             return
           }
                   
@@ -326,7 +326,7 @@ extension BrowserViewController: TabManagerDelegate {
           handler: UIAction.deferredActionHandler { [weak self] _ in
             guard let self = self else { return }
             
-            if privateBrowsingManager.isPrivateBrowsing {
+            if self.privateBrowsingManager.isPrivateBrowsing {
               return
             }
             

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
@@ -540,7 +540,7 @@ extension BrowserViewController: TopToolbarDelegate {
           // Feedback indicating recognition is finalized
           AudioServicesPlayAlertSound(SystemSoundID(kSystemSoundID_Vibrate))
           UIImpactFeedbackGenerator(style: .medium).bzzt()
-          stopVoiceSearch(searchQuery: finalizedRecognition.searchQuery)
+          self.stopVoiceSearch(searchQuery: finalizedRecognition.searchQuery)
         }
       }
       

--- a/Sources/Brave/Frontend/Browser/Search/Voice Search/SpeechRecognizer.swift
+++ b/Sources/Brave/Frontend/Browser/Search/Voice Search/SpeechRecognizer.swift
@@ -122,8 +122,8 @@ class SpeechRecognizer: ObservableObject {
         
         // Check voice input final
         if isFinal {
-          animationType = .stable
-          transcriptedIcon = "leo.check.circle-outline"
+          self.animationType = .stable
+          self.transcriptedIcon = "leo.check.circle-outline"
           
           // Remove audio buffer input
           audioEngine.inputNode.removeTap(onBus: 0)

--- a/Sources/Brave/Frontend/Sync/SyncWelcomeViewController.swift
+++ b/Sources/Brave/Frontend/Sync/SyncWelcomeViewController.swift
@@ -259,11 +259,11 @@ class SyncWelcomeViewController: SyncViewController {
     askForAuthentication() { [weak self] status, error in
       guard let self = self, status else { return }
       
-      let syncInternalsController = syncAPI.createSyncInternalsController().then {
+      let syncInternalsController = self.syncAPI.createSyncInternalsController().then {
         $0.title = Strings.braveSyncInternalsTitle
       }
       
-      navigationController?.pushViewController(syncInternalsController, animated: true)
+      self.navigationController?.pushViewController(syncInternalsController, animated: true)
     }
   }
 

--- a/Sources/BraveVPN/InstallVPNViewController.swift
+++ b/Sources/BraveVPN/InstallVPNViewController.swift
@@ -68,7 +68,7 @@ class InstallVPNViewController: VPNSetupLoadingController {
         // Retry installing profile twice if it fails
         // Error generated is WireGuard capabilities are not yet enabled on this node
         if self.installVPNProfileRetryCount < 2 {
-          installVPNAction()
+          self.installVPNAction()
         } else {
           presentErrorVPNInstallProfile()
         }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7938 building issue in development branch. In some closure self in missing when accessing function outside of the closure. 

![Screenshot 2023-08-24 at 2 26 54 AM](https://github.com/brave/brave-ios/assets/22428886/1554d958-83d3-4f2a-925e-14dccf4162f6)


## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
