### PR TITLE
Fix #7947, #7944, #7948, #7946: Portfolio Fixes

### DIFF
--- a/Sources/BraveWallet/Crypto/FiltersDisplaySettingsView.swift
+++ b/Sources/BraveWallet/Crypto/FiltersDisplaySettingsView.swift
@@ -202,8 +202,8 @@ struct FiltersDisplaySettingsView: View {
           Button(action: resetToDefaults) {
             Text(Strings.Wallet.settingsResetTransactionAlertButtonTitle)
               .fontWeight(.semibold)
-              .foregroundColor(Color(uiColor: WalletV2Design.textInteractive))
           }
+          .disabled(isResetDisabled)
         }
       }
     }
@@ -378,6 +378,19 @@ struct FiltersDisplaySettingsView: View {
         .ignoresSafeArea()
     )
     .shadow(color: Color.black.opacity(0.04), radius: 16, x: 0, y: -8)
+  }
+  
+  private var isResetDisabled: Bool {
+    groupBy == GroupBy(rawValue: Preferences.Wallet.groupByFilter.defaultValue) ?? .none
+    && sortOrder == SortOrder(rawValue: Preferences.Wallet.sortOrderFilter.defaultValue) ?? .valueDesc
+    && isHidingSmallBalances == Preferences.Wallet.isHidingSmallBalancesFilter.defaultValue
+    && isHidingUnownedNFTs == Preferences.Wallet.isHidingUnownedNFTsFilter.defaultValue
+    && isShowingNFTNetworkLogo == Preferences.Wallet.isShowingNFTNetworkLogoFilter.defaultValue
+    && accounts.allSatisfy(\.isSelected)
+    && networks.allSatisfy { selectableNetwork in
+      let isTestnet = WalletConstants.supportedTestNetworkChainIds.contains(selectableNetwork.model.chainId)
+      return selectableNetwork.isSelected == !isTestnet
+    }
   }
   
   func resetToDefaults() {

--- a/Sources/BraveWallet/Crypto/FiltersDisplaySettingsView.swift
+++ b/Sources/BraveWallet/Crypto/FiltersDisplaySettingsView.swift
@@ -569,7 +569,21 @@ struct FilterPickerRowView<T: Equatable & Identifiable & Hashable, Content: View
           Image(braveSystemName: "leo.carat.down")
         }
       })
+      .osAvailabilityModifiers({
+        if #unavailable(iOS 17) {
+          // Prior to iOS 17, if selection changes from outside
+          // the Menu (ex. Reset button) the view might not
+          // resize to fit a larger label
+          $0.id(selection)
+        } else {
+          $0
+        }
+      })
       .foregroundColor(Color(WalletV2Design.textInteractive))
+      .transaction { transaction in
+        transaction.animation = nil
+        transaction.disablesAnimations = true
+      }
     }
   }
 }

