### PR TITLE
Fix #8066: Remove invalid selectors

### DIFF
--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Sandboxed/SelectorsPollerScript.js
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Sandboxed/SelectorsPollerScript.js
@@ -789,7 +789,21 @@ window.__firefox__.execute(function($) {
     }
 
     return Array.from(CC.hiddenSelectors).filter((selector) => {
-      return element.matches(selector)
+      try {
+        return element.matches(selector)
+      } catch (error) {
+        console.error(`Invalid selector '${selector}'`)
+        
+        // Remove the culprit from everywhere so it doesn't cause errors
+        CC.hiddenSelectors.delete(selector)
+        CC.unhiddenSelectors.add(selector)
+        
+        for (let queueIndex = 0; queueIndex < CC.runQueues.length; queueIndex += 1) {
+          CC.runQueues[queueIndex]
+          CC.runQueues[queueIndex].delete(selector)
+        }
+        return false
+      }
     })
   }
 

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Sandboxed/SelectorsPollerScript.js
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Sandboxed/SelectorsPollerScript.js
@@ -792,8 +792,6 @@ window.__firefox__.execute(function($) {
       try {
         return element.matches(selector)
       } catch (error) {
-        console.error(`Invalid selector '${selector}'`)
-        
         // Remove the culprit from everywhere so it doesn't cause errors
         CC.hiddenSelectors.delete(selector)
         CC.unhiddenSelectors.add(selector)

--- a/Tests/ClientTests/User Scripts/ScriptExecutionTests.swift
+++ b/Tests/ClientTests/User Scripts/ScriptExecutionTests.swift
@@ -205,6 +205,9 @@ final class ScriptExecutionTests: XCTestCase {
   @MainActor func testCosmeticFilteringScript() async throws {
     // Given
     let viewController = MockScriptsViewController()
+    let invalidSelectors = Set([
+      "div.invalid-selector:has(span.update-components-actor__description:-abp-contains(/Anzeige|Sponsored|Promoted|Dipromosikan|Propagováno|Promoveret|Gesponsert|Promocionado|促銷內容|Post sponsorisé|프로모션|Post sponsorizzato|广告|プロモーション|Treść promowana|Patrocinado|Promovat|Продвигается|Marknadsfört|Nai-promote|ได้รับการโปรโมท|Öne çıkarılan içerik|Gepromoot|الترويج/))"
+    ])
     let initialStandardSelectors = Set([".test-ads-primary-standard div"])
     let initialAggressiveSelectors = Set([".test-ads-primary-aggressive div"])
     let polledAggressiveIds = ["test-ad-aggressive"]
@@ -220,7 +223,7 @@ final class ScriptExecutionTests: XCTestCase {
       switchToSelectorsPollingThreshold: 1000,
       fetchNewClassIdRulesThrottlingMs: 100,
       aggressiveSelectors: initialAggressiveSelectors,
-      standardSelectors: initialStandardSelectors,
+      standardSelectors: initialStandardSelectors.union(invalidSelectors),
       styleSelectors: []
     )
     


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
In the modified method, selectors are returned so they can be re-enabled. These are first party selectors that are being re-shown after a 1st party async check. the matches method fails in some rare cases when the selector is invalid as seen in the linked issue. A try catch allows the failure to not affect the whole script and allows me to remove invalid selectors so they will no longer be processed.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8066 

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Unit tests have been updated to cover this scenario (and other similar scenarios)
Additional STR can be found in issue

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
