### PR TITLE
Fix #8148: Problem with toggling Sync Types from Settings

### DIFF
--- a/Sources/Brave/Frontend/Sync/BraveCore/BraveSyncAPIExtensions.swift
+++ b/Sources/Brave/Frontend/Sync/BraveCore/BraveSyncAPIExtensions.swift
@@ -55,9 +55,11 @@ extension BraveSyncAPI {
   }
   
   @discardableResult
-  func joinSyncGroup(codeWords: String, syncProfileService: BraveSyncProfileServiceIOS, shouldEnableBookmarks: Bool) -> Bool {
+  func joinSyncGroup(codeWords: String, syncProfileService: BraveSyncProfileServiceIOS) -> Bool {
     if setSyncCode(codeWords) {
-      enableSyncTypes(syncProfileService: syncProfileService, shouldEnableBookmarks: shouldEnableBookmarks)
+      // Enable default sync type Bookmarks when joining a chain
+      Preferences.Chromium.syncBookmarksEnabled.value = true
+      enableSyncTypes(syncProfileService: syncProfileService)
       requestSync()
       setSetupComplete()
       Preferences.Chromium.syncEnabled.value = true
@@ -92,13 +94,9 @@ extension BraveSyncAPI {
     resetSync()
   }
 
-  func enableSyncTypes(syncProfileService: BraveSyncProfileServiceIOS, shouldEnableBookmarks: Bool) {
+  func enableSyncTypes(syncProfileService: BraveSyncProfileServiceIOS) {
     syncProfileService.userSelectedTypes = []
     
-    // This value is true by default
-    // In some cases while joining a sync chain all values must be disabled
-    Preferences.Chromium.syncBookmarksEnabled.value = shouldEnableBookmarks
-      
     if Preferences.Chromium.syncBookmarksEnabled.value {
       syncProfileService.userSelectedTypes.update(with: .BOOKMARKS)
     }

--- a/Sources/Brave/Frontend/Sync/SyncSettingsTableViewController.swift
+++ b/Sources/Brave/Frontend/Sync/SyncSettingsTableViewController.swift
@@ -305,7 +305,7 @@ class SyncSettingsTableViewController: SyncViewController, UITableViewDelegate, 
         }
       }
 
-      syncAPI.enableSyncTypes(syncProfileService: syncProfileService, shouldEnableBookmarks: false)
+      syncAPI.enableSyncTypes(syncProfileService: syncProfileService)
     }
   }
   

--- a/Sources/Brave/Frontend/Sync/SyncWelcomeViewController.swift
+++ b/Sources/Brave/Frontend/Sync/SyncWelcomeViewController.swift
@@ -7,6 +7,7 @@ import BraveShared
 import BraveCore
 import BraveUI
 import os.log
+import Preferences
 
 /// Sometimes during heavy operations we want to prevent user from navigating back, changing screen etc.
 protocol NavigationPrevention {
@@ -261,7 +262,7 @@ class SyncWelcomeViewController: SyncViewController {
         }
       }
       
-      self.syncAPI.joinSyncGroup(codeWords: self.syncAPI.getSyncCode(), syncProfileService: self.syncProfileServices, shouldEnableBookmarks: true)
+      self.syncAPI.joinSyncGroup(codeWords: self.syncAPI.getSyncCode(), syncProfileService: self.syncProfileServices)
       self.handleSyncSetupFailure()
     }
     
@@ -337,7 +338,7 @@ extension SyncWelcomeViewController: SyncPairControllerDelegate {
 
     // In parallel set code words - request sync and setup complete
     // should be called on brave-core side
-    syncAPI.joinSyncGroup(codeWords: codeWords, syncProfileService: syncProfileServices, shouldEnableBookmarks: false)
+    syncAPI.joinSyncGroup(codeWords: codeWords, syncProfileService: syncProfileServices)
     handleSyncSetupFailure()
   }
   
@@ -485,8 +486,9 @@ extension SyncWelcomeViewController: SyncPairControllerDelegate {
   }
   
   private func enableDefaultTypeAndPushSettings() {
-    // Enable Bookmark Syncing and push settings
-    syncAPI.enableSyncTypes(syncProfileService: syncProfileServices, shouldEnableBookmarks: true)
+    // Enable default sync type Bookmarks and push settings
+    Preferences.Chromium.syncBookmarksEnabled.value = true
+    syncAPI.enableSyncTypes(syncProfileService: syncProfileServices)
     pushSettings()
   }
   

--- a/Sources/Brave/Migration/Migration.swift
+++ b/Sources/Brave/Migration/Migration.swift
@@ -41,7 +41,6 @@ public class Migration {
     }
 
     // Adding Observer to enable sync types
-
     NotificationCenter.default.addObserver(
       self,
       selector: #selector(enableUserSelectedTypesForSync),
@@ -56,7 +55,7 @@ public class Migration {
       return
     }
 
-    braveCore.syncAPI.enableSyncTypes(syncProfileService: braveCore.syncProfileService, shouldEnableBookmarks: true)
+    braveCore.syncAPI.enableSyncTypes(syncProfileService: braveCore.syncProfileService)
   }
 
   /// Adblock files don't have to be moved, they now have a new directory and will be downloaded there.


### PR DESCRIPTION
Altering sync type change method and deleting unnecessary parameter to enable default bookmarks type

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8148

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
- Join brand new sync chain and check bookmarks is enabled
- Toggle another sync type and check if it is enabled and bookmark is still enabled
-Restart the app and check the types are enabled properly and some variations of toggling

Check all enable disable action with Sync Internal types

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
