### PR TITLE
Fix #8178: Set the NTP-SI P3A total count correctly

### DIFF
--- a/Sources/Brave/Frontend/Browser/New Tab Page/Backgrounds/NewTabPageP3AHelper.swift
+++ b/Sources/Brave/Frontend/Browser/New Tab Page/Backgrounds/NewTabPageP3AHelper.swift
@@ -143,6 +143,8 @@ final class NewTabPageP3AHelper {
         let name = DynamicHistogramName(creativeInstanceId: creativeInstanceId, eventType: eventType)
         countsStorage.eventCounts[creativeInstanceId]?.inflightCounts[eventType] = count
         UmaHistogramRecordValueToBucket(name.histogramName, buckets: countBuckets, value: count)
+      }
+      if !eventCounts.counts.isEmpty {
         totalActiveCreatives += 1
       }
     }


### PR DESCRIPTION
Should have been per-creative not per-event which was resulting in high totals

## Summary of Changes

This pull request fixes #8178 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
