### PR TITLE
Fix #8035: Certain schemas not going to the app store

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -110,15 +110,14 @@ extension BrowserViewController: WKNavigationDelegate {
   // them then iOS will actually first open Safari, which then redirects to the app store. This works but it will
   // leave a 'Back to Safari' button in the status bar, which we do not want.
   fileprivate func isStoreURL(_ url: URL) -> Bool {
-    if url.scheme == "http" || url.scheme == "https" {
-      if url.host == "itunes.apple.com" || url.host == "apps.apple.com" || url.host == "appsto.re" {
-        return true
-      }
-    }
-    if url.scheme == "itms-appss" || url.scheme == "itms-apps" || url.scheme == "itmss" {
+    let isStoreScheme = ["itms-apps", "itms-appss", "itmss"].contains(url.scheme)
+    if isStoreScheme {
       return true
     }
-    return false
+
+    let isHttpScheme = ["http", "https"].contains(url.scheme)
+    let isAppStoreHost = ["itunes.apple.com", "apps.apple.com", "appsto.re"].contains(url.host)
+    return isHttpScheme && isAppStoreHost
   }
 
   // This is the place where we decide what to do with a new navigation action. There are a number of special schemes

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -111,11 +111,11 @@ extension BrowserViewController: WKNavigationDelegate {
   // leave a 'Back to Safari' button in the status bar, which we do not want.
   fileprivate func isStoreURL(_ url: URL) -> Bool {
     if url.scheme == "http" || url.scheme == "https" {
-      if url.host == "itunes.apple.com" {
+      if url.host == "itunes.apple.com" || url.host == "apps.apple.com" {
         return true
       }
     }
-    if url.scheme == "itms-appss" || url.scheme == "itmss" {
+    if url.scheme == "itms-appss" || url.scheme == "itms-apps" || url.scheme == "itmss" {
       return true
     }
     return false

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -111,7 +111,7 @@ extension BrowserViewController: WKNavigationDelegate {
   // leave a 'Back to Safari' button in the status bar, which we do not want.
   fileprivate func isStoreURL(_ url: URL) -> Bool {
     if url.scheme == "http" || url.scheme == "https" {
-      if url.host == "itunes.apple.com" || url.host == "apps.apple.com" {
+      if url.host == "itunes.apple.com" || url.host == "apps.apple.com" || url.host == "appsto.re" {
         return true
       }
     }

--- a/Sources/Brave/Frontend/Browser/Playlist/Managers & Cache/PlaylistCacheLoader.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/Managers & Cache/PlaylistCacheLoader.swift
@@ -511,15 +511,14 @@ extension PlaylistWebLoader: WKNavigationDelegate {
   // them then iOS will actually first open Safari, which then redirects to the app store. This works but it will
   // leave a 'Back to Safari' button in the status bar, which we do not want.
   fileprivate func isStoreURL(_ url: URL) -> Bool {
-    if url.scheme == "http" || url.scheme == "https" {
-      if url.host == "itunes.apple.com" || url.host == "apps.apple.com" || url.host == "appsto.re" {
-        return true
-      }
-    }
-    if url.scheme == "itms-appss" || url.scheme == "itms-apps" || url.scheme == "itmss" {
+    let isStoreScheme = ["itms-apps", "itms-appss", "itmss"].contains(url.scheme)
+    if isStoreScheme {
       return true
     }
-    return false
+
+    let isHttpScheme = ["http", "https"].contains(url.scheme)
+    let isAppStoreHost = ["itunes.apple.com", "apps.apple.com", "appsto.re"].contains(url.host)
+    return isHttpScheme && isAppStoreHost
   }
   
   func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {

--- a/Sources/Brave/Frontend/Browser/Playlist/Managers & Cache/PlaylistCacheLoader.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/Managers & Cache/PlaylistCacheLoader.swift
@@ -512,11 +512,11 @@ extension PlaylistWebLoader: WKNavigationDelegate {
   // leave a 'Back to Safari' button in the status bar, which we do not want.
   fileprivate func isStoreURL(_ url: URL) -> Bool {
     if url.scheme == "http" || url.scheme == "https" {
-      if url.host == "itunes.apple.com" {
+      if url.host == "itunes.apple.com" || url.host == "apps.apple.com" {
         return true
       }
     }
-    if url.scheme == "itms-appss" || url.scheme == "itmss" {
+    if url.scheme == "itms-appss" || url.scheme == "itms-apps" || url.scheme == "itmss" {
       return true
     }
     return false

--- a/Sources/Brave/Frontend/Browser/Playlist/Managers & Cache/PlaylistCacheLoader.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/Managers & Cache/PlaylistCacheLoader.swift
@@ -512,7 +512,7 @@ extension PlaylistWebLoader: WKNavigationDelegate {
   // leave a 'Back to Safari' button in the status bar, which we do not want.
   fileprivate func isStoreURL(_ url: URL) -> Bool {
     if url.scheme == "http" || url.scheme == "https" {
-      if url.host == "itunes.apple.com" || url.host == "apps.apple.com" {
+      if url.host == "itunes.apple.com" || url.host == "apps.apple.com" || url.host == "appsto.re" {
         return true
       }
     }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8035

Same bug, but on Brave it leads to search

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
1. Enter the URL `itms-apps://apps.apple.com/app/pulse-secure/id945832041?l=en` in the address bar
2. Should present alert go to the app store

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
