### PR TITLE
Fix #7952: Opening link in private tab will bypass biometrics authentication

### DIFF
--- a/Sources/Brave/Extensions/SceneExtensions.swift
+++ b/Sources/Brave/Extensions/SceneExtensions.swift
@@ -5,6 +5,7 @@
 
 import Foundation
 import UIKit
+import LocalAuthentication
 
 extension UIWindowScene {
   /// A single scene should only have ONE browserViewController
@@ -24,5 +25,25 @@ extension UIWindowScene {
   /// Returns the first instance of `BrowserViewController` that is found in the current scene
   public var browserViewController: BrowserViewController? {
     return browserViewControllers.first
+  }
+}
+
+extension UIViewController {
+  func askForLocalAuthentication(completion: ((Bool, LAError.Code?) -> Void)? = nil) {
+    guard let windowProtection = currentScene?.browserViewController?.windowProtection else {
+      completion?(false, nil)
+      return
+    }
+
+    // No Pincode set on device
+    // Local Authentication is not necesseary
+    if !windowProtection.isPassCodeAvailable {
+      completion?(true, nil)
+    } else {
+      windowProtection.presentAuthenticationForViewController(
+        determineLockWithPasscode: false, viewType: .general) { status, error in
+          completion?(status, error)
+      }
+    }
   }
 }

--- a/Sources/Brave/Frontend/Browser/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController.swift
@@ -2987,11 +2987,23 @@ extension BrowserViewController: NewTabPageDelegate {
     guard let url = favorite.url else { return }
     switch action {
     case .opened(let inNewTab, let switchingToPrivateMode):
-      navigateToInput(
-        url,
-        inNewTab: inNewTab,
-        switchingToPrivateMode: switchingToPrivateMode
-      )
+      if privateBrowsingManager.isPrivateBrowsing {
+        navigateToInput(
+          url,
+          inNewTab: inNewTab,
+          switchingToPrivateMode: switchingToPrivateMode
+        )
+      } else {
+        self.askForLocalAuthentication { [weak self] success, error in
+          if success {
+            self?.navigateToInput(
+              url,
+              inNewTab: inNewTab,
+              switchingToPrivateMode: switchingToPrivateMode
+            )
+          }
+        }
+      }
     case .edited:
       guard let title = favorite.displayTitle, let urlString = favorite.url else { return }
       let editPopup =

--- a/Sources/Brave/Frontend/Browser/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController.swift
@@ -2987,7 +2987,7 @@ extension BrowserViewController: NewTabPageDelegate {
     guard let url = favorite.url else { return }
     switch action {
     case .opened(let inNewTab, let switchingToPrivateMode):
-      if !privateBrowsingManager.isPrivateBrowsing, Preferences.Privacy.privateBrowsingLock.value {
+      if switchingToPrivateMode, Preferences.Privacy.privateBrowsingLock.value {
         self.askForLocalAuthentication { [weak self] success, error in
           if success {
             self?.navigateToInput(

--- a/Sources/Brave/Frontend/Browser/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController.swift
@@ -2987,13 +2987,7 @@ extension BrowserViewController: NewTabPageDelegate {
     guard let url = favorite.url else { return }
     switch action {
     case .opened(let inNewTab, let switchingToPrivateMode):
-      if privateBrowsingManager.isPrivateBrowsing {
-        navigateToInput(
-          url,
-          inNewTab: inNewTab,
-          switchingToPrivateMode: switchingToPrivateMode
-        )
-      } else {
+      if !privateBrowsingManager.isPrivateBrowsing, Preferences.Privacy.privateBrowsingLock.value {
         self.askForLocalAuthentication { [weak self] success, error in
           if success {
             self?.navigateToInput(
@@ -3003,6 +2997,12 @@ extension BrowserViewController: NewTabPageDelegate {
             )
           }
         }
+      } else {
+        navigateToInput(
+          url,
+          inNewTab: inNewTab,
+          switchingToPrivateMode: switchingToPrivateMode
+        )
       }
     case .edited:
       guard let title = favorite.displayTitle, let urlString = favorite.url else { return }

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -6,6 +6,7 @@ import Shared
 import Foundation
 import UIKit
 import Data
+import Preferences
 
 extension BrowserViewController {
   
@@ -49,15 +50,15 @@ extension BrowserViewController {
   @objc private func newPrivateTabKeyCommand() {
     // NOTE: We cannot and should not distinguish between "new-tab" and "new-private-tab"
     // when recording telemetry for key commands.
-    if privateBrowsingManager.isPrivateBrowsing {
-      openBlankNewTab(attemptLocationFieldFocus: false, isPrivate: true)
-    } else {
+    if !privateBrowsingManager.isPrivateBrowsing, Preferences.Privacy.privateBrowsingLock.value {
       self.askForLocalAuthentication { [weak self] success, error in
         if success {
           self?.openBlankNewTab(attemptLocationFieldFocus: false, isPrivate: true)
 
         }
       }
+    } else {
+      openBlankNewTab(attemptLocationFieldFocus: false, isPrivate: true)
     }
   }
 

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -49,7 +49,16 @@ extension BrowserViewController {
   @objc private func newPrivateTabKeyCommand() {
     // NOTE: We cannot and should not distinguish between "new-tab" and "new-private-tab"
     // when recording telemetry for key commands.
-    openBlankNewTab(attemptLocationFieldFocus: false, isPrivate: true)
+    if privateBrowsingManager.isPrivateBrowsing {
+      openBlankNewTab(attemptLocationFieldFocus: false, isPrivate: true)
+    } else {
+      self.askForLocalAuthentication { [weak self] success, error in
+        if success {
+          self?.openBlankNewTab(attemptLocationFieldFocus: false, isPrivate: true)
+
+        }
+      }
+    }
   }
 
   @objc private func closeTabKeyCommand() {

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+TabManagerDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+TabManagerDelegate.swift
@@ -221,7 +221,11 @@ extension BrowserViewController: TabManagerDelegate {
         title: Strings.Hotkey.newPrivateTabTitle,
         image: UIImage(systemName: "plus.square.fill.on.square.fill"),
         handler: UIAction.deferredActionHandler { [unowned self] _ in
-          self.openBlankNewTab(attemptLocationFieldFocus: false, isPrivate: true)
+          self.askForLocalAuthentication { [weak self] success, error in
+            if success {
+              self?.openBlankNewTab(attemptLocationFieldFocus: false, isPrivate: true)
+            }
+          }
         })
 
       if (UIDevice.current.userInterfaceIdiom == .pad && tabsBar.view.isHidden == true) || (UIDevice.current.userInterfaceIdiom == .phone && toolbar == nil) {

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+TabManagerDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+TabManagerDelegate.swift
@@ -13,6 +13,7 @@ import BraveCore
 import BraveUI
 import BraveWallet
 import os.log
+import Preferences
 
 extension BrowserViewController: TabManagerDelegate {
   func tabManager(_ tabManager: TabManager, didSelectedTabChange selected: Tab?, previous: Tab?) {
@@ -221,10 +222,14 @@ extension BrowserViewController: TabManagerDelegate {
         title: Strings.Hotkey.newPrivateTabTitle,
         image: UIImage(systemName: "plus.square.fill.on.square.fill"),
         handler: UIAction.deferredActionHandler { [unowned self] _ in
-          self.askForLocalAuthentication { [weak self] success, error in
-            if success {
-              self?.openBlankNewTab(attemptLocationFieldFocus: false, isPrivate: true)
+          if Preferences.Privacy.privateBrowsingLock.value {
+            self.askForLocalAuthentication { [weak self] success, error in
+              if success {
+                self?.openBlankNewTab(attemptLocationFieldFocus: false, isPrivate: true)
+              }
             }
+          } else {
+            self.openBlankNewTab(attemptLocationFieldFocus: false, isPrivate: true)
           }
         })
 

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -985,14 +985,14 @@ extension BrowserViewController: WKUIDelegate {
           title: Strings.openNewPrivateTabButtonTitle,
           image: UIImage(named: "private_glasses", in: .module, compatibleWith: nil)!.template
         ) { _ in
-          if tabType.isPrivate {
-            self.addTab(url: url, inPrivateMode: true, currentTab: currentTab)
-          } else {
+          if !tabType.isPrivate, Preferences.Privacy.privateBrowsingLock.value {
             self.askForLocalAuthentication { [weak self] success, error in
               if success {
                 self?.addTab(url: url, inPrivateMode: true, currentTab: currentTab)
               }
             }
+          } else {
+            self.addTab(url: url, inPrivateMode: true, currentTab: currentTab)
           }
         }
         openNewPrivateTabAction.accessibilityLabel = "linkContextMenu.openInNewPrivateTab"
@@ -1015,14 +1015,14 @@ extension BrowserViewController: WKUIDelegate {
             title: Strings.openInNewPrivateWindowTitle,
             image: UIImage(braveSystemNamed: "leo.window.tab-private")
           ) { _ in
-            if tabType.isPrivate {
-              
-            } else {
+            if !tabType.isPrivate, Preferences.Privacy.privateBrowsingLock.value {
               self.askForLocalAuthentication { [weak self] success, error in
                 if success {
                   self?.openInNewWindow(url: url, isPrivate: true)
                 }
               }
+            } else {
+              self.openInNewWindow(url: url, isPrivate: true)
             }
           }
           

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -15,6 +15,7 @@ import os.log
 import Favicon
 import Growth
 import SafariServices
+import LocalAuthentication
 
 extension WKNavigationAction {
   /// Allow local requests only if the request is privileged.
@@ -984,7 +985,15 @@ extension BrowserViewController: WKUIDelegate {
           title: Strings.openNewPrivateTabButtonTitle,
           image: UIImage(named: "private_glasses", in: .module, compatibleWith: nil)!.template
         ) { _ in
-          self.addTab(url: url, inPrivateMode: true, currentTab: currentTab)
+          if tabType.isPrivate {
+            self.addTab(url: url, inPrivateMode: true, currentTab: currentTab)
+          } else {
+            self.askForLocalAuthentication { [weak self] success, error in
+              if success {
+                self?.addTab(url: url, inPrivateMode: true, currentTab: currentTab)
+              }
+            }
+          }
         }
         openNewPrivateTabAction.accessibilityLabel = "linkContextMenu.openInNewPrivateTab"
         actions.append(openNewPrivateTabAction)
@@ -1006,7 +1015,15 @@ extension BrowserViewController: WKUIDelegate {
             title: Strings.openInNewPrivateWindowTitle,
             image: UIImage(braveSystemNamed: "leo.window.tab-private")
           ) { _ in
-            self.openInNewWindow(url: url, isPrivate: true)
+            if tabType.isPrivate {
+              
+            } else {
+              self.askForLocalAuthentication { [weak self] success, error in
+                if success {
+                  self?.openInNewWindow(url: url, isPrivate: true)
+                }
+              }
+            }
           }
           
           openNewPrivateWindowAction.accessibilityLabel = "linkContextMenu.openInNewPrivateWindow"

--- a/Sources/Brave/Frontend/Browser/Favorites/FavoritesViewController.swift
+++ b/Sources/Brave/Frontend/Browser/Favorites/FavoritesViewController.swift
@@ -358,11 +358,15 @@ extension FavoritesViewController: UICollectionViewDelegateFlowLayout {
           let openInNewPrivateTab = UIAction(
             title: Strings.openNewPrivateTabButtonTitle,
             handler: UIAction.deferredActionHandler { _ in
-              self.askForLocalAuthentication { [weak self] success, error in
-                if success {
-                  self?.action(bookmark, .opened(inNewTab: true, switchingToPrivateMode: true))
+              if Preferences.Privacy.privateBrowsingLock.value {
+                self.askForLocalAuthentication { [weak self] success, error in
+                  if success {
+                    self?.action(bookmark, .opened(inNewTab: true, switchingToPrivateMode: true))
+                  }
                 }
-              }              
+              } else {
+                self.action(bookmark, .opened(inNewTab: true, switchingToPrivateMode: true))
+              }
             })
           urlChildren.append(openInNewPrivateTab)
         }

--- a/Sources/Brave/Frontend/Browser/Favorites/FavoritesViewController.swift
+++ b/Sources/Brave/Frontend/Browser/Favorites/FavoritesViewController.swift
@@ -358,7 +358,11 @@ extension FavoritesViewController: UICollectionViewDelegateFlowLayout {
           let openInNewPrivateTab = UIAction(
             title: Strings.openNewPrivateTabButtonTitle,
             handler: UIAction.deferredActionHandler { _ in
-              self.action(bookmark, .opened(inNewTab: true, switchingToPrivateMode: true))
+              self.askForLocalAuthentication { [weak self] success, error in
+                if success {
+                  self?.action(bookmark, .opened(inNewTab: true, switchingToPrivateMode: true))
+                }
+              }              
             })
           urlChildren.append(openInNewPrivateTab)
         }

--- a/Sources/Brave/Frontend/Browser/Favorites/FavoritesViewController.swift
+++ b/Sources/Brave/Frontend/Browser/Favorites/FavoritesViewController.swift
@@ -358,15 +358,7 @@ extension FavoritesViewController: UICollectionViewDelegateFlowLayout {
           let openInNewPrivateTab = UIAction(
             title: Strings.openNewPrivateTabButtonTitle,
             handler: UIAction.deferredActionHandler { _ in
-              if Preferences.Privacy.privateBrowsingLock.value {
-                self.askForLocalAuthentication { [weak self] success, error in
-                  if success {
-                    self?.action(bookmark, .opened(inNewTab: true, switchingToPrivateMode: true))
-                  }
-                }
-              } else {
-                self.action(bookmark, .opened(inNewTab: true, switchingToPrivateMode: true))
-              }
+              self.action(bookmark, .opened(inNewTab: true, switchingToPrivateMode: true))
             })
           urlChildren.append(openInNewPrivateTab)
         }

--- a/Sources/Brave/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
+++ b/Sources/Brave/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
@@ -624,7 +624,7 @@ class NewTabPageViewController: UIViewController {
           completion: { _ in }
         )
       }
-      if tab?.isPrivate == false, Preferences.Privacy.privateBrowsingLock.value {
+      if switchingToPrivateMode, Preferences.Privacy.privateBrowsingLock.value {
         self.askForLocalAuthentication { [weak self] success, error in
           if success {
             self?.delegate?.navigateToInput(

--- a/Sources/Brave/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
+++ b/Sources/Brave/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
@@ -624,11 +624,23 @@ class NewTabPageViewController: UIViewController {
           completion: { _ in }
         )
       }
-      delegate?.navigateToInput(
-        url.absoluteString,
-        inNewTab: inNewTab,
-        switchingToPrivateMode: switchingToPrivateMode
-      )
+      if tab?.isPrivate == true {
+        delegate?.navigateToInput(
+          url.absoluteString,
+          inNewTab: inNewTab,
+          switchingToPrivateMode: switchingToPrivateMode
+        )
+      } else {
+        self.askForLocalAuthentication { [weak self] success, error in
+          if success {
+            self?.delegate?.navigateToInput(
+              url.absoluteString,
+              inNewTab: inNewTab,
+              switchingToPrivateMode: switchingToPrivateMode
+            )
+          }
+        }
+      }
       // Donate Open Brave News Activity for Custom Suggestions
       let openBraveNewsActivity = ActivityShortcutManager.shared.createShortcutActivity(type: .openBraveNews)
       self.userActivity = openBraveNewsActivity

--- a/Sources/Brave/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
+++ b/Sources/Brave/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
@@ -624,13 +624,7 @@ class NewTabPageViewController: UIViewController {
           completion: { _ in }
         )
       }
-      if tab?.isPrivate == true {
-        delegate?.navigateToInput(
-          url.absoluteString,
-          inNewTab: inNewTab,
-          switchingToPrivateMode: switchingToPrivateMode
-        )
-      } else {
+      if tab?.isPrivate == false, Preferences.Privacy.privateBrowsingLock.value {
         self.askForLocalAuthentication { [weak self] success, error in
           if success {
             self?.delegate?.navigateToInput(
@@ -640,6 +634,12 @@ class NewTabPageViewController: UIViewController {
             )
           }
         }
+      } else {
+        delegate?.navigateToInput(
+          url.absoluteString,
+          inNewTab: inNewTab,
+          switchingToPrivateMode: switchingToPrivateMode
+        )
       }
       // Donate Open Brave News Activity for Custom Suggestions
       let openBraveNewsActivity = ActivityShortcutManager.shared.createShortcutActivity(type: .openBraveNews)

--- a/Sources/Brave/Frontend/Browser/Playlist/Controllers/PlaylistListViewController+TableViewDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/Controllers/PlaylistListViewController+TableViewDelegate.swift
@@ -264,7 +264,7 @@ extension PlaylistListViewController: UITableViewDelegate {
                 UIAction(
                   title: Strings.PlayList.sharePlaylistOpenInNewTabTitle, image: UIImage(systemName: "plus.square.on.square"),
                   handler: { [weak self] _ in
-                    self?.openInPrivateTabWithAuthentication(currentItem)
+                    self?.openInNewTab(currentItem, isPrivate: false)
                   }))
             }
 
@@ -272,7 +272,7 @@ extension PlaylistListViewController: UITableViewDelegate {
               UIAction(
                 title: Strings.PlayList.sharePlaylistOpenInNewPrivateTabTitle, image: UIImage(systemName: "plus.square.fill.on.square.fill"),
                 handler: { [weak self] _ in
-                  self?.openInNewTab(currentItem, isPrivate: true)
+                  self?.openInPrivateTabWithAuthentication(currentItem)
                 }))
 
             return actions

--- a/Sources/Brave/Frontend/Browser/Playlist/Controllers/PlaylistListViewController+TableViewDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/Controllers/PlaylistListViewController+TableViewDelegate.swift
@@ -173,7 +173,15 @@ extension PlaylistListViewController: UITableViewDelegate {
           UIAlertAction(
             title: Strings.PlayList.sharePlaylistOpenInNewPrivateTabTitle, style: .default,
             handler: { [weak self] _ in
-              self?.openInNewTab(currentItem, isPrivate: true)
+              if isPrivateBrowsing {
+                self?.openInNewTab(currentItem, isPrivate: true)
+              } else {
+                self?.askForLocalAuthentication { [weak self] success, error in
+                  if success {
+                    self?.openInNewTab(currentItem, isPrivate: true)
+                  }
+                }
+              }
             }))
 
         if !isSharedFolder {

--- a/Sources/Brave/Frontend/Browser/Playlist/Controllers/PlaylistListViewController+TableViewDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/Controllers/PlaylistListViewController+TableViewDelegate.swift
@@ -107,6 +107,19 @@ private extension PlaylistListViewController {
       }
     }
   }
+  
+  func openInPrivateTabWithAuthentication(_ item: PlaylistInfo) {
+    if !isPrivateBrowsing, Preferences.Privacy.privateBrowsingLock.value {
+      askForLocalAuthentication { [weak self] success, _ in
+        if success {
+          self?.openInNewTab(item, isPrivate: true)
+        }
+      }
+    } else {
+      self.openInNewTab(item, isPrivate: true)
+    }
+  }
+  
 }
 
 // MARK: UITableViewDelegate
@@ -174,15 +187,7 @@ extension PlaylistListViewController: UITableViewDelegate {
           UIAlertAction(
             title: Strings.PlayList.sharePlaylistOpenInNewPrivateTabTitle, style: .default,
             handler: { [weak self] _ in
-              if !isPrivateBrowsing, Preferences.Privacy.privateBrowsingLock.value {
-                self?.askForLocalAuthentication { [weak self] success, error in
-                  if success {
-                    self?.openInNewTab(currentItem, isPrivate: true)
-                  }
-                }
-              } else {
-                self?.openInNewTab(currentItem, isPrivate: true)
-              }
+              self?.openInPrivateTabWithAuthentication(currentItem)
             }))
 
         if !isSharedFolder {
@@ -259,7 +264,7 @@ extension PlaylistListViewController: UITableViewDelegate {
                 UIAction(
                   title: Strings.PlayList.sharePlaylistOpenInNewTabTitle, image: UIImage(systemName: "plus.square.on.square"),
                   handler: { [weak self] _ in
-                    self?.openInNewTab(currentItem, isPrivate: false)
+                    self?.openInPrivateTabWithAuthentication(currentItem)
                   }))
             }
 

--- a/Sources/Brave/Frontend/Browser/Playlist/Controllers/PlaylistListViewController+TableViewDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/Controllers/PlaylistListViewController+TableViewDelegate.swift
@@ -11,6 +11,7 @@ import Shared
 import Data
 import MediaPlayer
 import os.log
+import Preferences
 
 private extension PlaylistListViewController {
   func shareItem(_ item: PlaylistInfo, anchorView: UIView?) {
@@ -173,14 +174,14 @@ extension PlaylistListViewController: UITableViewDelegate {
           UIAlertAction(
             title: Strings.PlayList.sharePlaylistOpenInNewPrivateTabTitle, style: .default,
             handler: { [weak self] _ in
-              if isPrivateBrowsing {
-                self?.openInNewTab(currentItem, isPrivate: true)
-              } else {
+              if !isPrivateBrowsing, Preferences.Privacy.privateBrowsingLock.value {
                 self?.askForLocalAuthentication { [weak self] success, error in
                   if success {
                     self?.openInNewTab(currentItem, isPrivate: true)
                   }
                 }
+              } else {
+                self?.openInNewTab(currentItem, isPrivate: true)
               }
             }))
 

--- a/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarksViewController.swift
+++ b/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarksViewController.swift
@@ -594,16 +594,16 @@ class BookmarksViewController: SiteTableViewController, ToolbarUrlActionsProtoco
         title: Strings.openNewPrivateTabButtonTitle,
         image: UIImage(systemName: "plus.square.fill.on.square.fill"),
         handler: UIAction.deferredActionHandler { [unowned self] _ in
-          if isPrivateBrowsing {
-            self.toolbarUrlActionsDelegate?.openInNewTab(bookmarkItemURL, isPrivate: true)
-            parent?.presentingViewController?.dismiss(animated: true)
-          } else {
+          if !isPrivateBrowsing, Preferences.Privacy.privateBrowsingLock.value {
             self.askForLocalAuthentication { [weak self] success, error in
               if success {
                 self?.toolbarUrlActionsDelegate?.openInNewTab(bookmarkItemURL, isPrivate: true)
                 self?.parent?.presentingViewController?.dismiss(animated: true)
               }
             }
+          } else {
+            self.toolbarUrlActionsDelegate?.openInNewTab(bookmarkItemURL, isPrivate: true)
+            parent?.presentingViewController?.dismiss(animated: true)
           }
         })
 

--- a/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarksViewController.swift
+++ b/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarksViewController.swift
@@ -594,8 +594,17 @@ class BookmarksViewController: SiteTableViewController, ToolbarUrlActionsProtoco
         title: Strings.openNewPrivateTabButtonTitle,
         image: UIImage(systemName: "plus.square.fill.on.square.fill"),
         handler: UIAction.deferredActionHandler { [unowned self] _ in
-          self.toolbarUrlActionsDelegate?.openInNewTab(bookmarkItemURL, isPrivate: true)
-          parent?.presentingViewController?.dismiss(animated: true)
+          if isPrivateBrowsing {
+            self.toolbarUrlActionsDelegate?.openInNewTab(bookmarkItemURL, isPrivate: true)
+            parent?.presentingViewController?.dismiss(animated: true)
+          } else {
+            self.askForLocalAuthentication { [weak self] success, error in
+              if success {
+                self?.toolbarUrlActionsDelegate?.openInNewTab(bookmarkItemURL, isPrivate: true)
+                self?.parent?.presentingViewController?.dismiss(animated: true)
+              }
+            }
+          }
         })
 
       let copyAction = UIAction(

--- a/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/HistoryViewController.swift
+++ b/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/HistoryViewController.swift
@@ -321,7 +321,15 @@ class HistoryViewController: SiteTableViewController, ToolbarUrlActionsProtocol 
         title: Strings.openNewPrivateTabButtonTitle,
         image: UIImage(systemName: "plus.square.fill.on.square.fill"),
         handler: UIAction.deferredActionHandler { _ in
-          self.toolbarUrlActionsDelegate?.openInNewTab(historyItemURL, isPrivate: true)
+          if self.isPrivateBrowsing {
+            self.toolbarUrlActionsDelegate?.openInNewTab(historyItemURL, isPrivate: true)
+          } else {
+            self.askForLocalAuthentication { [weak self] success, error in
+              if success {
+                self?.toolbarUrlActionsDelegate?.openInNewTab(historyItemURL, isPrivate: true)
+              }
+            }
+          }
         })
 
       let copyAction = UIAction(

--- a/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/HistoryViewController.swift
+++ b/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/HistoryViewController.swift
@@ -320,15 +320,15 @@ class HistoryViewController: SiteTableViewController, ToolbarUrlActionsProtocol 
       let newPrivateTabAction = UIAction(
         title: Strings.openNewPrivateTabButtonTitle,
         image: UIImage(systemName: "plus.square.fill.on.square.fill"),
-        handler: UIAction.deferredActionHandler { _ in
-          if self.isPrivateBrowsing {
-            self.toolbarUrlActionsDelegate?.openInNewTab(historyItemURL, isPrivate: true)
-          } else {
+        handler: UIAction.deferredActionHandler { [unowned self] _ in
+          if !isPrivateBrowsing, Preferences.Privacy.privateBrowsingLock.value {
             self.askForLocalAuthentication { [weak self] success, error in
               if success {
                 self?.toolbarUrlActionsDelegate?.openInNewTab(historyItemURL, isPrivate: true)
               }
             }
+          } else {
+            self.toolbarUrlActionsDelegate?.openInNewTab(historyItemURL, isPrivate: true)
           }
         })
 

--- a/Sources/Brave/Frontend/Passcode/WindowProtection.swift
+++ b/Sources/Brave/Frontend/Passcode/WindowProtection.swift
@@ -89,6 +89,7 @@ public class WindowProtection {
   private var protectedWindow: UIWindow
   private var passcodeWindow: UIWindow
   private var context = LAContext()
+  private var viewType: AuthViewType = .general
 
   private var isVisible: Bool = false {
     didSet {
@@ -174,7 +175,7 @@ public class WindowProtection {
   }
 
   @objc private func tappedUnlock() {
-    presentLocalAuthentication()
+    presentLocalAuthentication(viewType: viewType)
   }
   
   @objc private func tappedCancel() {
@@ -208,7 +209,7 @@ public class WindowProtection {
     }
   }
 
-  private func presentLocalAuthentication(viewType: AuthViewType = .general, completion: ((Bool, LAError.Code?) -> Void)? = nil) {
+  private func presentLocalAuthentication(viewType: AuthViewType, completion: ((Bool, LAError.Code?) -> Void)? = nil) {
     if !context.canEvaluatePolicy(.deviceOwnerAuthentication, error: nil) {
       completion?(false, .passcodeNotSet)
       return
@@ -229,7 +230,7 @@ public class WindowProtection {
               completion?(true, nil)
             })
         } else {
-          lockedViewController.unlockButton.isHidden = false
+          lockedViewController.unlockButton.isHidden = viewType == .general
           
           let errorPolicy = error as? LAError
           completion?(false, errorPolicy?.code)
@@ -248,6 +249,8 @@ public class WindowProtection {
     if isVisible {
       return
     }
+    
+    self.viewType = viewType
 
     context = LAContext()
     updateVisibleStatusForForeground(determineLockWithPasscode, viewType: viewType) { status, error in

--- a/Sources/Brave/Frontend/Sync/SyncSettingsTableViewController.swift
+++ b/Sources/Brave/Frontend/Sync/SyncSettingsTableViewController.swift
@@ -274,7 +274,7 @@ class SyncSettingsTableViewController: SyncViewController, UITableViewDelegate, 
       if toggleExistingStatus {
         performSyncDataTypeStatusChange(type: syncDataType)
       } else {
-        askForAuthentication() { status, error in
+        askForAuthentication(viewType: .sync) { status, error in
           guard status else {
             toggle.setOn(toggleExistingStatus, animated: false)
             return
@@ -336,7 +336,7 @@ class SyncSettingsTableViewController: SyncViewController, UITableViewDelegate, 
 
   @objc
   private func onSyncInternalsTapped() {
-    askForAuthentication() { [weak self] status, error in
+    askForAuthentication(viewType: .sync) { [weak self] status, error in
       guard let self = self, status else { return }
       
       let syncInternalsController = self.syncAPI.createSyncInternalsController().then {
@@ -592,7 +592,7 @@ extension SyncSettingsTableViewController {
   }
 
   private func addAnotherDevice() {
-    askForAuthentication() { [weak self] status, error in
+    askForAuthentication(viewType: .sync) { [weak self] status, error in
       guard let self = self, status else { return }
       
       let view = SyncSelectDeviceTypeViewController()

--- a/Sources/Brave/Frontend/Sync/SyncViewController.swift
+++ b/Sources/Brave/Frontend/Sync/SyncViewController.swift
@@ -54,7 +54,7 @@ class SyncViewController: AuthenticationController {
     super.viewWillAppear(animated)
     
     if requiresAuthentication {
-      askForAuthentication() { [weak self] success, error in
+      askForAuthentication(viewType: .sync) { [weak self] success, error in
         guard let self else { return }
         
         if !success, error != .userCancel {

--- a/Sources/Brave/Frontend/Sync/SyncWelcomeViewController.swift
+++ b/Sources/Brave/Frontend/Sync/SyncWelcomeViewController.swift
@@ -256,7 +256,7 @@ class SyncWelcomeViewController: SyncViewController {
   
   @objc
   private func onSyncInternalsAction() {
-    askForAuthentication() { [weak self] status, error in
+    askForAuthentication(viewType: .sync) { [weak self] status, error in
       guard let self = self, status else { return }
       
       let syncInternalsController = syncAPI.createSyncInternalsController().then {

--- a/Sources/Brave/Frontend/Widgets/LoadingViewController.swift
+++ b/Sources/Brave/Frontend/Widgets/LoadingViewController.swift
@@ -59,7 +59,7 @@ public class AuthenticationController: LoadingViewController {
   
   /// A method to ask biometric authentication to user
   /// - Parameter completion: block returning authentication status
-  func askForAuthentication(viewType: AuthViewType = .sync, completion: ((Bool, LAError.Code?) -> Void)? = nil) {
+  func askForAuthentication(viewType: AuthViewType, completion: ((Bool, LAError.Code?) -> Void)? = nil) {
     guard let windowProtection = windowProtection else {
       completion?(false, nil)
       return


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

The conditions of opening in private tab is handled

* Context menu open in private tab
* Context menu open in private window
* Playlist context menu open in new private tab
* Playlist share open in new private tab
* NTP favourite open in new private tab
* NTP favourite show more open in private tab
* Bookmarks open in a new private tab
* History open in new private tab
* Bottom bar long press middle icon action open in new private tab
* News open in new Private tab 


<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7952

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
The test plan is determined in the ticket

## Screenshots:

### Context menu open in private tab - Context menu open in private window

https://github.com/brave/brave-ios/assets/6643505/207f5b0d-9caf-4a75-b46e-85c5ce406eb4

### Playlist context menu open in private tab - Playlist share open in private tab


https://github.com/brave/brave-ios/assets/6643505/86ee8d8a-6f08-45df-a843-28a7970c25a5


### NTP favourite open in private new tab - NTP favourite show more open in new private tab


https://github.com/brave/brave-ios/assets/6643505/a895d62e-529a-41b4-938b-72e37b67f263


### Bookmarks open in a new private tab


https://github.com/brave/brave-ios/assets/6643505/3b12509f-4c4e-4987-b9e6-9470d6cbd690


### History open in new private tab


https://github.com/brave/brave-ios/assets/6643505/99ccb51a-7172-4915-97cf-1b2ae7add9b9


###  Bottom bar long press middle icon action open in new private tab


https://github.com/brave/brave-ios/assets/6643505/37698fe7-54ff-484c-97e3-cbb961f15b49


### News open in new private tab


https://github.com/brave/brave-ios/assets/6643505/b36ab458-0bf6-4765-baef-a8010b87ae20



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
