### PR TITLE
Fix #7835: Add Suppress button to Allow link to switch apps? 

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController.swift
@@ -2778,6 +2778,13 @@ extension BrowserViewController: TabDelegate {
     handleIPFSSchemeURL(url, visitType: .unknown)
   }
 
+  func didReloadTab(_ tab: Tab) {
+    // Resetting External Alert Properties
+    externalAppAlertCounter = 0
+    isExternalAppAlertPresented = false
+    isExternalAppAlertSuppressed = false
+  }
+  
   @MainActor
   private func isPendingRequestAvailable() async -> Bool {
     let privateMode = privateBrowsingManager.isPrivateBrowsing

--- a/Sources/Brave/Frontend/Browser/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController.swift
@@ -266,12 +266,6 @@ public class BrowserViewController: UIViewController {
   
   var processAddressBarTask: Task<(), Never>?
   var topToolbarDidPressReloadTask: Task<(), Never>?
-  
-  /// Boolean tracking custom url-scheme alert presented
-  var isExternalAppAlertPresented = false
-  var externalAppAlertCounter = 0
-  var isExternalAppAlertSuppressed = false
-  var externalAppURLOrigin: String?
 
   public init(
     windowId: UUID,
@@ -2780,9 +2774,9 @@ extension BrowserViewController: TabDelegate {
 
   func didReloadTab(_ tab: Tab) {
     // Resetting External Alert Properties
-    externalAppAlertCounter = 0
-    isExternalAppAlertPresented = false
-    isExternalAppAlertSuppressed = false
+    tab.externalAppAlertCounter = 0
+    tab.isExternalAppAlertPresented = false
+    tab.isExternalAppAlertSuppressed = false
   }
   
   @MainActor

--- a/Sources/Brave/Frontend/Browser/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController.swift
@@ -1599,6 +1599,7 @@ public class BrowserViewController: UIViewController {
       return true
     } else if let selectedTab = tabManager.selectedTab, selectedTab.canGoBack {
       selectedTab.goBack()
+      resetExternalAlertProperties(selectedTab)
       return true
     }
     return false
@@ -2774,9 +2775,7 @@ extension BrowserViewController: TabDelegate {
 
   func didReloadTab(_ tab: Tab) {
     // Resetting External Alert Properties
-    tab.externalAppAlertCounter = 0
-    tab.isExternalAppAlertPresented = false
-    tab.isExternalAppAlertSuppressed = false
+    resetExternalAlertProperties(tab)
   }
   
   @MainActor
@@ -2796,6 +2795,12 @@ extension BrowserViewController: TabDelegate {
       return WalletProviderPermissionRequestsManager.shared.hasPendingRequest(for: selectedTabOrigin, coinType: .eth)
     }
     return false
+  }
+  
+  func resetExternalAlertProperties(_ tab: Tab?) {
+    if let tab = tab {
+      tab.resetExternalAlertProperties()
+    }
   }
 }
 

--- a/Sources/Brave/Frontend/Browser/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController.swift
@@ -266,6 +266,12 @@ public class BrowserViewController: UIViewController {
   
   var processAddressBarTask: Task<(), Never>?
   var topToolbarDidPressReloadTask: Task<(), Never>?
+  
+  /// Boolean tracking custom url-scheme alert presented
+  var isExternalAppAlertPresented = false
+  var externalAppAlertCounter = 0
+  var isExternalAppAlertSuppressed = false
+  var externalAppURLOrigin: String?
 
   public init(
     windowId: UUID,

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -21,12 +21,14 @@ extension BrowserViewController {
   @objc private func goBackKeyCommand() {
     if let tab = tabManager.selectedTab, tab.canGoBack, favoritesController == nil {
       tab.goBack()
+      resetExternalAlertProperties(tab)
     }
   }
 
   @objc private func goForwardKeyCommand() {
     if let tab = tabManager.selectedTab, tab.canGoForward {
       tab.goForward()
+      resetExternalAlertProperties(tab)
     }
   }
 

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
@@ -820,6 +820,7 @@ extension BrowserViewController: ToolbarDelegate {
 
   func tabToolbarDidPressBack(_ tabToolbar: ToolbarProtocol, button: UIButton) {
     tabManager.selectedTab?.goBack()
+    resetExternalAlertProperties(tabManager.selectedTab)
     recordNavigationActionP3A(isNavigationActionForward: false)
   }
 
@@ -830,6 +831,7 @@ extension BrowserViewController: ToolbarDelegate {
 
   func tabToolbarDidPressForward(_ tabToolbar: ToolbarProtocol, button: UIButton) {
     tabManager.selectedTab?.goForward()
+    resetExternalAlertProperties(tabManager.selectedTab)
     recordNavigationActionP3A(isNavigationActionForward: true)
   }
 

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -786,12 +786,12 @@ extension BrowserViewController {
     var alertTitle = Strings.openExternalAppURLGenericTitle
     
     // Check if the current url of the caller has changed
-    if let unfragmentedURLString = tab?.url?.schemelessAbsoluteString,
-       unfragmentedURLString != tab?.externalAppURLOrigin {
+    if let domain = tab?.url?.baseDomain,
+       domain != tab?.externalAppURLDomain {
       tab?.externalAppAlertCounter = 0
       tab?.isExternalAppAlertSuppressed = false
     }
-    tab?.externalAppURLOrigin = tab?.url?.schemelessAbsoluteString
+    tab?.externalAppURLDomain = tab?.url?.baseDomain
     
     // Do not try to present over existing warning
     if tab?.isExternalAppAlertPresented == true || tab?.isExternalAppAlertSuppressed == true {

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -851,8 +851,11 @@ extension BrowserViewController {
     }
 
     // A click is synthetic if its value is 0 which is WKSyntheticClickTypeNoTap or navigationType is other
-    // The counter is only increased with actual click 
-    if let clickType = navigationAction.value(forKey: "syntheticClickType") as? Int, clickType == 0 ||
+    // The counter is only increased with actual click
+    let argumentItemClick: [Any] = ["synt", "het", "icCli", "ckTyp", "e"]
+    let valueKeyClickType = argumentItemClick.compactMap { $0 as? String }.joined()
+
+    if let clickType = navigationAction.value(forKey: valueKeyClickType) as? Int, clickType == 0 ||
         navigationAction.navigationType == .other {
       tab?.externalAppAlertCounter += 1
     }

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -850,7 +850,12 @@ extension BrowserViewController {
       popup.showWithType(showType: .flyUp)
     }
 
-    tab?.externalAppAlertCounter += 1
+    // A click is synthetic if its value is 0 which is WKSyntheticClickTypeNoTap or navigationType is other
+    // The counter is only increased with actual click 
+    if let clickType = navigationAction.value(forKey: "syntheticClickType") as? Int, clickType == 0 ||
+        navigationAction.navigationType == .other {
+      tab?.externalAppAlertCounter += 1
+    }
     showExternalSchemeAlert(isSuppressActive: tab?.externalAppAlertCounter ?? 0 > 2)
   }
 }

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -787,15 +787,14 @@ extension BrowserViewController {
     
     // Check if the current url of the caller has changed
     if let unfragmentedURLString = tab?.url?.schemelessAbsoluteString,
-        unfragmentedURLString != externalAppURLOrigin {
-      externalAppAlertCounter = 0
-      isExternalAppAlertPresented = false
-      isExternalAppAlertSuppressed = false
+       unfragmentedURLString != tab?.externalAppURLOrigin {
+      tab?.externalAppAlertCounter = 0
+      tab?.isExternalAppAlertSuppressed = false
     }
-    externalAppURLOrigin = tab?.url?.schemelessAbsoluteString
+    tab?.externalAppURLOrigin = tab?.url?.schemelessAbsoluteString
     
     // Do not try to present over existing warning
-    if isExternalAppAlertPresented || isExternalAppAlertSuppressed {
+    if tab?.isExternalAppAlertPresented == true || tab?.isExternalAppAlertSuppressed == true {
       return
     }
 
@@ -821,7 +820,7 @@ extension BrowserViewController {
     // Show the external sceheme invoke alert
     func showExternalSchemeAlert(isSuppressActive: Bool) {
       view.endEditing(true)
-      isExternalAppAlertPresented = true
+      tab?.isExternalAppAlertPresented = true
 
       let popup = AlertPopupView(
         imageView: nil,
@@ -831,28 +830,28 @@ extension BrowserViewController {
         titleSize: 21
       )
       if isSuppressActive {
-        popup.addButton(title: Strings.suppressAlertsActionTitle, type: .destructive) { () -> PopupViewDismissType in
-          self.isExternalAppAlertSuppressed = true
+        popup.addButton(title: Strings.suppressAlertsActionTitle, type: .destructive) { [weak tab] () -> PopupViewDismissType in
+          tab?.isExternalAppAlertSuppressed = true
           return .flyDown
         }
       } else {
-        popup.addButton(title: Strings.openExternalAppURLDontAllow) { () -> PopupViewDismissType in
+        popup.addButton(title: Strings.openExternalAppURLDontAllow) { [weak tab] () -> PopupViewDismissType in
           removeTabIfEmpty()
-          self.isExternalAppAlertPresented = false
+          tab?.isExternalAppAlertPresented = false
           return .flyDown
         }
       }
-      popup.addButton(title: Strings.openExternalAppURLAllow, type: .primary) { () -> PopupViewDismissType in
+      popup.addButton(title: Strings.openExternalAppURLAllow, type: .primary) { [weak tab] () -> PopupViewDismissType in
         UIApplication.shared.open(url, options: [:], completionHandler: openedURLCompletionHandler)
         removeTabIfEmpty()
-        self.isExternalAppAlertPresented = false
+        tab?.isExternalAppAlertPresented = false
         return .flyDown
       }
       popup.showWithType(showType: .flyUp)
     }
-    
-    externalAppAlertCounter += 1
-    showExternalSchemeAlert(isSuppressActive: externalAppAlertCounter > 2)
+
+    tab?.externalAppAlertCounter += 1
+    showExternalSchemeAlert(isSuppressActive: tab?.externalAppAlertCounter ?? 0 > 2)
   }
 }
 

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -847,14 +847,20 @@ extension BrowserViewController {
     
     externalAppAlertCounter += 1
 
-    if externalAppAlertCounter > 2 {
+    if externalAppAlertCounter > 1 {
       // Show confirm alert
-      let suppressSheet = UIAlertController(title: nil, message: "Prevent this page from creating additional external application alerts.", preferredStyle: .actionSheet)
-      suppressSheet.addAction(UIAlertAction(title: Strings.suppressAlertsActionTitle, style: .destructive, handler: { [weak self] _ in
+      let suppressSheet = UIAlertController(
+        title: nil,
+        message: Strings.suppressExternalApplicationAlertsTitle,
+        preferredStyle: .actionSheet)
+      
+      suppressSheet.addAction(
+        UIAlertAction(title: Strings.suppressAlertsActionTitle, style: .destructive, handler: { [weak self] _ in
         self?.isExternalAppAlertSuppressed = true
       }))
 
-      suppressSheet.addAction(UIAlertAction(title: "Show Switch App Alert", style: .cancel, handler: { _ in
+      suppressSheet.addAction(
+        UIAlertAction(title: Strings.suppressExternalApplicationShowActionTitle, style: .cancel, handler: { _ in
         showExternalSchemeAlert()
       }))
       

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -850,15 +850,7 @@ extension BrowserViewController {
       popup.showWithType(showType: .flyUp)
     }
 
-    // A click is synthetic if its value is 0 which is WKSyntheticClickTypeNoTap or navigationType is other
-    // The counter is only increased with actual click
-    let argumentItemClick: [Any] = ["synt", "het", "icCli", "ckTyp", "e"]
-    let valueKeyClickType = argumentItemClick.compactMap { $0 as? String }.joined()
-
-    if let clickType = navigationAction.value(forKey: valueKeyClickType) as? Int, clickType == 0 ||
-        navigationAction.navigationType == .other {
-      tab?.externalAppAlertCounter += 1
-    }
+    tab?.externalAppAlertCounter += 1
     showExternalSchemeAlert(isSuppressActive: tab?.externalAppAlertCounter ?? 0 > 2)
   }
 }

--- a/Sources/Brave/Frontend/Browser/Tab.swift
+++ b/Sources/Brave/Frontend/Browser/Tab.swift
@@ -48,6 +48,7 @@ protocol TabDelegate {
   func updateURLBarWalletButton()
   func isTabVisible(_ tab: Tab) -> Bool
   func reloadIPFSSchemeUrl(_ url: URL)
+  func didReloadTab(_ tab: Tab)
 }
 
 @objc
@@ -662,6 +663,8 @@ class Tab: NSObject {
         refreshControl.endRefreshing()
       }
     }
+    
+    tabDelegate?.didReloadTab(self)
 
     // If the current page is an error page, and the reload button is tapped, load the original URL
     if let url = webView?.url, let internalUrl = InternalURL(url), let page = internalUrl.originalURLFromErrorPage {

--- a/Sources/Brave/Frontend/Browser/Tab.swift
+++ b/Sources/Brave/Frontend/Browser/Tab.swift
@@ -80,6 +80,12 @@ class Tab: NSObject {
   var isPrivate: Bool {
     return type.isPrivate
   }
+  
+  /// Boolean tracking custom url-scheme alert presented
+  var isExternalAppAlertPresented = false
+  var externalAppAlertCounter = 0
+  var isExternalAppAlertSuppressed = false
+  var externalAppURLOrigin: String?
 
   var secureContentState: TabSecureContentState = .unknown
   var sslPinningError: Error?

--- a/Sources/Brave/Frontend/Browser/Tab.swift
+++ b/Sources/Brave/Frontend/Browser/Tab.swift
@@ -80,12 +80,6 @@ class Tab: NSObject {
   var isPrivate: Bool {
     return type.isPrivate
   }
-  
-  /// Boolean tracking custom url-scheme alert presented
-  var isExternalAppAlertPresented = false
-  var externalAppAlertCounter = 0
-  var isExternalAppAlertSuppressed = false
-  var externalAppURLDomain: String?
 
   var secureContentState: TabSecureContentState = .unknown
   var sslPinningError: Error?
@@ -314,6 +308,19 @@ class Tab: NSObject {
       
       self.setScript(script: .nightMode, enabled: isNightModeEnabled)
     }
+  }
+  
+  /// Boolean tracking custom url-scheme alert presented
+  var isExternalAppAlertPresented = false
+  var externalAppAlertCounter = 0
+  var isExternalAppAlertSuppressed = false
+  var externalAppURLDomain: String?
+  
+  func resetExternalAlertProperties() {
+    externalAppAlertCounter = 0
+    isExternalAppAlertPresented = false
+    isExternalAppAlertSuppressed = false
+    externalAppURLDomain = nil
   }
 
   init(configuration: WKWebViewConfiguration, id: UUID = UUID(), type: TabType = .regular, tabGeneratorAPI: BraveTabGeneratorAPI? = nil) {

--- a/Sources/Brave/Frontend/Browser/Tab.swift
+++ b/Sources/Brave/Frontend/Browser/Tab.swift
@@ -85,7 +85,7 @@ class Tab: NSObject {
   var isExternalAppAlertPresented = false
   var externalAppAlertCounter = 0
   var isExternalAppAlertSuppressed = false
-  var externalAppURLOrigin: String?
+  var externalAppURLDomain: String?
 
   var secureContentState: TabSecureContentState = .unknown
   var sslPinningError: Error?

--- a/Sources/Brave/Frontend/Browser/TabManager.swift
+++ b/Sources/Brave/Frontend/Browser/TabManager.swift
@@ -573,6 +573,7 @@ class TabManager: NSObject {
             return
           }
 
+          tab.resetExternalAlertProperties()
           self.preserveScreenshot(for: tab)
           self.saveTab(tab)
         }

--- a/Sources/BraveStrings/BraveStrings.swift
+++ b/Sources/BraveStrings/BraveStrings.swift
@@ -134,6 +134,20 @@ extension Strings {
       comment: "Action item title of long press for Opening the existing - active Tab url in a new Tab")
   public static let suppressAlertsActionTitle = NSLocalizedString("SuppressAlertsActionTitle", tableName: "BraveShared", bundle: .module, value: "Suppress Alerts", comment: "Title of alert that seeks permission from user to suppress future JS alerts")
   public static let suppressAlertsActionMessage = NSLocalizedString("SuppressAlertsActionMessage", tableName: "BraveShared", bundle: .module, value: "Prevent this page from creating additional alerts", comment: "Message body of alert that seeks permission from user to suppress future JS alerts")
+  public static let suppressExternalApplicationAlertsTitle =
+    NSLocalizedString(
+      "SuppressExternalApplicationAlertTitle",
+      tableName: "BraveShared",
+      bundle: .module,
+      value: "Prevent this page from creating additional external application alerts.",
+      comment: "Title body of alert that seeks permission from user to suppress external application alerts")
+  public static let suppressExternalApplicationShowActionTitle =
+    NSLocalizedString(
+      "SuppressExternalApplicationShowActionTitle",
+      tableName: "BraveShared",
+      bundle: .module,
+      value: "Show Switch App Alert",
+      comment: "Title of the action that allow showing switch ato the external application")
   public static let openDownloadsFolderErrorDescription =
     NSLocalizedString(
       "OpenDownloadsFolderErrorDescription",

--- a/Sources/BraveStrings/BraveStrings.swift
+++ b/Sources/BraveStrings/BraveStrings.swift
@@ -134,20 +134,6 @@ extension Strings {
       comment: "Action item title of long press for Opening the existing - active Tab url in a new Tab")
   public static let suppressAlertsActionTitle = NSLocalizedString("SuppressAlertsActionTitle", tableName: "BraveShared", bundle: .module, value: "Suppress Alerts", comment: "Title of alert that seeks permission from user to suppress future JS alerts")
   public static let suppressAlertsActionMessage = NSLocalizedString("SuppressAlertsActionMessage", tableName: "BraveShared", bundle: .module, value: "Prevent this page from creating additional alerts", comment: "Message body of alert that seeks permission from user to suppress future JS alerts")
-  public static let suppressExternalApplicationAlertsTitle =
-    NSLocalizedString(
-      "SuppressExternalApplicationAlertTitle",
-      tableName: "BraveShared",
-      bundle: .module,
-      value: "Prevent this page from creating additional external application alerts.",
-      comment: "Title body of alert that seeks permission from user to suppress external application alerts")
-  public static let suppressExternalApplicationShowActionTitle =
-    NSLocalizedString(
-      "SuppressExternalApplicationShowActionTitle",
-      tableName: "BraveShared",
-      bundle: .module,
-      value: "Show Switch App Alert",
-      comment: "Title of the action that allow showing switch ato the external application")
   public static let openDownloadsFolderErrorDescription =
     NSLocalizedString(
       "OpenDownloadsFolderErrorDescription",


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

Handling possible abuse of external application alerts by adding suppress alert dialog when alerts triggered to be shown multiple times. 

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7835

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

- Test to open a website that triggers facetime-audio repeatedly
- Check open external alert is shown and website cant trigger more alerts while pop up is active
- Do not allow external app launch
- Check instead of open external alert, an alert with suppress app launch is presented
- Check suppress works as expected
- Check show switch app alert works expected

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

![4323221](https://github.com/brave/brave-ios/assets/6643505/dc542034-76cd-4492-a6db-31b117166847)


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
