### PR TITLE
Ref #8076: Bump BraveCore to 1.59.111

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@mozilla/readability": "^0.4.2",
-        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.59.84/brave-core-ios-1.59.84.tgz",
+        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.59.111/brave-core-ios-1.59.111.tgz",
         "leo": "github:brave/leo#7f2dfddb70aff1501ef5a2f3c640a8c74a7343ee",
         "leo-sf-symbols": "github:brave/leo-sf-symbols#d6056328b8d6ef06e68996ff02a22e06f52590c3",
         "page-metadata-parser": "^1.1.3",
@@ -493,9 +493,9 @@
       }
     },
     "node_modules/brave-core-ios": {
-      "version": "1.59.84",
-      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.59.84/brave-core-ios-1.59.84.tgz",
-      "integrity": "sha512-DmhGMo6+diZNYs8EZyIog0ZlHANdVmHPHNHQtce2WK6V1XGwStVQQ0E+GpMq4S7SUmrC/v2F4iqMW8x8Ed44/w==",
+      "version": "1.59.111",
+      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.59.111/brave-core-ios-1.59.111.tgz",
+      "integrity": "sha512-G2lG6YySDJgxbi51IksiP6ITqPfIlqgD08yVNT1nvXPYHJLygEQevb3IDRV5S4VHk0+lAJTVaMM8FulGfdj98Q==",
       "license": "ISC"
     },
     "node_modules/browserslist": {
@@ -3171,8 +3171,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-browser/releases/download/v1.59.84/brave-core-ios-1.59.84.tgz",
-      "integrity": "sha512-DmhGMo6+diZNYs8EZyIog0ZlHANdVmHPHNHQtce2WK6V1XGwStVQQ0E+GpMq4S7SUmrC/v2F4iqMW8x8Ed44/w=="
+      "version": "https://github.com/brave/brave-browser/releases/download/v1.59.111/brave-core-ios-1.59.111.tgz",
+      "integrity": "sha512-G2lG6YySDJgxbi51IksiP6ITqPfIlqgD08yVNT1nvXPYHJLygEQevb3IDRV5S4VHk0+lAJTVaMM8FulGfdj98Q=="
     },
     "browserslist": {
       "version": "4.17.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "license": "MPL-2.0",
   "dependencies": {
     "@mozilla/readability": "^0.4.2",
-    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.59.84/brave-core-ios-1.59.84.tgz",
+    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.59.111/brave-core-ios-1.59.111.tgz",
     "leo": "github:brave/leo#7f2dfddb70aff1501ef5a2f3c640a8c74a7343ee",
     "leo-sf-symbols": "github:brave/leo-sf-symbols#d6056328b8d6ef06e68996ff02a22e06f52590c3",
     "page-metadata-parser": "^1.1.3",


### PR DESCRIPTION
This is a 1.59.x release candidate and includes a fresh install launch crash fix

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
