### PR TITLE
Fix #8087: VPN Reset Configuration Clear confirmation

### DIFF
--- a/Sources/BraveStrings/BraveStrings.swift
+++ b/Sources/BraveStrings/BraveStrings.swift
@@ -2950,6 +2950,16 @@ extension Strings {
       NSLocalizedString("vpn.resetVPNErrorBody", tableName: "BraveShared", bundle: .module,
         value: "Failed to reset vpn configuration, please try again later.",
         comment: "Message to show when vpn configuration reset fails.")
+    
+    public static let resetVPNSuccessTitle =
+      NSLocalizedString("vpn.resetVPNSuccessTitle", tableName: "BraveShared", bundle: .module,
+        value: "Success",
+        comment: "Title for success message when vpn configuration reset succeeds.")
+
+    public static let resetVPNSuccessBody =
+      NSLocalizedString("vpn.resetVPNSuccessBody", tableName: "BraveShared", bundle: .module,
+        value: "VPN Configuration is resetted successfully.",
+        comment: "Message to show when vpn configuration reset succeeds.")
 
     public static let contactFormDoNotEditText =
       NSLocalizedString("vpn.contactFormDoNotEditText", tableName: "BraveShared", bundle: .module,

--- a/Sources/BraveVPN/BraveVPNSettingsViewController.swift
+++ b/Sources/BraveVPN/BraveVPNSettingsViewController.swift
@@ -244,9 +244,7 @@ public class BraveVPNSettingsViewController: TableViewController {
           self.isLoading = false
           self.vpnReconfigurationPending = false
           self.updateServerInfo()
-          if !success {
-            self.showVPNResetErrorAlert()
-          }
+          self.showVPNResetAlert(success: success)
         }
       }
     })
@@ -294,9 +292,11 @@ public class BraveVPNSettingsViewController: TableViewController {
     navigationController?.pushViewController(vc, animated: true)
   }
 
-  private func showVPNResetErrorAlert() {
-    let alert = UIAlertController(title: Strings.VPN.resetVPNErrorTitle,
-                                  message: Strings.VPN.resetVPNErrorBody, preferredStyle: .alert)
+  private func showVPNResetAlert(success: Bool) {
+    let alert = UIAlertController(
+      title: success ? Strings.VPN.resetVPNSuccessTitle : Strings.VPN.resetVPNErrorTitle,
+      message: success ? Strings.VPN.resetVPNSuccessBody : Strings.VPN.resetVPNErrorBody,
+      preferredStyle: .alert)
 
     let okAction = UIAlertAction(title: Strings.OKString, style: .default)
     alert.addAction(okAction)

--- a/Sources/BraveVPN/InstallVPNView.swift
+++ b/Sources/BraveVPN/InstallVPNView.swift
@@ -93,7 +93,7 @@ extension InstallVPNViewController {
 
     let installVPNButton = BraveButton().then {
       $0.setTitle(Strings.VPN.installProfileButtonText, for: .normal)
-      $0.backgroundColor = .braveBlurpleTint
+      $0.backgroundColor = .braveDarkerBlurple
       $0.titleLabel?.font = .systemFont(ofSize: 16, weight: .semibold)
       $0.setTitleColor(.white, for: .normal)
       $0.snp.makeConstraints { make in
@@ -109,7 +109,7 @@ extension InstallVPNViewController {
     let contactSupportButton = BraveButton(type: .system).then {
       $0.setTitle(Strings.VPN.settingsContactSupport, for: .normal)
       $0.titleLabel?.font = .systemFont(ofSize: 16)
-      $0.setTitleColor(.braveLabel, for: .normal)
+      $0.setTitleColor(.secondaryBraveLabel, for: .normal)
       $0.snp.makeConstraints { make in
         make.height.equalTo(44)
       }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8087

An alert is added for confirmation success case 
Additionally color fix for profile add screen

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->

- Launch Brave
- Three-dot menu > VPN
- Buy a subscription and Install VPN profile
- Three-dot menu > Settings > Brave Firewall + VPN
- Reset Configuration > Reset > Observe

## Screenshots:

![test121 11](https://github.com/brave/brave-ios/assets/6643505/eed16150-65d4-4280-bf44-f64977d77cd2)

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
