### PR TITLE
Fix #8085: Update widgets to support building with Xcode 15/iOS 17 SDK

### DIFF
--- a/App/BraveWidgets/FavoritesWidget.swift
+++ b/App/BraveWidgets/FavoritesWidget.swift
@@ -17,6 +17,9 @@ struct FavoritesWidget: Widget {
     .configurationDisplayName(Strings.Widgets.favoritesWidgetTitle)
     .description(Strings.Widgets.favoritesWidgetDescription)
     .supportedFamilies([.systemMedium, .systemLarge])
+#if swift(>=5.9)
+    .contentMarginsDisabled()
+#endif
   }
 }
 
@@ -82,7 +85,7 @@ private struct FavoritesView: View {
       }
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
-    .background(Color(UIColor.secondaryBraveBackground))
+    .widgetBackground { Color(UIColor.secondaryBraveBackground) }
   }
 }
 

--- a/App/BraveWidgets/LockScreenFavoriteWidget.swift
+++ b/App/BraveWidgets/LockScreenFavoriteWidget.swift
@@ -71,44 +71,45 @@ private struct LockScreenFavoriteView: View {
   var entry: LockScreenFavoriteEntry
   
   var body: some View {
-    if let fav = entry.favorite {
-      Group {
-        if let attributes = fav.favicon, let image = attributes.image {
-          FaviconImage(image: image, contentMode: .scaleAspectFit, includePadding: false) // includePadding forced to false here since we are providing our own padding below
-            .background(attributes.backgroundColor.cgColor.alpha == 0 ? .white :  Color(attributes.backgroundColor))
-            .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
-            .padding(12)
-            .background(Color.black)
-        } else {
-          Text(verbatim: fav.url.baseDomain?.first?.uppercased() ?? "")
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .font(.system(size: 28))
-            .clipped()
-            .padding(4)
-            .background(
-              Color.white.aspectRatio(1, contentMode: .fit)
-                .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
-            )
-            .padding(12)
-            .foregroundColor(Color.black)
-            .background(Color.black)
+    ZStack {
+      AccessoryWidgetBackground()
+        .widgetBackground { EmptyView() }
+      if let fav = entry.favorite {
+        Group {
+          if let attributes = fav.favicon, let image = attributes.image {
+            FaviconImage(image: image, contentMode: .scaleAspectFit, includePadding: false) // includePadding forced to false here since we are providing our own padding below
+              .background(attributes.backgroundColor.cgColor.alpha == 0 ? .white :  Color(attributes.backgroundColor))
+              .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+              .padding(12)
+          } else {
+            Text(verbatim: fav.url.baseDomain?.first?.uppercased() ?? "")
+              .frame(maxWidth: .infinity, maxHeight: .infinity)
+              .font(.system(size: 28))
+              .clipped()
+              .padding(4)
+              .background(
+                Color.white.aspectRatio(1, contentMode: .fit)
+                  .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+              )
+              .padding(12)
+              .foregroundColor(Color.black)
+          }
         }
+        .accessibilityLabel(fav.title ?? fav.url.absoluteString)
+        .widgetLabel(fav.title ?? "")
+        .widgetURL(fav.url)
+      } else {
+        Image(braveSystemName: "leo.brave.icon-monochrome")
+          .imageScale(.large)
+          .font(.system(size: 24))
+          .foregroundColor(Color.black)
+          .frame(maxWidth: .infinity, maxHeight: .infinity)
+          .background(
+            Color(white: 0.9)
+              .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+              .padding(12)
+          )
       }
-      .accessibilityLabel(fav.title ?? fav.url.absoluteString)
-      .widgetLabel(fav.title ?? "")
-      .widgetURL(fav.url)
-    } else {
-      Image(braveSystemName: "leo.brave.icon-monochrome")
-        .imageScale(.large)
-        .font(.system(size: 24))
-        .foregroundColor(Color.black)
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(
-          Color(white: 0.9)
-            .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
-            .padding(12)
-        )
-        .background(Color.black)
     }
   }
 }

--- a/App/BraveWidgets/LockScreenShortcutWidget.swift
+++ b/App/BraveWidgets/LockScreenShortcutWidget.swift
@@ -58,29 +58,18 @@ struct LockScreenShortcutView: View {
   var entry: LockScreenShortcutEntry
   
   var body: some View {
-    Color.black
-      .overlay(
-        entry.widgetShortcut.image
-          .imageScale(.large)
-          .font(.system(size: 20))
-          .widgetLabel(entry.widgetShortcut.displayString)
-          .accessibilityLabel(Text(entry.widgetShortcut.displayString))
-          .unredacted()
-      )
-      .widgetURL(URL(string: "\(AppURLScheme.appURLScheme)://shortcut?path=\(entry.widgetShortcut.rawValue)"))
-  }
-}
-
-#if DEBUG
-struct LockScreenShortcutPreviews: PreviewProvider {
-  static var previews: some View {
-    if #available(iOS 16.0, *) {
-      ForEach([WidgetShortcut.playlist, .bookmarks, .newTab, .newPrivateTab, .downloads, .history, .wallet, .search], id: \.self) { shortcut in
-        LockScreenShortcutView(entry: .init(date: Date(), widgetShortcut: shortcut))
-          .previewDisplayName(shortcut.displayString)
-      }
-        .previewContext(WidgetPreviewContext(family: .accessoryCircular))
+    ZStack {
+      AccessoryWidgetBackground()
+        .widgetBackground { EmptyView() }
+      entry.widgetShortcut.image
+        .imageScale(.large)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .font(.system(size: 20))
+        .widgetLabel(entry.widgetShortcut.displayString)
+        .accessibilityLabel(Text(entry.widgetShortcut.displayString))
+        .unredacted()
+        .widgetURL(URL(string: "\(AppURLScheme.appURLScheme)://shortcut?path=\(entry.widgetShortcut.rawValue)"))
     }
   }
 }
-#endif
+

--- a/App/BraveWidgets/News Topics/NewsTopicsModel.swift
+++ b/App/BraveWidgets/News Topics/NewsTopicsModel.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 import CodableHelpers
-import Collections
+import OrderedCollections
 import UIKit
 
 /// Handles fetching Brave News Topics for widgets

--- a/App/BraveWidgets/ShortcutsWidget.swift
+++ b/App/BraveWidgets/ShortcutsWidget.swift
@@ -22,6 +22,9 @@ struct ShortcutsWidget: Widget {
     .configurationDisplayName(Strings.Widgets.shortcutsWidgetTitle)
     .description(Strings.Widgets.shortcutsWidgetDescription)
     .supportedFamilies([.systemMedium])
+#if swift(>=5.9)
+    .contentMarginsDisabled()
+#endif
   }
 }
 
@@ -214,12 +217,19 @@ private struct ShortcutsView: View {
       .frame(maxHeight: .infinity)
     }
     .padding(8)
-    .background(Color(UIColor.secondaryBraveBackground))
+    .widgetBackground { Color(UIColor.secondaryBraveBackground) }
   }
 }
 
 // MARK: - Previews
 
