### PR TITLE
Fix #8188: Add ability to run tests against the latest iOS version.

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -7,43 +7,35 @@ on:
       - beta
   pull_request:
 
-defaults:
-  runs-on: macOS-13
-  env:
-    XCODE_VERSION: "14.3.1"
-  steps:
-    - name: Select XCode
-      run: sudo xcode-select --switch /Applications/Xcode_${{ env.XCODE_VERSION }}.app
-    - name: Checkout
-      uses: actions/checkout@v3
-    - name: Update node
-      uses: actions/setup-node@v3
-      with:
-        node-version: '18.x'
-    - uses: actions/cache@v3
-      with:
-        path: ~/.npm
-        key: npm-${{ hashFiles('package-lock.json') }}
-        restore-keys: npm-
-    - name: Run bootstrap script
-      run: ./bootstrap.sh --ci
-
 jobs:
   test:
     if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'CI/skip')) }}
     name: Run tests
+    runs-on: macOS-13
+    env:
+        # The XCode version to use. If you want to update it please refer to this document:
+        # https://docs.github.com/en/actions/reference/specifications-for-github-hosted-runners#supported-software
+        # and set proper version.
+        XCODE_VERSION: "14.3.1"
 
     steps:
+      - name: Select XCode
+        # Use XCODE_VERSION env variable to set the XCode version you want.
+        run: sudo xcode-select --switch /Applications/Xcode_${{ env.XCODE_VERSION }}.app
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Update node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
+      - uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: npm-
+      - name: Run bootstrap script
+        run: ./bootstrap.sh --ci
       - name: Run tests
         run: |
           set -o pipefail
           fastlane ios test
-
-  test_latest_os:
-    if: github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'CI/latest_os'
-    name: Run tests on the latest available iOS simulator
-    steps:
-      - name: Run latest OS tests
-        run: |
-          set -o pipefail
-          fastlane ios test use_latest_os:true

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -42,7 +42,7 @@ jobs:
           fastlane ios test
 
   test_latest_os:
-     if: >-
+    if: >-
       (github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'CI/latest_os') || 
       (github.event_name == 'pull_request' && github.event.action == 'opened' && contains(github.event.pull_request.labels.*.name, 'CI/latest_os')) || 
       (github.event_name == 'pull_request' && github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'CI/latest_os'))

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -43,15 +43,9 @@ jobs:
 
   test_latest_os:
      if: >-
-      (github.event_name == 'pull_request' && 
-       github.event.action == 'labeled' && 
-       github.event.label.name == 'CI/latest_os') || 
-      (github.event_name == 'pull_request' && 
-       github.event.action == 'opened' && 
-       contains(github.event.pull_request.labels.*.name, 'CI/latest_os')) || 
-      (github.event_name == 'pull_request' && 
-       github.event.action == 'synchronize' && 
-       contains(github.event.pull_request.labels.*.name, 'CI/latest_os'))
+      (github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'CI/latest_os') || 
+      (github.event_name == 'pull_request' && github.event.action == 'opened' && contains(github.event.pull_request.labels.*.name, 'CI/latest_os')) || 
+      (github.event_name == 'pull_request' && github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'CI/latest_os'))
     name: Run latest OS tests
     runs-on: macOS-13
     env:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -7,35 +7,43 @@ on:
       - beta
   pull_request:
 
+defaults:
+  runs-on: macOS-13
+  env:
+    XCODE_VERSION: "14.3.1"
+  steps:
+    - name: Select XCode
+      run: sudo xcode-select --switch /Applications/Xcode_${{ env.XCODE_VERSION }}.app
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Update node
+      uses: actions/setup-node@v3
+      with:
+        node-version: '18.x'
+    - uses: actions/cache@v3
+      with:
+        path: ~/.npm
+        key: npm-${{ hashFiles('package-lock.json') }}
+        restore-keys: npm-
+    - name: Run bootstrap script
+      run: ./bootstrap.sh --ci
+
 jobs:
   test:
     if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'CI/skip')) }}
     name: Run tests
-    runs-on: macOS-13
-    env:
-        # The XCode version to use. If you want to update it please refer to this document:
-        # https://docs.github.com/en/actions/reference/specifications-for-github-hosted-runners#supported-software
-        # and set proper version.
-        XCODE_VERSION: "14.3.1"
 
     steps:
-      - name: Select XCode
-        # Use XCODE_VERSION env variable to set the XCode version you want.
-        run: sudo xcode-select --switch /Applications/Xcode_${{ env.XCODE_VERSION }}.app
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Update node
-        uses: actions/setup-node@v3
-        with:
-          node-version: '18.x'
-      - uses: actions/cache@v3
-        with:
-          path: ~/.npm
-          key: npm-${{ hashFiles('package-lock.json') }}
-          restore-keys: npm-
-      - name: Run bootstrap script
-        run: ./bootstrap.sh --ci
       - name: Run tests
         run: |
           set -o pipefail
           fastlane ios test
+
+  test_latest_os:
+    if: github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'CI/latest_os'
+    name: Run tests on the latest available iOS simulator
+    steps:
+      - name: Run latest OS tests
+        run: |
+          set -o pipefail
+          fastlane ios test use_latest_os:true

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -6,6 +6,7 @@ on:
       - development
       - beta
   pull_request:
