### PR TITLE
Fix #8183: Allow menu to be presented properly in compact-width iPads

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
@@ -878,7 +878,7 @@ extension BrowserViewController: ToolbarDelegate {
     presentPanModal(menuController, sourceView: tabToolbar.menuButton, sourceRect: tabToolbar.menuButton.bounds)
     if menuController.modalPresentationStyle == .popover {
       menuController.popoverPresentationController?.popoverLayoutMargins = .init(equalInset: 4)
-      menuController.popoverPresentationController?.permittedArrowDirections = [.up]
+      menuController.popoverPresentationController?.permittedArrowDirections = [.up, .down]
     }
   }
 


### PR DESCRIPTION
Unfortunately PanModal enforces the presentation to a `popover` on iPads regardless of size classes, so we must allow the arrow direction to be `down` as well here since the toolbar will be at the bottom on compact-width size classes. This also means that on iPads even with iPhone layouts they get shown as a popover which is not ideal and should be fixed later.

## Summary of Changes

This pull request fixes #8183 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
