### PR TITLE
Fix #8013: Fix Playlist Crash on iPad due to invalid Scene

### DIFF
--- a/Sources/Brave/Frontend/Browser/Playlist/Controllers/PlaylistListViewController.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/Controllers/PlaylistListViewController.swift
@@ -704,7 +704,7 @@ extension PlaylistListViewController {
           }
         }
         
-        let items = try await PlaylistSharedFolderNetwork.fetchMediaItemInfo(item: model, viewForInvisibleWebView: self.view)
+        let items = try await PlaylistSharedFolderNetwork.fetchMediaItemInfo(item: model, viewForInvisibleWebView: self.playerView.window ?? self.playerView.superview ?? self.playerView)
         try Task.checkCancellation()
         
         try folder.playlistItems?.forEach({ playlistItem in

--- a/Sources/Brave/Frontend/Browser/Playlist/Managers & Cache/PlaylistCacheLoader.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/Managers & Cache/PlaylistCacheLoader.swift
@@ -340,7 +340,7 @@ class PlaylistWebLoader: UIView {
       
       guard let webView = tab.webView,
             let browserViewController = self.currentScene?.browserViewController else {
-        continuation.resume(returning: nil)
+        self.handler?(nil)
         return
       }
       


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- On iPad in Landscape, the ListView has no `currentScene` because it is `hidden` in the side-bar. So creating an `invisibleWebView` is impossible as it must have a visible view for pages to load.

- This can cause a crash when the async handler returns `nil` which is called TWICE.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8013

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
