### PR TITLE
Fix #8078: Update browser colors

### DIFF
--- a/Sources/Brave/Extensions/SceneExtensions.swift
+++ b/Sources/Brave/Extensions/SceneExtensions.swift
@@ -26,6 +26,14 @@ extension UIWindowScene {
   public var browserViewController: BrowserViewController? {
     return browserViewControllers.first
   }
+  
+  /// Returns the browser colors of the current window scene
+  var browserColors: any BrowserColors {
+    if let bvc = browserViewController, bvc.privateBrowsingManager.isPrivateBrowsing {
+      return .privateMode
+    }
+    return .standard
+  }
 }
 
 extension UIViewController {

--- a/Sources/Brave/Frontend/Browser/BrowserColors.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserColors.swift
@@ -1,0 +1,263 @@
+// Copyright 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import UIKit
+import DesignSystem
+import BraveUI
+
+/// A set of browser theme colors found in the `🦁 Browser` Figma doc. There will be a separate set depending
+/// on the browsing mode you're in (standard vs private)
+protocol BrowserColors {
+  // MARK: - Text
+  var textPrimary: UIColor { get }
+  var textSecondary: UIColor { get }
+  var textTertiary: UIColor { get }
+  var textDisabled: UIColor { get }
+  var textInteractive: UIColor { get }
+  
+  // MARK: - Icon
+  var iconDefault: UIColor { get }
+  var iconDisabled: UIColor { get }
+  var iconActive: UIColor { get }
+  
+  // MARK: - BrowserButton
+  var browserButtonBackgroundHover: UIColor { get }
+  var browserButtonBackgroundActive: UIColor { get }
+  
+  // MARK: - TabSwitcher
+  var tabSwitcherButton: UIColor { get }
+  var tabSwitcherBackground: UIColor { get }
+  
+  // MARK: - Container
+  var containerBackground: UIColor { get }
+  var containerInteractive: UIColor { get }
+  var containerScrim: UIColor { get }
+  var containerFrostedGlass: UIColor { get }
+  
+  // MARK: - Chrome
+  var chromeBackground: UIColor { get }
+  
+  // MARK: - Divider
+  var dividerSubtle: UIColor { get }
+  var dividerStrong: UIColor { get }
+  
+  // MARK: - TabBar
+  var tabBarTabBackground: UIColor { get }
+  var tabBarTabActiveBackground: UIColor { get }
+}
+
+extension BrowserColors where Self == StandardBrowserColors {
+  /// The standard set of light & dark mode browser colors
+  static var standard: StandardBrowserColors { .init() }
+}
+
+extension BrowserColors where Self == PrivateModeBrowserColors {
+  /// The set of browser colors specific to private mode
+  static var privateMode: PrivateModeBrowserColors { .init() }
+}
+
+/// The standard set of light & dark mode browser colors
+struct StandardBrowserColors: BrowserColors {
+  var textPrimary: UIColor {
+    .init(light: .primitiveGray100, dark: .primitiveGray1)
+  }
+  
+  var textSecondary: UIColor {
+    .init(light: .primitiveGray70, dark: .primitiveGray30)
+  }
+  
+  var textTertiary: UIColor {
+    .init(light: .primitiveGray50, dark: .primitiveGray40)
+  }
+  
+  var textDisabled: UIColor {
+    .init(lightRGBA: 0x21242A80, darkRGBA: 0xEDEEF180)
+  }
+  
+  var textInteractive: UIColor {
+    .init(light: .primitivePrimary60, dark: .primitivePrimary40)
+  }
+  
+  var iconDefault: UIColor {
+    .init(light: .primitiveGray50, dark: .primitiveGray40)
+  }
+  
+  var iconDisabled: UIColor {
+    .init(lightRGBA: 0x68748580, darkRGBA: 0xA1ABBA80)
+  }
+  
+  var iconActive: UIColor {
+    .init(light: .primitivePrimary60, dark: .primitivePrimary40)
+  }
+  
+  var browserButtonBackgroundHover: UIColor {
+    .init(light: .primitiveGray10, dark: .primitiveGray80)
+  }
+  
+  var browserButtonBackgroundActive: UIColor {
+    .init(light: .primitiveGray20, dark: .primitiveGray100)
+  }
+  
+  var tabSwitcherButton: UIColor {
+    .init(lightColor: .white, darkColor: .init(braveSystemName: .primitiveGray90))
+  }
+  
+  var tabSwitcherBackground: UIColor {
+    .init(light: .primitiveGray1, dark: .primitiveGray80)
+  }
+  
+  var containerBackground: UIColor {
+    .init(lightColor: .white, darkColor: .init(braveSystemName: .primitiveGray90))
+  }
+  
+  var containerInteractive: UIColor {
+    .init(light: .primitivePrimary10, dark: .primitivePrimary80)
+  }
+  
+  var containerScrim: UIColor {
+    .init(lightRGBA: 0x0D0F1459, darkRGBA: 0x0D0F14B3)
+  }
+  
+  var containerFrostedGlass: UIColor {
+    .init(lightRGBA: 0xFFFFFFF7, darkRGBA: 0x21242AEB)
+  }
+  
+  var chromeBackground: UIColor {
+    .init(light: .primitiveGray1, dark: .primitiveGray100)
+  }
+  
+  var dividerSubtle: UIColor {
+    .init(lightRGBA: 0xA1ABBA66, darkRGBA: 0x68748566)
+  }
+  
+  var dividerStrong: UIColor {
+    .init(lightRGBA: 0x68748566, darkRGBA: 0xA1ABBA66)
+  }
+  
+  var tabBarTabBackground: UIColor {
+    .init(light: .primitiveGray10, dark: .primitiveGray100)
+  }
+  
+  var tabBarTabActiveBackground: UIColor {
+    .init(light: .primitiveGray1, dark: .primitiveGray90)
+  }
+}
+
+/// The set of browser colors specific to private mode
+struct PrivateModeBrowserColors: BrowserColors {
+  var textPrimary: UIColor {
+    .init(braveSystemName: .primitivePrivateWindow1)
+  }
+  
+  var textSecondary: UIColor {
+    .init(braveSystemName: .primitivePrivateWindow30)
+  }
+  
+  var textTertiary: UIColor {
+    .init(braveSystemName: .primitivePrivateWindow40)
+  }
+  
+  var textDisabled: UIColor {
+    .init(rgba: 0xEEEBFF80)
+  }
+  
+  var textInteractive: UIColor {
+    .init(braveSystemName: .primitivePrimary40)
+  }
+  
+  var iconDefault: UIColor {
+    .init(braveSystemName: .primitivePrivateWindow40)
+  }
+  
+  var iconDisabled: UIColor {
+    .init(rgba: 0xA380FF80)
+  }
+  
+  var iconActive: UIColor {
+    .init(braveSystemName: .primitivePrimary40)
+  }
+  
+  var browserButtonBackgroundHover: UIColor {
+    .init(braveSystemName: .primitivePrivateWindow80)
+  }
+  
+  var browserButtonBackgroundActive: UIColor {
+    .init(braveSystemName: .primitivePrivateWindow100)
+  }
+  
+  var tabSwitcherButton: UIColor {
+    .init(braveSystemName: .primitivePrimary90)
+  }
+  
+  var tabSwitcherBackground: UIColor {
+    .init(braveSystemName: .primitivePrimary80)
+  }
+  
+  var containerBackground: UIColor {
+    .init(braveSystemName: .primitivePrivateWindow90)
+  }
+  
+  var containerInteractive: UIColor {
+    .init(braveSystemName: .primitivePrimary90)
+  }
+  
+  var containerScrim: UIColor {
+    .init(rgba: 0x13052AB3)
+  }
+  
+  var containerFrostedGlass: UIColor {
+    .init(rgba: 0x2A0D58EB)
+  }
+  
+  var chromeBackground: UIColor {
+    .init(braveSystemName: .primitivePrivateWindow100)
+  }
+  
+  var dividerSubtle: UIColor {
+    .init(rgba: 0x7B63BF66)
+  }
+  
+  var dividerStrong: UIColor {
+    .init(rgba: 0xA380FF66)
+  }
+  
+  var tabBarTabBackground: UIColor {
+    .init(braveSystemName: .primitivePrivateWindow100)
+  }
+  
+  var tabBarTabActiveBackground: UIColor {
+    .init(braveSystemName: .primitivePrivateWindow90)
+  }
+}
+
+extension UIColor {
+  fileprivate convenience init(light: FigmaColorResource, dark: FigmaColorResource) {
+    self.init(dynamicProvider: { traitCollection in
+      if traitCollection.userInterfaceStyle == .dark {
+        return .init(braveSystemName: dark)
+      }
+      return .init(braveSystemName: light)
+    })
+  }
+  
+  fileprivate convenience init(lightColor: UIColor, darkColor: UIColor) {
+    self.init(dynamicProvider: { traitCollection in
+      if traitCollection.userInterfaceStyle == .dark {
+        return darkColor
+      }
+      return lightColor
+    })
+  }
+  
+  fileprivate convenience init(lightRGBA: UInt32, darkRGBA: UInt32) {
+    self.init(dynamicProvider: { traitCollection in
+      if traitCollection.userInterfaceStyle == .dark {
+        return .init(rgba: darkRGBA)
+      }
+      return .init(rgba: lightRGBA)
+    })
+  }
+}

--- a/Sources/Brave/Frontend/Browser/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController.swift
@@ -102,10 +102,10 @@ public class BrowserViewController: UIViewController {
   var readerModeBar: ReaderModeBarView?
   var readerModeCache: ReaderModeCache
   
-  let statusBarOverlay: UIView = {
+  private(set) lazy var statusBarOverlay: UIView = {
     // Temporary work around for covering the non-clipped web view content
     let statusBarOverlay = UIView()
-    statusBarOverlay.backgroundColor = Preferences.General.nightModeEnabled.value ? .nightModeBackground : .urlBarBackground
+    statusBarOverlay.backgroundColor = privateBrowsingManager.browserColors.chromeBackground
     return statusBarOverlay
   }()
   
@@ -899,9 +899,12 @@ public class BrowserViewController: UIViewController {
     privateModeCancellable = privateBrowsingManager
       .$isPrivateBrowsing
       .removeDuplicates()
+      .receive(on: RunLoop.main)
       .sink(receiveValue: { [weak self] isPrivateBrowsing in
-        self?.updateStatusBarOverlayColor()
-        self?.bottomBarKeyboardBackground.backgroundColor = self?.topToolbar.backgroundColor
+        guard let self = self else { return }
+        self.updateStatusBarOverlayColor()
+        self.bottomBarKeyboardBackground.backgroundColor = self.topToolbar.backgroundColor
+        self.collapsedURLBarView.browserColors = self.privateBrowsingManager.browserColors
       })
     
     appReviewCancelable = AppReviewManager.shared
@@ -917,14 +920,6 @@ public class BrowserViewController: UIViewController {
           AppReviewManager.shared.handleAppReview(for: .revised, using: self)
         }
       })
-    
-    Preferences.General.nightModeEnabled.objectWillChange
-      .receive(on: RunLoop.main)
-      .sink { [weak self] _ in
-        self?.updateStatusBarOverlayColor()
-        self?.bottomBarKeyboardBackground.backgroundColor = self?.topToolbar.backgroundColor
-      }
-      .store(in: &cancellables)
     
     Preferences.General.isUsingBottomBar.objectWillChange
       .receive(on: RunLoop.main)
@@ -1388,7 +1383,8 @@ public class BrowserViewController: UIViewController {
       activeNewTabPageViewController = ntpController
 
       addChild(ntpController)
-      view.insertSubview(ntpController.view, belowSubview: header)
+      let subview = isUsingBottomBar ? header : statusBarOverlay
+      view.insertSubview(ntpController.view, belowSubview: subview)
       ntpController.didMove(toParent: self)
 
       ntpController.view.snp.makeConstraints {
@@ -2323,11 +2319,7 @@ public class BrowserViewController: UIViewController {
     defer { setNeedsStatusBarAppearanceUpdate() }
     guard isUsingBottomBar, let tab = tabManager.selectedTab, tab.url.map(InternalURL.isValid) == false,
           let color = tab.webView?.sampledPageTopColor else {
-      if privateBrowsingManager.isPrivateBrowsing {
-        statusBarOverlay.backgroundColor = .privateModeBackground
-      } else {
-        statusBarOverlay.backgroundColor = Preferences.General.nightModeEnabled.value ? .nightModeBackground : .urlBarBackground
-      }
+      statusBarOverlay.backgroundColor = privateBrowsingManager.browserColors.chromeBackground
       return
     }
     statusBarOverlay.backgroundColor = color

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
@@ -618,6 +618,7 @@ extension BrowserViewController: TopToolbarDelegate {
       searchController.removeFromParent()
       self.searchController = nil
       searchLoader = nil
+      favoritesController?.view.isHidden = false
     }
   }
 
@@ -631,7 +632,7 @@ extension BrowserViewController: TopToolbarDelegate {
       searchEngines: profile.searchEngines)
     
     // Setting up controller for SearchSuggestions
-    searchController = SearchViewController(with: searchDataSource)
+    searchController = SearchViewController(with: searchDataSource, browserColors: privateBrowsingManager.browserColors)
     searchController?.isUsingBottomBar = isUsingBottomBar
     guard let searchController = searchController else { return }
     searchController.setupSearchEngineList()
@@ -654,11 +655,13 @@ extension BrowserViewController: TopToolbarDelegate {
       view.insertSubview(searchController.view, belowSubview: header)
     }
     searchController.view.snp.makeConstraints {
-      $0.edges.equalTo(view.safeAreaLayoutGuide)
+      $0.edges.equalTo(view)
     }
     searchController.didMove(toParent: self)
     searchController.view.setNeedsLayout()
     searchController.view.layoutIfNeeded()
+    
+    favoritesController?.view.isHidden = true
   }
 
   private func displayFavoritesController() {
@@ -666,6 +669,7 @@ extension BrowserViewController: TopToolbarDelegate {
       let tabType = TabType.of(tabManager.selectedTab)
       let favoritesController = FavoritesViewController(
         tabType: tabType,
+        privateBrowsingManager: privateBrowsingManager,
         action: { [weak self] bookmark, action in
           self?.handleFavoriteAction(favorite: bookmark, action: action)
         },

--- a/Sources/Brave/Frontend/Browser/PrivacyProtection/PrivateBrowsingManager.swift
+++ b/Sources/Brave/Frontend/Browser/PrivacyProtection/PrivateBrowsingManager.swift
@@ -19,4 +19,8 @@ public final class PrivateBrowsingManager: ObservableObject {
       }
     }
   }
+  
+  var browserColors: any BrowserColors {
+    isPrivateBrowsing ? .privateMode : .standard
+  }
 }

--- a/Sources/Brave/Frontend/Browser/Search/BraveSearchPromotionCell.swift
+++ b/Sources/Brave/Frontend/Browser/Search/BraveSearchPromotionCell.swift
@@ -70,7 +70,7 @@ class BraveSearchPromotionCell: UITableViewCell {
   override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
     super.init(style: style, reuseIdentifier: reuseIdentifier)
     
-    backgroundColor = .secondaryBraveBackground
+    backgroundColor = .clear
     selectionStyle = .none
     
     contentView.addSubview(promotionContentView)

--- a/Sources/Brave/Frontend/Browser/Search/SearchSuggestionCell.swift
+++ b/Sources/Brave/Frontend/Browser/Search/SearchSuggestionCell.swift
@@ -34,7 +34,7 @@ class SuggestionCell: UITableViewCell {
   override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
     super.init(style: style, reuseIdentifier: reuseIdentifier)
 
-    backgroundColor = .secondaryBraveBackground
+    backgroundColor = .clear
 
     contentView.addSubview(stackView)
     stackView.addArrangedSubview(titleLabel)

--- a/Sources/Brave/Frontend/Browser/Search/SearchSuggestionsPromptView.swift
+++ b/Sources/Brave/Frontend/Browser/Search/SearchSuggestionsPromptView.swift
@@ -76,7 +76,7 @@ class SearchSuggestionPromptCell: UITableViewCell {
   override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
     super.init(style: style, reuseIdentifier: reuseIdentifier)
 
-    backgroundColor = .secondaryBraveBackground
+    backgroundColor = .clear
 
     contentView.addSubview(vStackView)
     vStackView.snp.makeConstraints {

--- a/Sources/Brave/Frontend/Browser/Tabs/TabBar/TabsBarViewController.swift
+++ b/Sources/Brave/Frontend/Browser/Tabs/TabBar/TabsBarViewController.swift
@@ -68,7 +68,6 @@ class TabsBarViewController: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    view.backgroundColor = Preferences.General.nightModeEnabled.value ? .nightModeBackground : .urlBarBackground
     collectionView.backgroundColor = view.backgroundColor
     collectionView.dragDelegate = UIApplication.shared.supportsMultipleScenes ? self : nil
     collectionView.dropDelegate = UIApplication.shared.supportsMultipleScenes ? self : nil
@@ -132,20 +131,16 @@ class TabsBarViewController: UIViewController {
       self.delegate?.tabsBarDidSelectAddNewWindow(true)
     }))
 
+    updateColors()
+    
     plusButton.menu = UIMenu(title: "", identifier: nil, children: newTabMenu)
     privateModeCancellable = tabManager?.privateBrowsingManager
       .$isPrivateBrowsing
       .removeDuplicates()
-      .sink(receiveValue: { [weak self] isPrivateBrowsing in
-        self?.updateColors(isPrivateBrowsing)
-      })
-    
-    Preferences.General.nightModeEnabled.objectWillChange
       .receive(on: RunLoop.main)
-      .sink { [weak self] _ in
-        self?.updateColors(self?.tabManager?.privateBrowsingManager.isPrivateBrowsing == true)
-      }
-      .store(in: &cancellables)
+      .sink(receiveValue: { [weak self] isPrivateBrowsing in
+        self?.updateColors()
+      })
   }
   
   override func viewDidAppear(_ animated: Bool) {
@@ -155,14 +150,9 @@ class TabsBarViewController: UIViewController {
   }
 
   private var privateModeCancellable: AnyCancellable?
-  private func updateColors(_ isPrivateBrowsing: Bool) {
-    let backgroundColor: UIColor
-    if isPrivateBrowsing {
-      backgroundColor = .privateModeBackground
-    } else {
-      backgroundColor = Preferences.General.nightModeEnabled.value ? .nightModeBackground : .urlBarBackground
-    }
-    view.backgroundColor = backgroundColor
+  private func updateColors() {
+    let browserColors: any BrowserColors = tabManager?.privateBrowsingManager.browserColors ?? .standard
+    view.backgroundColor = browserColors.chromeBackground
     collectionView.backgroundColor = view.backgroundColor
   }
 

--- a/Sources/Brave/Frontend/Browser/Tabs/TabTray/TabTrayAnimation.swift
+++ b/Sources/Brave/Frontend/Browser/Tabs/TabTray/TabTrayAnimation.swift
@@ -190,12 +190,6 @@ extension TabTrayController: BasicAnimationControllerDelegate {
 
     // Allow the UI to render to make the snapshotting code more performant
     DispatchQueue.main.async { [self] in
-      // BVC snapshot animates from the cell to its final resting spot
-      let toVCSnapshot: UIView = toView.snapshotView(afterScreenUpdates: true) ?? UIImageView(image: toView.snapshot)
-      toVCSnapshot.layer.cornerCurve = .continuous
-      toVCSnapshot.layer.cornerRadius = TabCell.UX.cornerRadius
-      toVCSnapshot.clipsToBounds = true
-
       // Just a small background view for animation sake between the tab tray and the bvc
       let backgroundView = UIView()
       backgroundView.backgroundColor = .init(white: 0.0, alpha: 0.3)
@@ -204,11 +198,19 @@ extension TabTrayController: BasicAnimationControllerDelegate {
 
       context.containerView.addSubview(toView)
       context.containerView.addSubview(backgroundView)
-      context.containerView.addSubview(toVCSnapshot)
-      context.containerView.addSubview(tabSnapshot)
-
+      
       toView.setNeedsLayout()
       toView.layoutIfNeeded()
+      
+      // BVC snapshot animates from the cell to its final resting spot
+      let toVCSnapshot: UIView = toView.snapshotView(afterScreenUpdates: true) ?? UIImageView(image: toView.snapshot)
+      toVCSnapshot.layer.cornerCurve = .continuous
+      toVCSnapshot.layer.cornerRadius = TabCell.UX.cornerRadius
+      toVCSnapshot.clipsToBounds = true
+
+      context.containerView.addSubview(toVCSnapshot)
+      context.containerView.addSubview(tabSnapshot)
+      
       // Hide the destination as we're animating a snapshot into place
       toView.isHidden = true
 

--- a/Sources/Brave/Frontend/Browser/Tabs/TabTray/TabTrayController+TableViewDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/Tabs/TabTray/TabTrayController+TableViewDelegate.swift
@@ -79,7 +79,8 @@ extension TabTrayController: UITableViewDataSource, UITableViewDelegate {
     }
         
     let headerView = tableView.dequeueReusableHeaderFooter() as TabSyncHeaderView
-
+    let browserColors: some BrowserColors = .standard // Sync devices dont appear in private mode
+    
     headerView.do {
       $0.imageIconView.image = deviceTypeImage?.template
       $0.titleLabel.text = sectionDetails.name
@@ -89,8 +90,8 @@ extension TabTrayController: UITableViewDataSource, UITableViewDelegate {
       $0.isCollapsed = hiddenSections.contains(section)
       $0.section = section
       $0.delegate = self
-      $0.backgroundColor = .secondaryBraveBackground
-      $0.tintColor = .secondaryBraveBackground
+      $0.backgroundColor = browserColors.chromeBackground
+      $0.tintColor = browserColors.chromeBackground
     }
          
     return headerView

--- a/Sources/Brave/Frontend/Browser/Tabs/TabTray/Views/TabSyncContainerView.swift
+++ b/Sources/Brave/Frontend/Browser/Tabs/TabTray/Views/TabSyncContainerView.swift
@@ -28,7 +28,7 @@ extension TabTrayController {
     override init(frame: CGRect) {
       super.init(frame: frame)
       
-      backgroundColor = .braveBackground
+      backgroundColor = .clear
       
       addSubview(tableView)
       tableView.snp.makeConstraints { make in
@@ -38,7 +38,7 @@ extension TabTrayController {
       tableView.do {
         $0.register(TabSyncTableViewCell.self)
         $0.registerHeaderFooter(TabSyncHeaderView.self)
-        $0.backgroundColor = .secondaryBraveBackground
+        $0.backgroundColor = .clear
         $0.estimatedRowHeight = SiteTableViewControllerUX.rowHeight
         $0.estimatedSectionHeaderHeight = SiteTableViewControllerUX.rowHeight
         $0.separatorColor = .braveSeparator

--- a/Sources/Brave/Frontend/Browser/Tabs/TabTray/Views/TabTrayContainerView.swift
+++ b/Sources/Brave/Frontend/Browser/Tabs/TabTray/Views/TabTrayContainerView.swift
@@ -45,7 +45,7 @@ extension TabTrayController {
 
     lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: generateLayout(numberOfColumns: numberOfColumns)).then {
       $0.setContentHuggingPriority(.defaultLow, for: .vertical)
-      $0.backgroundColor = .secondaryBraveBackground
+      $0.backgroundColor = .clear
       $0.register(TabCell.self, forCellWithReuseIdentifier: TabCell.identifier)
     }
 
@@ -60,7 +60,6 @@ extension TabTrayController {
     override init(frame: CGRect) {
       super.init(frame: frame)
 
-      backgroundColor = .braveBackground
       accessibilityLabel = Strings.tabTrayAccessibilityLabel
 
       let stackView = UIStackView().then {

--- a/Sources/Brave/Frontend/Browser/Tabs/TabTray/Views/TabTrayPrivateModeInfoView.swift
+++ b/Sources/Brave/Frontend/Browser/Tabs/TabTray/Views/TabTrayPrivateModeInfoView.swift
@@ -73,8 +73,6 @@ extension TabTrayController {
     override init(frame: CGRect) {
       super.init(frame: frame)
 
-      backgroundColor = .secondaryBraveBackground
-
       addSubview(scrollView)
       scrollView.addSubview(stackView)
       stackView.addArrangedSubview(iconImageView)

--- a/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/EmptyStateOverlayView.swift
+++ b/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/EmptyStateOverlayView.swift
@@ -109,8 +109,6 @@ class EmptyStateOverlayView: UIView {
   }
   
   private func doLayout(details: EmptyOverlayStateDetails) {
-    backgroundColor = .secondaryBraveBackground
-    
     let heightOffset = traitCollection.verticalSizeClass == .compact ? 0 : -50
 
     addSubview(containerView)

--- a/Sources/Brave/Frontend/Browser/Toolbars/ToolbarButton.swift
+++ b/Sources/Brave/Frontend/Browser/Toolbars/ToolbarButton.swift
@@ -18,38 +18,42 @@ extension UITraitCollection {
 }
 
 class ToolbarButton: UIButton {
-  fileprivate var selectedTintColor: UIColor?
-  fileprivate var primaryTintColor: UIColor?
-  fileprivate var disabledTintColor: UIColor?
+  var selectedTintColor: UIColor? {
+    didSet {
+      updateTintColor()
+    }
+  }
+  var primaryTintColor: UIColor? {
+    didSet {
+      updateTintColor()
+    }
+  }
+  var disabledTintColor: UIColor? {
+    didSet {
+      updateTintColor()
+    }
+  }
 
-  required init() {
+  init() {
     super.init(frame: .zero)
     adjustsImageWhenHighlighted = false
     imageView?.contentMode = .scaleAspectFit
-
-    selectedTintColor = .braveBlurpleTint
-    primaryTintColor = .braveLabel
-    tintColor = primaryTintColor
-    imageView?.tintColor = tintColor
   }
-
-  override init(frame: CGRect) {
-    fatalError("init(coder:) has not been implemented")
-  }
-
-  required init?(coder aDecoder: NSCoder) {
-    fatalError("init(coder:) has not been implemented")
+  
+  @available(*, unavailable)
+  required init(coder: NSCoder) {
+    fatalError()
   }
 
   override open var isHighlighted: Bool {
     didSet {
-      self.tintColor = isHighlighted ? selectedTintColor : primaryTintColor
+      updateTintColor()
     }
   }
 
   override open var isEnabled: Bool {
     didSet {
-      self.tintColor = primaryTintColor?.withAlphaComponent(isEnabled ? 1.0 : 0.4)
+      updateTintColor()
     }
   }
 
@@ -57,6 +61,23 @@ class ToolbarButton: UIButton {
     didSet {
       self.imageView?.tintColor = self.tintColor
     }
+  }
+  
+  private func updateTintColor() {
+    let tintColor: UIColor? = {
+      if !isEnabled {
+        if let disabledTintColor {
+          return disabledTintColor
+        } else {
+          return primaryTintColor?.withAlphaComponent(0.4)
+        }
+      }
+      if isHighlighted {
+        return selectedTintColor
+      }
+      return primaryTintColor
+    }()
+    self.tintColor = tintColor
   }
 
   override func contextMenuInteraction(_ interaction: UIContextMenuInteraction, willDisplayMenuFor configuration: UIContextMenuConfiguration, animator: UIContextMenuInteractionAnimating?) {

--- a/Sources/Brave/Frontend/Browser/Toolbars/ToolbarHelper.swift
+++ b/Sources/Brave/Frontend/Browser/Toolbars/ToolbarHelper.swift
@@ -85,7 +85,7 @@ class ToolbarHelper: NSObject {
     toolbar.tabToolbarDelegate?.tabToolbarDidPressSearch(toolbar, button: toolbar.searchButton)
   }
   
-  func updateForTraitCollection(_ traitCollection: UITraitCollection, additionalButtons: [UIButton] = []) {
+  func updateForTraitCollection(_ traitCollection: UITraitCollection, browserColors: some BrowserColors, additionalButtons: [UIButton] = []) {
     let toolbarTraitCollection = UITraitCollection(preferredContentSizeCategory: traitCollection.toolbarButtonContentSizeCategory)
     let config = UIImage.SymbolConfiguration(pointSize: UIFont.preferredFont(forTextStyle: .body, compatibleWith: toolbarTraitCollection).pointSize, weight: .regular, scale: .large)
     let buttons: [UIButton] = [
@@ -97,6 +97,13 @@ class ToolbarHelper: NSObject {
     ] + additionalButtons
     for button in buttons {
       button.setPreferredSymbolConfiguration(config, forImageIn: .normal)
+      button.tintColor = browserColors.iconDefault
+      if let button = button as? ToolbarButton {
+        button.primaryTintColor = browserColors.iconDefault
+        button.selectedTintColor = browserColors.iconActive
+        button.disabledTintColor = browserColors.iconDisabled
+      }
     }
+    toolbar.tabsButton.browserColors = browserColors
   }
 }

--- a/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/CollapsedURLBarView.swift
+++ b/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/CollapsedURLBarView.swift
@@ -36,6 +36,12 @@ class CollapsedURLBarView: UIView {
     $0.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
   }
   
+  var browserColors: any BrowserColors = .standard {
+    didSet {
+      updateForTraitCollectionAndBrowserColors()
+    }
+  }
+  
   var isUsingBottomBar: Bool = false {
     didSet {
       setNeedsUpdateConstraints()
@@ -101,15 +107,15 @@ class CollapsedURLBarView: UIView {
       $0.centerX.equalToSuperview()
     }
     
-    updateForTraitCollection()
+    updateForTraitCollectionAndBrowserColors()
   }
   
   override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
     super.traitCollectionDidChange(previousTraitCollection)
-    updateForTraitCollection()
+    updateForTraitCollectionAndBrowserColors()
   }
   
-  private func updateForTraitCollection() {
+  private func updateForTraitCollectionAndBrowserColors() {
     let clampedTraitCollection = traitCollection.clampingSizeCategory(maximum: .accessibilityLarge)
     lockImageView.setPreferredSymbolConfiguration(
       .init(
@@ -122,6 +128,8 @@ class CollapsedURLBarView: UIView {
       forImageIn: .normal
     )
     urlLabel.font = .preferredFont(forTextStyle: .caption1, compatibleWith: clampedTraitCollection)
+    lockImageView.tintColor = browserColors.iconDefault
+    urlLabel.textColor = browserColors.textPrimary
   }
   
   override func updateConstraints() {

--- a/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/ReaderModeButton.swift
+++ b/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/ReaderModeButton.swift
@@ -6,8 +6,16 @@ import UIKit
 import DesignSystem
 
 class ReaderModeButton: UIButton {
-  var selectedTintColor: UIColor?
-  var unselectedTintColor: UIColor?
+  var selectedTintColor: UIColor? {
+    didSet {
+      updateAppearance()
+    }
+  }
+  var unselectedTintColor: UIColor? {
+    didSet {
+      updateAppearance()
+    }
+  }
 
   override init(frame: CGRect) {
     super.init(frame: frame)

--- a/Sources/Brave/Frontend/Widgets/TabsButton.swift
+++ b/Sources/Brave/Frontend/Widgets/TabsButton.swift
@@ -17,7 +17,6 @@ class TabsButton: UIButton {
   private let countLabel = UILabel().then {
     $0.textAlignment = .center
     $0.isUserInteractionEnabled = false
-    $0.textColor = .braveLabel
   }
 
   private let borderView = UIView().then {
@@ -25,6 +24,12 @@ class TabsButton: UIButton {
     $0.layer.cornerRadius = TabsButtonUX.cornerRadius
     $0.layer.cornerCurve = .continuous
     $0.isUserInteractionEnabled = false
+  }
+  
+  var browserColors: any BrowserColors = .standard {
+    didSet {
+      updateForTraitCollectionAndBrowserColors()
+    }
   }
 
   override init(frame: CGRect) {
@@ -40,7 +45,7 @@ class TabsButton: UIButton {
     countLabel.snp.makeConstraints {
       $0.edges.equalToSuperview()
     }
-    updateForTraitCollection()
+    updateForTraitCollectionAndBrowserColors()
   }
 
   @available(*, unavailable)
@@ -50,7 +55,7 @@ class TabsButton: UIButton {
 
   override var isHighlighted: Bool {
     didSet {
-      let color: UIColor = isHighlighted ? .braveBlurpleTint : .braveLabel
+      let color: UIColor = isHighlighted ? browserColors.iconActive : browserColors.iconDefault
       countLabel.textColor = color
       borderView.layer.borderColor = color.resolvedColor(with: traitCollection).cgColor
     }
@@ -58,12 +63,13 @@ class TabsButton: UIButton {
 
   override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
     super.traitCollectionDidChange(previousTraitCollection)
-    updateForTraitCollection()
+    updateForTraitCollectionAndBrowserColors()
   }
   
-  private func updateForTraitCollection() {
+  private func updateForTraitCollectionAndBrowserColors() {
     // CGColor's do not get automatic updates
-    borderView.layer.borderColor = isHighlighted ? UIColor.braveBlurpleTint.cgColor : UIColor.braveLabel.resolvedColor(with: traitCollection).cgColor
+    countLabel.textColor = isHighlighted ? browserColors.iconActive : browserColors.iconDefault
+    borderView.layer.borderColor = isHighlighted ? browserColors.iconActive.cgColor : browserColors.iconDefault.resolvedColor(with: traitCollection).cgColor
     
     let toolbarTraitCollection = UITraitCollection(preferredContentSizeCategory: traitCollection.toolbarButtonContentSizeCategory)
     let metrics = UIFontMetrics(forTextStyle: .body)

--- a/Sources/BraveUI/Buttons/InsetButton.swift
+++ b/Sources/BraveUI/Buttons/InsetButton.swift
@@ -47,7 +47,7 @@ public class SelectedInsetButton: InsetButton {
     }
   }
 
-  var selectedBackgroundColor: UIColor? {
+  public var selectedBackgroundColor: UIColor? {
     didSet {
       if isSelected {
         backgroundColor = selectedBackgroundColor

--- a/Sources/DesignSystem/Colors/LegacyColors.swift
+++ b/Sources/DesignSystem/Colors/LegacyColors.swift
@@ -168,37 +168,9 @@ extension UIColor {
   }
 }
 
-extension UIColor {
-  public static var urlBarBackground: UIColor {
-    .init { traitCollection in
-      if traitCollection.userInterfaceStyle == .dark {
-        return .tertiaryBraveBackground
-      }
-      return .secondaryBraveBackground
-    }
-  }
-  public static var urlBarSeparator: UIColor {
-    .init { traitCollection in
-      if traitCollection.userInterfaceStyle == .dark {
-        return UIColor(white: 1.0, alpha: 0.1)
-      }
-      return .braveSeparator
-    }
-  }
-  public static var nightModeBackground: UIColor {
-    return .secondaryBraveBackground
-  }
-}
-
 // MARK: - Static Colors
 
 extension UIColor {
-  public static var privateModeBackground: UIColor {
-    .init(hex: 0x2C2153)
-  }
-  public static var secondaryPrivateModeBackground: UIColor {
-    .init(hex: 0x0D0920)
-  }
   public static var statsAdsBlockedTint: UIColor {
     .braveOrange
   }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes #8078 
This pull request fixes #6839

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

- Test browser chrome UI across light, dark and private mode

## Screenshots:

Examples:

| Light | Dark | Private |
| --- | --- | --- |
| ![Simulator Screenshot - iPhone 15 Pro - 2023-09-18 at 11 22 26](https://github.com/brave/brave-ios/assets/529104/4ec4c047-e48a-45ac-81f5-b1e1081c6e2b) | ![Simulator Screenshot - iPhone 15 Pro - 2023-09-18 at 11 22 29](https://github.com/brave/brave-ios/assets/529104/6ae05e43-b104-4e5f-aff4-a145e5dc50ca) | ![Simulator Screenshot - iPhone 15 Pro - 2023-09-18 at 11 22 35](https://github.com/brave/brave-ios/assets/529104/df0585d0-c53a-4e9e-a28d-86102bec2a9c) |

But there are many more changes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
