### PR TITLE
Fix #7969: [Follow up to #7860] Data on NTP with SI is not aligned properly

### DIFF
--- a/Sources/Brave/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
+++ b/Sources/Brave/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
@@ -199,13 +199,15 @@ class NewTabPageViewController: UIViewController {
       }),
     ]
 
+    var isBackgroundNTPSI = false
+    if let ntpBackground = background.currentBackground, case .sponsoredImage = ntpBackground {
+      isBackgroundNTPSI = true
+    }
+    let ntpDefaultBrowserCalloutProvider = NTPDefaultBrowserCalloutProvider(isBackgroundNTPSI: isBackgroundNTPSI)
+    
     // This is a one-off view, adding it to the NTP only if necessary.
-    if NTPDefaultBrowserCalloutProvider.shouldShowCallout {
-      // Never show Default Browser Notification over an NPT SI
-      if let ntpBackground = background.currentBackground, case .sponsoredImage = ntpBackground {
-        return
-      }
-      sections.insert(NTPDefaultBrowserCalloutProvider(), at: 0)
+    if ntpDefaultBrowserCalloutProvider.shouldShowCallout() {
+      sections.insert(ntpDefaultBrowserCalloutProvider, at: 0)
     }
 
     if !privateBrowsingManager.isPrivateBrowsing {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

Fixing should show NTP callouts on for default browsing on SI
<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7969 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

- Fresh install and launch Brave
- Start onboarding flow > Don't set Brave as the default browser and select Not now
- Tap Done > Wait until landed on NTP > Confirm there is no Default browser prompt is shown
- Go to device settings and update the date to be 8 days from today
- Close and relaunch Brave > Confirm that Default browser prompt is shown on regular NTP
- Open another NTP until you see SI page > Observe

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


https://github.com/brave/brave-ios/assets/6643505/2fd78a3c-aa41-4ee8-b5a4-218ccbe89dae


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
