### PR TITLE
Fix #8060: Increase performance of closing tabs

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+TabManagerDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+TabManagerDelegate.swift
@@ -384,7 +384,7 @@ extension BrowserViewController: TabManagerDelegate {
           let alert = UIAlertController(title: nil, message: Strings.closeAllTabsPrompt, preferredStyle: .actionSheet)
           let cancelAction = UIAlertAction(title: Strings.CancelString, style: .cancel)
           let closedTabsTitle = String(format: Strings.closeAllTabsTitle, tabManager.tabsForCurrentMode.count)
-          let closeAllAction = UIAlertAction(title: closedTabsTitle, style: .destructive) { _ in
+          let closeAllAction = UIAlertAction(title: closedTabsTitle, style: .destructive) { [unowned self] _ in
             if !privateBrowsingManager.isPrivateBrowsing {
               // Add the tab information to recently closed before removing
               tabManager.addAllTabsToRecentlyClosed()

--- a/Sources/Brave/Frontend/Browser/Helpers/ScreenshotHelper.swift
+++ b/Sources/Brave/Frontend/Browser/Helpers/ScreenshotHelper.swift
@@ -39,15 +39,15 @@ class ScreenshotHelper {
       // This is for a bug in certain iOS 13 versions, snapshots cannot be taken correctly without this boolean being set
       configuration.afterScreenUpdates = false
 
-      webView.takeSnapshot(with: configuration) { image, error in
+      webView.takeSnapshot(with: configuration) { [weak tab] image, error in
         if let image = image {
-          tab.setScreenshot(image)
+          tab?.setScreenshot(image)
         } else if let error = error {
           Logger.module.error("\(error.localizedDescription)")
-          tab.setScreenshot(nil)
+          tab?.setScreenshot(nil)
         } else {
           Logger.module.error("Cannot snapshot Tab Screenshot - No error description")
-          tab.setScreenshot(nil)
+          tab?.setScreenshot(nil)
         }
       }
     }

--- a/Sources/Brave/Frontend/Browser/Tab.swift
+++ b/Sources/Brave/Frontend/Browser/Tab.swift
@@ -281,7 +281,7 @@ class Tab: NSObject {
   var onPageReadyStateChanged: ((ReadyState.State) -> Void)?
 
   // If this tab has been opened from another, its parent will point to the tab from which it was opened
-  var parent: Tab?
+  weak var parent: Tab?
 
   fileprivate var contentScriptManager = TabContentScriptManager()
   private var userScripts = Set<UserScriptManager.ScriptType>()
@@ -420,6 +420,7 @@ class Tab: NSObject {
     }
     
     // Remove the tab history from saved tabs
+    // To remove history from WebKit, we simply update the session data AFTER calling "clear" above
     SessionTab.update(tabId: id, interactionState: webView.sessionData ?? Data(), title: title, url: webView.url ?? TabManager.ntpInteralURL)
   }
 


### PR DESCRIPTION
## Summary of Changes
- Preserve screenshots only for the selected tab when a tab is selected. 
- Preserve screenshots only for the current tab when its history has changed.
- Fixed strong retain cycle between a child tab and its parent.
- Screenshot helper was made weak because there's no point of setting screenshots on a deallocated tab.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8060

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
