### PR TITLE
Fix #8095: Favorites are shown in Private Tab mode when switching the apps 

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController.swift
@@ -722,6 +722,7 @@ public class BrowserViewController: UIViewController {
       webViewContainer.alpha = 0
       activeNewTabPageViewController?.view.alpha = 0
       favoritesController?.view.alpha = 0
+      searchController?.view.alpha = 0
       header.contentView.alpha = 0
       presentedViewController?.popoverPresentationController?.containerView?.alpha = 0
       presentedViewController?.view.alpha = 0
@@ -753,6 +754,7 @@ public class BrowserViewController: UIViewController {
         self.header.contentView.alpha = 1
         self.activeNewTabPageViewController?.view.alpha = 1
         self.favoritesController?.view.alpha = 1
+        self.searchController?.view.alpha = 1
         self.presentedViewController?.popoverPresentationController?.containerView?.alpha = 1
         self.presentedViewController?.view.alpha = 1
         self.view.backgroundColor = .clear

--- a/Sources/Brave/Frontend/Browser/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController.swift
@@ -721,6 +721,7 @@ public class BrowserViewController: UIViewController {
       webViewContainerBackdrop.alpha = 1
       webViewContainer.alpha = 0
       activeNewTabPageViewController?.view.alpha = 0
+      favoritesController?.view.alpha = 0
       header.contentView.alpha = 0
       presentedViewController?.popoverPresentationController?.containerView?.alpha = 0
       presentedViewController?.view.alpha = 0
@@ -751,6 +752,7 @@ public class BrowserViewController: UIViewController {
         self.webViewContainer.alpha = 1
         self.header.contentView.alpha = 1
         self.activeNewTabPageViewController?.view.alpha = 1
+        self.favoritesController?.view.alpha = 1
         self.presentedViewController?.popoverPresentationController?.containerView?.alpha = 1
         self.presentedViewController?.view.alpha = 1
         self.view.backgroundColor = .clear


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8095

Hide Active background favorites when backgrounding the app in private mode

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

- Begin Brave
- Open NTP in Private Tab mode
- Tap Search button > Use the app switch gesture to see all opened apps > Observe

## Screenshots:

![1testss](https://github.com/brave/brave-ios/assets/6643505/25c64c1d-9cd2-46cb-8e8d-75486414466c)


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
