### PR TITLE
Fix #8088: Connected/Disconnected button state fails to update

### DIFF
--- a/Sources/BraveWallet/Panels/WalletPanelView.swift
+++ b/Sources/BraveWallet/Panels/WalletPanelView.swift
@@ -205,7 +205,6 @@ struct WalletPanelView: View {
   }
   
   @State private var ethPermittedAccounts: [String] = []
-  @State private var solConnectedAddresses: Set<String> = .init()
   @State private var isConnectHidden: Bool = false
   
   enum ConnectionStatus {
@@ -238,7 +237,7 @@ struct WalletPanelView: View {
       if !allowSolProviderAccess.value {
         return .blocked
       } else {
-        return solConnectedAddresses.contains(selectedAccount.address) ? .connected : .disconnected
+        return tabDappStore.solConnectedAddresses.contains(selectedAccount.address) ? .connected : .disconnected
       }
     case .fil, .btc:
       return .blocked
@@ -255,8 +254,6 @@ struct WalletPanelView: View {
         presentWalletWithContext(.editSiteConnection(origin, handler: { accounts in
           if keyringStore.selectedAccount.coin == .eth {
             ethPermittedAccounts = accounts
-          } else if keyringStore.selectedAccount.coin == .sol {
-            solConnectedAddresses = Set(accounts)
           }
           isConnectHidden = isConnectButtonHidden()
         }))
@@ -500,9 +497,6 @@ struct WalletPanelView: View {
         presentWalletWithContext(.pendingRequests)
       }
     }
-    .onChange(of: tabDappStore.solConnectedAddresses) { newValue in
-      solConnectedAddresses = newValue
-    }
     .onChange(of: keyringStore.selectedAccount) { _ in
       isConnectHidden = isConnectButtonHidden()
     }
@@ -512,9 +506,6 @@ struct WalletPanelView: View {
           if request.coinType == .eth {
             ethPermittedAccounts = accounts
           } else if request.coinType == .sol {
-            // User might be prompted with only non-connected accounts, but have other accounts connected.
-            // If they cancel the request, `accounts` would be empty despite having connected accounts.
-            solConnectedAddresses = tabDappStore.solConnectedAddresses
             isConnectHidden = false
           }
           tabDappStore.latestPendingPermissionRequest = nil
@@ -529,9 +520,6 @@ struct WalletPanelView: View {
           if request.coinType == .eth {
             ethPermittedAccounts = accounts
           } else if request.coinType == .sol {
-            // User might be prompted with only non-connected accounts, but have other accounts connected.
-            // If they cancel the request, `accounts` would be empty despite having connected accounts.
-            solConnectedAddresses = tabDappStore.solConnectedAddresses
             isConnectHidden = false
           }
         }))
@@ -544,9 +532,7 @@ struct WalletPanelView: View {
       if let url = origin.url, let accounts = Domain.walletPermissions(forUrl: url, coin: .eth) {
         ethPermittedAccounts = accounts
       }
-      
-      solConnectedAddresses = tabDappStore.solConnectedAddresses
-      
+            
       isConnectHidden = isConnectButtonHidden()
       
       accountActivityStore.update()

--- a/Sources/BraveWallet/Panels/WalletPanelView.swift
+++ b/Sources/BraveWallet/Panels/WalletPanelView.swift
@@ -512,7 +512,9 @@ struct WalletPanelView: View {
           if request.coinType == .eth {
             ethPermittedAccounts = accounts
           } else if request.coinType == .sol {
-            solConnectedAddresses = Set(accounts)
+            // User might be prompted with only non-connected accounts, but have other accounts connected.
+            // If they cancel the request, `accounts` would be empty despite having connected accounts.
+            solConnectedAddresses = tabDappStore.solConnectedAddresses
             isConnectHidden = false
           }
           tabDappStore.latestPendingPermissionRequest = nil
@@ -527,7 +529,9 @@ struct WalletPanelView: View {
           if request.coinType == .eth {
             ethPermittedAccounts = accounts
           } else if request.coinType == .sol {
-            solConnectedAddresses = Set(accounts)
+            // User might be prompted with only non-connected accounts, but have other accounts connected.
+            // If they cancel the request, `accounts` would be empty despite having connected accounts.
+            solConnectedAddresses = tabDappStore.solConnectedAddresses
             isConnectHidden = false
           }
         }))


### PR DESCRIPTION
## Summary of Changes
- Debugged issue to change to only show non-connected accounts in New Site Connection View. 
    - When switching from Account 2 to Account 1, we prompt user to connect with Account 1 _only_.
    - When user would cancel/dismiss this request, `onPermittedAccountsUpdated` is called with 0 accounts as none were selected, however Account 2 is connected it was just not shown.
- Improved on above fix by removing duplicate storage of `solConnectedAddresses`. We were storing these addresses in `TabDappStore` and then copying to `WalletPanelView` state when we detected a change; we can just use the `TabDappStore` original values instead to avoid any de-sync between `TabDappStore` and `WalletPanelView` connected solana addresses

This pull request fixes #8088

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
  1. Have/Create 2 Solana accounts
  2. Connect Solana Account 2 on `https://pwgoom.csb.app`
  3. Disconnect account on the page
  4. Select Wallet panel and switch to Solana Account 1
  5. Shows connect prompt, dismiss it
  6. Panel shows Solana Account 1 in disconnected state
  7. Switch to Solana Account 2 
  8. Verify status button correctly shows as `Connected`
  9. Repeat step 4-8 to confirm.
  10. Select Wallet panel and switch to Solana Account 1, then connect the account.
  11. Verify status button correctly shows as `Connected` for both accounts.


## Screenshots:

https://github.com/brave/brave-ios/assets/5314553/fbc55c17-e082-467d-937d-2a097eb886ae



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
