### PR TITLE
Fix #8107: Fix incorrect account opening Send from Filecoin asset detail

### DIFF
--- a/Sources/BraveWallet/Crypto/Accounts/Add/AddAccountView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/Add/AddAccountView.swift
@@ -29,6 +29,7 @@ struct AddAccountView: View {
   private var allFilNetworks: [BraveWallet.NetworkInfo]
   
   var preSelectedCoin: BraveWallet.CoinType?
+  var preSelectedFilecoinNetwork: BraveWallet.NetworkInfo?
   var onCreate: (() -> Void)?
   var onDismiss: (() -> Void)?
   
@@ -36,6 +37,7 @@ struct AddAccountView: View {
     keyringStore: KeyringStore,
     networkStore: NetworkStore,
     preSelectedCoin: BraveWallet.CoinType? = nil,
+    preSelectedFilecoinNetwork: BraveWallet.NetworkInfo? = nil,
     onCreate: (() -> Void)? = nil,
     onDismiss: (() -> Void)? = nil
   ) {
@@ -44,7 +46,13 @@ struct AddAccountView: View {
     self.preSelectedCoin = preSelectedCoin
     self.onCreate = onCreate
     self.onDismiss = onDismiss
-    _filNetwork = .init(initialValue: self.allFilNetworks.first ?? .init())
+    if let preSelectedFilecoinNetwork, preSelectedFilecoinNetwork.coin == .fil { // make sure the prefilled
+      // network is a Filecoin network
+      self.preSelectedFilecoinNetwork = preSelectedFilecoinNetwork
+      _filNetwork = .init(initialValue: preSelectedFilecoinNetwork)
+    } else {
+      _filNetwork = .init(initialValue: self.allFilNetworks.first ?? .init())
+    }
   }
 
   private func addAccount(for coin: BraveWallet.CoinType) {
@@ -114,6 +122,7 @@ struct AddAccountView: View {
           Text(Strings.Wallet.transactionDetailsNetworkTitle)
             .foregroundColor(Color(.braveLabel))
         }
+        .disabled(preSelectedFilecoinNetwork != nil)
         .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
       accountNameSection

--- a/Sources/BraveWallet/Crypto/Asset Details/AssetDetailHeaderView.swift
+++ b/Sources/BraveWallet/Crypto/Asset Details/AssetDetailHeaderView.swift
@@ -22,6 +22,7 @@ struct AssetDetailHeaderView: View {
   @ObservedObject var networkStore: NetworkStore
   @Binding var buySendSwapDestination: BuySendSwapDestination?
   @Binding var isShowingBridgeAlert: Bool
+  var onAccountCreationNeeded: (_ savedDestination: BuySendSwapDestination) -> Void
 
   @Environment(\.sizeCategory) private var sizeCategory
   @Environment(\.horizontalSizeClass) private var horizontalSizeClass
@@ -73,10 +74,15 @@ struct AssetDetailHeaderView: View {
       if assetDetailStore.isBuySupported {
         Button(
           action: {
-            buySendSwapDestination = BuySendSwapDestination(
+            let destination = BuySendSwapDestination(
               kind: .buy,
               initialToken: assetDetailStore.assetDetailToken
             )
+            if assetDetailStore.accounts.isEmpty {
+              onAccountCreationNeeded(destination)
+            } else {
+              buySendSwapDestination = destination
+            }
           }
         ) {
           Text(Strings.Wallet.buy)
@@ -85,10 +91,15 @@ struct AssetDetailHeaderView: View {
       if assetDetailStore.isSendSupported {
         Button(
           action: {
-            buySendSwapDestination = BuySendSwapDestination(
+            let destination = BuySendSwapDestination(
               kind: .send,
               initialToken: assetDetailStore.assetDetailToken
             )
+            if assetDetailStore.accounts.isEmpty {
+              onAccountCreationNeeded(destination)
+            } else {
+              buySendSwapDestination = destination
+            }
           }
         ) {
           Text(Strings.Wallet.send)
@@ -97,10 +108,15 @@ struct AssetDetailHeaderView: View {
       if assetDetailStore.isSwapSupported && assetDetailStore.assetDetailToken.isFungibleToken {
         Button(
           action: {
-            buySendSwapDestination = BuySendSwapDestination(
+            let destination = BuySendSwapDestination(
               kind: .swap,
               initialToken: assetDetailStore.assetDetailToken
             )
+            if assetDetailStore.accounts.isEmpty {
+              onAccountCreationNeeded(destination)
+            } else {
+              buySendSwapDestination = destination
+            }
           }
         ) {
           Text(Strings.Wallet.swap)
@@ -251,7 +267,8 @@ struct CurrencyDetailHeaderView_Previews: PreviewProvider {
       keyringStore: .previewStore,
       networkStore: .previewStore,
       buySendSwapDestination: .constant(nil),
-      isShowingBridgeAlert: .constant(false)
+      isShowingBridgeAlert: .constant(false),
+      onAccountCreationNeeded: { _ in }
     )
     .padding(.vertical)
     .previewLayout(.sizeThatFits)

--- a/Sources/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
+++ b/Sources/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
@@ -23,6 +23,9 @@ struct AssetDetailView: View {
   @State private var isShowingAddAccount: Bool = false
   @State private var transactionDetails: TransactionDetailsStore?
   @State private var isShowingAuroraBridgeAlert: Bool = false
+  @State private var isPresentingAddAccount: Bool = false
+  @State private var isPresentingAddAccountConfirmation: Bool = false
+  @State private var savedBSSDestination: BuySendSwapDestination?
   
   @Environment(\.sizeCategory) private var sizeCategory
   /// Reference to the collection view used to back the `List` on iOS 16+
@@ -160,7 +163,11 @@ struct AssetDetailView: View {
           keyringStore: keyringStore,
           networkStore: networkStore,
           buySendSwapDestination: buySendSwapDestination,
-          isShowingBridgeAlert: $isShowingAuroraBridgeAlert
+          isShowingBridgeAlert: $isShowingAuroraBridgeAlert,
+          onAccountCreationNeeded: { savedDestination in
+            isPresentingAddAccountConfirmation = true
+            savedBSSDestination = savedDestination
+          }
         )
         .resetListHeaderStyle()
         .padding(.horizontal, tableInset)  // inset grouped layout margins workaround
@@ -300,6 +307,25 @@ struct AssetDetailView: View {
         isShowingAuroraBridgeAlert = false
       }
     }
+    .addAccount(
+      keyringStore: keyringStore,
+      networkStore: networkStore,
+      accountCoin: assetDetailStore.assetDetailToken.coin,
+      isShowingConfirmation: $isPresentingAddAccountConfirmation,
+      isShowingAddAccount: $isPresentingAddAccount,
+      onConfirmAddAccount: { isPresentingAddAccount = true },
+      onCancelAddAccount: {},
+      onAddAccountDismissed: {
+        Task { @MainActor in
+          if await assetDetailStore.handleDismissAddAccount() {
+            if let savedBSSDestination {
+              buySendSwapDestination.wrappedValue = savedBSSDestination
+              self.savedBSSDestination = nil
+            }
+          }
+        }
+      }
+    )
   }
 }
 

--- a/Sources/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
+++ b/Sources/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
@@ -310,7 +310,7 @@ struct AssetDetailView: View {
     .addAccount(
       keyringStore: keyringStore,
       networkStore: networkStore,
-      accountCoin: assetDetailStore.assetDetailToken.coin,
+      accountNetwork: networkStore.network(for: assetDetailStore.assetDetailToken),
       isShowingConfirmation: $isPresentingAddAccountConfirmation,
       isShowingAddAccount: $isPresentingAddAccount,
       onConfirmAddAccount: { isPresentingAddAccount = true },

--- a/Sources/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
+++ b/Sources/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
@@ -314,7 +314,7 @@ struct AssetDetailView: View {
       isShowingConfirmation: $isPresentingAddAccountConfirmation,
       isShowingAddAccount: $isPresentingAddAccount,
       onConfirmAddAccount: { isPresentingAddAccount = true },
-      onCancelAddAccount: {},
+      onCancelAddAccount: nil,
       onAddAccountDismissed: {
         Task { @MainActor in
           if await assetDetailStore.handleDismissAddAccount() {

--- a/Sources/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
+++ b/Sources/BraveWallet/Crypto/BuySendSwap/SendTokenView.swift
@@ -294,7 +294,7 @@ struct SendTokenView: View {
         }
       }
     }
-    .task { @MainActor in
+    .task {
       if !didAutoShowSelectAccountToken {
         isShowingSelectAccountTokenView = true
         didAutoShowSelectAccountToken = true

--- a/Sources/BraveWallet/Crypto/NetworkSelectionView.swift
+++ b/Sources/BraveWallet/Crypto/NetworkSelectionView.swift
@@ -53,44 +53,25 @@ struct NetworkSelectionView: View {
         selectNetwork(network)
       }
     )
-    .background(
-      Color.clear
-        .alert(
-          isPresented: $store.isPresentingNextNetworkAlert
-        ) {
-          Alert(
-            title: Text(String.localizedStringWithFormat(Strings.Wallet.createAccountAlertTitle, store.nextNetwork?.shortChainName ?? "")),
-            message: Text(Strings.Wallet.createAccountAlertMessage),
-            primaryButton: .default(Text(Strings.yes), action: {
-              store.handleCreateAccountAlertResponse(shouldCreateAccount: true)
-            }),
-            secondaryButton: .cancel(Text(Strings.no), action: {
-              store.handleCreateAccountAlertResponse(shouldCreateAccount: false)
-            })
-          )
-        }
-    )
-    .background(
-      Color.clear
-        .sheet(
-          isPresented: $store.isPresentingAddAccount
-        ) {
-          NavigationView {
-            AddAccountView(
-              keyringStore: keyringStore,
-              networkStore: networkStore,
-              preSelectedCoin: store.nextNetwork?.coin
-            )
-          }
-          .navigationViewStyle(.stack)
-          .onDisappear {
-            Task { @MainActor in
-              if await store.handleDismissAddAccount() {
-                presentationMode.dismiss()
-              }
-            }
+    .addAccount(
+      keyringStore: keyringStore,
+      networkStore: networkStore,
+      accountCoin: store.nextNetwork?.coin,
+      isShowingConfirmation: $store.isPresentingNextNetworkAlert,
+      isShowingAddAccount: $store.isPresentingAddAccount,
+      onConfirmAddAccount: {
+        store.handleCreateAccountAlertResponse(shouldCreateAccount: true)
+      },
+      onCancelAddAccount: {
+        store.handleCreateAccountAlertResponse(shouldCreateAccount: false)
+      },
+      onAddAccountDismissed: {
+        Task { @MainActor in
+          if await store.handleDismissAddAccount() {
+            presentationMode.dismiss()
           }
         }
+      }
     )
   }
   

--- a/Sources/BraveWallet/Crypto/NetworkSelectionView.swift
+++ b/Sources/BraveWallet/Crypto/NetworkSelectionView.swift
@@ -56,7 +56,7 @@ struct NetworkSelectionView: View {
     .addAccount(
       keyringStore: keyringStore,
       networkStore: networkStore,
-      accountCoin: store.nextNetwork?.coin,
+      accountNetwork: store.nextNetwork,
       isShowingConfirmation: $store.isPresentingNextNetworkAlert,
       isShowingAddAccount: $store.isPresentingAddAccount,
       onConfirmAddAccount: {

--- a/Sources/BraveWallet/Crypto/Stores/AssetDetailStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/AssetDetailStore.swift
@@ -362,7 +362,7 @@ class AssetDetailStore: ObservableObject {
   
   /// Should be called after dismissing create account. Returns true if an account was created
   @MainActor func handleDismissAddAccount() async -> Bool {
-    if await keyringService.isKeyringAvailable(for: assetDetailToken.coin) {
+    if await keyringService.isAccountAvailable(for: assetDetailToken.coin, chainId: assetDetailToken.chainId) {
       self.update()
       return true
     } else {

--- a/Sources/BraveWallet/Crypto/Stores/AssetDetailStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/AssetDetailStore.swift
@@ -326,6 +326,8 @@ class AssetDetailStore: ObservableObject {
           return tokenContractAddress.caseInsensitiveCompare(token.contractAddress) == .orderedSame
         case .erc1155SafeTransferFrom, .solanaDappSignTransaction, .solanaDappSignAndSendTransaction, .solanaSwap:
           return false
+        case .ethFilForwarderTransfer:
+          return false
         @unknown default:
           return false
         }
@@ -356,6 +358,16 @@ class AssetDetailStore: ObservableObject {
       solanaTxManagerProxy: solTxManagerProxy,
       userAssetManager: assetManager
     )
+  }
+  
+  /// Should be called after dismissing create account. Returns true if an account was created
+  @MainActor func handleDismissAddAccount() async -> Bool {
+    if await keyringService.isKeyringAvailable(for: assetDetailToken.coin) {
+      self.update()
+      return true
+    } else {
+      return false
+    }
   }
 }
 

--- a/Sources/BraveWallet/Crypto/Stores/NetworkStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/NetworkStore.swift
@@ -273,8 +273,8 @@ public class NetworkStore: ObservableObject {
     assetManager.addUserAsset(network.nativeToken, completion: completion)
   }
   
-  func network(for token: BraveWallet.BlockchainToken) -> BraveWallet.NetworkInfo {
-    return allChains.first { $0.chainId == token.chainId } ?? customChains.first { $0.chainId == token.chainId } ?? allChains.first ?? .init()
+  func network(for token: BraveWallet.BlockchainToken) -> BraveWallet.NetworkInfo? {
+    return allChains.first { $0.chainId == token.chainId } ?? customChains.first { $0.chainId == token.chainId }
   }
 }
 

--- a/Sources/BraveWallet/Crypto/Stores/NetworkStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/NetworkStore.swift
@@ -272,6 +272,10 @@ public class NetworkStore: ObservableObject {
   func customNetworkNativeAssetMigration(_ network: BraveWallet.NetworkInfo, completion: (() -> Void)? = nil) {
     assetManager.addUserAsset(network.nativeToken, completion: completion)
   }
+  
+  func network(for token: BraveWallet.BlockchainToken) -> BraveWallet.NetworkInfo {
+    return allChains.first { $0.chainId == token.chainId } ?? customChains.first { $0.chainId == token.chainId } ?? allChains.first ?? .init()
+  }
 }
 
 extension NetworkStore: BraveWalletJsonRpcServiceObserver {

--- a/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
@@ -238,25 +238,6 @@ public class SendTokenStore: ObservableObject {
     }
     self.prefilledToken = nil
   }
-  
-  /// Check if prefilled token's coin type has associated keyring created.
-  @MainActor func checkPrefilledTokenCoinKeyring() async -> (BraveWallet.CoinType, BraveWallet.BlockchainToken)? {
-    guard let prefilledToken = self.prefilledToken else { return nil }
-    return await keyringService.checkTokenCoinTypeKeyring(token: prefilledToken)
-  }
-  
-  /// Should be called after dismissing create account. Returns true if an account was created
-  @MainActor func handleDismissAddAccount(_ coin: BraveWallet.CoinType, _ prefilledToken: BraveWallet.BlockchainToken) async -> Bool {
-    let keyrings = await keyringService.keyrings(for: [coin])
-    if keyrings.first(where: { $0.isKeyringCreated }) == nil {
-      return false
-    } else {
-      self.prefilledToken = prefilledToken
-      self.update()
-      await self.selectTokenStore.update()
-      return true
-    }
-  }
 
   /// Cancellable for the last running `update()` Task.
   private var updateTask: Task<(), Never>?

--- a/Sources/BraveWallet/Extensions/KeyringServiceExtensions.swift
+++ b/Sources/BraveWallet/Extensions/KeyringServiceExtensions.swift
@@ -64,8 +64,14 @@ extension BraveWalletKeyringService {
     return allKeyrings
   }
   
-  /// Check if prefilled token's coin type has an associated keyring created.
-  @MainActor func isKeyringAvailable(for coin: BraveWallet.CoinType) async -> Bool {
-    await !keyrings(for: coin.keyringIds).filter(\.isKeyringCreated).isEmpty
+  /// Check if any wallet account has been created given a coin type and a chain id
+  @MainActor func isAccountAvailable(for coin: BraveWallet.CoinType, chainId: String) async -> Bool {
+    let keyringId = BraveWallet.KeyringId.keyringId(for: coin, on: chainId)
+    let keyringInfo = await keyringInfo(keyringId)
+    // If user restore a wallet, `BraveWallet.KeyringInfo.isKeyringCreated` can be true,
+    // but `BraveWallet.KeyringInfo.accountInfos` will be empty.
+    // Hence, we will have to check if `BraveWallet.KeyringInfo.accountInfos` is empty instead of
+    // checking the boolean of `BraveWallet.KeyringInfo.isKeyringCreated`
+    return !keyringInfo.accountInfos.isEmpty
   }
 }

--- a/Sources/BraveWallet/Extensions/KeyringServiceExtensions.swift
+++ b/Sources/BraveWallet/Extensions/KeyringServiceExtensions.swift
@@ -63,4 +63,16 @@ extension BraveWalletKeyringService {
     )
     return allKeyrings
   }
+  
+  /// Check if prefilled token's coin type has associated keyring has been created.
+  /// Return a tuple of token's coin type and token itself if there is no keyring has been created has the same coin type as the givin token
+  /// Return nil if there is a keyring has been created has the same coin type as the given token
+  @MainActor func checkTokenCoinTypeKeyring(token: BraveWallet.BlockchainToken) async -> (BraveWallet.CoinType, BraveWallet.BlockchainToken)? {
+    let keyrings = await keyrings(for: [token.coin])
+    if keyrings.first(where: { $0.isKeyringCreated }) == nil {
+      return (token.coin, token)
+    } else {
+      return nil
+    }
+  }
 }

--- a/Sources/BraveWallet/Extensions/KeyringServiceExtensions.swift
+++ b/Sources/BraveWallet/Extensions/KeyringServiceExtensions.swift
@@ -64,15 +64,8 @@ extension BraveWalletKeyringService {
     return allKeyrings
   }
   
-  /// Check if prefilled token's coin type has associated keyring has been created.
-  /// Return a tuple of token's coin type and token itself if there is no keyring has been created has the same coin type as the givin token
-  /// Return nil if there is a keyring has been created has the same coin type as the given token
-  @MainActor func checkTokenCoinTypeKeyring(token: BraveWallet.BlockchainToken) async -> (BraveWallet.CoinType, BraveWallet.BlockchainToken)? {
-    let keyrings = await keyrings(for: [token.coin])
-    if keyrings.first(where: { $0.isKeyringCreated }) == nil {
-      return (token.coin, token)
-    } else {
-      return nil
-    }
+  /// Check if prefilled token's coin type has an associated keyring created.
+  @MainActor func isKeyringAvailable(for coin: BraveWallet.CoinType) async -> Bool {
+    await !keyrings(for: coin.keyringIds).filter(\.isKeyringCreated).isEmpty
   }
 }

--- a/Sources/BraveWallet/Extensions/ViewExtensions.swift
+++ b/Sources/BraveWallet/Extensions/ViewExtensions.swift
@@ -39,7 +39,7 @@ extension View {
     isShowingConfirmation: Binding<Bool>,
     isShowingAddAccount: Binding<Bool>,
     onConfirmAddAccount: @escaping () -> Void,
-    onCancelAddAccount: @escaping () -> Void,
+    onCancelAddAccount: (() -> Void)?,
     onAddAccountDismissed: @escaping () -> Void
   ) -> some View {
     self.background(
@@ -52,7 +52,7 @@ extension View {
               onConfirmAddAccount()
             }),
             secondaryButton: .cancel(Text(Strings.no), action: {
-              onCancelAddAccount()
+              onCancelAddAccount?()
             })
           )
         }

--- a/Sources/BraveWallet/Extensions/ViewExtensions.swift
+++ b/Sources/BraveWallet/Extensions/ViewExtensions.swift
@@ -35,7 +35,7 @@ extension View {
   func addAccount(
     keyringStore: KeyringStore,
     networkStore: NetworkStore,
-    accountCoin: BraveWallet.CoinType,
+    accountCoin: BraveWallet.CoinType?,
     isShowingConfirmation: Binding<Bool>,
     isShowingAddAccount: Binding<Bool>,
     onConfirmAddAccount: @escaping () -> Void,
@@ -46,7 +46,7 @@ extension View {
       Color.clear
         .alert(isPresented: isShowingConfirmation) {
           Alert(
-            title: Text(String.localizedStringWithFormat(Strings.Wallet.createAccountAlertTitle, accountCoin.localizedTitle)),
+            title: Text(String.localizedStringWithFormat(Strings.Wallet.createAccountAlertTitle, accountCoin?.localizedTitle ?? "")),
             message: Text(Strings.Wallet.createAccountAlertMessage),
             primaryButton: .default(Text(Strings.yes), action: {
               onConfirmAddAccount()

--- a/Sources/BraveWallet/Extensions/ViewExtensions.swift
+++ b/Sources/BraveWallet/Extensions/ViewExtensions.swift
@@ -35,7 +35,7 @@ extension View {
   func addAccount(
     keyringStore: KeyringStore,
     networkStore: NetworkStore,
-    accountCoin: BraveWallet.CoinType?,
+    accountNetwork: BraveWallet.NetworkInfo?,
     isShowingConfirmation: Binding<Bool>,
     isShowingAddAccount: Binding<Bool>,
     onConfirmAddAccount: @escaping () -> Void,
@@ -46,7 +46,7 @@ extension View {
       Color.clear
         .alert(isPresented: isShowingConfirmation) {
           Alert(
-            title: Text(String.localizedStringWithFormat(Strings.Wallet.createAccountAlertTitle, accountCoin?.localizedTitle ?? "")),
+            title: Text(String.localizedStringWithFormat(Strings.Wallet.createAccountAlertTitle, accountNetwork?.shortChainName ?? "")),
             message: Text(Strings.Wallet.createAccountAlertMessage),
             primaryButton: .default(Text(Strings.yes), action: {
               onConfirmAddAccount()
@@ -66,7 +66,8 @@ extension View {
             AddAccountView(
               keyringStore: keyringStore,
               networkStore: networkStore,
-              preSelectedCoin: accountCoin
+              preSelectedCoin: accountNetwork?.coin,
+              preSelectedFilecoinNetwork: accountNetwork
             )
           }
           .navigationViewStyle(.stack)

--- a/Sources/BraveWallet/Extensions/ViewExtensions.swift
+++ b/Sources/BraveWallet/Extensions/ViewExtensions.swift
@@ -5,6 +5,7 @@
 
 import SwiftUI
 import UIKit
+import BraveCore
 
 extension View {
   /// Helper for `hidden()` modifier that accepts a boolean determining if we should hide the view or not.
@@ -29,5 +30,48 @@ extension View {
       vc.navigationItem.backButtonTitle = backButtonTitle
       vc.navigationItem.backButtonDisplayMode = backButtonDisplayMode
     }
+  }
+  
+  func addAccount(
+    keyringStore: KeyringStore,
+    networkStore: NetworkStore,
+    accountCoin: BraveWallet.CoinType,
+    isShowingConfirmation: Binding<Bool>,
+    isShowingAddAccount: Binding<Bool>,
+    onConfirmAddAccount: @escaping () -> Void,
+    onCancelAddAccount: @escaping () -> Void,
+    onAddAccountDismissed: @escaping () -> Void
+  ) -> some View {
+    self.background(
+      Color.clear
+        .alert(isPresented: isShowingConfirmation) {
+          Alert(
+            title: Text(String.localizedStringWithFormat(Strings.Wallet.createAccountAlertTitle, accountCoin.localizedTitle)),
+            message: Text(Strings.Wallet.createAccountAlertMessage),
+            primaryButton: .default(Text(Strings.yes), action: {
+              onConfirmAddAccount()
+            }),
+            secondaryButton: .cancel(Text(Strings.no), action: {
+              onCancelAddAccount()
+            })
+          )
+        }
+    )
+    .background(
+      Color.clear
+        .sheet(
+          isPresented: isShowingAddAccount
+        ) {
+          NavigationView {
+            AddAccountView(
+              keyringStore: keyringStore,
+              networkStore: networkStore,
+              preSelectedCoin: accountCoin
+            )
+          }
+          .navigationViewStyle(.stack)
+          .onDisappear { onAddAccountDismissed() }
+        }
+    )
   }
 }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8107

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
1. make sure you wallet has no filecoin account (create a new wallet)
2. turn on show test networks in Settings
3. go to `FIL` asset detail screen
4. click either buy or send button
5. you should get prompt with an alert asking you if you want to create an account
6. Click no an the alert to dismiss the alert, you will still be at the asset detail screen, and not be redirected to other screen.
7. Click yes to bring up account creation screen with Filecoin UI with correct Filecoin network preselected and no way to change it. (e.x if you comes from FIL on testnet asset details screen, account creation screen should pre-selected Filecoin Testnet instead of Mainnet.)
8. Either click cancel or swipe down to dismiss account creation screen, you will still be at the asset detail screen, and not be redirected to other screen.
9. Repeat step 4 - 6
10. Fill in all the information or leave them as they are then click `Add` to create a new account
11. Observe that the account creation screen will be dismissed and you will be redirected to Buy/Send screen depends on which button you clicked in step 8
12. Goes back to the asset screen again
13. repeat step 3
14. Observe this time, you will be redirect to Buy/Send screen depends on which button you clicked in step 12 since now we a filecoin account 

=====================

1. make sure you wallet has no filecoin account (create a new wallet)
2. turn on show test networks in Settings 
3. got buy/swap screen 
4. open network selection and choose either Filecoin Mainnet or Filecoin Testnet
5. you should get prompt with an alert asking you if you want to create an account
6. Click no an the alert to dismiss the alert, you will still be at the network selection screen, and not be redirected to other screen.
7. Click yes to bring up account creation screen with Filecoin UI with correct Filecoin network preselected and no way to change it. (e.x if you comes from FIL on testnet asset details screen, account creation screen should pre-selected Filecoin Testnet instead of Mainnet.)
8. Either click cancel or swipe down to dismiss account creation screen, you will still be at the network selection screen, and not be redirected to other screen.
9. Repeat step 4 - 6
10. Fill in all the information or leave them as they are then click `Add` to create a new account
11. Observe that the account creation screen will be dismissed then network selection will be dismissed and the correct network has been selected.


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

https://github.com/brave/brave-ios/assets/1187676/0268fe56-11c5-4beb-b9c8-6bc5d20b2fcb

https://github.com/brave/brave-ios/assets/1187676/fc86db6c-aec8-439f-bb35-e583235e2c2d


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
