### PR TITLE
[v1.59] Fix #7866: AccountId Transaction Refactor, BraveCore v1.59.59

### DIFF
--- a/Sources/BraveWallet/Crypto/Stores/AssetDetailStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/AssetDetailStore.swift
@@ -291,7 +291,7 @@ class AssetDetailStore: ObservableObject {
           await self.txService.allTransactionInfo(
             network.coin,
             chainId: network.chainId,
-            from: account.address
+            from: account.accountId
           )
         }
       }

--- a/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -24,15 +24,24 @@ enum PendingRequest: Equatable {
 extension PendingRequest: Identifiable {
   var id: String {
     switch self {
-    case let .transactions(transactions): return "transactions-\(transactions.map(\.id))"
-    case let .addChain(request): return "addChain-\(request.networkInfo.chainId)"
-    case let .switchChain(chainRequest): return "switchChain-\(chainRequest.chainId)"
-    case let .addSuggestedToken(tokenRequest): return "addSuggestedToken-\(tokenRequest.token.id)"
-    case let .signMessage(signRequests): return "signMessage-\(signRequests.map(\.id))"
-    case let .getEncryptionPublicKey(request): return "getEncryptionPublicKey-\(request.address)-\(request.requestId)"
-    case let .decrypt(request): return "decrypt-\(request.address)-\(request.requestId)"
-    case let .signTransaction(requests): return "signTransaction-\(requests.map(\.id))"
-    case let .signAllTransactions(requests): return "signAllTransactions-\(requests.map(\.id))"
+    case let .transactions(transactions):
+      return "transactions-\(transactions.map(\.id))"
+    case let .addChain(request):
+      return "addChain-\(request.networkInfo.chainId)"
+    case let .switchChain(chainRequest):
+      return "switchChain-\(chainRequest.chainId)"
+    case let .addSuggestedToken(tokenRequest):
+      return "addSuggestedToken-\(tokenRequest.token.id)"
+    case let .signMessage(signRequests):
+      return "signMessage-\(signRequests.map(\.id))"
+    case let .getEncryptionPublicKey(request):
+      return "getEncryptionPublicKey-\(request.accountId.uniqueKey)-\(request.requestId)"
+    case let .decrypt(request):
+      return "decrypt-\(request.accountId.uniqueKey)-\(request.requestId)"
+    case let .signTransaction(requests):
+      return "signTransaction-\(requests.map(\.id))"
+    case let .signAllTransactions(requests):
+      return "signAllTransactions-\(requests.map(\.id))"
     }
   }
 }

--- a/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
@@ -287,12 +287,12 @@ public class SendTokenStore: ObservableObject {
   private func makeEIP1559Tx(
     chainId: String,
     baseData: BraveWallet.TxData,
-    from address: String,
+    from accountId: BraveWallet.AccountId,
     completion: @escaping (_ success: Bool, _ errMsg: String?) -> Void
   ) {
     let eip1559Data = BraveWallet.TxData1559(baseData: baseData, chainId: chainId, maxPriorityFeePerGas: "", maxFeePerGas: "", gasEstimation: nil)
     let txDataUnion = BraveWallet.TxDataUnion(ethTxData1559: eip1559Data)
-    self.txService.addUnapprovedTransaction(txDataUnion, from: address, origin: nil, groupId: nil) { success, txMetaId, errorMessage in
+    self.txService.addUnapprovedTransaction(txDataUnion, from: accountId, origin: nil, groupId: nil) { success, txMetaId, errorMessage in
       completion(success, errorMessage)
     }
   }
@@ -485,9 +485,9 @@ public class SendTokenStore: ObservableObject {
       }
       switch selectedAccount.coin {
       case .eth:
-        self.sendTokenOnEth(amount: amount, token: token, fromAddress: selectedAccount.address, completion: completion)
+        self.sendTokenOnEth(amount: amount, token: token, from: selectedAccount.accountId, completion: completion)
       case .sol:
-        self.sendTokenOnSol(amount: amount, token: token, fromAddress: selectedAccount.address, completion: completion)
+        self.sendTokenOnSol(amount: amount, token: token, from: selectedAccount.accountId, completion: completion)
       default:
         completion(false, Strings.Wallet.internalErrorMessage)
       }
@@ -497,7 +497,7 @@ public class SendTokenStore: ObservableObject {
   func sendTokenOnEth(
     amount: String,
     token: BraveWallet.BlockchainToken,
-    fromAddress: String,
+    from fromAccountId: BraveWallet.AccountId,
     completion: @escaping (_ success: Bool, _ errMsg: String?) -> Void
   ) {
     let weiFormatter = WeiFormatter(decimalFormatStyle: .decimals(precision: 18))
@@ -514,26 +514,26 @@ public class SendTokenStore: ObservableObject {
       if network.isNativeAsset(token) {
         let baseData = BraveWallet.TxData(nonce: "", gasPrice: "", gasLimit: "", to: sendToAddress, value: "0x\(weiHexString)", data: .init(), signOnly: false, signedTransaction: nil)
         if network.isEip1559 {
-          self.makeEIP1559Tx(chainId: network.chainId, baseData: baseData, from: fromAddress) { success, errorMessage  in
+          self.makeEIP1559Tx(chainId: network.chainId, baseData: baseData, from: fromAccountId) { success, errorMessage  in
             self.isMakingTx = false
             completion(success, errorMessage)
           }
         } else {
           let txDataUnion = BraveWallet.TxDataUnion(ethTxData: baseData)
-          self.txService.addUnapprovedTransaction(txDataUnion, from: fromAddress, origin: nil, groupId: nil) { success, txMetaId, errorMessage in
+          self.txService.addUnapprovedTransaction(txDataUnion, from: fromAccountId, origin: nil, groupId: nil) { success, txMetaId, errorMessage in
             self.isMakingTx = false
             completion(success, errorMessage)
           }
         }
       } else if token.isErc721 {
-        self.ethTxManagerProxy.makeErc721Transfer(fromData: fromAddress, to: sendToAddress, tokenId: token.tokenId, contractAddress: token.contractAddress) { success, data in
+        self.ethTxManagerProxy.makeErc721Transfer(fromData: fromAccountId.address, to: sendToAddress, tokenId: token.tokenId, contractAddress: token.contractAddress) { success, data in
           guard success else {
             completion(false, nil)
             return
           }
           let baseData = BraveWallet.TxData(nonce: "", gasPrice: "", gasLimit: "", to: token.contractAddress, value: "0x0", data: data, signOnly: false, signedTransaction: nil)
           let txDataUnion = BraveWallet.TxDataUnion(ethTxData: baseData)
-          self.txService.addUnapprovedTransaction(txDataUnion, from: fromAddress, origin: nil, groupId: nil) { success, txMetaId, errorMessage in
+          self.txService.addUnapprovedTransaction(txDataUnion, from: fromAccountId, origin: nil, groupId: nil) { success, txMetaId, errorMessage in
             self.isMakingTx = false
             completion(success, errorMessage)
           }
@@ -546,13 +546,13 @@ public class SendTokenStore: ObservableObject {
           }
           let baseData = BraveWallet.TxData(nonce: "", gasPrice: "", gasLimit: "", to: token.contractAddress, value: "0x0", data: data, signOnly: false, signedTransaction: nil)
           if network.isEip1559 {
-            self.makeEIP1559Tx(chainId: network.chainId, baseData: baseData, from: fromAddress) { success, errorMessage  in
+            self.makeEIP1559Tx(chainId: network.chainId, baseData: baseData, from: fromAccountId) { success, errorMessage  in
               self.isMakingTx = false
               completion(success, errorMessage)
             }
           } else {
             let txDataUnion = BraveWallet.TxDataUnion(ethTxData: baseData)
-            self.txService.addUnapprovedTransaction(txDataUnion, from: fromAddress, origin: nil, groupId: nil) { success, txMetaId, errorMessage in
+            self.txService.addUnapprovedTransaction(txDataUnion, from: fromAccountId, origin: nil, groupId: nil) { success, txMetaId, errorMessage in
               self.isMakingTx = false
               completion(success, errorMessage)
             }
@@ -565,7 +565,7 @@ public class SendTokenStore: ObservableObject {
   private func sendTokenOnSol(
     amount: String,
     token: BraveWallet.BlockchainToken,
-    fromAddress: String,
+    from fromAccountId: BraveWallet.AccountId,
     completion: @escaping (_ success: Bool, _ errMsg: String?) -> Void
   ) {
     guard let amount = WeiFormatter.decimalToAmount(amount.normalizedDecimals, tokenDecimals: Int(token.decimals)) else {
@@ -579,7 +579,7 @@ public class SendTokenStore: ObservableObject {
       guard let self = self else { return }
       if network.isNativeAsset(token) {
         self.solTxManagerProxy.makeSystemProgramTransferTxData(
-          fromAddress,
+          fromAccountId.address,
           to: sendToAddress,
           lamports: amount
         ) { solTxData, error, errMsg in
@@ -588,7 +588,7 @@ public class SendTokenStore: ObservableObject {
             return
           }
           let txDataUnion = BraveWallet.TxDataUnion(solanaTxData: solanaTxData)
-          self.txService.addUnapprovedTransaction(txDataUnion, from: fromAddress, origin: nil, groupId: nil) { success, txMetaId, errMsg in
+          self.txService.addUnapprovedTransaction(txDataUnion, from: fromAccountId, origin: nil, groupId: nil) { success, txMetaId, errMsg in
             completion(success, errMsg)
           }
         }
@@ -596,7 +596,7 @@ public class SendTokenStore: ObservableObject {
         self.solTxManagerProxy.makeTokenProgramTransferTxData(
           network.chainId,
           splTokenMintAddress: token.contractAddress,
-          fromWalletAddress: fromAddress,
+          fromWalletAddress: fromAccountId.address,
           toWalletAddress: sendToAddress,
           amount: amount
         ) { solTxData, error, errMsg in
@@ -605,7 +605,7 @@ public class SendTokenStore: ObservableObject {
             return
           }
           let txDataUnion = BraveWallet.TxDataUnion(solanaTxData: solanaTxData)
-          self.txService.addUnapprovedTransaction(txDataUnion, from: fromAddress, origin: nil, groupId: nil) { success, txMetaId, errorMessage in
+          self.txService.addUnapprovedTransaction(txDataUnion, from: fromAccountId, origin: nil, groupId: nil) { success, txMetaId, errorMessage in
             completion(success, errorMessage)
           }
         }

--- a/Sources/BraveWallet/Crypto/Stores/SwapTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SwapTokenStore.swift
@@ -299,7 +299,7 @@ public class SwapTokenStore: ObservableObject {
         signedTransaction: nil
       )
       let txDataUnion = BraveWallet.TxDataUnion(ethTxData: baseData)
-      let (success, _, _) = await txService.addUnapprovedTransaction(txDataUnion, from: accountInfo.address, origin: nil, groupId: nil)
+      let (success, _, _) = await txService.addUnapprovedTransaction(txDataUnion, from: accountInfo.accountId, origin: nil, groupId: nil)
       if !success {
         self.state = .error(Strings.Wallet.unknownError)
         self.clearAllAmount()
@@ -401,7 +401,7 @@ public class SwapTokenStore: ObservableObject {
       return success
     } else {
       let txDataUnion = BraveWallet.TxDataUnion(ethTxData: baseData)
-      let (success, _, _) = await txService.addUnapprovedTransaction(txDataUnion, from: accountInfo.address, origin: nil, groupId: nil)
+      let (success, _, _) = await txService.addUnapprovedTransaction(txDataUnion, from: accountInfo.accountId, origin: nil, groupId: nil)
       if !success {
         self.state = .error(Strings.Wallet.unknownError)
         self.clearAllAmount()
@@ -431,7 +431,7 @@ public class SwapTokenStore: ObservableObject {
     }
     let eip1559Data = BraveWallet.TxData1559(baseData: baseData, chainId: chainId, maxPriorityFeePerGas: maxPriorityFeePerGas, maxFeePerGas: maxFeePerGas, gasEstimation: gasEstimation)
     let txDataUnion = BraveWallet.TxDataUnion(ethTxData1559: eip1559Data)
-    let (success, _, _) = await txService.addUnapprovedTransaction(txDataUnion, from: account.address, origin: nil, groupId: nil)
+    let (success, _, _) = await txService.addUnapprovedTransaction(txDataUnion, from: account.accountId, origin: nil, groupId: nil)
     if !success {
       self.state = .error(Strings.Wallet.unknownError)
       self.clearAllAmount()
@@ -601,13 +601,15 @@ public class SwapTokenStore: ObservableObject {
     guard let jupiterQuote,
           let route = jupiterQuote.routes.first,
           let accountInfo = self.accountInfo,
-          let selectedToToken else {
+          let selectedToToken,
+          let selectedFromToken else {
       return false
     }
     let network = await rpcService.network(.sol, origin: nil)
     let jupiterSwapParams: BraveWallet.JupiterSwapParams = .init(
       route: route,
       userPublicKey: accountInfo.address,
+      inputMint: selectedFromToken.contractAddress(in: network),
       outputMint: selectedToToken.contractAddress(in: network)
     )
     let (swapTransactions, errorResponse, _) = await swapService.jupiterSwapTransactions(jupiterSwapParams)
@@ -651,7 +653,7 @@ public class SwapTokenStore: ObservableObject {
     }
     let (success, _, _) = await txService.addUnapprovedTransaction(
       .init(solanaTxData: solTxData),
-      from: accountInfo.address,
+      from: accountInfo.accountId,
       origin: nil,
       groupId: nil
     )

--- a/Sources/BraveWallet/Crypto/Transaction Confirmations/EditPermissionsView.swift
+++ b/Sources/BraveWallet/Crypto/Transaction Confirmations/EditPermissionsView.swift
@@ -41,7 +41,7 @@ struct EditPermissionsView: View {
   }
   
   private var accountName: String {
-    NamedAddresses.name(for: activeTransaction.fromAddress, accounts: keyringStore.allAccounts)
+    NamedAddresses.name(for: activeTransaction.fromAccountId.address, accounts: keyringStore.allAccounts)
   }
   
   init(

--- a/Sources/BraveWallet/Crypto/Transactions/TransactionParser+TransactionSummary.swift
+++ b/Sources/BraveWallet/Crypto/Transactions/TransactionParser+TransactionSummary.swift
@@ -10,7 +10,7 @@ struct TransactionSummary: Equatable, Identifiable {
   /// The transaction
   let txInfo: BraveWallet.TransactionInfo
   /// From address of the transaction
-  var fromAddress: String { txInfo.fromAddress }
+  var fromAddress: String { txInfo.fromAccountId.address }
   /// Account name for the from address of the transaction
   let namedFromAddress: String
   /// To address of the transaction
@@ -69,7 +69,7 @@ extension TransactionParser {
       }
       return .init(
         txInfo: transaction,
-        namedFromAddress: NamedAddresses.name(for: transaction.fromAddress, accounts: accountInfos),
+        namedFromAddress: NamedAddresses.name(for: transaction.fromAccountId.address, accounts: accountInfos),
         toAddress: toAddress,
         namedToAddress: NamedAddresses.name(for: transaction.ethTxToAddress, accounts: accountInfos),
         title: "",

--- a/Sources/BraveWallet/Crypto/Transactions/TransactionParser.swift
+++ b/Sources/BraveWallet/Crypto/Transactions/TransactionParser.swift
@@ -101,8 +101,8 @@ enum TransactionParser {
        */
       return .init(
         transaction: transaction,
-        namedFromAddress: NamedAddresses.name(for: transaction.fromAddress, accounts: accountInfos),
-        fromAddress: transaction.fromAddress,
+        namedFromAddress: NamedAddresses.name(for: transaction.fromAccountId.address, accounts: accountInfos),
+        fromAddress: transaction.fromAccountId.address,
         namedToAddress: NamedAddresses.name(for: transaction.ethTxToAddress, accounts: accountInfos),
         toAddress: transaction.ethTxToAddress,
         networkSymbol: network.symbol,
@@ -145,8 +145,8 @@ enum TransactionParser {
        */
       return .init(
         transaction: transaction,
-        namedFromAddress: NamedAddresses.name(for: transaction.fromAddress, accounts: accountInfos),
-        fromAddress: transaction.fromAddress,
+        namedFromAddress: NamedAddresses.name(for: transaction.fromAccountId.address, accounts: accountInfos),
+        fromAddress: transaction.fromAccountId.address,
         namedToAddress: NamedAddresses.name(for: toAddress, accounts: accountInfos),
         toAddress: toAddress,
         networkSymbol: network.symbol,
@@ -200,8 +200,8 @@ enum TransactionParser {
        */
       return .init(
         transaction: transaction,
-        namedFromAddress: NamedAddresses.name(for: transaction.fromAddress, accounts: accountInfos),
-        fromAddress: transaction.fromAddress,
+        namedFromAddress: NamedAddresses.name(for: transaction.fromAccountId.address, accounts: accountInfos),
+        fromAddress: transaction.fromAccountId.address,
         namedToAddress: NamedAddresses.name(for: transaction.ethTxToAddress, accounts: accountInfos),
         toAddress: transaction.ethTxToAddress,
         networkSymbol: network.symbol,
@@ -251,8 +251,8 @@ enum TransactionParser {
        */
       return .init(
         transaction: transaction,
-        namedFromAddress: NamedAddresses.name(for: transaction.fromAddress, accounts: accountInfos),
-        fromAddress: transaction.fromAddress,
+        namedFromAddress: NamedAddresses.name(for: transaction.fromAccountId.address, accounts: accountInfos),
+        fromAddress: transaction.fromAccountId.address,
         namedToAddress: NamedAddresses.name(for: transaction.ethTxToAddress, accounts: accountInfos),
         toAddress: transaction.ethTxToAddress,
         networkSymbol: network.symbol,
@@ -284,8 +284,8 @@ enum TransactionParser {
       
       return .init(
         transaction: transaction,
-        namedFromAddress: NamedAddresses.name(for: transaction.fromAddress, accounts: accountInfos),
-        fromAddress: transaction.fromAddress, // The caller, which may not be the owner
+        namedFromAddress: NamedAddresses.name(for: transaction.fromAccountId.address, accounts: accountInfos),
+        fromAddress: transaction.fromAccountId.address, // The caller, which may not be the owner
         namedToAddress: NamedAddresses.name(for: toAddress, accounts: accountInfos),
         toAddress: toAddress,
         networkSymbol: network.symbol,
@@ -324,8 +324,8 @@ enum TransactionParser {
        */
       return .init(
         transaction: transaction,
-        namedFromAddress: NamedAddresses.name(for: transaction.fromAddress, accounts: accountInfos),
-        fromAddress: transaction.fromAddress,
+        namedFromAddress: NamedAddresses.name(for: transaction.fromAccountId.address, accounts: accountInfos),
+        fromAddress: transaction.fromAccountId.address,
         namedToAddress: NamedAddresses.name(for: toAddress, accounts: accountInfos),
         toAddress: toAddress,
         networkSymbol: network.symbol,
@@ -375,8 +375,8 @@ enum TransactionParser {
        */
       return .init(
         transaction: transaction,
-        namedFromAddress: NamedAddresses.name(for: transaction.fromAddress, accounts: accountInfos),
-        fromAddress: transaction.fromAddress,
+        namedFromAddress: NamedAddresses.name(for: transaction.fromAccountId.address, accounts: accountInfos),
+        fromAddress: transaction.fromAccountId.address,
         namedToAddress: NamedAddresses.name(for: toAddress, accounts: accountInfos),
         toAddress: toAddress,
         networkSymbol: network.symbol,
@@ -486,8 +486,8 @@ enum TransactionParser {
       }
       return .init(
         transaction: transaction,
-        namedFromAddress: NamedAddresses.name(for: transaction.fromAddress, accounts: accountInfos),
-        fromAddress: transaction.fromAddress,
+        namedFromAddress: NamedAddresses.name(for: transaction.fromAccountId.address, accounts: accountInfos),
+        fromAddress: transaction.fromAccountId.address,
         namedToAddress: NamedAddresses.name(for: toAddress ?? "", accounts: accountInfos),
         toAddress: toAddress ?? "",
         networkSymbol: network.symbol,

--- a/Sources/BraveWallet/Extensions/BraveWalletSwiftUIExtensions.swift
+++ b/Sources/BraveWallet/Extensions/BraveWalletSwiftUIExtensions.swift
@@ -142,7 +142,7 @@ extension BraveWallet.SignMessageRequest {
     .init(
       originInfo: .init(originSpec: "https://app.uniswap.org", eTldPlusOne: "uniswap.org"),
       id: 1,
-      address: "",
+      accountId: BraveWallet.AccountInfo.previewAccount.accountId,
       domain: "example.com",
       message: "To avoid digital cat burglars, sign below to authenticate with CryptoKitties.",
       isEip712: false,

--- a/Sources/BraveWallet/Extensions/WalletTxServiceExtensions.swift
+++ b/Sources/BraveWallet/Extensions/WalletTxServiceExtensions.swift
@@ -33,7 +33,7 @@ extension BraveWalletTxService {
           for chainId in chainIdsForKeyringCoin {
             for info in keyring.accountInfos {
               group.addTask { @MainActor in
-                await self.allTransactionInfo(info.coin, chainId: chainId, from: info.address)
+                await self.allTransactionInfo(info.coin, chainId: chainId, from: info.accountId)
               }
             }
           }
@@ -57,7 +57,7 @@ extension BraveWalletTxService {
       body: { @MainActor group in
         for network in networks {
           group.addTask { @MainActor in
-            await self.allTransactionInfo(accountInfo.coin, chainId: network.chainId, from: accountInfo.address)
+            await self.allTransactionInfo(accountInfo.coin, chainId: network.chainId, from: accountInfo.accountId)
           }
         }
         var allTx: [BraveWallet.TransactionInfo] = []

--- a/Sources/BraveWallet/Panels/Encryption/EncryptionView.swift
+++ b/Sources/BraveWallet/Panels/Encryption/EncryptionView.swift
@@ -16,9 +16,9 @@ struct EncryptionView: View {
     var address: String {
       switch self {
       case let .getEncryptionPublicKey(request):
-        return request.address
+        return request.accountId.address
       case let .decrypt(request):
-        return request.address
+        return request.accountId.address
       }
     }
     
@@ -233,7 +233,7 @@ struct EncryptionView: View {
 #if DEBUG
 struct EncryptionView_Previews: PreviewProvider {
   static var previews: some View {
-    let address = BraveWallet.AccountInfo.previewAccount.address
+    let account = BraveWallet.AccountInfo.previewAccount
     let originInfo = BraveWallet.OriginInfo(
       originSpec: WalletConstants.braveWalletOriginSpec,
       eTldPlusOne: ""
@@ -243,14 +243,14 @@ struct EncryptionView_Previews: PreviewProvider {
         .init(
           requestId: UUID().uuidString,
           originInfo: originInfo,
-          address: address
+          accountId: account.accountId
         )
       ),
       .decrypt(
         .init(
           requestId: UUID().uuidString,
           originInfo: originInfo,
-          address: address,
+          accountId: account.accountId,
           unsafeMessage: "Secret message"
         )
       )

--- a/Sources/BraveWallet/Panels/Sign Transaction/SignTransactionView.swift
+++ b/Sources/BraveWallet/Panels/Sign Transaction/SignTransactionView.swift
@@ -326,6 +326,7 @@ struct SignTransaction_Previews: PreviewProvider {
       request: .signTransaction([BraveWallet.SignTransactionRequest(
         originInfo: .init(),
         id: 0,
+        from: BraveWallet.AccountInfo.previewAccount.accountId,
         fromAddress: BraveWallet.AccountInfo.previewAccount.address,
         txData: .init(),
         rawMessage: .init(),

--- a/Sources/BraveWallet/Panels/Signature Request/SignatureRequestView.swift
+++ b/Sources/BraveWallet/Panels/Signature Request/SignatureRequestView.swift
@@ -34,7 +34,7 @@ struct SignatureRequestView: View {
   }
   
   private var account: BraveWallet.AccountInfo {
-    keyringStore.allAccounts.first(where: { $0.address == currentRequest.address }) ?? keyringStore.selectedAccount
+    keyringStore.allAccounts.first(where: { $0.address == currentRequest.accountId.address }) ?? keyringStore.selectedAccount
   }
   
   private var network: BraveWallet.NetworkInfo? {

--- a/Sources/BraveWallet/Preview Content/MockEthTxService.swift
+++ b/Sources/BraveWallet/Preview Content/MockEthTxService.swift
@@ -19,14 +19,14 @@ class MockTxService: BraveWalletTxService {
     completion(txs.first(where: { $0.id == txMetaId }))
   }
 
-  func addUnapprovedTransaction(_ txDataUnion: BraveWallet.TxDataUnion, from: String, origin: URLOrigin?, groupId: String?, completion: @escaping (Bool, String, String) -> Void) {
+  func addUnapprovedTransaction(_ txDataUnion: BraveWallet.TxDataUnion, from: BraveWallet.AccountId, origin: URLOrigin?, groupId: String?, completion: @escaping (Bool, String, String) -> Void) {
     completion(true, "txMetaId", "")
   }
 
   func rejectTransaction(_ coinType: BraveWallet.CoinType, chainId: String, txMetaId: String, completion: @escaping (Bool) -> Void) {
   }
 
-  func allTransactionInfo(_ coinType: BraveWallet.CoinType, chainId: String?, from: String?, completion: @escaping ([BraveWallet.TransactionInfo]) -> Void) {
+  func allTransactionInfo(_ coinType: BraveWallet.CoinType, chainId: String?, from: BraveWallet.AccountId?, completion: @escaping ([BraveWallet.TransactionInfo]) -> Void) {
     completion(txs.map { tx in
       tx.txStatus = .unapproved
       return tx

--- a/Sources/BraveWallet/Preview Content/MockSwapService.swift
+++ b/Sources/BraveWallet/Preview Content/MockSwapService.swift
@@ -14,11 +14,11 @@ class MockSwapService: BraveWalletSwapService {
   }
 
   func transactionPayload(_ params: BraveWallet.SwapParams, completion: @escaping (BraveWallet.SwapResponse?, BraveWallet.SwapErrorResponse?, String) -> Void) {
-    completion(.init(price: "", guaranteedPrice: "", to: "", data: "", value: "", gas: "", estimatedGas: "", gasPrice: "", protocolFee: "", minimumProtocolFee: "", buyTokenAddress: "", sellTokenAddress: "", buyAmount: "", sellAmount: "", allowanceTarget: "", sellTokenToEthRate: "", buyTokenToEthRate: "", estimatedPriceImpact: "", sources: []), nil, "")
+    completion(.init(price: "", guaranteedPrice: "", to: "", data: "", value: "", gas: "", estimatedGas: "", gasPrice: "", protocolFee: "", minimumProtocolFee: "", buyTokenAddress: "", sellTokenAddress: "", buyAmount: "", sellAmount: "", allowanceTarget: "", sellTokenToEthRate: "", buyTokenToEthRate: "", estimatedPriceImpact: "", sources: [], fees: .init(zeroExFee: nil)), nil, "")
   }
   
   func priceQuote(_ params: BraveWallet.SwapParams, completion: @escaping (BraveWallet.SwapResponse?, BraveWallet.SwapErrorResponse?, String) -> Void) {
-    completion(.init(price: "", guaranteedPrice: "", to: "", data: "", value: "", gas: "", estimatedGas: "", gasPrice: "", protocolFee: "", minimumProtocolFee: "", buyTokenAddress: "", sellTokenAddress: "", buyAmount: "", sellAmount: "", allowanceTarget: "", sellTokenToEthRate: "", buyTokenToEthRate: "", estimatedPriceImpact: "", sources: []), nil, "")
+    completion(.init(price: "", guaranteedPrice: "", to: "", data: "", value: "", gas: "", estimatedGas: "", gasPrice: "", protocolFee: "", minimumProtocolFee: "", buyTokenAddress: "", sellTokenAddress: "", buyAmount: "", sellAmount: "", allowanceTarget: "", sellTokenToEthRate: "", buyTokenToEthRate: "", estimatedPriceImpact: "", sources: [], fees: .init(zeroExFee: nil)), nil, "")
   }
   
   func jupiterQuote(_ params: BraveWallet.JupiterQuoteParams, completion: @escaping (BraveWallet.JupiterQuote?, BraveWallet.JupiterErrorResponse?, String) -> Void) {
@@ -35,6 +35,10 @@ class MockSwapService: BraveWalletSwapService {
   
   func jupiterSwapTransactions(_ params: BraveWallet.JupiterSwapParams, completion: @escaping (BraveWallet.JupiterSwapTransactions?, BraveWallet.JupiterErrorResponse?, String) -> Void) {
     completion(nil, .init(statusCode: "0", error: "Error", message: "Error Message", isInsufficientLiquidity: false), "")
+  }
+  
+  func braveFee(_ params: BraveWallet.BraveSwapFeeParams, completion: @escaping (BraveWallet.BraveSwapFeeResponse?, String) -> Void) {
+    completion(nil, "Error Message")
   }
 }
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -52,6 +52,7 @@ platform :ios do
         "ClientTests/HttpCookieExtensionTest/testSaveAndLoadCookie",
         "ClientTests/UserAgentTests",
         "ClientTests/AdBlockEngineManagerTests/testPerformance",
+        "ClientTests/AdBlockEngineManagerTests/testCompilationofResources",
         "DataTests",
         "BraveWalletTests/ManageSiteConnectionsStoreTests/testRemoveAllPermissions",
         "BraveWalletTests/ManageSiteConnectionsStoreTests/testRemovePermissions",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@mozilla/readability": "^0.4.2",
-        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.59.44/brave-core-ios-1.59.44.tgz",
+        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.59.59/brave-core-ios-1.59.59.tgz",
         "leo-sf-symbols": "github:brave/leo-sf-symbols#992b64e89da8195041382804337bda9599cfdbf9",
         "page-metadata-parser": "^1.1.3",
         "webpack-cli": "^4.8.0"
@@ -356,9 +356,9 @@
       }
     },
     "node_modules/brave-core-ios": {
-      "version": "1.59.44",
-      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.59.44/brave-core-ios-1.59.44.tgz",
-      "integrity": "sha512-49kp4A0mcGA6qj2OHTOcs61EoEdafi0UzxBXPIqk2gf1iW9P9XLJ2WuGq18N5kHzJutCSxWBONsra4nmS+wC8Q==",
+      "version": "1.59.59",
+      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.59.59/brave-core-ios-1.59.59.tgz",
+      "integrity": "sha512-OI/6/G8VN9e5JGZ3bZ78eyjo3L6+0TJ/TGS82MpGc5d/Ffyk1WChPVqAQ6PcW+se458dmv12UAyi5HUEIdeb8g==",
       "license": "ISC"
     },
     "node_modules/browserslist": {
@@ -1738,8 +1738,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-browser/releases/download/v1.59.44/brave-core-ios-1.59.44.tgz",
-      "integrity": "sha512-49kp4A0mcGA6qj2OHTOcs61EoEdafi0UzxBXPIqk2gf1iW9P9XLJ2WuGq18N5kHzJutCSxWBONsra4nmS+wC8Q=="
+      "version": "https://github.com/brave/brave-browser/releases/download/v1.59.59/brave-core-ios-1.59.59.tgz",
+      "integrity": "sha512-OI/6/G8VN9e5JGZ3bZ78eyjo3L6+0TJ/TGS82MpGc5d/Ffyk1WChPVqAQ6PcW+se458dmv12UAyi5HUEIdeb8g=="
     },
     "browserslist": {
       "version": "4.17.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@mozilla/readability": "^0.4.2",
-        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.59.41/brave-core-ios-1.59.41.tgz",
+        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.59.44/brave-core-ios-1.59.44.tgz",
         "leo-sf-symbols": "github:brave/leo-sf-symbols#992b64e89da8195041382804337bda9599cfdbf9",
         "page-metadata-parser": "^1.1.3",
         "webpack-cli": "^4.8.0"
@@ -356,9 +356,9 @@
       }
     },
     "node_modules/brave-core-ios": {
-      "version": "1.59.41",
-      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.59.41/brave-core-ios-1.59.41.tgz",
-      "integrity": "sha512-3veYqS6l8s+au+l50u/XEh85jQfwKILS9AmcrJbZ6wtD6ltROEJaYt8xeYsAemoAVsEN7j630ASxiyEa9cHjdQ==",
+      "version": "1.59.44",
+      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.59.44/brave-core-ios-1.59.44.tgz",
+      "integrity": "sha512-49kp4A0mcGA6qj2OHTOcs61EoEdafi0UzxBXPIqk2gf1iW9P9XLJ2WuGq18N5kHzJutCSxWBONsra4nmS+wC8Q==",
       "license": "ISC"
     },
     "node_modules/browserslist": {
@@ -1738,8 +1738,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-browser/releases/download/v1.59.41/brave-core-ios-1.59.41.tgz",
-      "integrity": "sha512-3veYqS6l8s+au+l50u/XEh85jQfwKILS9AmcrJbZ6wtD6ltROEJaYt8xeYsAemoAVsEN7j630ASxiyEa9cHjdQ=="
+      "version": "https://github.com/brave/brave-browser/releases/download/v1.59.44/brave-core-ios-1.59.44.tgz",
+      "integrity": "sha512-49kp4A0mcGA6qj2OHTOcs61EoEdafi0UzxBXPIqk2gf1iW9P9XLJ2WuGq18N5kHzJutCSxWBONsra4nmS+wC8Q=="
     },
     "browserslist": {
       "version": "4.17.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "license": "MPL-2.0",
   "dependencies": {
     "@mozilla/readability": "^0.4.2",
-    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.59.41/brave-core-ios-1.59.41.tgz",
+    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.59.44/brave-core-ios-1.59.44.tgz",
     "leo-sf-symbols": "github:brave/leo-sf-symbols#992b64e89da8195041382804337bda9599cfdbf9",
     "page-metadata-parser": "^1.1.3",
     "webpack-cli": "^4.8.0"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "license": "MPL-2.0",
   "dependencies": {
     "@mozilla/readability": "^0.4.2",
-    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.59.44/brave-core-ios-1.59.44.tgz",
+    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.59.59/brave-core-ios-1.59.59.tgz",
     "leo-sf-symbols": "github:brave/leo-sf-symbols#992b64e89da8195041382804337bda9599cfdbf9",
     "page-metadata-parser": "^1.1.3",
     "webpack-cli": "^4.8.0"


### PR DESCRIPTION
## Summary of Changes
- Relatively easy change of using `AccountId` model instead of from address for most transaction methods. 
- Using `AccountId` address for most lookups; this will change eventually with Bitcoin (array of from addresses instead of a single from address) but [not yet determined exactly how](https://github.com/brave/brave-core/pull/19586#discussion_r1302420025). 

This pull request fixes #7866

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Verify creating Send transactions is still working as expected for all coin types (verify from account is correct).
2. Verify creating Swap transactions is still working as expected for all coin types (verify from account is correct).
3. Verify Tx Confirmation showing transactions as expected, transactions show in Activity tab, Asset Detail & Account Detail.
4. Verify correct account displayed in Encrypt / Decrypt request (create request, dismiss request without cancel/approve, change accounts & verify account encryption request is for still shown).


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