+#if swift(>=5.9)
+#Preview(as: .systemMedium, widget: {
+  ShortcutsWidget()
+}, timeline: {
+  ShortcutEntry(date: .now, shortcutSlots: [.newTab, .newPrivateTab, .bookmarks])
+})
+#else
 #if DEBUG
 struct ShortcutsWidget_Previews: PreviewProvider {
   static var previews: some View {
@@ -231,4 +241,5 @@ struct ShortcutsWidget_Previews: PreviewProvider {
       .previewContext(WidgetPreviewContext(family: .systemMedium))
   }
 }
+#endif
 #endif

--- a/App/BraveWidgets/SingleStatWidget.swift
+++ b/App/BraveWidgets/SingleStatWidget.swift
@@ -72,8 +72,7 @@ private struct StatView: View {
         .unredacted()
     }
     .frame(maxWidth: .infinity, alignment: .leading)
-    .padding()
-    .background(Color(UIColor.secondaryBraveBackground))
+    .widgetBackground { Color(UIColor.secondaryBraveBackground) }
     .foregroundColor(Color(UIColor.braveLabel))
   }
 }

--- a/App/BraveWidgets/StatsWidget.swift
+++ b/App/BraveWidgets/StatsWidget.swift
@@ -16,6 +16,9 @@ struct StatsWidget: Widget {
     .supportedFamilies([.systemMedium])
     .configurationDisplayName(Strings.Widgets.shieldStatsTitle)
     .description(Strings.Widgets.shieldStatsDescription)
+#if swift(>=5.9)
+    .contentMarginsDisabled()
+#endif
   }
 }
 
@@ -95,7 +98,7 @@ private struct StatsView: View {
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .padding(.vertical, 12)
     .padding(.horizontal, 16)
-    .background(Color(UIColor.secondaryBraveBackground))
+    .widgetBackground { Color(UIColor.secondaryBraveBackground) }
     .foregroundColor(Color(UIColor.braveLabel))
   }
 }