+    types: [ labeled ]
 
 jobs:
   test:
@@ -42,7 +43,7 @@ jobs:
 
   test_latest_os:
     if: ${{ github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'CI/latest_os' }}
-    name: Run tests
+    name: Run latest OS tests
     runs-on: macOS-13
     env:
         # The XCode version to use. If you want to update it please refer to this document:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -39,3 +39,35 @@ jobs:
         run: |
           set -o pipefail
           fastlane ios test
+
+  test_latest_os:
+    if: ${{ github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'CI/latest_os' }}
+    name: Run tests
+    runs-on: macOS-13
+    env:
+        # The XCode version to use. If you want to update it please refer to this document:
+        # https://docs.github.com/en/actions/reference/specifications-for-github-hosted-runners#supported-software
+        # and set proper version.
+        XCODE_VERSION: "14.3.1"
+
+    steps:
+      - name: Select XCode
+        # Use XCODE_VERSION env variable to set the XCode version you want.
+        run: sudo xcode-select --switch /Applications/Xcode_${{ env.XCODE_VERSION }}.app
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Update node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
+      - uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: npm-
+      - name: Run bootstrap script
+        run: ./bootstrap.sh --ci
+      - name: Run tests
+        run: |
+          set -o pipefail
+          fastlane ios test use_latest_os:true

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -6,7 +6,7 @@ on:
       - development
       - beta
   pull_request:
-    types: [ labeled ]
+    types: [ labeled, opened, synchronize ]
 
 jobs:
   test:
@@ -42,7 +42,16 @@ jobs:
           fastlane ios test
 
   test_latest_os:
-    if: ${{ github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'CI/latest_os' }}
+     if: >-
+      (github.event_name == 'pull_request' && 
+       github.event.action == 'labeled' && 
+       github.event.label.name == 'CI/latest_os') || 
+      (github.event_name == 'pull_request' && 
+       github.event.action == 'opened' && 
+       contains(github.event.pull_request.labels.*.name, 'CI/latest_os')) || 
+      (github.event_name == 'pull_request' && 
+       github.event.action == 'synchronize' && 
+       contains(github.event.pull_request.labels.*.name, 'CI/latest_os'))
     name: Run latest OS tests
     runs-on: macOS-13
     env:

--- a/.github/workflows/test_all_on_pr.yml
+++ b/.github/workflows/test_all_on_pr.yml
@@ -1,16 +1,16 @@
-name: Build
+name: Test all
 
 on: 
-  push:
-    branches:
-      - development
-      - beta
   pull_request:
+    types: [ labeled, opened, synchronize ]
 
 jobs:
-  test:
-    if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'CI/skip')) }}
-    name: Run tests
+  test_all:
+    if: >-
+      (github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'CI/test_all') || 
+      (github.event_name == 'pull_request' && github.event.action == 'opened' && contains(github.event.pull_request.labels.*.name, 'CI/test_all')) || 
+      (github.event_name == 'pull_request' && github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'CI/test_all'))
+    name: Test all supported major platform versions
     runs-on: macOS-13
     env:
         # The XCode version to use. If you want to update it please refer to this document:
@@ -38,4 +38,4 @@ jobs:
       - name: Run tests
         run: |
           set -o pipefail
-          fastlane ios test
+          fastlane ios test test_all:true

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -11,10 +11,6 @@ LOCAL_PATH = "#{CONFIG_PATH}/Local"
 DEFAULT_IOS_SIMULATOR_VERSION = "16.4"
 LATEST_IOS_SIMULATOR_VERSION = "17.0"
 
-def device_version(options)
-  options[:use_latest_os] ? LATEST_IOS_SIMULATOR_VERSION : DEFAULT_IOS_SIMULATOR_VERSION
-end
-
 platform :ios do
   before_all do |lane, options|
     device_version options
