### PR TITLE
Fix #8017: Opening Private Tab from App Icon Long Press with Basic Challenge

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
@@ -154,10 +154,7 @@ extension BrowserViewController: TopToolbarDelegate {
   }
 
   func topToolbarDidPressStop(_ topToolbar: TopToolbarView) {
-    tabManager.selectedTab?.stop()
-    processAddressBarTask?.cancel()
-    topToolbarDidPressReloadTask?.cancel()
-    topToolbar.locationView.loading = tabManager.selectedTab?.loading ?? false
+    stopTabToolbarLoading()
   }
 
   func topToolbarDidLongPressReloadButton(_ topToolbar: TopToolbarView, from button: UIButton) {
@@ -916,6 +913,13 @@ extension BrowserViewController: ToolbarDelegate {
     if newTabIndex >= 0 && newTabIndex < tabs.count {
       tabManager.selectTab(tabs[newTabIndex])
     }
+  }
+  
+  func stopTabToolbarLoading() {
+    tabManager.selectedTab?.stop()
+    processAddressBarTask?.cancel()
+    topToolbarDidPressReloadTask?.cancel()
+    topToolbar.locationView.loading = tabManager.selectedTab?.loading ?? false
   }
 }
 

--- a/Sources/Brave/Frontend/Browser/QuickActions.swift
+++ b/Sources/Brave/Frontend/Browser/QuickActions.swift
@@ -60,6 +60,8 @@ public class QuickActions: NSObject {
     case .newTab:
       handleOpenNewTab(withBrowserViewController: browserViewController, isPrivate: false)
     case .newPrivateTab:
+      browserViewController.stopTabToolbarLoading()
+      
       if Preferences.Privacy.lockWithPasscode.value {
         handleOpenNewTab(withBrowserViewController: browserViewController, isPrivate: true)
       } else {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
Stopping to load tab before new tab challenge is called

This pull request fixes #8017

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

- [ ] Open normal mode and load
- [ ] https://search.brave.software/
- [ ] Check Basic Authentication is presented
- [ ] Kill the app
- [ ] Open from app icon long press using private mode
- [ ] check same website with basic authentication is shown in private mode

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


https://github.com/brave/brave-ios/assets/6643505/fe69d273-ba14-449d-92c4-9cc3299c1d7f


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