--- a/App/BraveWidgets/TopNewsListWidget.swift
+++ b/App/BraveWidgets/TopNewsListWidget.swift
@@ -22,6 +22,9 @@ struct TopNewsListWidget: Widget {
     .supportedFamilies([.systemMedium, .systemLarge])
     .configurationDisplayName(Strings.Widgets.newsClusteringWidgetTitle)
     .description(Strings.Widgets.newsClusteringWidgetDescription)
+#if swift(>=5.9)
+    .contentMarginsDisabled()
+#endif
   }
 }
 
@@ -91,74 +94,76 @@ private struct TopNewsListView: View {
   }
   
   var body: some View {
-    if let topics = entry.topics, !topics.isEmpty {
-      VStack(alignment: .leading, spacing: widgetFamily == .systemLarge ? 12 : 8) {
-        headerView
-          .background(Color(.braveGroupedBackground))
-        VStack(alignment: .leading, spacing: 8) {
-          ForEach(topics.prefix(widgetFamily == .systemLarge ? 5 : 2)) { topic in
-            HStack {
-              Link(destination: topic.url) {
-                VStack(alignment: .leading, spacing: 2) {
-                  Text(topic.title)
-                    .lineLimit(widgetFamily == .systemLarge ? 3 : 2)
-                    .font(.system(size: widgetFamily == .systemLarge ? 14 : 13, weight: .semibold, design: .rounded))
-                    .foregroundColor(.primary)
-                  Text(topic.publisherName)
-                    .lineLimit(1)
-                    .font(.system(size: 10, weight: .medium, design: .rounded))
-                    .foregroundColor(.secondary)
+    Group {
+      if let topics = entry.topics, !topics.isEmpty {
+        VStack(alignment: .leading, spacing: widgetFamily == .systemLarge ? 12 : 8) {
+          headerView
+            .background(Color(.braveGroupedBackground))
+          VStack(alignment: .leading, spacing: 8) {
+            ForEach(topics.prefix(widgetFamily == .systemLarge ? 5 : 2)) { topic in
+              HStack {
+                Link(destination: topic.url) {
+                  VStack(alignment: .leading, spacing: 2) {
+                    Text(topic.title)
+                      .lineLimit(widgetFamily == .systemLarge ? 3 : 2)
+                      .font(.system(size: widgetFamily == .systemLarge ? 14 : 13, weight: .semibold, design: .rounded))
+                      .foregroundColor(.primary)
+                    Text(topic.publisherName)
+                      .lineLimit(1)
+                      .font(.system(size: 10, weight: .medium, design: .rounded))
+                      .foregroundColor(.secondary)
+                  }
                 }
-              }
-              if let image = entry.images[topic.id] {
-                Spacer()
-                Color.clear
-                  .aspectRatio(1, contentMode: .fit)
-                  .frame(maxHeight: 50)
-                  .overlay(
-                    Image(uiImage: image)
-                      .resizable()
-                      .aspectRatio(contentMode: .fill)
-                  )
-                  .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
-                  .overlay(RoundedRectangle(cornerRadius: 8, style: .continuous).strokeBorder(Color.primary.opacity(0.3), lineWidth: pixelLength))
+                if let image = entry.images[topic.id] {
+                  Spacer()
+                  Color.clear
+                    .aspectRatio(1, contentMode: .fit)
+                    .frame(maxHeight: 50)
+                    .overlay(
+                      Image(uiImage: image)
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                    )
+                    .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+                    .overlay(RoundedRectangle(cornerRadius: 8, style: .continuous).strokeBorder(Color.primary.opacity(0.3), lineWidth: pixelLength))
+                }
               }
             }
           }
+          .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+          .padding(.horizontal)
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-        .padding(.horizontal)
-      }
-      .padding(.bottom)
-    } else {
-      ZStack(alignment: .top) {
-        Text(Strings.Widgets.newsClusteringErrorLabel)
-          .font(.system(size: widgetFamily == .systemLarge ? 26 : 18, weight: .semibold, design: .rounded))
-        .padding()
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background {
-          LinearGradient(braveGradient: .darkGradient01)
-          .mask {
-            Image("brave-today-error")
-              .renderingMode(.template)
-              .resizable(resizingMode: .tile)
-              .opacity(0.1)
-              .rotationEffect(.degrees(-45))
-              .scaleEffect(x: 2.1, y: 2.1)
-          }
+        .padding(.bottom)
+      } else {
+        ZStack(alignment: .top) {
+          Text(Strings.Widgets.newsClusteringErrorLabel)
+            .font(.system(size: widgetFamily == .systemLarge ? 26 : 18, weight: .semibold, design: .rounded))
+            .padding()
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background {
+              LinearGradient(braveGradient: .darkGradient01)
+                .mask {
+                  Image("brave-today-error")
+                    .renderingMode(.template)
+                    .resizable(resizingMode: .tile)
+                    .opacity(0.1)
+                    .rotationEffect(.degrees(-45))
+                    .scaleEffect(x: 2.1, y: 2.1)
+                }
+            }
+          headerView
+            .background {
+              LinearGradient(
+                colors: [Color(.braveBackground), Color(.braveBackground).opacity(0.0)],
+                startPoint: .top,
+                endPoint: .bottom
+              )
+            }
         }
-        headerView
-          .background {
-            LinearGradient(
-              colors: [Color(.braveBackground), Color(.braveBackground).opacity(0.0)],
-              startPoint: .top,
-              endPoint: .bottom
-            )
-          }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
       }
-      .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-      .background(Color(.braveBackground))
     }
+    .widgetBackground { Color(.braveBackground) }
   }
 }
 

--- a/App/BraveWidgets/TopNewsWidget.swift
+++ b/App/BraveWidgets/TopNewsWidget.swift
@@ -10,7 +10,7 @@ import Shared
 import DesignSystem
 import os
 import AVFoundation
-import Collections
+import OrderedCollections
 
 struct TopNewsWidget: Widget {
   var supportedFamilies: [WidgetFamily] {
@@ -28,6 +28,10 @@ struct TopNewsWidget: Widget {
     .supportedFamilies(supportedFamilies)
     .configurationDisplayName(Strings.Widgets.newsClusteringWidgetTitle)
     .description(Strings.Widgets.newsClusteringWidgetDescription)
+#if swift(>=5.9)
+    .contentMarginsDisabled()
+    .containerBackgroundRemovable(false)
+#endif
   }
 }
 
@@ -144,6 +148,7 @@ private struct LockScreenTopNewsView: View {
       .allowsTightening(true)
       .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
       .widgetURL(topic.url)
+      .widgetBackground { Color.clear }
     } else {
       VStack(spacing: 4) {
         Image("brave-today-error")
@@ -163,6 +168,7 @@ private struct LockScreenTopNewsView: View {
       }
       .allowsTightening(true)
       .frame(maxWidth: .infinity, maxHeight: .infinity)
+      .widgetBackground { Color.clear }
     }
   }
 }
@@ -199,22 +205,20 @@ private struct WidgetTopNewsView: View {
       }
       .padding()
       .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
-      .background(
-        Group {
-          if let image = entry.image {
-            Image(uiImage: image)
-              .resizable()
-              .aspectRatio(contentMode: .fill)
-              .overlay(
-                LinearGradient(
-                  colors: [.black.opacity(0.0), .black.opacity(0.6)], startPoint: .top, endPoint: .bottom
-                )
+      .widgetBackground {
+        if let image = entry.image {
+          Image(uiImage: image)
+            .resizable()
+            .aspectRatio(contentMode: .fill)
+            .overlay(
+              LinearGradient(
+                colors: [.black.opacity(0.0), .black.opacity(0.6)], startPoint: .top, endPoint: .bottom
               )
-          } else {
-            LinearGradient(braveGradient: .darkGradient01)
-          }
+            )
+        } else {
+          LinearGradient(braveGradient: .darkGradient01)
         }
-      )
+      }
       .widgetURL(topic.url)
     } else {
       VStack(alignment: .leading) {
@@ -230,7 +234,7 @@ private struct WidgetTopNewsView: View {
       }
       .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
       .padding()
-      .background {
+      .widgetBackground {
         LinearGradient(braveGradient: .darkGradient01)
           .mask {
             Image("brave-today-error")
@@ -241,7 +245,7 @@ private struct WidgetTopNewsView: View {
               .scaleEffect(x: 1.5, y: 1.5)
           }
       }
-      .background(Color(.braveBackground))
+//      .background(Color(.braveBackground))
     }
   }
 }

--- a/App/BraveWidgets/WidgetBackground.swift
+++ b/App/BraveWidgets/WidgetBackground.swift
@@ -1,0 +1,33 @@
+// Copyright 2022 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import WidgetKit
+import SwiftUI
+
+struct WidgetBackgroundViewModifier<BackgroundContent: View>: ViewModifier {
+  var backgroundView: BackgroundContent
+  
+  func body(content: Content) -> some View {
+#if swift(>=5.9)
+    if #available(iOS 17.0, *) {
+      content.containerBackground(for: .widget) {
+        backgroundView
+      }
+    } else {
+      content.background(backgroundView)
+    }
+#else
+    content.background(backgroundView)
+#endif
+  }
+}
+
+extension View {
+  /// Adds a `containerBackground` on iOS 17
+  func widgetBackground<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
+    modifier(WidgetBackgroundViewModifier(backgroundView: content()))
+  }
+}

--- a/App/Client.xcodeproj/project.pbxproj
+++ b/App/Client.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		0A5E04F923FEADA800E5A3E9 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0A5E04F823FEADA800E5A3E9 /* LaunchScreen.storyboard */; };
 		0A5E04FB23FEB53700E5A3E9 /* LaunchScreen.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0A5E04FA23FEB53700E5A3E9 /* LaunchScreen.xcassets */; };
 		270ECFC82838210F0089B8B7 /* Brave in Frameworks */ = {isa = PBXBuildFile; productRef = 270ECFC72838210F0089B8B7 /* Brave */; };
+		2713FCD82A96429600398A57 /* WidgetBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2713FCD72A96429100398A57 /* WidgetBackground.swift */; };
 		272947DE29C8DB2000BF2FDC /* topics_news.en_US.json in Resources */ = {isa = PBXBuildFile; fileRef = 27444B6A29831BBE002E1EBE /* topics_news.en_US.json */; };
 		272947E329C8F86A00BF2FDC /* NewsTopicsModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 272947E029C8F6F200BF2FDC /* NewsTopicsModel.swift */; };
 		272FC5AF2979EA700027C53D /* TopNewsWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 272FC5AE2979E9D60027C53D /* TopNewsWidget.swift */; };
@@ -165,6 +166,7 @@
 		0A6AC4E824484FBC003D1ED7 /* StoreKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = StoreKit.framework; path = System/Library/Frameworks/StoreKit.framework; sourceTree = SDKROOT; };
 		2703FC14284FDB6300970FD2 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = Shortcuts/ru.lproj/BrowserIntents.strings; sourceTree = "<group>"; };
 		270ECFC628381E270089B8B7 /* brave-ios */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "brave-ios"; path = ..; sourceTree = "<group>"; };
+		2713FCD72A96429100398A57 /* WidgetBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetBackground.swift; sourceTree = "<group>"; };
 		271D0F3A284FDB12002BCF91 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = Shortcuts/it.lproj/BrowserIntents.strings; sourceTree = "<group>"; };
 		27262B4C28BEB3D800A2E526 /* Intents.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Intents.framework; path = System/Library/Frameworks/Intents.framework; sourceTree = SDKROOT; };
 		272947E029C8F6F200BF2FDC /* NewsTopicsModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsTopicsModel.swift; sourceTree = "<group>"; };
@@ -567,6 +569,7 @@
 				272947DF29C8DE4300BF2FDC /* News Topics */,
 				27444B6929831B9E002E1EBE /* Development Assets */,
 				CA0391DA271E12D9000EB13C /* Entitlements */,
+				2713FCD72A96429100398A57 /* WidgetBackground.swift */,
 				27A28ED428C00C19001466A4 /* LockScreenShortcutWidget.swift */,
 				27DB270728BE9CAE005CB7AC /* LockScreenFavoriteWidget.swift */,
 				CA0391F4271E143F000EB13C /* FavoritesWidget.swift */,
@@ -1016,6 +1019,7 @@
 				CA0391FC271E143F000EB13C /* SingleStatWidget.swift in Sources */,
 				27A28ED528C00C1D001466A4 /* LockScreenShortcutWidget.swift in Sources */,
 				CA0391FB271E143F000EB13C /* StatsWidget.swift in Sources */,
+				2713FCD82A96429600398A57 /* WidgetBackground.swift in Sources */,
 				CA0391F8271E143F000EB13C /* ShortcutsWidget.swift in Sources */,
 				27DB270828BE9CB4005CB7AC /* LockScreenFavoriteWidget.swift in Sources */,
 				441A6360272445F9001492C3 /* StatDataModel.swift in Sources */,


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #8085 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

- Sanity test widgets when built with Xcode 14 (no changes)
- Test widgets when built with Xcode 15 (no changes)

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
