### PR TITLE
Fix #8045: Default Browser Notification - Update (Text - Default Logic)

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController.swift
@@ -3184,8 +3184,12 @@ extension BrowserViewController {
   public func handleNavigationPath(path: NavigationPath) {
     // Remove Default Browser Callout - Do not show scheduled notification
     // in case an external url is triggered
-    Preferences.General.defaultBrowserCalloutDismissed.value = true
-    Preferences.DefaultBrowserIntro.defaultBrowserNotificationShouldBeShown.value = false
+    if case .url(let navigatedURL, _) = path {
+      if navigatedURL?.isWebPage(includeDataURIs: false) == true {
+        Preferences.General.defaultBrowserCalloutDismissed.value = true
+        Preferences.DefaultBrowserIntro.defaultBrowserNotificationShouldBeShown.value = false
+      }
+    }
     
     executeAfterSetup {
       NavigationPath.handle(nav: path, with: self)

--- a/Sources/BraveStrings/BraveStrings.swift
+++ b/Sources/BraveStrings/BraveStrings.swift
@@ -184,14 +184,14 @@ extension Strings {
       NSLocalizedString(
         "defaultBrowserCallout.notificationTitle",
         tableName: "BraveShared", bundle: .module,
-        value: "Brave Web Browser",
+        value: "Get Brave protection, on every link",
         comment: "Notification title to promote setting Brave app as default browser")
 
     public static let notificationBody =
       NSLocalizedString(
         "defaultBrowserCallout.notificationBody",
         tableName: "BraveShared", bundle: .module,
-        value: "Optimized for iOS %@. Make Brave your default browser today.",
+        value: "Set Brave as your default browser",
         comment: "Notification body to promote setting Brave app as default browser")
   }
 }

--- a/Sources/Onboarding/OnboardingPreferences.swift
+++ b/Sources/Onboarding/OnboardingPreferences.swift
@@ -84,9 +84,14 @@ extension Preferences {
       key: "defaultBrowserIntro.intro-completed",
       default: false)
     
-    /// Whether system notification showed or not
+    /// Whether system notification scheduled or not
     public static let defaultBrowserNotificationScheduled = Option<Bool>(
       key: "general.default-browser-notification-scheduled",
       default: false)
+    
+    /// Whether a default browser local notification should be shown
+    public static let defaultBrowserNotificationShouldBeShown = Option<Bool>(
+      key: "general.default-browser-notification-shown",
+      default: true)
   }
 }


### PR DESCRIPTION

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8045

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
Check If notification will be presented after opening an external link while browser is set default
Check new text 

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
