### PR TITLE
Fix #7851: Tab selection for TabsBar interface is done after active website is loaded

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController.swift
@@ -1069,6 +1069,8 @@ public class BrowserViewController: UIViewController {
     }
     searchController?.additionalSafeAreaInsets = additionalInsets
     favoritesController?.additionalSafeAreaInsets = additionalInsets
+    
+    tabsBar.reloadDataAndRestoreSelectedTab(isAnimated: false)
   }
 
   override public var canBecomeFirstResponder: Bool {

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -686,8 +686,6 @@ extension BrowserViewController: WKNavigationDelegate {
         // Set rewards inter site url as new page load url.
         rewardsXHRLoadURL = webView.url
       }
-
-      tabsBar.reloadDataAndRestoreSelectedTab()
       
       if tab.walletEthProvider != nil {
         tab.emitEthereumEvent(.connect)

--- a/Sources/Brave/Frontend/Browser/Tabs/TabBar/TabsBarViewController.swift
+++ b/Sources/Brave/Frontend/Browser/Tabs/TabBar/TabsBarViewController.swift
@@ -240,17 +240,23 @@ class TabsBarViewController: UIViewController {
     }
   }
 
-  func reloadDataAndRestoreSelectedTab() {
+  func reloadDataAndRestoreSelectedTab(isAnimated: Bool? = nil) {
     collectionView.reloadData()
 
     guard let tabManager = tabManager, let selectedTabIndex = selectedTabIndexPath else {
       return
     }
+    
+    var scrollTabsBarAnimated = !tabManager.isRestoring
+    
+    if let isAnimated = isAnimated {
+      scrollTabsBarAnimated = isAnimated
+    }
 
     if selectedTabIndex.row < tabList.count() {
       collectionView.selectItem(
         at: selectedTabIndex,
-        animated: (!tabManager.isRestoring),
+        animated: scrollTabsBarAnimated,
         scrollPosition: .centeredHorizontally)
     }
   }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7851

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

- > Enable Tabs Bar
- > Load multiple tabs (+10 tabs etc)
- > Remove the app from background if it is active
- > Launch fresh
- > Observe the active tab is selected after website is loaded


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


https://github.com/brave/brave-ios/assets/6643505/16a1b28d-8c3e-408b-9c04-5f99b2705749



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
