### PR TITLE
Fix #7875: VPN Restore Infinite Loading

### DIFF
--- a/Sources/BraveVPN/IAPObserver.swift
+++ b/Sources/BraveVPN/IAPObserver.swift
@@ -85,4 +85,14 @@ public class IAPObserver: NSObject, SKPaymentTransactionObserver {
     Logger.module.debug("Restoring transaction failed")
     self.delegate?.purchaseFailed(error: .transactionError(error: error as? SKError))
   }
+  
+  // Used to handle restoring transaction error for users never purchased but trying to restore
+  public func paymentQueueRestoreCompletedTransactionsFinished(_ queue: SKPaymentQueue) {
+    if queue.transactions.isEmpty {
+      Logger.module.debug("Restoring transaction failed - Nothing to restore - Account never bought this product")
+
+      let errorRestore = SKError(SKError.unknown, userInfo: ["detail": "not-purchased"])
+      delegate?.purchaseFailed(error: .transactionError(error: errorRestore))
+    }
+  }
 }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7875

So there is problem probably with users who never did iap from Brave and trying to restore the purchase.

So when they go to buy screen and try to restore, they might see infinite loading for restoring since we dont handle paymentQueueRestoreCompletedTransactionsFinished call with no transactions.

In addition a maximum limit of 60 sec is added for timer and canceling restoration.

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
- Try restoring VPN purchase for devices and accounts which doesnt have a subscription.

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


https://github.com/brave/brave-ios/assets/6643505/c57036f3-6e06-4a36-a1e7-9c873d50f98d


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
