### PR TITLE
Fix #7645: Explicitly end interactive tab reorder before starting again

### DIFF
--- a/Sources/Brave/Frontend/Browser/Tabs/TabBar/TabsBarViewController.swift
+++ b/Sources/Brave/Frontend/Browser/Tabs/TabBar/TabsBarViewController.swift
@@ -266,6 +266,9 @@ class TabsBarViewController: UIViewController {
         break
       }
       
+      // _UIDragSnappingFeedbackGenerator will occasionally throw an exception that its "already being
+      // interacted with" without explicitly ending the interactive movement on begin
+      collectionView.endInteractiveMovement()
       Task.delayed(bySeconds: 0.1) { @MainActor in
         self.collectionView.beginInteractiveMovementForItem(at: selectedIndexPath)
       }


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #7645 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

- Prefix: enable tab bar always and ensure system haptics are enabled
- Open multiple tabs
- Long press each tab over and over again (ensuring you feel the haptic feedback each time) and don't crash hopefully

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
