### PR TITLE
Fix #8026: Fixed BasicAuthCredentialsManager to use credentials from WebKit

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -503,7 +503,8 @@ extension BrowserViewController: WKNavigationDelegate {
 
     // If this is a certificate challenge, see if the certificate has previously been
     // accepted by the user.
-    let origin = "\(challenge.protectionSpace.host):\(challenge.protectionSpace.port)"
+    let host = challenge.protectionSpace.host
+    let origin = "\(host):\(challenge.protectionSpace.port)"
     if challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust,
        let trust = challenge.protectionSpace.serverTrust,
        let cert = (SecTrustCopyCertificateChain(trust) as? [SecCertificate])?.first, profile.certStore.containsCertificate(cert, forOrigin: origin) {
@@ -578,6 +579,11 @@ extension BrowserViewController: WKNavigationDelegate {
           protectionSpace: protectionSpace,
           previousFailureCount: previousFailureCount
         )
+        
+        if BasicAuthCredentialsManager.validDomains.contains(host) {
+          BasicAuthCredentialsManager.setCredential(origin: origin, credential: credentials.credentials)
+        }
+        
         return (.useCredential, credentials.credentials)
       } catch {
         return (.rejectProtectionSpace, nil)

--- a/Sources/Brave/Frontend/Browser/Playlist/BasicAuthCredentials.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/BasicAuthCredentials.swift
@@ -13,13 +13,12 @@ class BasicAuthCredentialsManager: NSObject, URLSessionDataDelegate {
   
   public static let validDomains: Set<String> = [
     // Brave Search
-    "search.brave.com", "search.brave.software",
-    "search.bravesoftware.com", "safesearch.brave.com",
+    "search.brave.software", "search.bravesoftware.com",
     "safesearch.brave.software", "safesearch.bravesoftware.com",
     "search-dev-local.brave.com",
     
     // Playlist
-    "playlist.bravesoftware.com", "playlist.brave.com"
+    "playlist.bravesoftware.com"
   ]
   
   static func setCredential(origin: String, credential: URLCredential?) {

--- a/Sources/Brave/Frontend/Browser/Playlist/BasicAuthCredentials.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/BasicAuthCredentials.swift
@@ -5,44 +5,87 @@
 
 import Foundation
 import UIKit
+import BraveCore
+import os.log
 
 class BasicAuthCredentialsManager: NSObject, URLSessionDataDelegate {
-  private let domains: [String]
+  private static var credentials = [String: URLCredential]()  // ["origin:port": credential]
   
-  init(for domains: [String]) {
-    self.domains = domains
+  public static let validDomains: Set<String> = [
+    // Brave Search
+    "search.brave.com", "search.brave.software",
+    "search.bravesoftware.com", "safesearch.brave.com",
+    "safesearch.brave.software", "safesearch.bravesoftware.com",
+    "search-dev-local.brave.com",
+    
+    // Playlist
+    "playlist.bravesoftware.com", "playlist.brave.com"
+  ]
+  
+  static func setCredential(origin: String, credential: URLCredential?) {
+    credentials[origin] = credential
   }
 
   func urlSession(
     _ session: URLSession,
     didReceive challenge: URLAuthenticationChallenge
   ) async -> (URLSession.AuthChallengeDisposition, URLCredential?) {
-    guard challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodHTTPBasic ||
-            challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodHTTPDigest ||
-            challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodNTLM else {
-      return (.performDefaultHandling, nil)
+    // Certificate Pinning
+    if challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust {
+      if let serverTrust = challenge.protectionSpace.serverTrust {
+        let host = challenge.protectionSpace.host
+        let port = challenge.protectionSpace.port
+        
+        let result = BraveCertificateUtility.verifyTrust(serverTrust,
+                                                         host: host,
+                                                         port: port)
+        // Cert is valid and should be pinned
+        if result == 0 {
+          return (.useCredential, URLCredential(trust: serverTrust))
+        }
+        
+        // Cert is valid and should not be pinned
+        // Let the system handle it and we'll show an error if the system cannot validate it
+        if result == Int32.min {
+          return (.performDefaultHandling, nil)
+        }
+        
+        // Cert is invalid and cannot be pinned
+        Logger.module.error("CERTIFICATE_INVALID")
+        return (.cancelAuthenticationChallenge, nil)
+      }
     }
-
-    if !domains.contains(challenge.protectionSpace.host) {
-      return (.performDefaultHandling, nil)
-    }
-
-    // -- Handle Authentication --
+    
+    // MARK: -- Handle Authentication --
 
     // Too many failed attempts
     if challenge.previousFailureCount >= 3 {
       return (.rejectProtectionSpace, nil)
     }
+    
+    // URLAuthenticationChallenge isn't Sendable atm
+    let protectionSpace = challenge.protectionSpace
+    let origin = "\(challenge.protectionSpace.host):\(challenge.protectionSpace.port)"
+    
+    guard protectionSpace.authenticationMethod == NSURLAuthenticationMethodHTTPBasic ||
+            protectionSpace.authenticationMethod == NSURLAuthenticationMethodHTTPDigest ||
+            protectionSpace.authenticationMethod == NSURLAuthenticationMethodNTLM else {
+      return (.performDefaultHandling, nil)
+    }
 
-    if let proposedCredential = challenge.proposedCredential,
+    if let proposedCredential = challenge.proposedCredential ?? BasicAuthCredentialsManager.credentials[origin],
       !(proposedCredential.user?.isEmpty ?? true),
       challenge.previousFailureCount == 0 {
       return (.useCredential, proposedCredential)
     }
 
-
-    // No proposed credential - reject challenge
-    return (.rejectProtectionSpace, nil)
+    // No proposed credential - reject the request
+    if BasicAuthCredentialsManager.validDomains.contains(protectionSpace.host) {
+      return (.rejectProtectionSpace, nil)
+    }
+    
+    // No proposed credential - perform default handling
+    return (.performDefaultHandling, nil)
   }
 
   func urlSession(

--- a/Sources/Brave/Frontend/Browser/Playlist/Controllers/PlaylistListViewController.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/Controllers/PlaylistListViewController.swift
@@ -685,7 +685,7 @@ extension PlaylistListViewController {
         self.loadingState = .partial
         
         if let folderImageUrl = model.folderImage {
-          let authManager = BasicAuthCredentialsManager(for: [folderImageUrl.absoluteString])
+          let authManager = BasicAuthCredentialsManager()
           let session = URLSession(configuration: .ephemeral, delegate: authManager, delegateQueue: .main)
           
           try await withTaskCancellationHandler {

--- a/Sources/Brave/Frontend/Browser/Playlist/PlaylistSharedFolder.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/PlaylistSharedFolder.swift
@@ -87,7 +87,7 @@ struct PlaylistSharedFolderNetwork {
       throw Status.invalidURL
     }
     
-    let authenticator = BasicAuthCredentialsManager(for: Array(DomainUserScript.bravePlaylistFolderSharingHelper.associatedDomains))
+    let authenticator = BasicAuthCredentialsManager()
     let session = URLSession(configuration: .ephemeral, delegate: authenticator, delegateQueue: .main)
     defer { session.finishTasksAndInvalidate() }
     


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8026

## Submitter Checklist:

- [] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
- Test Brave-Search APIs working on Staging
- Test Playlist Shared Folders working on Staging


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
