### PR TITLE
Fix #8056: Update P3A callout text.

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Callout.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Callout.swift
@@ -75,7 +75,7 @@ extension BrowserViewController {
         toggleTitle: Strings.Callout.p3aCalloutToggleTitle,
         details: Strings.Callout.p3aCalloutDescription,
         linkDescription: Strings.Callout.p3aCalloutLinkTitle,
-        primaryButtonTitle: Strings.done,
+        primaryButtonTitle: Strings.P3A.continueButton,
         toggleAction: { [weak self] isOn in
           self?.braveCore.p3aUtils.isP3AEnabled = isOn
         },

--- a/Sources/BraveStrings/BraveStrings.swift
+++ b/Sources/BraveStrings/BraveStrings.swift
@@ -4576,6 +4576,11 @@ extension Strings {
       "p3a.settingSubtitle", tableName: "BraveShared", bundle: .module,
       value: "Anonymised P3A info helps Brave estimate overall usage and ensure we're improving popular features.",
       comment: "A subtitle shown on the setting that toggles analytics on Brave.")
+    
+    public static let continueButton = NSLocalizedString(
+      "p3a.continue", tableName: "BraveShared", bundle: .module,
+      value: "Continue",
+      comment: "A button to proceed with the rest of the user onboarding after they see the P3A introduction. It means to continue browsing or continue with the rest of the onboarding")
   }
 }
 

--- a/Sources/Onboarding/Welcome/WelcomeViewController.swift
+++ b/Sources/Onboarding/Welcome/WelcomeViewController.swift
@@ -364,7 +364,7 @@ public class WelcomeViewController: UIViewController {
         toggleTitle: Strings.Callout.p3aCalloutToggleTitle,
         details: Strings.Callout.p3aCalloutDescription,
         linkDescription: Strings.Callout.p3aCalloutLinkTitle,
-        primaryButtonTitle: Strings.done,
+        primaryButtonTitle: Strings.P3A.continueButton,
         toggleAction: { [weak self] isOn in
           self?.p3aUtilities.isP3AEnabled = isOn
         },


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8056 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
