### PR TITLE
Fix #7991: Opening in private using app context menu or shortcut widget does not respect biometrics toggle

### DIFF
--- a/Sources/Brave/Frontend/Browser/NavigationRouter.swift
+++ b/Sources/Brave/Frontend/Browser/NavigationRouter.swift
@@ -114,10 +114,14 @@ public enum NavigationPath: Equatable {
       if Preferences.Privacy.lockWithPasscode.value {
         bvc.openBlankNewTab(attemptLocationFieldFocus: false, isPrivate: true)
       } else {
-        bvc.askForLocalAuthentication(viewType: .widget) { [weak bvc] success, _ in
-          if success {
-            bvc?.openBlankNewTab(attemptLocationFieldFocus: false, isPrivate: true)
+        if Preferences.Privacy.privateBrowsingLock.value {
+          bvc.askForLocalAuthentication(viewType: .widget) { [weak bvc] success, _ in
+            if success {
+              bvc?.openBlankNewTab(attemptLocationFieldFocus: false, isPrivate: true)
+            }
           }
+        } else {
+          bvc.openBlankNewTab(attemptLocationFieldFocus: false, isPrivate: true)
         }
       }
     case .bookmarks:

--- a/Sources/Brave/Frontend/Browser/QuickActions.swift
+++ b/Sources/Brave/Frontend/Browser/QuickActions.swift
@@ -63,10 +63,14 @@ public class QuickActions: NSObject {
       if Preferences.Privacy.lockWithPasscode.value {
         handleOpenNewTab(withBrowserViewController: browserViewController, isPrivate: true)
       } else {
-        browserViewController.askForLocalAuthentication(viewType: .widget) { [weak self] success, _ in
-          if success {
-            self?.handleOpenNewTab(withBrowserViewController: browserViewController, isPrivate: true)
+        if Preferences.Privacy.privateBrowsingLock.value {
+          browserViewController.askForLocalAuthentication(viewType: .widget) { [weak self] success, _ in
+            if success {
+              self?.handleOpenNewTab(withBrowserViewController: browserViewController, isPrivate: true)
+            }
           }
+        } else {
+          handleOpenNewTab(withBrowserViewController: browserViewController, isPrivate: true)
         }
       }
     case .scanQRCode:


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
Adding private lock case to the external link open

This pull request fixes #7991

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

1. Fresh profile install
2. From the homescreen, use app context menu and select New Private Tab
3. From the homescreen, add the brave shortcuts widget, use Private Tab button to open private tab

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


https://github.com/brave/brave-ios/assets/6643505/9e1d7142-f908-4b4e-90d2-75e3976b6310


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
