### PR TITLE
Fix #8109: Don't call fetch promotions on uninitialized rewards services

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
@@ -80,8 +80,6 @@ extension BrowserViewController {
     }
     // Hide the current tab
     rewards.rewardsAPI?.selectedTabId = 0
-    // Fetch new promotions
-    rewards.rewardsAPI?.fetchPromotions(nil)
   }
 
   func claimPendingPromotions() {


### PR DESCRIPTION
Calling rewards engine APIs before the engine has been initialized can cause a crash because the `WhenReady` method used inside `RewardsEngineImpl` will queue up what is assumed a `SingleThreadedTaskRunner`. This is not the case for iOS which uses a standard sequenced task runner.

This call to fetch promotions happens when showing the rewards panel but the rewards engine may not be initialized until the panel is shown (a sec/privacy requirement to not make API calls to rewards services until a user interacts with the feature), so it was being scheduled instead of executing immediately, thus hitting the threading issue on the brave-core side

## Summary of Changes

This pull request fixes #8109 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
