### PR TITLE
Fix #7996: Switching Private Mode Tab Tray cause position loss in Normal Mode

### DIFF
--- a/Sources/Brave/Frontend/Browser/TabManager.swift
+++ b/Sources/Brave/Frontend/Browser/TabManager.swift
@@ -85,6 +85,7 @@ class TabManager: NSObject {
     return _selectedIndex
   }
   var normalTabSelectedIndex: Int = 0
+  var privateTabSelectedIndex: Int = 0
   var tempTabs: [Tab]?
   private weak var rewards: BraveRewards?
   private weak var tabGeneratorAPI: BraveTabGeneratorAPI?

--- a/Sources/Brave/Frontend/Browser/Tabs/TabTray/TabTrayController.swift
+++ b/Sources/Brave/Frontend/Browser/Tabs/TabTray/TabTrayController.swift
@@ -621,7 +621,7 @@ class TabTrayController: AuthenticationController {
       return
     }
 
-    // Record the slected index before private mode navigation
+    // Record the selected index before private mode navigation
     if !privateMode {
       tabManager.normalTabSelectedIndex = tabManager.selectedIndex
     }
@@ -655,8 +655,13 @@ class TabTrayController: AuthenticationController {
       
       // When you go back from private mode, a previous current tab is selected
       // Reloding the collection view in order to mark the selecte the tab
-      tabManager.selectTab(tabManager.tabsForCurrentMode[safe: tabManager.normalTabSelectedIndex])
+      let normalModeTabSelected = tabManager.tabsForCurrentMode[safe: tabManager.normalTabSelectedIndex]
+      
+      tabManager.selectTab(normalModeTabSelected)
       tabTrayView.collectionView.reloadData()
+      
+      scrollToSelectedTab(normalModeTabSelected)
+      
       navigationController?.setNavigationBarHidden(false, animated: false)
     }
     
@@ -722,6 +727,15 @@ class TabTrayController: AuthenticationController {
     UIDevice.current.forcePortraitIfIphone(for: UIApplication.shared)
 
     present(settingsNavigationController, animated: true)
+  }
+  
+  private func scrollToSelectedTab(_ tab: Tab?) {
+    if let selectedTab = tab,
+       let selectedIndexPath = dataSource.indexPath(for: selectedTab) {
+      DispatchQueue.main.async {
+        self.tabTrayView.collectionView.scrollToItem(at: selectedIndexPath, at: .centeredVertically, animated: false)
+      }
+    }
   }
   
   @objc private func tappedCollectionViewBackground() {

--- a/Sources/Brave/Frontend/Browser/Tabs/TabTray/TabTrayController.swift
+++ b/Sources/Brave/Frontend/Browser/Tabs/TabTray/TabTrayController.swift
@@ -621,8 +621,10 @@ class TabTrayController: AuthenticationController {
       return
     }
 
-    // Record the selected index before private mode navigation
-    if !privateMode {
+    // Record the selected index before mode navigation
+    if privateMode {
+      tabManager.privateTabSelectedIndex = Preferences.Privacy.persistentPrivateBrowsing.value ? tabManager.selectedIndex : 0
+    } else {
       tabManager.normalTabSelectedIndex = tabManager.selectedIndex
     }
     
@@ -646,8 +648,19 @@ class TabTrayController: AuthenticationController {
           tabManager.addTabAndSelect(isPrivate: true)
         }
         
+        let privateModeTabSelected = tabManager.allTabs[safe: tabManager.privateTabSelectedIndex]
+
+        if Preferences.Privacy.persistentPrivateBrowsing.value {
+          tabManager.selectTab(privateModeTabSelected)
+        }
         tabTrayView.hidePrivateModeInfo()
         tabTrayView.collectionView.reloadData()
+        
+        // When you go back from normal mode, current tab should be selected
+        // in case private tabs are persistent
+        if Preferences.Privacy.persistentPrivateBrowsing.value {
+          scrollToSelectedTab(privateModeTabSelected)
+        }
         navigationController?.setNavigationBarHidden(false, animated: false)
       }
     } else {
@@ -655,13 +668,12 @@ class TabTrayController: AuthenticationController {
       
       // When you go back from private mode, a previous current tab is selected
       // Reloding the collection view in order to mark the selecte the tab
-      let normalModeTabSelected = tabManager.tabsForCurrentMode[safe: tabManager.normalTabSelectedIndex]
+      let normalModeTabSelected = tabManager.allTabs[safe: tabManager.normalTabSelectedIndex]
       
       tabManager.selectTab(normalModeTabSelected)
       tabTrayView.collectionView.reloadData()
       
       scrollToSelectedTab(normalModeTabSelected)
-      
       navigationController?.setNavigationBarHidden(false, animated: false)
     }
     


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7996

Fixing normal mode private mode persistent tab switches as well as positioning in tab tray

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

- Open Tab Tray
- Check which tab is highlighted in the collection view and where is the scrool
- Switch to private mode
- And back to normal mode
- Check position in Tab tray is lost entirely and positioned to top
- Check

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


https://github.com/brave/brave-ios/assets/6643505/0c1fb628-a9ab-49b4-b983-d83ee0597c48


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
