### PR TITLE
Fix 8163: Notification asking to set Brave as the default browser is still shown after an external link opened via the 3P app

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController.swift
@@ -890,14 +890,8 @@ public class BrowserViewController: UIViewController {
     // Schedule Default Browser Local Notification
     // If notification is not already scheduled or
     // an external URL opened in Brave (which indicates Brave is set as default)
-    if !Preferences.DefaultBrowserIntro.defaultBrowserNotificationScheduled.value,
-        Preferences.DefaultBrowserIntro.defaultBrowserNotificationShouldBeShown.value {
+    if !Preferences.DefaultBrowserIntro.defaultBrowserNotificationScheduled.value {
       scheduleDefaultBrowserNotification()
-    }
-    
-    // Remove pending notification if default browser is already set
-    if !Preferences.DefaultBrowserIntro.defaultBrowserNotificationShouldBeShown.value {
-      cancelScheduleDefaultBrowserNotification()
     }
 
     privateModeCancellable = privateBrowsingManager
@@ -988,6 +982,8 @@ public class BrowserViewController: UIViewController {
   private func cancelScheduleDefaultBrowserNotification() {
     let center = UNUserNotificationCenter.current()
     center.removePendingNotificationRequests(withIdentifiers: [Self.defaultBrowserNotificationId])
+    
+    Preferences.DefaultBrowserIntro.defaultBrowserNotificationIsCanceled.value = true
   }
   
   private func executeAfterSetup(_ block: @escaping () -> Void) {
@@ -3229,7 +3225,13 @@ extension BrowserViewController {
     if case .url(let navigatedURL, _) = path {
       if navigatedURL?.isWebPage(includeDataURIs: false) == true {
         Preferences.General.defaultBrowserCalloutDismissed.value = true
-        Preferences.DefaultBrowserIntro.defaultBrowserNotificationShouldBeShown.value = false
+        Preferences.DefaultBrowserIntro.defaultBrowserNotificationScheduled.value = true
+        
+        // Remove pending notification if default browser is set brave
+        // Recognized by external link is open
+        if !Preferences.DefaultBrowserIntro.defaultBrowserNotificationIsCanceled.value {
+          cancelScheduleDefaultBrowserNotification()
+        }
       }
     }
     

--- a/Sources/Onboarding/OnboardingPreferences.swift
+++ b/Sources/Onboarding/OnboardingPreferences.swift
@@ -90,8 +90,8 @@ extension Preferences {
       default: false)
     
     /// Whether a default browser local notification should be shown
-    public static let defaultBrowserNotificationShouldBeShown = Option<Bool>(
-      key: "general.default-browser-notification-shown",
-      default: true)
+    public static let defaultBrowserNotificationIsCanceled = Option<Bool>(
+      key: "general.default-browser-notification-canceled",
+      default: false)
   }
 }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

Canceling Default browser notification asap when external link is open

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8163

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

- Launch Brave
- Go through onboarding and don't set it as Default browser
- Launch Gmail > Open a link with Brave
- Go to device settings > Update time on 2 hours forward
- Check notification > Observe

## Screenshots:


https://github.com/brave/brave-ios/assets/6643505/ebf7704c-5815-47ba-8993-4055aa3c46ef



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
