### PR TITLE
Fix # 7770: Discrepancy in the titles of multiple settings screens

### DIFF
--- a/Sources/Brave/Frontend/Browser/PageZoom/PageZoomSettingsView.swift
+++ b/Sources/Brave/Frontend/Browser/PageZoom/PageZoomSettingsView.swift
@@ -113,7 +113,6 @@ struct PageZoomSettingsView: View {
       }
     }
     .listBackgroundColor(Color(UIColor.braveGroupedBackground))
-    .navigationTitle(Strings.PageZoom.settingsTitle)
     .navigationBarTitleDisplayMode(.inline)
     .listStyle(.insetGrouped)
   }

--- a/Sources/Brave/Frontend/Settings/Display/MediaSettingsView.swift
+++ b/Sources/Brave/Frontend/Settings/Display/MediaSettingsView.swift
@@ -45,7 +45,7 @@ fileprivate struct QualitySettingsView: View {
   
   var body: some View {
     Form {
-      Section(header: Text("")) {
+      Section(header: Text(Strings.Settings.qualitySettings)) {
         Button(action: {
           qualityOption.value = YoutubeHighQualityPreference.on.rawValue
           presentationMode.dismiss()
@@ -69,7 +69,7 @@ fileprivate struct QualitySettingsView: View {
       }
       .listRowBackground(Color(.secondaryBraveGroupedBackground))
     }
-    .navigationBarTitle(Strings.Settings.qualitySettings)
+    .navigationBarTitle(Strings.Settings.highestQualityPlayback)
     .listBackgroundColor(Color(UIColor.braveGroupedBackground))
   }
   

--- a/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/FilterLists/FilterListsView.swift
+++ b/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/FilterLists/FilterListsView.swift
@@ -104,7 +104,7 @@ struct FilterListsView: View {
     .animation(.default, value: customFilterListStorage.filterListsURLs)
     .listBackgroundColor(Color(UIColor.braveGroupedBackground))
     .listStyle(.insetGrouped)
-    .navigationTitle(Strings.filterLists)
+    .navigationTitle(Strings.contentFiltering)
     .toolbar {
       EditButton().disabled(
         customFilterListStorage.filterListsURLs.isEmpty &&

--- a/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/PrivacyReportSettingsView.swift
+++ b/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/PrivacyReportSettingsView.swift
@@ -73,6 +73,7 @@ struct PrivacyReportSettingsView: View {
         .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
     }
+    .navigationTitle(Strings.PrivacyHub.privacyReportsTitle)
     .listStyle(.insetGrouped)
     .listBackgroundColor(Color(UIColor.braveGroupedBackground))
   }

--- a/Sources/Brave/Frontend/Settings/General/SearchEngines/SearchCustomEngineViewController.swift
+++ b/Sources/Brave/Frontend/Settings/General/SearchEngines/SearchCustomEngineViewController.swift
@@ -99,7 +99,7 @@ class SearchCustomEngineViewController: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    title = Strings.CustomSearchEngine.customEngineNavigationTitle
+    title = Strings.searchSettingAddCustomEngineCellTitle
 
     setup()
     doLayout()

--- a/Sources/Brave/Frontend/Settings/General/SearchEngines/SearchEnginePicker.swift
+++ b/Sources/Brave/Frontend/Settings/General/SearchEngines/SearchEnginePicker.swift
@@ -31,7 +31,7 @@ class SearchEnginePicker: UITableViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    navigationItem.title = Strings.searchEnginePickerNavTitle
+    navigationItem.title = type == .standard ? Strings.standardTabSearch : Strings.privateTabSearch
     if showCancel {
       navigationItem.leftBarButtonItem = UIBarButtonItem(title: Strings.cancelButtonTitle, style: .plain, target: self, action: #selector(cancel))
     }

--- a/Sources/Brave/Frontend/Settings/General/SearchEngines/SearchSettingsTableViewController.swift
+++ b/Sources/Brave/Frontend/Settings/General/SearchEngines/SearchSettingsTableViewController.swift
@@ -62,8 +62,6 @@ class SearchSettingsTableViewController: UITableViewController {
   private var privateBrowsingManager: PrivateBrowsingManager
 
   private func searchPickerEngines(type: DefaultEngineType) -> [OpenSearchEngine] {
-    let isPrivate = type == .privateMode
-
     var orderedEngines = searchEngines.orderedEngines
       .sorted { $0.shortName < $1.shortName }
       .sorted { engine, _ in engine.shortName == OpenSearchEngine.EngineNames.brave }
@@ -99,7 +97,7 @@ class SearchSettingsTableViewController: UITableViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    navigationItem.title = Strings.searchSettingNavTitle
+    navigationItem.title = Strings.searchEngines
 
     tableView.do {
       $0.allowsSelectionDuringEditing = true

--- a/Sources/Brave/Frontend/Settings/SettingsViewController.swift
+++ b/Sources/Brave/Frontend/Settings/SettingsViewController.swift
@@ -417,6 +417,7 @@ class SettingsViewController: TableViewController {
           }
         )
         optionsViewController.headerText = Strings.showTabsBar
+        optionsViewController.navigationItem.title = Strings.showTabsBar
         self.navigationController?.pushViewController(optionsViewController, animated: true)
       }
       tabs.rows.append(row)
@@ -443,6 +444,7 @@ class SettingsViewController: TableViewController {
       )
       optionsViewController.headerText = Strings.Settings.autocloseTabsSetting
       optionsViewController.footerText = Strings.Settings.autocloseTabsSettingFooter
+      optionsViewController.navigationItem.title = Strings.Settings.autocloseTabsSetting
       self.navigationController?.pushViewController(optionsViewController, animated: true)
     }
 
@@ -494,7 +496,8 @@ class SettingsViewController: TableViewController {
       )
       optionsViewController.headerText = Strings.themesDisplayBrightness
       optionsViewController.footerText = Strings.themesDisplayBrightnessFooter
-
+      optionsViewController.navigationItem.title = Strings.themesDisplayBrightness
+      
       let nightModeSection = Section(
         header: .title(Strings.NightMode.sectionTitle.uppercased()),
         rows: [
@@ -527,9 +530,10 @@ class SettingsViewController: TableViewController {
     // We do NOT persistently save page-zoom settings in Private Browsing
     if !tabManager.privateBrowsingManager.isPrivateBrowsing {
       display.rows.append(
-        Row(text: Strings.PageZoom.settingsMenuTitle,
+        Row(text: Strings.PageZoom.settingsTitle,
             selection: { [weak self] in
               let controller = PageZoomSettingsController()
+              controller.navigationItem.title = Strings.PageZoom.settingsTitle
               self?.navigationController?.pushViewController(controller, animated: true)
             },
             image: UIImage(braveSystemNamed: "leo.font.size"),
@@ -683,6 +687,7 @@ class SettingsViewController: TableViewController {
           selection: { [unowned self] in
             // Show privacy policy
             let privacy = SettingsContentViewController().then { $0.url = .brave.privacy }
+            privacy.navigationItem.title = Strings.privacyPolicy
             self.navigationController?.pushViewController(privacy, animated: true)
           },
           accessory: .disclosureIndicator, cellClass: MultilineValue1Cell.self),
@@ -691,6 +696,7 @@ class SettingsViewController: TableViewController {
           selection: { [unowned self] in
             // Show terms of use
             let toc = SettingsContentViewController().then { $0.url = .brave.termsOfUse }
+            toc.navigationItem.title = Strings.termsOfUse
             self.navigationController?.pushViewController(toc, animated: true)
           },
           accessory: .disclosureIndicator, cellClass: MultilineValue1Cell.self),

--- a/Sources/Brave/Frontend/Share/PageZoomActivity.swift
+++ b/Sources/Brave/Frontend/Share/PageZoomActivity.swift
@@ -16,7 +16,7 @@ class PageZoomActivity: UIActivity, MenuActivity {
   }
 
   override var activityTitle: String? {
-    return Strings.PageZoom.settingsMenuTitle
+    return Strings.PageZoom.settingsTitle
   }
 
   override var activityImage: UIImage? {

--- a/Sources/BraveStrings/BraveStrings.swift
+++ b/Sources/BraveStrings/BraveStrings.swift
@@ -529,11 +529,6 @@ extension Strings {
       value: "Reader Mode", comment: "Title of a bar that show up when you enter reader mode.")
 }
 
-// MARK:-  SearchEnginePicker.swift
-extension Strings {
-  public static let searchEnginePickerNavTitle = NSLocalizedString("SearchEnginePickerNavTitle", tableName: "BraveShared", bundle: .module, value: "Default Search Engine", comment: "Title for default search engine picker.")
-}
-
 // MARK:-  SearchSettingsTableViewController.swift
 extension Strings {
   public static let searchSettingNavTitle = NSLocalizedString("SearchSettingNavTitle", tableName: "BraveShared", bundle: .module, value: "Search", comment: "Navigation title for search settings.")
@@ -1783,7 +1778,7 @@ extension Strings {
 
     public static let playlistStartPlaybackSettingsOptionTitle =
       NSLocalizedString("playlist.playlistStartPlaybackSettingsOptionTitle", tableName: "BraveShared", bundle: .module,
-        value: "Remember file playback position",
+        value: "Remember File Playback Position",
         comment: "Title for the Playlist Settings Option for Enable/Disable ability to start playing from the point where user last left-off")
 
     public static let playlistStartPlaybackSettingsFooterText =
@@ -4597,13 +4592,8 @@ extension Strings {
 // Page Zoom
 extension Strings {
   public struct PageZoom {
-    public static let settingsMenuTitle = NSLocalizedString("pagezoom.settings.menu-title", tableName: "BraveShared", bundle: .module,
-      value: "Page Zoom",
-      comment: "Title of the Web-Page Zoom settings menu"
-    )
-    
     public static let settingsTitle = NSLocalizedString("pagezoom.settings.title", tableName: "BraveShared", bundle: .module,
-      value: "Page Zoom Settings",
+      value: "Page Zoom",
       comment: "Title of the Web-Page Zoom screen"
     )
     
@@ -4858,7 +4848,6 @@ extension Strings {
   public static let contentFiltering = NSLocalizedString("ContentFiltering", tableName: "BraveShared", bundle: .module, value: "Content Filtering", comment: "A title to the content filtering page under global shield settings and the title on the Content filtering page")
   public static let blockMobileAnnoyances = NSLocalizedString("blockMobileAnnoyances", tableName: "BraveShared", bundle: .module, value: "Block 'Switch to App' Notices", comment: "A title for setting which blocks 'switch to app' popups")
   public static let contentFilteringDescription = NSLocalizedString("ContentFilteringDescription", tableName: "BraveShared", bundle: .module, value: "Enable custom filters that block regional and language-specific trackers and Annoyances", comment: "A description of the content filtering page.")
-  public static let filterLists = NSLocalizedString("FilterLists", tableName: "BraveShared", bundle: .module, value: "Filter Lists", comment: "A title on the content filtering screen that allows you to enable/disable filter lists")
   public static let defaultFilterLists = NSLocalizedString("DefaultFilterLists", tableName: "BraveShared", bundle: .module, value: "Default Filter Lists", comment: "A section title that contains default (predefined) filter lists a user can enable/diable.")
   public static let filterListsDescription = NSLocalizedString("FilterListsDescription", tableName: "BraveShared", bundle: .module, value: "Additional popular community lists. Note that enabling too many filters will degrade browsing speeds.", comment: "A description on the content filtering screen for the filter lists section.")
   public static let addCustomFilterList = NSLocalizedString("AddCustomFilterList", tableName: "BraveShared", bundle: .module, value: "Add Custom Filter List", comment: "A title within a cell where a user can navigate to an add screen.")


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

Fixing multiple title discrepancy inside title settings

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7770

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

Check 
- [ ] Brave Shields & Privacy -> Content Filtering
- [ ] Brave Shields & Privacy -> Privacy Hub
- [ ] Search Engines
- [ ] Search Engines -> Standard Tab
- [ ] Search Engines -> Private Tab
- [ ] Search Engines -> Add Custom Search Engine
- [ ] Media -> Highest Quality Playback 
- [ ] Appearance
- [ ] Page Zoom
- [ ] Tabs Bar
- [ ] Close Tabs
- [ ] Privacy Policy
- [ ] Terms of Use 

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


Uploading RPReplay_Final1695411360.mov…


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
