### PR TITLE
Fix #7966: Improve NFT balance fetching performance

### DIFF
--- a/Sources/BraveWallet/Crypto/Accounts/AccountSelectionRootView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/AccountSelectionRootView.swift
@@ -92,6 +92,7 @@ private struct AccountListRowView: View {
           AccountView(address: account.address, name: account.name)
           checkmark
         }
+        .contentShape(Rectangle())
       }
       .buttonStyle(FadeButtonStyle())
     }

--- a/Sources/BraveWallet/Crypto/FiltersDisplaySettingsView.swift
+++ b/Sources/BraveWallet/Crypto/FiltersDisplaySettingsView.swift
@@ -529,6 +529,7 @@ private struct FilterDetailRowView<SelectionView: View>: View {
         .font(.body.weight(.semibold))
         .foregroundColor(Color(.separator))
     }
+    .contentShape(Rectangle())
   }
 }
 

--- a/Tests/BraveWalletTests/NFTStoreTests.swift
+++ b/Tests/BraveWalletTests/NFTStoreTests.swift
@@ -162,10 +162,10 @@ class NFTStoreTests: XCTestCase {
     XCTAssertTrue(store.userVisibleNFTs.isEmpty)  // Initial state
     store.$userVisibleNFTs
       .dropFirst()
-      .collect(2)
+      .collect(3)
       .sink { userVisibleNFTs in
         defer { userVisibleNFTsException.fulfill() }
-        XCTAssertEqual(userVisibleNFTs.count, 2) // empty nfts, populated nfts
+        XCTAssertEqual(userVisibleNFTs.count, 3) // empty nfts, populated w/ balance nfts, populated w/ metadata
         guard let lastUpdatedVisibleNFTs = userVisibleNFTs.last else {
           XCTFail("Unexpected test result")
           return
@@ -225,10 +225,10 @@ class NFTStoreTests: XCTestCase {
     let hidingUnownedExpectation = expectation(description: "update-hidingUnowned")
     store.$userVisibleNFTs
       .dropFirst()
-      .collect(2)
+      .collect(3)
       .sink { userVisibleNFTs in
         defer { hidingUnownedExpectation.fulfill() }
-        XCTAssertEqual(userVisibleNFTs.count, 2) // empty nfts, populated nfts
+        XCTAssertEqual(userVisibleNFTs.count, 3) // empty nfts, populated w/ balance nfts, populated w/ metadata
         guard let lastUpdatedVisibleNFTs = userVisibleNFTs.last else {
           XCTFail("Unexpected test result")
           return


### PR DESCRIPTION
## Summary of Changes
- Balances for NFTs were being fetched one by one, for each account. Threaded the balance calls so they are concurrent.
- After balance improvement, I noticed NFT tab was still slow to update owned NFTs as it was waiting on NFT metadata fetching. Added another UI assignment so we now fetch NFTs and display them as appropriate, then fetch balances for those NFTs and update them as appropriate, then fetch NFT metadata and update NFTs with their metadata.

This pull request fixes #7966

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Restore a wallet with multiple owned NFTs.
2. Open NFT tab and tap Filters & Display Settings button.
    - Assuming starting from fresh so `Hide Unowned` toggle is disabled. If enabled, tap `Reset` then `Save Changes` and close/re-open native wallet to reset balance cache.
3. Enabled `Hide Unowned` toggle and tap `Save Changes`.
4. All NFTs should disappear while balance is fetched, but the _owned_ NFTs should re-appear much quicker.

Small fix to tap area on `Select Accounts` & `Select Networks` row: you should be able to tap anywhere on these rows to open the account/network filter detail screens.
Similarly, in the Accounts filter detail screen you should be able to tap anywhere on the account rows to select/de-select an account.


## Screenshots:

### NFT Balance Fetch Improvement

https://github.com/brave/brave-ios/assets/5314553/08e276c0-7bc1-4e1d-9d41-b4f133f72d3f


### Tap area fixes

https://github.com/brave/brave-ios/assets/5314553/cf63b1fb-cef4-434f-b226-8252cf4675d2



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
