### PR TITLE
 Fix #8146: Fixes Tab Selection and mode switching

### DIFF
--- a/Sources/Brave/Frontend/Browser/Tabs/TabTray/TabTrayController.swift
+++ b/Sources/Brave/Frontend/Browser/Tabs/TabTray/TabTrayController.swift
@@ -671,11 +671,12 @@ class TabTrayController: AuthenticationController {
           tabManager.addTabAndSelect(isPrivate: true)
         }
         
-        let privateModeTabSelected = tabManager.allTabs[safe: tabManager.privateTabSelectedIndex]
+        let privateModeTabSelected = tabManager.tabsForCurrentMode[safe: tabManager.privateTabSelectedIndex] ?? tabManager.tabsForCurrentMode.last
 
         if Preferences.Privacy.persistentPrivateBrowsing.value {
           tabManager.selectTab(privateModeTabSelected)
         }
+        
         tabTrayView.hidePrivateModeInfo()
         tabTrayView.collectionView.reloadData()
         
@@ -691,8 +692,8 @@ class TabTrayController: AuthenticationController {
       
       // When you go back from private mode, a previous current tab is selected
       // Reloding the collection view in order to mark the selecte the tab
-      let normalModeTabSelected = tabManager.allTabs[safe: tabManager.normalTabSelectedIndex]
-      
+      let normalModeTabSelected = tabManager.tabsForCurrentMode[safe: tabManager.normalTabSelectedIndex] ?? tabManager.tabsForCurrentMode.last
+
       tabManager.selectTab(normalModeTabSelected)
       tabTrayView.collectionView.reloadData()
       


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Add a default tab to select instead of `nil` when switching back and forth with persistent private browsing enabled.
- There must always be a tab to select.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8146

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