--- a/Sources/BraveWallet/Crypto/FiltersDisplaySettingsView.swift
+++ b/Sources/BraveWallet/Crypto/FiltersDisplaySettingsView.swift
@@ -199,7 +199,7 @@ struct FiltersDisplaySettingsView: View {
       .navigationBarTitleDisplayMode(.inline)
       .toolbar {
         ToolbarItem(placement: .navigationBarTrailing) {
-          Button(action: restoreToDefaults) {
+          Button(action: resetToDefaults) {
             Text(Strings.Wallet.settingsResetTransactionAlertButtonTitle)
               .fontWeight(.semibold)
               .foregroundColor(Color(uiColor: WalletV2Design.textInteractive))
@@ -380,12 +380,14 @@ struct FiltersDisplaySettingsView: View {
     .shadow(color: Color.black.opacity(0.04), radius: 16, x: 0, y: -8)
   }
   
-  func restoreToDefaults() {
-    self.groupBy = .none
+  func resetToDefaults() {
+    /// Assets are not grouped by default
+    self.groupBy = GroupBy(rawValue: Preferences.Wallet.groupByFilter.defaultValue) ?? .none
     // Fiat value in descending order (largest fiat to smallest) by default
-    self.sortOrder = .valueDesc
-    // Small balances shown by default
-    self.isHidingSmallBalances = false
+    self.sortOrder = SortOrder(rawValue: Preferences.Wallet.sortOrderFilter.defaultValue) ?? .valueDesc
+    self.isHidingSmallBalances = Preferences.Wallet.isHidingSmallBalancesFilter.defaultValue
+    self.isHidingUnownedNFTs = Preferences.Wallet.isHidingUnownedNFTsFilter.defaultValue
+    self.isShowingNFTNetworkLogo = Preferences.Wallet.isShowingNFTNetworkLogoFilter.defaultValue
     
     // All accounts selected by default
     self.accounts = self.accounts.map {

--- a/Sources/BraveWallet/Crypto/Stores/NFTStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/NFTStore.swift
@@ -114,6 +114,9 @@ public class NFTStore: ObservableObject {
     self.updateTask?.cancel()
     self.updateTask = Task { @MainActor in
       self.allAccounts = await keyringService.allAccounts().accounts
+        .filter { account in
+          WalletConstants.supportedCoinTypes.contains(account.coin)
+        }
       self.allNetworks = await rpcService.allNetworksForSupportedCoins().filter { network in
         if !Preferences.Wallet.showTestNetworks.value { // filter out test networks
           return !WalletConstants.supportedTestNetworkChainIds.contains(where: { $0 == network.chainId })

--- a/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
@@ -333,6 +333,9 @@ public class PortfolioStore: ObservableObject {
     self.updateTask = Task { @MainActor in
       self.isLoadingBalances = true
       self.allAccounts = await keyringService.allAccounts().accounts
+        .filter { account in
+          WalletConstants.supportedCoinTypes.contains(account.coin)
+        }
       self.allNetworks = await rpcService.allNetworksForSupportedCoins().filter { network in
         if !Preferences.Wallet.showTestNetworks.value { // filter out test networks
           return !WalletConstants.supportedTestNetworkChainIds.contains(where: { $0 == network.chainId })


### PR DESCRIPTION
## Summary of Changes
- Filter out Filecoin accounts when fetching All Accounts for Portfolio & NFT tabs. Filecoin accounts can exist when restoring a wallet with FIL balance.
- Fix `Hide Unowned` and `Show Network Logo` toggles not resetting when `Reset` tapped in NFT tab's Filters & Display Settings
- Disable `Reset` button in Filters & Display Settings when showing default values
- Remove animations & fix truncation on Picker label for `Sort Order` and other pickers.

This pull request...
fixes #7947
fixes #7948
fixes #7944
fixes #7946

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
### Filecoin Account groups displayed when grouping Portfolio by Accounts
1. Restore a wallet with a Filecoin balance
2. Open Filters & Display Settings and change `Group By` to `Accounts`
3. Tap `Save Changes`
4. Scroll through Portfolio to verify no Filecoin account groups are shown.

https://github.com/brave/brave-ios/assets/5314553/d442121e-671c-4ec8-866d-cfb766bc629e


### NFT Filters Reset button does not reset some filters
1. Open NFT tab and tap Filters & Display Settings button
2. Change `Hide Unowned` toggle to on/enabled, change `Show Network Logo` to on/enabled
3. Tap `Reset`
4. Verify both `Hide Unowned` & `Show Network Logo` are reset to off/disabled

https://github.com/brave/brave-ios/assets/5314553/7d136a47-f53c-4966-94a7-7f3e6862233c


### Disable Reset button if there are no changes done to portfolio settings
1. Open Portfolio and tap Filters & Display Settings button
2. If `Reset` is not disabled, tap it to reset to default filters.
3. Verify `Reset` button is disabled.
4. Change some filters, ex de-select 1 account, or de-select 1 network, enable/disable toggles
6. Verify `Reset` is not disabled when not showing default filter selections.

https://github.com/brave/brave-ios/assets/5314553/9ed7d1ce-f732-412b-87e0-2be4a58d1592


### Portfolio setting dropdown text doesn't have a smooth transition when changing
1. Open Portfolio tap Filters & Display Settings button
2. Change any filter / setting in a dropdown
3. Verify text showing selection updates immediately
4. Update `Sort Assets` to`A to Z`
5. Click on `Reset`
8. Drop down text only shows `Hig...` instead of `High to Low`

https://github.com/brave/brave-ios/assets/5314553/5fb56a5b-e569-46e5-a2a3-b42108d6c7fd


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
