### PR TITLE
Fix #8023: Incorrect asset detail opened from search

### DIFF
--- a/Sources/BraveWallet/Crypto/Stores/AssetDetailStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/AssetDetailStore.swift
@@ -25,7 +25,7 @@ enum AssetDetailType: Identifiable {
   var id: String {
     switch self {
     case .blockchainToken(let token):
-      return token.tokenId
+      return token.id
     case .coinMarket(let coinMarket):
       return coinMarket.id
     }


### PR DESCRIPTION
## Summary of Changes
- Incorrect identifier was used for `AssetDetailType` so the existing `AssetDetailStore` view model was being persisted in `CryptoStore`. 
- Updated `AssetSearchView` so `AssetDetailStore` is not re-initialized for each `AssetSearchView` computed / shown (The `NavigationLink(destination:)` was re-initializing the view model via `CryptoStore` function).

This pull request fixes #8023

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
  1. Open Asset Search View and tap on a token to open asset detail
  2. Tap back and tap on a different token
  3. Scroll down the list and verify correct token still opened


## Screenshots:

https://github.com/brave/brave-ios/assets/5314553/24a41caf-2303-42c8-9c19-d334103e5ad8



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
