### PR TITLE
No Bug: Add support for string & int enum preferences

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -233,7 +233,7 @@ var package = Package(
       ],
       plugins: ["LoggerPlugin"]
     ),
-    .target(name: "Preferences", dependencies: ["Shared"]),
+    .target(name: "Preferences", dependencies: ["Shared"], plugins: ["LoggerPlugin"]),
     .target(
       name: "Onboarding",
       dependencies: [

--- a/Sources/Growth/DAU.swift
+++ b/Sources/Growth/DAU.swift
@@ -146,7 +146,7 @@ public class DAU {
   struct ParamsAndPrefs {
     let queryParams: [URLQueryItem]
     let headers: [String: String]
-    let lastLaunchInfoPreference: [Optional<Int>]
+    let lastLaunchInfoPreference: [Int]
   }
   
   func migrateInvalidWeekOfInstallPref() {

--- a/Sources/Growth/GrowthPreferences.swift
+++ b/Sources/Growth/GrowthPreferences.swift
@@ -8,7 +8,7 @@ import Preferences
 
 extension Preferences {
   public final class DAU {
-    public static let lastLaunchInfo = Option<[Int?]?>(key: "dau.last-launch-info", default: nil)
+    public static let lastLaunchInfo = Option<[Int]?>(key: "dau.last-launch-info", default: nil)
     public static let weekOfInstallation = Option<String?>(key: "dau.week-of-installation", default: nil)
     // On old codebase we checked existence of `dau_stat` to determine whether it's first server ping.
     // We need to translate that to use the new `firstPingParam` preference.

--- a/Tests/BraveSharedTests/PreferencesTest.swift
+++ b/Tests/BraveSharedTests/PreferencesTest.swift
@@ -7,11 +7,24 @@ import Preferences
 
 private let optionalStringDefault: String? = nil
 private let intDefault: Int = 1
+private let optionalStringEnumDefault: StringEnum? = nil
+private let stringEnumDefault: StringEnum = .a
+private let intEnumDefault: IntEnum = .one
 
 extension Preferences {
   // Test preferences
   fileprivate static let optionalStringOption = Option<String?>(key: "option-one", default: optionalStringDefault)
   fileprivate static let intOption = Option<Int>(key: "option-two", default: intDefault)
+  fileprivate static let stringEnumOption = Option<StringEnum>(key: "option-three", default: stringEnumDefault)
+  fileprivate static let intEnumOption = Option<IntEnum>(key: "option-four", default: intEnumDefault)
+  fileprivate static let optionalStringEnumOption = Option<StringEnum?>(key: "option-five", default: optionalStringEnumDefault)
+}
+
+private enum StringEnum: String {
+  case a, b, c
+}
+private enum IntEnum: Int {
+  case one = 1, two = 2, three = 3
 }
 
 class PreferencesTest: XCTestCase {
@@ -19,9 +32,15 @@ class PreferencesTest: XCTestCase {
   override func setUp() {
     Preferences.optionalStringOption.reset()
     Preferences.intOption.reset()
+    Preferences.stringEnumOption.reset()
+    Preferences.optionalStringOption.reset()
+    Preferences.intEnumOption.reset()
 
     XCTAssertEqual(optionalStringDefault, Preferences.optionalStringOption.value)
     XCTAssertEqual(intDefault, Preferences.intOption.value)
+    XCTAssertEqual(stringEnumDefault, Preferences.stringEnumOption.value)
+    XCTAssertEqual(optionalStringEnumDefault, Preferences.optionalStringEnumOption.value)
+    XCTAssertEqual(intEnumDefault, Preferences.intEnumOption.value)
   }
 
   func testSettingPreference() {
@@ -36,6 +55,9 @@ class PreferencesTest: XCTestCase {
     intOption.value = newInt
     XCTAssertEqual(newInt, intOption.value)
     XCTAssertEqual(newInt, intOption.container.integer(forKey: Preferences.intOption.key))
+    
+    optionalStringOption.value = nil
+    XCTAssertEqual(optionalStringOption.value, nil)
   }
 
   func testResetPreference() {
@@ -51,4 +73,28 @@ class PreferencesTest: XCTestCase {
     XCTAssertEqual(intDefault, Preferences.intOption.value)
   }
 
+  func testEnumPreference() {
+    Preferences.stringEnumOption.value = .b
+    Preferences.intEnumOption.value = .two
+    
+    XCTAssertEqual(Preferences.stringEnumOption.value, .b)
+    XCTAssertEqual(Preferences.intEnumOption.value, .two)
+    
+    // Reset restoring an enum
+    let stringEnumOption = Preferences.Option<StringEnum>(key: "option-three", default: stringEnumDefault)
+    XCTAssertEqual(Preferences.stringEnumOption.value, stringEnumOption.value)
+    
+    let intEnumOption = Preferences.Option<IntEnum>(key: "option-four", default: intEnumDefault)
+    XCTAssertEqual(Preferences.intEnumOption.value, intEnumOption.value)
+    
+    // Optional
+    Preferences.optionalStringEnumOption.value = .a
+    XCTAssertEqual(Preferences.optionalStringEnumOption.value, .a)
+    
+    let optionalStringEnumOption = Preferences.Option<StringEnum?>(key: "option-five", default: optionalStringEnumDefault)
+    XCTAssertEqual(Preferences.optionalStringEnumOption.value, optionalStringEnumOption.value)
+    
+    Preferences.optionalStringEnumOption.value = nil
+    XCTAssertEqual(Preferences.optionalStringEnumOption.value, nil)
+  }
 }


### PR DESCRIPTION
This moves generic type constraints from the class generic (`UserDefaultsEncodable`) to generically constrained functions.

This should also allows us to create transforms for typically unsupported UserDefault types.

As a bonus, the hack around setting optional preferences is now also removed

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
