### PR TITLE
Fix #8120: Dismiss verify recovery phrases from Account Tab's backup

### DIFF
--- a/Sources/BraveWallet/Crypto/Onboarding/VerifyRecoveryPhraseView.swift
+++ b/Sources/BraveWallet/Crypto/Onboarding/VerifyRecoveryPhraseView.swift
@@ -85,6 +85,7 @@ struct VerifyRecoveryPhraseView: View {
                 Preferences.Wallet.isOnboardingCompleted.value = true
               } else { // coming from BackUpWalletView
                 keyringStore.notifyWalletBackupComplete()
+                modalPresentationMode = false
               }
             } else {
               // next check


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8120

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Please refer to the issue

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