@@ -44,7 +40,7 @@ platform :ios do
     run_tests(
       project: "App/Client.xcodeproj",
       scheme: "Debug",
-      device: "iPhone 14 (#{device_version(options)})",
+      devices: options[:test_all] ? ["iPhone 14 (16.4)", "iPhone 14 (17.0)"] : ["iPhone 14 (16.4)"]
       code_coverage: true,
       ensure_devices_found: true,
       skip_testing: [
@@ -79,7 +75,7 @@ platform :ios do
     run_tests(
       project: "App/Client.xcodeproj",
       scheme: "Debug",
-      device: "iPad (10th generation) (#{device_version(options)})",
+      devices: options[:test_all] ? ["iPad (10th generation) (16.4)", "iPad (10th generation) (17.0)"] : ["iPad (10th generation) (16.4)"]
       code_coverage: true,
       ensure_devices_found: true,
       skip_testing: [

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -37,8 +37,9 @@ platform :ios do
     run_tests(
       project: "App/Client.xcodeproj",
       scheme: "Debug",
-      device: "iPhone 14 (16.4)",
+      device: "iPhone 14 (17.0)",
       code_coverage: true,
+      ensure_devices_found: true,
       skip_testing: [
 	"CertificateUtilitiesTests/CertificatePinningTest/testSelfSignedRootAllowed",
         "CertificateUtilitiesTests/CertificatePinningTest/testSelfSignedRootAllowed2",
@@ -71,8 +72,9 @@ platform :ios do
     run_tests(
       project: "App/Client.xcodeproj",
       scheme: "Debug",
-      device: "iPad (10th generation) (16.4)",
+      device: "iPad (10th generation) (17.0)",
       code_coverage: true,
+      ensure_devices_found: true,
       skip_testing: [
         "ClientTests/UserAgentTests"
       ],

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -37,7 +37,7 @@ platform :ios do
     run_tests(
       project: "App/Client.xcodeproj",
       scheme: "Debug",
-      device: "iPhone 14 (17.0)",
+      device: "iPhone 14 (17.4)",
       code_coverage: true,
       ensure_devices_found: true,
       skip_testing: [
@@ -72,7 +72,7 @@ platform :ios do
     run_tests(
       project: "App/Client.xcodeproj",
       scheme: "Debug",
-      device: "iPad (10th generation) (17.0)",
+      device: "iPad (10th generation) (17.4)",
       code_coverage: true,
       ensure_devices_found: true,
       skip_testing: [

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -37,7 +37,7 @@ platform :ios do
     run_tests(
       project: "App/Client.xcodeproj",
       scheme: "Debug",
-      device: "iPhone 14 (17.4)",
+      device: "iPhone 14 (17.0)",
       code_coverage: true,
       ensure_devices_found: true,
       skip_testing: [
@@ -72,7 +72,7 @@ platform :ios do
     run_tests(
       project: "App/Client.xcodeproj",
       scheme: "Debug",
-      device: "iPad (10th generation) (17.4)",
+      device: "iPad (10th generation) (17.0)",
       code_coverage: true,
       ensure_devices_found: true,
       skip_testing: [

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -8,9 +8,16 @@ default_platform :ios
 
 CONFIG_PATH = "../App/Configuration"
 LOCAL_PATH = "#{CONFIG_PATH}/Local"
+DEFAULT_IOS_SIMULATOR_VERSION = "16.4"
+LATEST_IOS_SIMULATOR_VERSION = "17.0"
+
+def device_version(options)
+  options[:use_latest_os] ? LATEST_IOS_SIMULATOR_VERSION : DEFAULT_IOS_SIMULATOR_VERSION
+end
 
 platform :ios do
   before_all do |lane, options|
+    device_version options
     unless lane == :test || options[:skip_bootstrap]
       sh("pushd .. && ./bootstrap.sh --ci && popd")
     end
@@ -37,7 +44,7 @@ platform :ios do
     run_tests(
       project: "App/Client.xcodeproj",
       scheme: "Debug",
-      device: "iPhone 14 (17.0)",
+      device: "iPhone 14 (#{device_version(options)})",
       code_coverage: true,
       ensure_devices_found: true,
       skip_testing: [
@@ -72,7 +79,7 @@ platform :ios do
     run_tests(
       project: "App/Client.xcodeproj",
       scheme: "Debug",
-      device: "iPad (10th generation) (17.0)",
+      device: "iPad (10th generation) (#{device_version(options)})",
       code_coverage: true,
       ensure_devices_found: true,
       skip_testing: [

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -8,8 +8,6 @@ default_platform :ios
 
 CONFIG_PATH = "../App/Configuration"
 LOCAL_PATH = "#{CONFIG_PATH}/Local"
-DEFAULT_IOS_SIMULATOR_VERSION = "16.4"
-LATEST_IOS_SIMULATOR_VERSION = "17.0"
 
 platform :ios do
   before_all do |lane, options|
@@ -40,7 +38,7 @@ platform :ios do
     run_tests(
       project: "App/Client.xcodeproj",
       scheme: "Debug",
-      devices: options[:test_all] ? ["iPhone 14 (16.4)", "iPhone 14 (17.0)"] : ["iPhone 14 (16.4)"]
+      devices: options[:test_all] ? ["iPhone 14 (16.4)", "iPhone 14 (17.0)"] : ["iPhone 14 (16.4)"],
       code_coverage: true,
       ensure_devices_found: true,
       skip_testing: [
@@ -75,7 +73,7 @@ platform :ios do
     run_tests(
       project: "App/Client.xcodeproj",
       scheme: "Debug",
-      devices: options[:test_all] ? ["iPad (10th generation) (16.4)", "iPad (10th generation) (17.0)"] : ["iPad (10th generation) (16.4)"]
+      devices: options[:test_all] ? ["iPad (10th generation) (16.4)", "iPad (10th generation) (17.0)"] : ["iPad (10th generation) (16.4)"],
       code_coverage: true,
       ensure_devices_found: true,
       skip_testing: [

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -11,7 +11,6 @@ LOCAL_PATH = "#{CONFIG_PATH}/Local"
 
 platform :ios do
   before_all do |lane, options|
-    device_version options
     unless lane == :test || options[:skip_bootstrap]
       sh("pushd .. && ./bootstrap.sh --ci && popd")
     end


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8188 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
