### PR TITLE
Fix #7961: Tokens on Testnets still shown in Edit Visible Assets Screen when testnets are filtered out

### DIFF
--- a/Sources/BraveWallet/Crypto/Stores/NFTStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/NFTStore.swift
@@ -117,12 +117,7 @@ public class NFTStore: ObservableObject {
         .filter { account in
           WalletConstants.supportedCoinTypes.contains(account.coin)
         }
-      self.allNetworks = await rpcService.allNetworksForSupportedCoins().filter { network in
-        if !Preferences.Wallet.showTestNetworks.value { // filter out test networks
-          return !WalletConstants.supportedTestNetworkChainIds.contains(where: { $0 == network.chainId })
-        }
-        return true
-      }
+      self.allNetworks = await rpcService.allNetworksForSupportedCoins()
       let filters = self.filters
       let selectedAccounts = filters.accounts.filter(\.isSelected).map(\.model)
       let selectedNetworks = filters.networks.filter(\.isSelected).map(\.model)

--- a/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
@@ -336,12 +336,7 @@ public class PortfolioStore: ObservableObject {
         .filter { account in
           WalletConstants.supportedCoinTypes.contains(account.coin)
         }
-      self.allNetworks = await rpcService.allNetworksForSupportedCoins().filter { network in
-        if !Preferences.Wallet.showTestNetworks.value { // filter out test networks
-          return !WalletConstants.supportedTestNetworkChainIds.contains(where: { $0 == network.chainId })
-        }
-        return true
-      }
+      self.allNetworks = await rpcService.allNetworksForSupportedCoins()
       let filters = self.filters
       let selectedAccounts = filters.accounts.filter(\.isSelected).map(\.model)
       let selectedNetworks = filters.networks.filter(\.isSelected).map(\.model)

--- a/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
@@ -723,9 +723,6 @@ extension PortfolioStore: PreferencesObserver {
   public func preferencesDidChange(for key: String) {
     guard !isSavingFilters else { return }
     update()
-    if key == Preferences.Wallet.showTestNetworks.key {
-      userAssetsStore.networkFilters.removeAll()
-    }
   }
 }
 

--- a/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
@@ -723,6 +723,9 @@ extension PortfolioStore: PreferencesObserver {
   public func preferencesDidChange(for key: String) {
     guard !isSavingFilters else { return }
     update()
+    if key == Preferences.Wallet.showTestNetworks.key {
+      userAssetsStore.networkFilters.removeAll()
+    }
   }
 }
 

--- a/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
@@ -84,6 +84,8 @@ public class UserAssetsStore: ObservableObject {
     self.ipfsApi = ipfsApi
     self.assetManager = userAssetManager
     self.keyringService.add(self)
+    
+    Preferences.Wallet.showTestNetworks.observe(from: self)
   }
   
   func update() {
@@ -294,4 +296,12 @@ extension UserAssetsStore: BraveWalletBraveWalletServiceObserver {
   public func onDiscoverAssetsCompleted(_ discoveredAssets: [BraveWallet.BlockchainToken]) { }
   
   public func onResetWallet() { }
+}
+
+extension UserAssetsStore: PreferencesObserver {
+  public func preferencesDidChange(for key: String) {
+    if key == Preferences.Wallet.showTestNetworks.key {
+      networkFilters.removeAll()
+    }
+  }
 }

--- a/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
@@ -90,16 +90,9 @@ public class UserAssetsStore: ObservableObject {
     Task { @MainActor in
       // setup network filters if not currently setup
       if self.networkFilters.isEmpty {
-        self.networkFilters = await self.rpcService.allNetworksForSupportedCoins()
-          .filter { network in
-            if !Preferences.Wallet.showTestNetworks.value { // filter out test networks
-              return !WalletConstants.supportedTestNetworkChainIds.contains(where: { $0 == network.chainId })
-            }
-            return true
-          }
-          .map {
-            .init(isSelected: true, model: $0)
-          }
+        self.networkFilters = await self.rpcService.allNetworksForSupportedCoins().map {
+          .init(isSelected: true, model: $0)
+        }
       }
       let networks: [BraveWallet.NetworkInfo] = self.networkFilters.filter(\.isSelected).map(\.model)
       let allUserAssets = assetManager.getAllUserAssetsInNetworkAssets(networks: networks)

--- a/Sources/BraveWallet/Extensions/RpcServiceExtensions.swift
+++ b/Sources/BraveWallet/Extensions/RpcServiceExtensions.swift
@@ -260,7 +260,7 @@ extension BraveWalletJsonRpcService {
   
   /// Returns an array of all networks for the supported coin types. Result will exclude test networks if test networks is set to
   /// not shown in Wallet Settings
-  @MainActor func allNetworksForSupportedCoins() async -> [BraveWallet.NetworkInfo] {
+  @MainActor func allNetworksForSupportedCoins(respectTestnetPreference: Bool = true) async -> [BraveWallet.NetworkInfo] {
     await withTaskGroup(of: [BraveWallet.NetworkInfo].self) { @MainActor [weak self] group -> [BraveWallet.NetworkInfo] in
       guard let self = self else { return [] }
       for coinType in WalletConstants.supportedCoinTypes {
@@ -272,7 +272,7 @@ extension BraveWalletJsonRpcService {
         }
       }
       let allChains = await group.reduce([BraveWallet.NetworkInfo](), { $0 + $1 }).filter { network in
-        if !Preferences.Wallet.showTestNetworks.value { // filter out test networks
+        if !Preferences.Wallet.showTestNetworks.value && respectTestnetPreference { // filter out test networks
           return !WalletConstants.supportedTestNetworkChainIds.contains(where: { $0 == network.chainId })
         }
         return true

--- a/Sources/BraveWallet/Extensions/RpcServiceExtensions.swift
+++ b/Sources/BraveWallet/Extensions/RpcServiceExtensions.swift
@@ -7,6 +7,7 @@ import Foundation
 import BraveCore
 import BigNumber
 import os.log
+import Preferences
 
 extension BraveWalletJsonRpcService {
   /// Obtain the decimal balance of an `BlockchainToken` for a given account
@@ -257,7 +258,8 @@ extension BraveWalletJsonRpcService {
     return balancesForAsset.reduce(0, +)
   }
   
-  /// Returns an array of all networks for the supported coin types.
+  /// Returns an array of all networks for the supported coin types. Result will exclude test networks if test networks is set to
+  /// not shown in Wallet Settings
   @MainActor func allNetworksForSupportedCoins() async -> [BraveWallet.NetworkInfo] {
     await withTaskGroup(of: [BraveWallet.NetworkInfo].self) { @MainActor [weak self] group -> [BraveWallet.NetworkInfo] in
       guard let self = self else { return [] }
@@ -269,7 +271,12 @@ extension BraveWalletJsonRpcService {
           }
         }
       }
-      let allChains = await group.reduce([BraveWallet.NetworkInfo](), { $0 + $1 })
+      let allChains = await group.reduce([BraveWallet.NetworkInfo](), { $0 + $1 }).filter { network in
+        if !Preferences.Wallet.showTestNetworks.value { // filter out test networks
+          return !WalletConstants.supportedTestNetworkChainIds.contains(where: { $0 == network.chainId })
+        }
+        return true
+      }
       return allChains.sorted { lhs, rhs in
         // sort solana chains to the front of the list
         lhs.coin == .sol && rhs.coin != .sol

--- a/Sources/BraveWallet/WalletUserAssetManager.swift
+++ b/Sources/BraveWallet/WalletUserAssetManager.swift
@@ -98,7 +98,7 @@ public class WalletUserAssetManager: WalletUserAssetManagerType {
       if let coin = coin {
         networks = await rpcService.allNetworks(coin)
       } else {
-        networks = await rpcService.allNetworksForSupportedCoins()
+        networks = await rpcService.allNetworksForSupportedCoins(respectTestnetPreference: false)
       }
       let networkAssets = await walletService.allUserAssets(in: networks)
       for networkAsset in networkAssets {

--- a/Tests/BraveWalletTests/NetworkStoreTests.swift
+++ b/Tests/BraveWalletTests/NetworkStoreTests.swift
@@ -6,13 +6,22 @@
 import XCTest
 import Combine
 import BraveCore
+import Preferences
 @testable import BraveWallet
 
 @MainActor class NetworkStoreTests: XCTestCase {
   
+  override func setUp() {
+    Preferences.Wallet.showTestNetworks.reset()
+  }
+  override func tearDown() {
+    Preferences.Wallet.showTestNetworks.reset()
+  }
+  
   private var cancellables: Set<AnyCancellable> = .init()
   
   private func setupServices() -> (BraveWallet.TestKeyringService, BraveWallet.TestJsonRpcService, BraveWallet.TestBraveWalletService, BraveWallet.TestSwapService) {
+    Preferences.Wallet.showTestNetworks.value = true
     let currentNetwork: BraveWallet.NetworkInfo = .mockMainnet
     let currentChainId = currentNetwork.chainId
     let allNetworks: [BraveWallet.CoinType: [BraveWallet.NetworkInfo]] = [

--- a/Tests/BraveWalletTests/NetworkStoreTests.swift
+++ b/Tests/BraveWalletTests/NetworkStoreTests.swift
@@ -12,7 +12,7 @@ import Preferences
 @MainActor class NetworkStoreTests: XCTestCase {
   
   override func setUp() {
-    Preferences.Wallet.showTestNetworks.reset()
+    Preferences.Wallet.showTestNetworks.value = true
   }
   override func tearDown() {
     Preferences.Wallet.showTestNetworks.reset()
@@ -21,7 +21,6 @@ import Preferences
   private var cancellables: Set<AnyCancellable> = .init()
   
   private func setupServices() -> (BraveWallet.TestKeyringService, BraveWallet.TestJsonRpcService, BraveWallet.TestBraveWalletService, BraveWallet.TestSwapService) {
-    Preferences.Wallet.showTestNetworks.value = true
     let currentNetwork: BraveWallet.NetworkInfo = .mockMainnet
     let currentChainId = currentNetwork.chainId
     let allNetworks: [BraveWallet.CoinType: [BraveWallet.NetworkInfo]] = [

--- a/Tests/BraveWalletTests/SelectAccountTokenStoreTests.swift
+++ b/Tests/BraveWalletTests/SelectAccountTokenStoreTests.swift
@@ -6,9 +6,17 @@
 import Combine
 import XCTest
 import BraveCore
+import Preferences
 @testable import BraveWallet
 
 @MainActor class SelectAccountTokenStoreTests: XCTestCase {
+  
+  override func setUp() {
+    Preferences.Wallet.showTestNetworks.reset()
+  }
+  override func tearDown() {
+    Preferences.Wallet.showTestNetworks.reset()
+  }
   
   private var cancellables: Set<AnyCancellable> = .init()
   
@@ -71,6 +79,8 @@ import BraveCore
   /// Test `update()` will update `accountSections` for each account, and verify
   /// `filteredAccountSections` displays non-zero balance by default.
   func testUpdate() async {
+    Preferences.Wallet.showTestNetworks.value = true
+    
     let mockETHBalance: Double = 0.896
     let mockETHPrice: String = "3059.99" // ETH value = $2741.75104
     let mockUSDCBalance: Double = 4
@@ -287,6 +297,8 @@ import BraveCore
   }
   
   func testNetworkFilter() {
+    Preferences.Wallet.showTestNetworks.value = true
+    
     let keyringService = BraveWallet.TestKeyringService()
     let rpcService = BraveWallet.TestJsonRpcService()
     let walletService = BraveWallet.TestBraveWalletService()

--- a/Tests/BraveWalletTests/SelectAccountTokenStoreTests.swift
+++ b/Tests/BraveWalletTests/SelectAccountTokenStoreTests.swift
@@ -12,7 +12,7 @@ import Preferences
 @MainActor class SelectAccountTokenStoreTests: XCTestCase {
   
   override func setUp() {
-    Preferences.Wallet.showTestNetworks.reset()
+    Preferences.Wallet.showTestNetworks.value = true
   }
   override func tearDown() {
     Preferences.Wallet.showTestNetworks.reset()
@@ -79,8 +79,6 @@ import Preferences
   /// Test `update()` will update `accountSections` for each account, and verify
   /// `filteredAccountSections` displays non-zero balance by default.
   func testUpdate() async {
-    Preferences.Wallet.showTestNetworks.value = true
-    
     let mockETHBalance: Double = 0.896
     let mockETHPrice: String = "3059.99" // ETH value = $2741.75104
     let mockUSDCBalance: Double = 4
@@ -297,8 +295,6 @@ import Preferences
   }
   
   func testNetworkFilter() {
-    Preferences.Wallet.showTestNetworks.value = true
-    
     let keyringService = BraveWallet.TestKeyringService()
     let rpcService = BraveWallet.TestJsonRpcService()
     let walletService = BraveWallet.TestBraveWalletService()

--- a/Tests/BraveWalletTests/TransactionConfirmationStoreTests.swift
+++ b/Tests/BraveWalletTests/TransactionConfirmationStoreTests.swift
@@ -6,9 +6,17 @@
 import Combine
 import XCTest
 import BraveCore
+import Preferences
 @testable import BraveWallet
 
 @MainActor class TransactionConfirmationStoreTests: XCTestCase {
+  
+  override func setUp() {
+    Preferences.Wallet.showTestNetworks.reset()
+  }
+  override func tearDown() {
+    Preferences.Wallet.showTestNetworks.reset()
+  }
   
   private var cancellables: Set<AnyCancellable> = .init()
   
@@ -28,6 +36,8 @@ import BraveCore
     makeErc20ApproveDataSuccess: Bool = true,
     setDataForUnapprovedTransactionSuccess: Bool = true
   ) -> TransactionConfirmationStore {
+    Preferences.Wallet.showTestNetworks.value = true
+    
     let mockEthAssetPrice: BraveWallet.AssetPrice = .init(fromAsset: "eth", toAsset: "usd", price: "3059.99", assetTimeframeChange: "-57.23")
     let mockSolAssetPrice: BraveWallet.AssetPrice = .init(fromAsset: "sol", toAsset: "usd", price: "39.57", assetTimeframeChange: "-57.23")
     let formatter = WeiFormatter(decimalFormatStyle: .decimals(precision: 18))

--- a/Tests/BraveWalletTests/TransactionConfirmationStoreTests.swift
+++ b/Tests/BraveWalletTests/TransactionConfirmationStoreTests.swift
@@ -12,7 +12,7 @@ import Preferences
 @MainActor class TransactionConfirmationStoreTests: XCTestCase {
   
   override func setUp() {
-    Preferences.Wallet.showTestNetworks.reset()
+    Preferences.Wallet.showTestNetworks.value = true
   }
   override func tearDown() {
     Preferences.Wallet.showTestNetworks.reset()
@@ -36,8 +36,6 @@ import Preferences
     makeErc20ApproveDataSuccess: Bool = true,
     setDataForUnapprovedTransactionSuccess: Bool = true
   ) -> TransactionConfirmationStore {
-    Preferences.Wallet.showTestNetworks.value = true
-    
     let mockEthAssetPrice: BraveWallet.AssetPrice = .init(fromAsset: "eth", toAsset: "usd", price: "3059.99", assetTimeframeChange: "-57.23")
     let mockSolAssetPrice: BraveWallet.AssetPrice = .init(fromAsset: "sol", toAsset: "usd", price: "39.57", assetTimeframeChange: "-57.23")
     let formatter = WeiFormatter(decimalFormatStyle: .decimals(precision: 18))

--- a/Tests/BraveWalletTests/TransactionsActivityStoreTests.swift
+++ b/Tests/BraveWalletTests/TransactionsActivityStoreTests.swift
@@ -6,9 +6,17 @@
 import Combine
 import XCTest
 import BraveCore
+import Preferences
 @testable import BraveWallet
 
 class TransactionsActivityStoreTests: XCTestCase {
+  
+  override func setUp() {
+    Preferences.Wallet.showTestNetworks.reset()
+  }
+  override func tearDown() {
+    Preferences.Wallet.showTestNetworks.reset()
+  }
   
   private var cancellables: Set<AnyCancellable> = .init()
   
@@ -35,6 +43,8 @@ class TransactionsActivityStoreTests: XCTestCase {
   ]
   
   func testUpdate() {
+    Preferences.Wallet.showTestNetworks.value = true
+    
     let keyringService = BraveWallet.TestKeyringService()
     keyringService._addObserver = { _ in }
     keyringService._keyringInfo = { keyringId, completion in

--- a/Tests/BraveWalletTests/TransactionsActivityStoreTests.swift
+++ b/Tests/BraveWalletTests/TransactionsActivityStoreTests.swift
@@ -12,7 +12,7 @@ import Preferences
 class TransactionsActivityStoreTests: XCTestCase {
   
   override func setUp() {
-    Preferences.Wallet.showTestNetworks.reset()
+    Preferences.Wallet.showTestNetworks.value = true
   }
   override func tearDown() {
     Preferences.Wallet.showTestNetworks.reset()
@@ -43,8 +43,6 @@ class TransactionsActivityStoreTests: XCTestCase {
   ]
   
   func testUpdate() {
-    Preferences.Wallet.showTestNetworks.value = true
-    
     let keyringService = BraveWallet.TestKeyringService()
     keyringService._addObserver = { _ in }
     keyringService._keyringInfo = { keyringId, completion in


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7961

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Please refer to the issue

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

https://github.com/brave/brave-ios/assets/1187676/d719a07b-0528-40b6-8d36-785f9cd5519b



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
