### PR TITLE
Fix #7980: [Follow up to #7952] Opening in private from home screen will bypass biometrics

### DIFF
--- a/Sources/Brave/Extensions/SceneExtensions.swift
+++ b/Sources/Brave/Extensions/SceneExtensions.swift
@@ -29,7 +29,7 @@ extension UIWindowScene {
 }
 
 extension UIViewController {
-  func askForLocalAuthentication(completion: ((Bool, LAError.Code?) -> Void)? = nil) {
+  func askForLocalAuthentication(viewType: AuthViewType = .general, completion: ((Bool, LAError.Code?) -> Void)? = nil) {
     guard let windowProtection = currentScene?.browserViewController?.windowProtection else {
       completion?(false, nil)
       return
@@ -41,7 +41,7 @@ extension UIViewController {
       completion?(true, nil)
     } else {
       windowProtection.presentAuthenticationForViewController(
-        determineLockWithPasscode: false, viewType: .general) { status, error in
+        determineLockWithPasscode: false, viewType: viewType) { status, error in
           completion?(status, error)
       }
     }

--- a/Sources/Brave/Frontend/Browser/NavigationRouter.swift
+++ b/Sources/Brave/Frontend/Browser/NavigationRouter.swift
@@ -111,7 +111,15 @@ public enum NavigationPath: Equatable {
     case .newTab:
       bvc.openBlankNewTab(attemptLocationFieldFocus: false, isPrivate: bvc.privateBrowsingManager.isPrivateBrowsing)
     case .newPrivateTab:
-      bvc.openBlankNewTab(attemptLocationFieldFocus: false, isPrivate: true)
+      if Preferences.Privacy.lockWithPasscode.value {
+        bvc.openBlankNewTab(attemptLocationFieldFocus: false, isPrivate: true)
+      } else {
+        bvc.askForLocalAuthentication(viewType: .widget) { [weak bvc] success, _ in
+          if success {
+            bvc?.openBlankNewTab(attemptLocationFieldFocus: false, isPrivate: true)
+          }
+        }
+      }
     case .bookmarks:
       bvc.navigationHelper.openBookmarks()
     case .history:

--- a/Sources/Brave/Frontend/Browser/QuickActions.swift
+++ b/Sources/Brave/Frontend/Browser/QuickActions.swift
@@ -7,6 +7,7 @@ import Storage
 import UIKit
 import Shared
 import BraveUI
+import Preferences
 
 enum ShortcutType: String {
   case newTab = "NewTab"
@@ -59,7 +60,15 @@ public class QuickActions: NSObject {
     case .newTab:
       handleOpenNewTab(withBrowserViewController: browserViewController, isPrivate: false)
     case .newPrivateTab:
-      handleOpenNewTab(withBrowserViewController: browserViewController, isPrivate: true)
+      if Preferences.Privacy.lockWithPasscode.value {
+        handleOpenNewTab(withBrowserViewController: browserViewController, isPrivate: true)
+      } else {
+        browserViewController.askForLocalAuthentication(viewType: .widget) { [weak self] success, _ in
+          if success {
+            self?.handleOpenNewTab(withBrowserViewController: browserViewController, isPrivate: true)
+          }
+        }
+      }
     case .scanQRCode:
       handleScanQR(withBrowserViewController: browserViewController)
     }

--- a/Sources/Brave/Frontend/Passcode/WindowProtection.swift
+++ b/Sources/Brave/Frontend/Passcode/WindowProtection.swift
@@ -13,7 +13,7 @@ import BraveUI
 import os.log
 
 public enum AuthViewType {
-  case general, sync, tabTray, passwords
+  case general, widget, sync, tabTray, passwords
 }
 
 public class WindowProtection {
@@ -216,6 +216,10 @@ public class WindowProtection {
     }
     
     lockedViewController.unlockButton.isHidden = true
+    if viewType == .widget {
+      isCancellable = false
+    }
+    
     context.evaluatePolicy(.deviceOwnerAuthentication, localizedReason: Strings.authenticationLoginsTouchReason) { success, error in
       DispatchQueue.main.async { [self] in
         if success {
@@ -230,8 +234,8 @@ public class WindowProtection {
               completion?(true, nil)
             })
         } else {
-          lockedViewController.unlockButton.isHidden = viewType == .general
-          
+          lockedViewController.unlockButton.isHidden = viewType == .general || viewType == .widget
+
           let errorPolicy = error as? LAError
           completion?(false, errorPolicy?.code)
           


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
Adding external open in private widget action biometrics

This pull request fixes #7980

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

- Enable Require Face ID in private tabs settings
- Kill app
- From the home screen, long press on Brave app and select New Private Tab
- Confirm biometrics is required
- Add the Brave Shortcuts Widget to the home screen, tap on the Private Tab button
- Confirm biometrics is required

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


https://github.com/brave/brave-ios/assets/6643505/08dae472-8312-4e5f-90ee-9cc5b4eb300e


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
