### PR TITLE
Ref #7980: [Follow up to #7952] Opening in private from home screen will bypass biometrics

### DIFF
--- a/Sources/Brave/Frontend/Browser/NavigationRouter.swift
+++ b/Sources/Brave/Frontend/Browser/NavigationRouter.swift
@@ -115,7 +115,7 @@ public enum NavigationPath: Equatable {
         bvc.openBlankNewTab(attemptLocationFieldFocus: false, isPrivate: true)
       } else {
         if Preferences.Privacy.privateBrowsingLock.value {
-          bvc.askForLocalAuthentication(viewType: .widget) { [weak bvc] success, _ in
+          bvc.askForLocalAuthentication(viewType: .external) { [weak bvc] success, _ in
             if success {
               bvc?.openBlankNewTab(attemptLocationFieldFocus: false, isPrivate: true)
             }

--- a/Sources/Brave/Frontend/Browser/QuickActions.swift
+++ b/Sources/Brave/Frontend/Browser/QuickActions.swift
@@ -64,7 +64,7 @@ public class QuickActions: NSObject {
         handleOpenNewTab(withBrowserViewController: browserViewController, isPrivate: true)
       } else {
         if Preferences.Privacy.privateBrowsingLock.value {
-          browserViewController.askForLocalAuthentication(viewType: .widget) { [weak self] success, _ in
+          browserViewController.askForLocalAuthentication(viewType: .external) { [weak self] success, _ in
             if success {
               self?.handleOpenNewTab(withBrowserViewController: browserViewController, isPrivate: true)
             }

--- a/Sources/Brave/Frontend/Passcode/WindowProtection.swift
+++ b/Sources/Brave/Frontend/Passcode/WindowProtection.swift
@@ -13,7 +13,7 @@ import BraveUI
 import os.log
 
 public enum AuthViewType {
-  case general, widget, sync, tabTray, passwords
+  case external, general, sync, tabTray, passwords
 }
 
 public class WindowProtection {
@@ -164,7 +164,7 @@ public class WindowProtection {
       .sink(receiveValue: { [weak self] _ in
         guard let self = self else { return }
         self.context = LAContext()  // Reset context for new session
-        self.updateVisibleStatusForForeground()
+        self.updateVisibleStatusForForeground(viewType: .external)
       })
       .store(in: &cancellables)
   }
@@ -216,7 +216,7 @@ public class WindowProtection {
     }
     
     lockedViewController.unlockButton.isHidden = true
-    if viewType == .widget {
+    if viewType == .external {
       isCancellable = false
     }
     
@@ -234,7 +234,7 @@ public class WindowProtection {
               completion?(true, nil)
             })
         } else {
-          lockedViewController.unlockButton.isHidden = viewType == .general || viewType == .widget
+          lockedViewController.unlockButton.isHidden = viewType == .general
 
           let errorPolicy = error as? LAError
           completion?(false, errorPolicy?.code)

--- a/Sources/Brave/Frontend/Passcode/WindowProtection.swift
+++ b/Sources/Brave/Frontend/Passcode/WindowProtection.swift
@@ -210,6 +210,8 @@ public class WindowProtection {
   }
 
   private func presentLocalAuthentication(viewType: AuthViewType, completion: ((Bool, LAError.Code?) -> Void)? = nil) {
+    self.viewType = viewType
+
     if !context.canEvaluatePolicy(.deviceOwnerAuthentication, error: nil) {
       completion?(false, .passcodeNotSet)
       return


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

Fixing the difference between external app launches and default mode

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7980

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

- Install build 1.57
- Enable Browser lock
- Close and reopen Brave
- When you see Biometric unlock, tap Cancel
- Observe just the lock icon, but not the CTA Unlock

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->



https://github.com/brave/brave-ios/assets/6643505/f224c829-042f-4fe7-ad23-c32a2e6fec3f



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
