### PR TITLE
Fix #8009: Update toolbar constraints to utilize safe area properly

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController.swift
@@ -1287,8 +1287,6 @@ public class BrowserViewController: UIViewController {
     footer.snp.remakeConstraints { make in
       make.bottom.equalTo(toolbarLayoutGuide)
       make.leading.trailing.equalTo(self.view)
-      let height = self.toolbar == nil ? 0 : UIConstants.bottomToolbarHeight
-      make.height.equalTo(height)
     }
 
     bottomBarKeyboardBackground.snp.remakeConstraints {

--- a/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/BottomToolbarView.swift
+++ b/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/BottomToolbarView.swift
@@ -99,6 +99,7 @@ class BottomToolbarView: UIView, ToolbarProtocol {
     contentView.snp.makeConstraints { make in
       make.leading.trailing.top.equalTo(self)
       make.bottom.equalTo(self.safeArea.bottom)
+      make.height.equalTo(UIConstants.toolbarHeight)
     }
     super.updateConstraints()
   }

--- a/Sources/Brave/Frontend/UIConstants.swift
+++ b/Sources/Brave/Frontend/UIConstants.swift
@@ -11,13 +11,7 @@ public struct UIConstants {
   static let defaultPadding: CGFloat = 10
   static let snackbarButtonHeight: CGFloat = 48
   static var toolbarHeight: CGFloat = 44
-  static var bottomToolbarHeight: CGFloat {
-    get {
-      let bottomInset: CGFloat = UIApplication.shared.keyWindow?.safeAreaInsets.bottom ?? 0.0
-      return toolbarHeight + bottomInset
-    }
-  }
-
+  
   // Static fonts
   static let defaultChromeSize: CGFloat = 16
   static let defaultChromeSmallSize: CGFloat = 11


### PR DESCRIPTION
The value of `UIApplication.shared.keyWindow?.safeAreaInsets.bottom` is not updated when the `updateViewConstraints` method is called. However calculating this height manually is not correct/not needed, as we can simply rely on the safe area layout guides

Bonus: `UIApplication.shared.keyWindow` is actually deprecated, so 1 less usage of this now exists in the codebase

## Summary of Changes

This pull request fixes #8009 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
