### PR TITLE
Fix #8089, #6538: Portfolio Settings / Menu View

### DIFF
--- a/Sources/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
+++ b/Sources/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
@@ -35,6 +35,7 @@ struct AssetDetailView: View {
   private var buySendSwapDestination: Binding<BuySendSwapDestination?>
 
   @Environment(\.openURL) private var openWalletURL
+  @ObservedObject private var isShowingBalances = Preferences.Wallet.isShowingBalances
 
   @ViewBuilder private var accountsBalanceView: some View {
     Section(
@@ -69,13 +70,19 @@ struct AssetDetailView: View {
                   .font(.footnote)
                   .foregroundColor(Color(.secondaryBraveLabel))
               } else {
-                VStack(alignment: .trailing) {
-                  Text(showFiatPlaceholder ? "$0.00" : viewModel.fiatBalance)
-                    .redacted(reason: showFiatPlaceholder ? .placeholder : [])
-                    .shimmer(assetDetailStore.isLoadingPrice)
-                  Text(showBalancePlaceholder ? "0.0000 \(assetDetailStore.assetDetailToken.symbol)" : "\(viewModel.balance) \(assetDetailStore.assetDetailToken.symbol)")
-                    .redacted(reason: showBalancePlaceholder ? .placeholder : [])
-                    .shimmer(assetDetailStore.isLoadingAccountBalances)
+                Group {
+                  if isShowingBalances.value {
+                    VStack(alignment: .trailing) {
+                      Text(showFiatPlaceholder ? "$0.00" : viewModel.fiatBalance)
+                        .redacted(reason: showFiatPlaceholder ? .placeholder : [])
+                        .shimmer(assetDetailStore.isLoadingPrice)
+                      Text(showBalancePlaceholder ? "0.0000 \(assetDetailStore.assetDetailToken.symbol)" : "\(viewModel.balance) \(assetDetailStore.assetDetailToken.symbol)")
+                        .redacted(reason: showBalancePlaceholder ? .placeholder : [])
+                        .shimmer(assetDetailStore.isLoadingAccountBalances)
+                    }
+                  } else {
+                    Text("****")
+                  }
                 }
                 .font(.footnote)
                 .foregroundColor(Color(.secondaryBraveLabel))

--- a/Sources/BraveWallet/Crypto/MainMenuView.swift
+++ b/Sources/BraveWallet/Crypto/MainMenuView.swift
@@ -79,8 +79,7 @@ struct MainMenuView: View {
       if #available(iOS 16, *) {
         view
           .presentationDetents([
-            .height(viewHeight),
-            .large
+            .height(viewHeight)
           ])
       } else {
         view
@@ -168,6 +167,7 @@ private struct MenuRowView<AccessoryContent: View>: View {
       Spacer()
       accessoryContent()
     }
+    .font(.callout.weight(.semibold))
     .padding(.horizontal)
   }
 }

--- a/Sources/BraveWallet/Crypto/MainMenuView.swift
+++ b/Sources/BraveWallet/Crypto/MainMenuView.swift
@@ -1,0 +1,176 @@
+/* Copyright 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import SwiftUI
+import Strings
+import Preferences
+
+struct MainMenuView: View {
+  
+  let isFromPortfolio: Bool
+  @Binding var isShowingSettings: Bool
+  let keyringStore: KeyringStore
+  
+  @ObservedObject private var isShowingBalances = Preferences.Wallet.isShowingBalances
+  @ObservedObject private var isShowingGraph = Preferences.Wallet.isShowingGraph
+  @ObservedObject private var isShowingNFTs = Preferences.Wallet.isShowingNFTsTab
+  
+  @Environment(\.presentationMode) @Binding private var presentationMode
+  @Environment(\.openURL) private var openWalletURL
+  
+  @ScaledMetric var rowHeight: CGFloat = 52
+  @State private var viewHeight: CGFloat = 0
+  
+  var body: some View {
+    ScrollView {
+      LazyVStack(spacing: 0) {
+        Button(action: {
+          presentationMode.dismiss()
+          // wait for view to dismiss so entire Wallet does not dismiss
+          DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            keyringStore.lock()
+          }
+        }) {
+          MenuRowView(
+            iconBraveSystemName: "leo.lock",
+            title: Strings.Wallet.lockWallet
+          )
+        }
+        .frame(height: rowHeight)
+        
+        Button(action: {
+          isShowingSettings = true
+          presentationMode.dismiss()
+        }) {
+          MenuRowView(
+            iconBraveSystemName: "leo.settings",
+            title: Strings.Wallet.walletSettings
+          )
+        }
+        .frame(height: rowHeight)
+        
+        if isFromPortfolio {
+          Divider()
+          portfolioSettings
+        }
+        
+        Divider()
+        Button(action: {
+          openWalletURL(WalletConstants.braveWalletSupportURL)
+        }) {
+          MenuRowView(
+            iconBraveSystemName: "leo.help.outline",
+            title: Strings.Wallet.helpCenter,
+            accessoryContent: {
+              Image(braveSystemName: "leo.launch")
+                .imageScale(.large)
+                .foregroundColor(Color(braveSystemName: .buttonBackground))
+            }
+          )
+        }
+        .frame(height: rowHeight)
+      }
+      .padding(.vertical, 8)
+      .readSize { size in
+        self.viewHeight = size.height
+      }
+    }
+    .background(Color(braveSystemName: .containerBackground))
+    .osAvailabilityModifiers({ view in
+      if #available(iOS 16, *) {
+        view
+          .presentationDetents([
+            .height(viewHeight),
+            .large
+          ])
+      } else {
+        view
+      }
+    })
+  }
+  
+  @ViewBuilder private var portfolioSettings: some View {
+    MenuRowView(
+      iconBraveSystemName: "leo.eye.on",
+      title: Strings.Wallet.balances,
+      accessoryContent: {
+        Toggle(isOn: $isShowingBalances.value) {
+          EmptyView()
+        }
+        .tint(Color(braveSystemName: .buttonBackground))
+      }
+    )
+    .frame(height: rowHeight)
+    
+    MenuRowView(
+      iconBraveSystemName: "leo.graph",
+      title: Strings.Wallet.graph,
+      accessoryContent: {
+        Toggle(isOn: $isShowingGraph.value) {
+          EmptyView()
+        }
+        .tint(Color(braveSystemName: .buttonBackground))
+      }
+    )
+    .frame(height: rowHeight)
+    
+    MenuRowView(
+      iconBraveSystemName: "leo.nft",
+      title: Strings.Wallet.nftsTab,
+      accessoryContent: {
+        Toggle(isOn: $isShowingNFTs.value) {
+          EmptyView()
+        }
+        .tint(Color(braveSystemName: .buttonBackground))
+      }
+    )
+    .frame(height: rowHeight)
+  }
+}
+
+#if DEBUG
+struct MainMenuView_Previews: PreviewProvider {
+  static var previews: some View {
+    Color.white
+      .sheet(isPresented: .constant(true), content: {
+        MainMenuView(
+          isFromPortfolio: true,
+          isShowingSettings: .constant(false),
+          keyringStore: .previewStoreWithWalletCreated
+        )
+      })
+  }
+}
+#endif
+
+private struct MenuRowView<AccessoryContent: View>: View {
+  
+  let iconBraveSystemName: String
+  let title: String
+  let accessoryContent: () -> AccessoryContent
+  
+  init(
+    iconBraveSystemName: String,
+    title: String,
+    accessoryContent: @escaping () -> AccessoryContent = { EmptyView() }
+  ) {
+    self.iconBraveSystemName = iconBraveSystemName
+    self.title = title
+    self.accessoryContent = accessoryContent
+  }
+  
+  var body: some View {
+    HStack(spacing: 12) {
+      Image(braveSystemName: iconBraveSystemName)
+        .imageScale(.medium)
+        .foregroundColor(Color(braveSystemName: .iconDefault))
+      Text(title)
+        .foregroundColor(Color(braveSystemName: .textPrimary))
+      Spacer()
+      accessoryContent()
+    }
+    .padding(.horizontal)
+  }
+}

--- a/Sources/BraveWallet/Crypto/MainMenuView.swift
+++ b/Sources/BraveWallet/Crypto/MainMenuView.swift
@@ -28,10 +28,7 @@ struct MainMenuView: View {
       LazyVStack(spacing: 0) {
         Button(action: {
           presentationMode.dismiss()
-          // wait for view to dismiss so entire Wallet does not dismiss
-          DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-            keyringStore.lock()
-          }
+          keyringStore.lock()
         }) {
           MenuRowView(
             iconBraveSystemName: "leo.lock",

--- a/Sources/BraveWallet/Crypto/Portfolio/PortfolioAssetView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/PortfolioAssetView.swift
@@ -4,6 +4,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import SwiftUI
+import Preferences
 
 struct PortfolioAssetView: View {
   var image: AssetIconView
@@ -12,6 +13,27 @@ struct PortfolioAssetView: View {
   let networkName: String
   var amount: String
   var quantity: String
+  let shouldHideBalance: Bool
+  
+  @ObservedObject private var isShowingBalances = Preferences.Wallet.isShowingBalances
+  
+  init(
+    image: AssetIconView,
+    title: String, 
+    symbol: String,
+    networkName: String,
+    amount: String,
+    quantity: String,
+    shouldHideBalance: Bool = false
+  ) {
+    self.image = image
+    self.title = title
+    self.symbol = symbol
+    self.networkName = networkName
+    self.amount = amount
+    self.quantity = quantity
+    self.shouldHideBalance = shouldHideBalance
+  }
 
   var body: some View {
     AssetView(
@@ -20,14 +42,20 @@ struct PortfolioAssetView: View {
       symbol: symbol,
       networkName: networkName,
       accessoryContent: {
-        VStack(alignment: .trailing) {
-          Text(amount.isEmpty ? "0.0" : amount)
-            .fontWeight(.semibold)
-          Text(verbatim: "\(quantity) \(symbol)")
+        Group {
+          if shouldHideBalance && !isShowingBalances.value {
+            Text("****")
+          } else {
+            VStack(alignment: .trailing) {
+              Text(amount.isEmpty ? "0.0" : amount)
+                .fontWeight(.semibold)
+              Text(verbatim: "\(quantity) \(symbol)")
+            }
+            .multilineTextAlignment(.trailing)
+          }
         }
         .font(.footnote)
         .foregroundColor(Color(.braveLabel))
-        .multilineTextAlignment(.trailing)
       }
     )
     .accessibilityLabel("\(title), \(quantity) \(symbol), \(amount)")
@@ -97,7 +125,7 @@ struct AssetView<ImageView: View, AccessoryContent: View>: View {
   let title: String
   let symbol: String
   let networkName: String
-  let accessoryContent: () -> AccessoryContent
+  @ViewBuilder var accessoryContent: () -> AccessoryContent
 
   var body: some View {
     HStack {

--- a/Sources/BraveWallet/Crypto/Portfolio/PortfolioAssetsView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/PortfolioAssetsView.swift
@@ -6,6 +6,7 @@
 import SwiftUI
 import DesignSystem
 import BraveCore
+import Preferences
 
 struct PortfolioAssetsView: View {
 
@@ -18,6 +19,7 @@ struct PortfolioAssetsView: View {
   @State private var isPresentingFiltersDisplaySettings: Bool = false
   @State private var selectedToken: BraveWallet.BlockchainToken?
   @State private var groupToggleState: [AssetGroupViewModel.ID: Bool] = [:]
+  @ObservedObject private var isShowingBalances = Preferences.Wallet.isShowingBalances
 
   var body: some View {
     LazyVStack(spacing: 16) {
@@ -153,7 +155,8 @@ struct PortfolioAssetsView: View {
           symbol: asset.token.symbol,
           networkName: asset.network.chainName,
           amount: asset.fiatAmount(currencyFormatter: portfolioStore.currencyFormatter),
-          quantity: asset.quantity
+          quantity: asset.quantity,
+          shouldHideBalance: true
         )
       }
     }
@@ -184,7 +187,8 @@ struct PortfolioAssetsView: View {
               symbol: asset.token.symbol,
               networkName: asset.network.chainName,
               amount: asset.fiatAmount(currencyFormatter: portfolioStore.currencyFormatter),
-              quantity: asset.quantity
+              quantity: asset.quantity,
+              shouldHideBalance: true
             )
           }
         }
@@ -224,7 +228,7 @@ struct PortfolioAssetsView: View {
         }
         .multilineTextAlignment(.leading)
         Spacer()
-        Text(portfolioStore.currencyFormatter.string(from: NSNumber(value: group.totalFiatValue)) ?? "")
+        Text(isShowingBalances.value ? portfolioStore.currencyFormatter.string(from: NSNumber(value: group.totalFiatValue)) ?? "" : "****")
           .font(.callout.weight(.semibold))
           .foregroundColor(Color(WalletV2Design.textPrimary))
           .multilineTextAlignment(.trailing)

--- a/Sources/BraveWallet/Crypto/Portfolio/PortfolioHeaderView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/PortfolioHeaderView.swift
@@ -6,6 +6,7 @@
 import SwiftUI
 import DesignSystem
 import BraveCore
+import Preferences
 
 struct PortfolioHeaderView: View {
   
@@ -20,6 +21,8 @@ struct PortfolioHeaderView: View {
   @State private var isPresentingBackup = false
   @State private var dismissedBackupBannerThisSession = false
   @State private var selectedBalance: BalanceTimePrice?
+  @ObservedObject private var isShowingGraph = Preferences.Wallet.isShowingGraph
+  @ObservedObject private var isShowingBalances = Preferences.Wallet.isShowingBalances
 
   private var isShowingBackupBanner: Bool {
     !keyringStore.defaultKeyring.isBackedUp && !dismissedBackupBannerThisSession
@@ -46,7 +49,9 @@ struct PortfolioHeaderView: View {
       
       Spacer().frame(height: 24)
       
-      lineChart
+      if isShowingGraph.value {
+        lineChart
+      }
     }
     .padding()
     .frame(maxWidth: .infinity)
@@ -79,13 +84,13 @@ struct PortfolioHeaderView: View {
   
   private var balanceAndPriceChanges: some View {
     VStack(spacing: 12) {
-      Text(balance)
+      Text(isShowingBalances.value ? balance : "****")
         .frame(maxWidth: .infinity)
         .opacity(selectedBalance == nil ? 1 : 0)
         .overlay(
           Group {
             if let dataPoint = selectedBalance {
-              Text(dataPoint.formattedPrice)
+              Text(isShowingBalances.value ?  dataPoint.formattedPrice : "****")
             }
           }
         )
@@ -94,10 +99,10 @@ struct PortfolioHeaderView: View {
       
       if let balanceDifference {
         HStack {
-          Text(balanceDifference.priceDifference)
+          Text(isShowingBalances.value ? balanceDifference.priceDifference : "****")
             .font(.footnote)
             .foregroundColor(Color(braveSystemName: balanceDifference.isBalanceUp ? .systemfeedbackSuccessText : .systemfeedbackErrorText))
-          Text(balanceDifference.percentageChange)
+          Text(isShowingBalances.value ? balanceDifference.percentageChange : "****")
             .font(.footnote)
             .padding(4)
             .foregroundColor(Color(braveSystemName: balanceDifference.isBalanceUp ? .green50 : .red50))

--- a/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
@@ -25,6 +25,7 @@ struct PortfolioView: View {
   private var buySendSwapDestination: Binding<BuySendSwapDestination?>
   
   @State private var selectedContent: PortfolioSegmentedControl.SelectedContent = .assets
+  @ObservedObject private var isShowingNFTsTab = Preferences.Wallet.isShowingNFTsTab
   
   var body: some View {
     ScrollView {
@@ -51,11 +52,13 @@ struct PortfolioView: View {
   
   private var contentDrawer: some View {
     LazyVStack {
-      PortfolioSegmentedControl(selected: $selectedContent)
-        .padding(.horizontal)
-        .padding(.bottom, 6)
+      if isShowingNFTsTab.value {
+        PortfolioSegmentedControl(selected: $selectedContent)
+          .padding(.horizontal)
+          .padding(.bottom, 6)
+      }
       Group {
-        if selectedContent == .assets {
+        if selectedContent == .assets || !isShowingNFTsTab.value {
           PortfolioAssetsView(
             cryptoStore: cryptoStore,
             keyringStore: keyringStore,

--- a/Sources/BraveWallet/Crypto/Stores/TabbedPageViewController.swift
+++ b/Sources/BraveWallet/Crypto/Stores/TabbedPageViewController.swift
@@ -68,7 +68,21 @@ class TabbedPageViewController: UIViewController {
   )
 
   private var contentOffsetObservation: NSKeyValueObservation?
-
+  
+  private let selectedIndexChanged: ((Int) -> Void)?
+  
+  public init(
+    selectedIndexChanged: ((Int) -> Void)?
+  ) {
+    self.selectedIndexChanged = selectedIndexChanged
+    super.init(nibName: nil, bundle: nil)
+  }
+  
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
   override func viewDidLoad() {
     super.viewDidLoad()
 
@@ -219,6 +233,7 @@ class TabbedPageViewController: UIViewController {
       self.updateTabsBarSelectionIndicator(pageIndex: indexPath.item)
     }.startAnimation()
     pageViewController.setViewControllers([vc], direction: direction, animated: true)
+    selectedIndexChanged?(indexPath.item)
   }
 }
 
@@ -282,6 +297,7 @@ extension TabbedPageViewController: UIPageViewControllerDelegate {
     }
     self.pageTransitionContext = nil
     if let currentIndex = currentIndex {
+      selectedIndexChanged?(currentIndex)
       // Update the selected tab for accessibility purposes and also in case UIPageViewController
       // ever changes how its `UIScrollView` is managed this will continue to show the user what the
       // selected tab is even if it doesn't interpolate while scrolling

--- a/Sources/BraveWallet/WalletHostingViewController.swift
+++ b/Sources/BraveWallet/WalletHostingViewController.swift
@@ -88,14 +88,18 @@ public class WalletHostingViewController: UIHostingController<CryptoView> {
         if !isLocked {
           onUnlock?()
         }
-        // SwiftUI has a bug where nested sheets do not dismiss correctly if the root View holding onto
-        // the sheet is removed from the view hierarchy. The root's sheet stays visible even though the
-        // root doesn't exist anymore.
+        // Prior to iOS 16.4, SwiftUI has a bug where nested sheets do not dismiss correctly if the
+        // root View holding onto the sheet is removed from the view hierarchy. The root's sheet
+        // stays visible even though the root doesn't exist anymore.
         //
         // As a workaround to this issue, we can just watch keyring's `isLocked` value from here
         // and dismiss the first sheet ourselves to ensure we dont get stuck with a child view visible
         // while the wallet is locked.
-        if let self = self, isLocked, self.presentedViewController != nil {
+        if #unavailable(iOS 16.4),
+           let self = self,
+           isLocked,
+           let presentedViewController = self.presentedViewController,
+           !presentedViewController.isBeingDismissed {
           self.dismiss(animated: true)
         }
       }

--- a/Sources/BraveWallet/WalletPreferences.swift
+++ b/Sources/BraveWallet/WalletPreferences.swift
@@ -47,6 +47,11 @@ extension Preferences {
     /// The option for users to turn off aurora popup
     public static let showAuroraPopup = Option<Bool>(key: "wallet.show-aurora-popup", default: true)
     
+    // MARK: Portfolio settings
+    public static let isShowingGraph = Option<Bool>(key: "wallet.isShowingGraph", default: true)
+    public static let isShowingBalances = Option<Bool>(key: "wallet.isShowingBalances", default: true)
+    public static let isShowingNFTsTab = Option<Bool>(key: "wallet.isShowingNFTsTab", default: true)
+    
     // MARK: Portfolio & NFT filters
     public static let groupByFilter = Option<Int>(key: "wallet.groupByFilter", default: GroupBy.none.rawValue)
     public static let sortOrderFilter = Option<Int>(key: "wallet.sortOrderFilter", default: SortOrder.valueDesc.rawValue)

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -1850,12 +1850,47 @@ extension Strings {
       value: "Lock",
       comment: "The title of the lock option inside the menu when user clicks the three dots button beside assets search button."
     )
+    public static let lockWallet = NSLocalizedString(
+      "wallet.lockWallet",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Lock Wallet",
+      comment: "The title of the lock option inside the menu when user clicks the three dots button beside assets search button."
+    )
     public static let settings = NSLocalizedString(
       "wallet.settings",
       tableName: "BraveWallet",
       bundle: .module,
       value: "Settings",
       comment: "The title of the settings option inside the menu when user clicks the three dots button beside assets search button."
+    )
+    public static let walletSettings = NSLocalizedString(
+      "wallet.walletSettings",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Wallet Settings",
+      comment: "The title of the settings option inside the menu when user clicks the three dots button beside assets search button."
+    )
+    public static let balances = NSLocalizedString(
+      "wallet.balances",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Balances",
+      comment: "The title of the settings option inside the menu when user clicks the three dots button beside assets search button with Portfolio tab open."
+    )
+    public static let graph = NSLocalizedString(
+      "wallet.graph",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Graph",
+      comment: "The title of the settings option inside the menu when user clicks the three dots button beside assets search button with Portfolio tab open."
+    )
+    public static let nftsTab = NSLocalizedString(
+      "wallet.nftsTab",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "NFTs Tab",
+      comment: "The title of the settings option inside the menu when user clicks the three dots button beside assets search button with Portfolio tab open."
     )
     public static let helpCenter = NSLocalizedString(
       "wallet.helpCenter",

--- a/Sources/DesignSystem/Icons/Symbols.xcassets/leo.graph.symbolset/Contents.json
+++ b/Sources/DesignSystem/Icons/Symbols.xcassets/leo.graph.symbolset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "symbols" : [
+    {
+      "idiom" : "universal"
+    }
+  ]
+}

--- a/Sources/DesignSystem/Icons/Symbols.xcassets/leo.help.outline.symbolset/Contents.json
+++ b/Sources/DesignSystem/Icons/Symbols.xcassets/leo.help.outline.symbolset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "symbols" : [
+    {
+      "idiom" : "universal"
+    }
+  ]
+}

--- a/Sources/DesignSystem/Icons/Symbols.xcassets/leo.launch.symbolset/Contents.json
+++ b/Sources/DesignSystem/Icons/Symbols.xcassets/leo.launch.symbolset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "symbols" : [
+    {
+      "idiom" : "universal"
+    }
+  ]
+}

--- a/Sources/DesignSystem/Icons/Symbols.xcassets/leo.nft.symbolset/Contents.json
+++ b/Sources/DesignSystem/Icons/Symbols.xcassets/leo.nft.symbolset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "symbols" : [
+    {
+      "idiom" : "universal"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary of Changes
- Update the 3-dot menu in Wallet to use a sheet/tray presentation style.
- Add hide/show Balances, hide/show Graph and hide/show NFTs Tab toggle

This pull request fixes #8089,
fixes #6538

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Open wallet and tap `...` menu
2. Verify `Balances`, `Graph` and `NFTs tab` toggle rows are displayed
3. Change to any tab except Portfolio, verify `Balances`, `Graph` and `NFTs tab` toggle rows are NOT displayed
4. Open `...` menu from Portfolio and toggle `Balances`, `Graph` and `NFTs tab` toggle to disabled.
5. Verify balances are hidden on Portfolio & Asset Detail
6. Verify graph is removed
7. Verify NFTs tab and Assets/NFTS control is hidden
8. Close & re-open Brave Wallet
9. Verify settings are persisted
10. Open wallet and tap `...` menu, tap `Wallet Settings`, verify wallet settings is opened
11. Open wallet and tap `...` menu, tap Help Centre, verify help center link is opened in a new tab

## Screenshots:

https://github.com/brave/brave-ios/assets/5314553/d677e185-3a49-401b-84f4-beade1d628ff


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
