### PR TITLE
Ref #8078: Improve tab bar look with new colours

### DIFF
--- a/Sources/Brave/Frontend/Browser/Tabs/TabBar/TabBarCell.swift
+++ b/Sources/Brave/Frontend/Browser/Tabs/TabBar/TabBarCell.swift
@@ -23,17 +23,17 @@ class TabBarCell: UICollectionViewCell {
     button.imageEdgeInsets.left = 6
     return button
   }()
-
-  private let separatorLine = UIView()
-
-  let separatorLineRight = UIView().then {
-    $0.isHidden = true
+  
+  private let highlightView = UIView().then {
+    $0.layer.cornerRadius = 4
+    $0.layer.cornerCurve = .continuous
+    $0.layer.shadowOffset = CGSize(width: 0, height: 1)
+    $0.layer.shadowRadius = 2
   }
 
   var currentIndex: Int = -1 {
     didSet {
       isSelected = currentIndex == tabManager?.currentDisplayedIndex
-      separatorLine.isHidden = currentIndex == 0
     }
   }
   weak var tab: Tab?
@@ -56,7 +56,7 @@ class TabBarCell: UICollectionViewCell {
   override init(frame: CGRect) {
     super.init(frame: frame)
     
-    [closeButton, titleLabel, separatorLine, separatorLineRight].forEach { contentView.addSubview($0) }
+    [highlightView, closeButton, titleLabel].forEach { contentView.addSubview($0) }
     initConstraints()
     updateFont()
     
@@ -66,9 +66,10 @@ class TabBarCell: UICollectionViewCell {
   private var privateModeCancellable: AnyCancellable?
   private func updateColors() {
     let browserColors: any BrowserColors = tabManager?.privateBrowsingManager.browserColors ?? .standard
-    separatorLine.backgroundColor = browserColors.dividerSubtle
-    separatorLineRight.backgroundColor = browserColors.dividerSubtle
-    backgroundColor = isSelected ? browserColors.tabBarTabActiveBackground : browserColors.tabBarTabBackground
+    backgroundColor = browserColors.tabBarTabBackground
+    highlightView.backgroundColor = isSelected ? browserColors.tabBarTabActiveBackground : .clear
+    highlightView.layer.shadowOpacity = isSelected ? 0.05 : 0.0
+    highlightView.layer.shadowColor = UIColor.black.cgColor
     closeButton.tintColor = browserColors.iconDefault
     titleLabel.textColor = isSelected ? browserColors.textPrimary : browserColors.textSecondary
   }
@@ -78,6 +79,10 @@ class TabBarCell: UICollectionViewCell {
   }
 
   private func initConstraints() {
+    highlightView.snp.makeConstraints {
+      $0.edges.equalToSuperview().inset(2)
+    }
+    
     titleLabel.snp.makeConstraints { make in
       make.top.bottom.equalTo(self)
       make.left.equalTo(self).inset(16)
@@ -88,20 +93,6 @@ class TabBarCell: UICollectionViewCell {
       make.top.bottom.equalTo(self)
       make.right.equalTo(self).inset(2)
       make.width.equalTo(30)
-    }
-
-    separatorLine.snp.makeConstraints { make in
-      make.left.equalTo(self)
-      make.width.equalTo(0.5)
-      make.height.equalTo(self)
-      make.centerY.equalTo(self.snp.centerY)
-    }
-
-    separatorLineRight.snp.makeConstraints { make in
-      make.right.equalTo(self)
-      make.width.equalTo(0.5)
-      make.height.equalTo(self)
-      make.centerY.equalTo(self.snp.centerY)
     }
   }
 
@@ -152,5 +143,11 @@ class TabBarCell: UICollectionViewCell {
       strongSelf.titleUpdateScheduled = false
       strongSelf.titleLabel.text = tab.displayTitle
     }
+  }
+  
+  override func layoutSubviews() {
+    super.layoutSubviews()
+    
+    highlightView.layer.shadowPath = UIBezierPath(roundedRect: highlightView.bounds, cornerRadius: 4).cgPath
   }
 }

--- a/Sources/Brave/Frontend/Browser/Tabs/TabBar/TabsBarViewController.swift
+++ b/Sources/Brave/Frontend/Browser/Tabs/TabBar/TabsBarViewController.swift
@@ -152,7 +152,7 @@ class TabsBarViewController: UIViewController {
   private var privateModeCancellable: AnyCancellable?
   private func updateColors() {
     let browserColors: any BrowserColors = tabManager?.privateBrowsingManager.browserColors ?? .standard
-    view.backgroundColor = browserColors.chromeBackground
+    view.backgroundColor = browserColors.tabBarTabBackground
     collectionView.backgroundColor = view.backgroundColor
   }
 
@@ -384,7 +384,6 @@ extension TabsBarViewController: UICollectionViewDataSource {
     cell.tab = tab
     cell.titleLabel.text = tab.displayTitle
     cell.currentIndex = indexPath.row
-    cell.separatorLineRight.isHidden = (indexPath.row != tabList.count() - 1)
     cell.configure()
 
     cell.closeTabCallback = { [weak self] tab in


### PR DESCRIPTION
## Summary of Changes

This insets the tab bar cells a little bit and removes the separators to make the new active tab bar color a bit more pleasing to look at

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Screenshots:

| Light | Dark | Private |
| --- | --- | --- |
| ![image](https://github.com/brave/brave-ios/assets/529104/eb16b502-210b-41a3-af8f-7ac191445672) | ![image](https://github.com/brave/brave-ios/assets/529104/1bee0cde-7f7d-4060-8d1f-fe604727a3a7) | ![image](https://github.com/brave/brave-ios/assets/529104/6f54621b-3a48-45d6-b0ae-78680ee2ed8e) |

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
