### PR TITLE
Fix #7953: Fix crash restoring tabs when private tabs are kept

### DIFF
--- a/App/iOS/Delegates/SceneDelegate.swift
+++ b/App/iOS/Delegates/SceneDelegate.swift
@@ -410,13 +410,13 @@ extension SceneDelegate {
       let windowIdString = userActivity.userInfo?["WindowID"] as? String ?? ""
       windowId = UUID(uuidString: windowIdString) ?? UUID()
       isPrivate = userActivity.userInfo?["isPrivate"] as? Bool == true
-      privateBrowsingManager.isPrivateBrowsing = isPrivate
       urlToOpen = userActivity.userInfo?["OpenURL"] as? URL
+      privateBrowsingManager.isPrivateBrowsing = isPrivate
       
       // Create a new session window
-      SessionWindow.createWindow(isPrivate: isPrivate, isSelected: true, uuid: windowId)
+      SessionWindow.createWindow(isPrivate: false, isSelected: true, uuid: windowId)
       
-      scene.userActivity = userActivity
+      scene.userActivity = BrowserState.userActivity(for: windowId, isPrivate: isPrivate)
       scene.session.userInfo?["WindowID"] = windowId
       scene.session.userInfo?["isPrivate"] = isPrivate
     } else if let sceneWindowId = scene.session.userInfo?["WindowID"] as? String,
@@ -513,8 +513,10 @@ extension SceneDelegate {
     }
     
     if let urlToOpen = urlToOpen {
-      browserViewController.loadViewIfNeeded()
-      browserViewController.switchToTabForURLOrOpen(urlToOpen, isPrivileged: false)
+      DispatchQueue.main.async {
+        browserViewController.loadViewIfNeeded()
+        browserViewController.switchToTabForURLOrOpen(urlToOpen, isPrivileged: false)
+      }
     }
 
     return browserViewController

--- a/Sources/Brave/Frontend/Browser/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController.swift
@@ -694,6 +694,7 @@ public class BrowserViewController: UIViewController {
   
   @objc func appWillTerminateNotification() {
     tabManager.saveAllTabs()
+    tabManager.removePrivateWindows()
   }
   
   @objc private func tappedCollapsedURLBar() {
@@ -988,7 +989,7 @@ public class BrowserViewController: UIViewController {
   }
 
   private func setupTabs() {
-    let isPrivate = Preferences.Privacy.privateBrowsingOnly.value
+    let isPrivate = privateBrowsingManager.isPrivateBrowsing || Preferences.Privacy.privateBrowsingOnly.value
     let noTabsAdded = self.tabManager.tabsForCurrentMode.isEmpty
     
     var tabToSelect: Tab?

--- a/Sources/Brave/Frontend/Browser/TabManager.swift
+++ b/Sources/Brave/Frontend/Browser/TabManager.swift
@@ -591,6 +591,12 @@ class TabManager: NSObject {
     return nil
   }
   
+  func removePrivateWindows() {
+    if Preferences.Privacy.privateBrowsingOnly.value || (privateBrowsingManager.isPrivateBrowsing && !Preferences.Privacy.persistentPrivateBrowsing.value) {
+      SessionWindow.deleteAllWindows(privateOnly: true)
+    }
+  }
+  
   func saveAllTabs() {
     if Preferences.Privacy.privateBrowsingOnly.value || (privateBrowsingManager.isPrivateBrowsing && !Preferences.Privacy.persistentPrivateBrowsing.value) { return }
     
@@ -1026,7 +1032,7 @@ class TabManager: NSObject {
     isRestoring = false
 
     // Always make sure there is at least one tab.
-    let isPrivate = Preferences.Privacy.privateBrowsingOnly.value
+    let isPrivate = privateBrowsingManager.isPrivateBrowsing || Preferences.Privacy.privateBrowsingOnly.value
     return tabToSelect ?? self.addTab(isPrivate: isPrivate)
   }
 

--- a/Sources/Data/models/SessionWindow.swift
+++ b/Sources/Data/models/SessionWindow.swift
@@ -145,6 +145,26 @@ extension SessionWindow {
       sessionWindow.delete(context: .existing(context))
     }
   }
+  
+  public static func deleteAllWindows(privateOnly: Bool) {
+    DataController.perform { context in
+      guard let sessionWindows = SessionWindow.all(where: NSPredicate(format: "isPrivate == %@", privateOnly ? "true" : "false"), context: context) else {
+        return
+      }
+      
+      sessionWindows.forEach { sessionWindow in
+        sessionWindow.sessionTabs?.forEach {
+          $0.delete(context: .existing(context))
+        }
+        
+        sessionWindow.sessionTabGroups?.forEach {
+          $0.delete(context: .existing(context))
+        }
+        
+        sessionWindow.delete(context: .existing(context))
+      }
+    }
+  }
 }
 
 // MARK: - Private


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Fixes white screen and crash when restoring the private tabs that are kept

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7953

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
