### PR TITLE
Fix #8167: Show Brave News onboarding if language support is added later

### DIFF
--- a/Sources/BraveNews/NewsPreferences.swift
+++ b/Sources/BraveNews/NewsPreferences.swift
@@ -12,6 +12,7 @@ extension Preferences {
     public static let userOptedIn = Option<Bool>(key: "brave-today.user-opted-in", default: false)
     public static let isEnabled = Option<Bool>(key: "brave-today.enabled", default: true)
     public static let languageChecked = Option<Bool>(key: "brave-today.language-checked", default: false)
+    public static let languageWasUnavailableDuringCheck = Option<Bool?>(key: "brave-today.language-unavailable-when-checked", default: nil)
     public static let debugEnvironment = Option<String?>(key: "brave-today.debug.environment", default: nil)
     /// A list of channels followed for a locale.
     ///


### PR DESCRIPTION
This is only supported for new users since a new preference is required to track language check failures

## Summary of Changes

This pull request fixes #8167 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
