### PR TITLE
Fix #7973: Fix favicons appearing blurry sometimes

### DIFF
--- a/Sources/Favicon/FaviconRenderer.swift
+++ b/Sources/Favicon/FaviconRenderer.swift
@@ -8,9 +8,9 @@ import UIKit
 import BraveCore
 
 /// A class for rendering a FavIcon onto a `UIImage`
-class FaviconRenderer {
+public class FaviconRenderer {
   @MainActor
-  static func loadIcon(for url: URL, persistent: Bool) async throws -> Favicon {
+  public static func loadIcon(for url: URL, persistent: Bool) async throws -> Favicon {
     // Load the Favicon from Brave-Core
     let attributes: FaviconAttributes = await withCheckedContinuation { continuation in
       FaviconLoader.getForPrivateMode(!persistent).favicon(forPageURLOrHost: url, sizeInPoints: .desiredLargest, minSizeInPoints: .desiredMedium /*32x32*/) { _, attributes in


### PR DESCRIPTION
## Summary of Changes
- Always fetch icons from the FaviconService database to get the highest res, skipping the icon downloaded callback

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7973

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
- Test Favicons on NTP by visiting one of the NTP websites
- Visit NTP websites multiple times to have icons update and see they won't be blurry


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
