### PR TITLE
[v1.60] Fix #8182: KeyringInfo Refactor, Bump BraveCore to v1.60.81

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
@@ -582,7 +582,7 @@ extension Tab: BraveWalletKeyringServiceObserver {
   func keyringCreated(_ keyringId: BraveWallet.KeyringId) {
   }
   
-  func keyringRestored(_ keyringId: BraveWallet.KeyringId) {
+  func walletRestored() {
   }
   
   func keyringReset() {

--- a/Sources/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
@@ -164,13 +164,13 @@ struct AccountActivityView: View {
           }
         }
     )
-    .onReceive(keyringStore.$allAccounts, perform: { allAccounts in
+    .onReceive(keyringStore.$allAccounts) { allAccounts in
       if !allAccounts.contains(where: { $0.address == accountInfo.address }) {
         // Account was deleted
         detailsPresentation = nil
         presentationMode.dismiss()
       }
-    })
+    }
     .onAppear {
       activityStore.update()
     }

--- a/Sources/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
@@ -164,14 +164,13 @@ struct AccountActivityView: View {
           }
         }
     )
-    .onReceive(keyringStore.$allKeyrings) { allKeyrings in
-      let allAccounts = allKeyrings.flatMap(\.accountInfos)
+    .onReceive(keyringStore.$allAccounts, perform: { allAccounts in
       if !allAccounts.contains(where: { $0.address == accountInfo.address }) {
         // Account was deleted
         detailsPresentation = nil
         presentationMode.dismiss()
       }
-    }
+    })
     .onAppear {
       activityStore.update()
     }

--- a/Sources/BraveWallet/Crypto/Accounts/Add/AddAccountView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/Add/AddAccountView.swift
@@ -348,12 +348,13 @@ struct AddAccountView: View {
   }
   
   private func defaultAccountName(for coin: BraveWallet.CoinType, chainId: String, isPrimary: Bool) -> String {
-    let keyringId = BraveWallet.KeyringId.keyringId(for: coin, on: chainId)
-    let keyringInfo = keyringStore.allKeyrings.first { $0.id == keyringId }
+    let accountsForCoin = keyringStore.allAccounts.filter { $0.coin == coin }
     if isPrimary {
-      return String.localizedStringWithFormat(coin.defaultAccountName, (keyringInfo?.accountInfos.filter(\.isPrimary).count ?? 0) + 1)
+      let numberOfPrimaryAccountsForCoin = accountsForCoin.filter(\.isPrimary).count
+      return String.localizedStringWithFormat(coin.defaultAccountName, numberOfPrimaryAccountsForCoin + 1)
     } else {
-      return String.localizedStringWithFormat(coin.defaultSecondaryAccountName, (keyringInfo?.accountInfos.filter(\.isImported).count ?? 0) + 1)
+      let numberOfImportedAccounts = accountsForCoin.filter(\.isImported).count
+      return String.localizedStringWithFormat(coin.defaultSecondaryAccountName, numberOfImportedAccounts + 1)
     }
   }
 }

--- a/Sources/BraveWallet/Crypto/Accounts/Details/AccountDetailsView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/Details/AccountDetailsView.swift
@@ -185,7 +185,7 @@ struct AccountDetailsView_Previews: PreviewProvider {
   static var previews: some View {
     AccountDetailsView(
       keyringStore: .previewStoreWithWalletCreated,
-      account: KeyringStore.previewStoreWithWalletCreated.defaultKeyring.accountInfos.first!,
+      account: KeyringStore.previewStoreWithWalletCreated.allAccounts.first!,
       editMode: false
     )
     .previewColorSchemes()

--- a/Sources/BraveWallet/Crypto/Stores/AccountActivityStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/AccountActivityStore.swift
@@ -118,7 +118,6 @@ class AccountActivityStore: ObservableObject {
       self.userVisibleAssets = updatedUserVisibleAssets
       self.userVisibleNFTs = updatedUserVisibleNFTs
       
-      let keyringForAccount = await keyringService.keyringInfo(account.keyringId)
       typealias TokenNetworkAccounts = (token: BraveWallet.BlockchainToken, network: BraveWallet.NetworkInfo, accounts: [BraveWallet.AccountInfo])
       let allTokenNetworkAccounts = allVisibleUserAssets.flatMap { networkAssets in
         networkAssets.tokens.map { token in
@@ -199,9 +198,10 @@ class AccountActivityStore: ObservableObject {
         $0[$1.token.assetRatioId.lowercased()] = Double($1.price)
       })
       
+      let allAccountsForCoin = await keyringService.allAccounts().accounts.filter { $0.coin == account.coin }
       self.transactionSummaries = await fetchTransactionSummarys(
         networksForAccountCoin: networksForAccountCoin,
-        accountInfos: keyringForAccount.accountInfos,
+        accountInfos: allAccountsForCoin,
         userVisibleTokens: userVisibleAssets.map(\.token),
         allTokens: allTokens,
         assetRatios: assetRatios
@@ -278,7 +278,7 @@ extension AccountActivityStore: BraveWalletKeyringServiceObserver {
   func keyringCreated(_ keyringId: BraveWallet.KeyringId) {
   }
 
-  func keyringRestored(_ keyringId: BraveWallet.KeyringId) {
+  func walletRestored() {
   }
   
   func keyringReset() {

--- a/Sources/BraveWallet/Crypto/Stores/BuyTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/BuyTokenStore.swift
@@ -244,7 +244,7 @@ extension BuyTokenStore: BraveWalletKeyringServiceObserver {
   public func keyringCreated(_ keyringId: BraveWallet.KeyringId) {
   }
   
-  public func keyringRestored(_ keyringId: BraveWallet.KeyringId) {
+  public func walletRestored() {
   }
   
   public func keyringReset() {

--- a/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -423,13 +423,13 @@ public class CryptoStore: ObservableObject {
 
   @MainActor
   func fetchPendingTransactions() async -> [BraveWallet.TransactionInfo] {
-    let allKeyrings = await keyringService.keyrings(for: WalletConstants.supportedCoinTypes())
+    let allAccounts = await keyringService.allAccounts().accounts
     var allNetworksForCoin: [BraveWallet.CoinType: [BraveWallet.NetworkInfo]] = [:]
     for coin in WalletConstants.supportedCoinTypes() {
       let allNetworks = await rpcService.allNetworks(coin)
       allNetworksForCoin[coin] = allNetworks
     }
-    return await txService.pendingTransactions(networksForCoin: allNetworksForCoin, for: allKeyrings)
+    return await txService.pendingTransactions(networksForCoin: allNetworksForCoin, for: allAccounts)
   }
 
   @MainActor
@@ -583,7 +583,7 @@ extension CryptoStore: BraveWalletKeyringServiceObserver {
     // when user creates or imports a new account with a new keyring since any new
     // supported coin type / keyring will be migrated inside `CryptoStore`'s init()
   }
-  public func keyringRestored(_ keyringId: BraveWallet.KeyringId) {
+  public func walletRestored() {
     // This observer method will only get called when user restore a wallet
     // from the lock screen
     // We will need to

--- a/Sources/BraveWallet/Crypto/Stores/KeyringStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/KeyringStore.swift
@@ -119,8 +119,7 @@ public class KeyringStore: ObservableObject {
     id: .default,
     isKeyringCreated: false,
     isLocked: true,
-    isBackedUp: false,
-    accountInfos: []
+    isBackedUp: false
   )
   /// A boolean indciates front-end has or has not loaded Keyring from the core
   @Published var isDefaultKeyringLoaded = false
@@ -154,9 +153,7 @@ public class KeyringStore: ObservableObject {
   /// keyring has been created
   @Published var isDefaultKeyringCreated: Bool = false
   /// All `AccountInfo` for all available keyrings
-  var allAccounts: [BraveWallet.AccountInfo] {
-    allKeyrings.flatMap(\.accountInfos)
-  }
+  @Published var allAccounts: [BraveWallet.AccountInfo] = []
   
   /// A list of default account with all support coin types
   @Published var defaultAccounts: [BraveWallet.AccountInfo] = []
@@ -220,8 +217,7 @@ public class KeyringStore: ObservableObject {
       return
     }
     Task { @MainActor in // fetch all KeyringInfo for all coin types
-      let selectedAccount = await keyringService.allAccounts().selectedAccount
-      let selectedAccountAddress = selectedAccount?.address
+      let allAccounts = await keyringService.allAccounts()
       let allKeyrings = await keyringService.keyrings(for: WalletConstants.supportedCoinTypes())
       if let defaultKeyring = allKeyrings.first(where: { $0.id == BraveWallet.KeyringId.default }) {
         self.defaultKeyring = defaultKeyring
@@ -229,16 +225,10 @@ public class KeyringStore: ObservableObject {
         self.isDefaultKeyringCreated = defaultKeyring.isKeyringCreated
       }
       self.allKeyrings = allKeyrings
-      if let selectedAccountKeyring = allKeyrings.first(where: { $0.id == selectedAccount?.keyringId }) {
-        if self.selectedAccount.address != selectedAccountAddress {
-          if let selectedAccount = selectedAccountKeyring.accountInfos.first(where: { $0.address == selectedAccountAddress }) {
-            self.selectedAccount = selectedAccount
-          } else if let firstAccount = selectedAccountKeyring.accountInfos.first {
-            // try and correct invalid state (no selected account for this coin type)
-            self.selectedAccount = firstAccount
-          } // else selected account address does not exist in keyring (should not occur...)
-        } // else `self.selectedAccount` is already the currently selected account
-      } // else keyring for selected coin is unavailable (should not occur...)
+      self.allAccounts = allAccounts.accounts
+      if let selectedAccount = allAccounts.selectedAccount {
+        self.selectedAccount = selectedAccount
+      }
     }
   }
   
@@ -514,18 +504,18 @@ extension KeyringStore: BraveWalletKeyringServiceObserver {
     }
 
     Task { @MainActor in
-      let newKeyring = await keyringService.keyringInfo(keyringId)
-      let selectedAccount = await keyringService.allAccounts().selectedAccount
+      let allAccounts = await keyringService.allAccounts()
+      let allAccountsForKeyring = allAccounts.accounts.filter { $0.keyringId == keyringId }
       // if the new Keyring doesn't have a selected account, select the first account
-      if selectedAccount == nil, let newAccount = newKeyring.accountInfos.first {
+      if allAccounts.selectedAccount == nil, let newAccount = allAccountsForKeyring.first {
         await keyringService.setSelectedAccount(newAccount.accountId)
       }
       updateKeyringInfo()
     }
   }
 
-  public func keyringRestored(_ keyringId: BraveWallet.KeyringId) {
-    if isOnboardingVisible && !isRestoringWallet, keyringId == BraveWallet.KeyringId.default {
+  public func walletRestored() {
+    if isOnboardingVisible && !isRestoringWallet {
       // Another window has restored a wallet. We should dismiss onboarding on this
       // window and allow the other window to continue with it's onboarding flow.
       isOnboardingVisible = false

--- a/Sources/BraveWallet/Crypto/Stores/NFTStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/NFTStore.swift
@@ -254,7 +254,7 @@ extension NFTStore: BraveWalletKeyringServiceObserver {
   }
   public func keyringCreated(_ keyringId: BraveWallet.KeyringId) {
   }
-  public func keyringRestored(_ keyringId: BraveWallet.KeyringId) {
+  public func walletRestored() {
   }
   public func locked() {
   }

--- a/Sources/BraveWallet/Crypto/Stores/NetworkStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/NetworkStore.swift
@@ -109,9 +109,9 @@ public class NetworkStore: ObservableObject {
     _ network: BraveWallet.NetworkInfo,
     isForOrigin: Bool
   ) async -> SetSelectedChainError? {
-    let keyringId = BraveWallet.KeyringId.keyringId(for: network.coin, on: network.chainId)
-    let keyringInfo = await keyringService.keyringInfo(keyringId)
-    if keyringInfo.accountInfos.isEmpty {
+    let allAccounts = await keyringService.allAccounts()
+    let allAccountsForNetworkCoin = allAccounts.accounts.filter { $0.coin == network.coin }
+    if allAccountsForNetworkCoin.isEmpty {
       // Need to prompt user to create new account via alert
       return .selectedChainHasNoAccounts
     } else {
@@ -121,7 +121,7 @@ public class NetworkStore: ObservableObject {
         self.defaultSelectedChainId = network.chainId
       }
       
-      let currentlySelectedCoin = await keyringService.allAccounts().selectedAccount?.coin ?? .eth
+      let currentlySelectedCoin = allAccounts.selectedAccount?.coin ?? .eth
       let rpcServiceNetwork = await rpcService.network(currentlySelectedCoin, origin: isForOrigin ? origin : nil)
       guard rpcServiceNetwork.chainId != network.chainId else {
         if !isForOrigin { // `isSwapSupported` is for the `defaultSelectedChain`
@@ -332,7 +332,7 @@ extension NetworkStore: BraveWalletKeyringServiceObserver {
   public func keyringCreated(_ keyringId: BraveWallet.KeyringId) {
   }
   
-  public func keyringRestored(_ keyringId: BraveWallet.KeyringId) {
+  public func walletRestored() {
   }
   
   public func keyringReset() {

--- a/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
@@ -658,7 +658,7 @@ extension PortfolioStore: BraveWalletKeyringServiceObserver {
   }
   public func keyringCreated(_ keyringId: BraveWallet.KeyringId) {
   }
-  public func keyringRestored(_ keyringId: BraveWallet.KeyringId) {
+  public func walletRestored() {
   }
   public func locked() {
   }

--- a/Sources/BraveWallet/Crypto/Stores/SelectAccountTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SelectAccountTokenStore.swift
@@ -143,7 +143,7 @@ class SelectAccountTokenStore: ObservableObject {
   }
   
   @MainActor func update() async {
-    let allKeyrings = await keyringService.keyrings(for: WalletConstants.supportedCoinTypes())
+    let allAccounts = await keyringService.allAccounts()
     let allNetworks = await rpcService.allNetworksForSupportedCoins()
     self.allNetworks = allNetworks
     // setup network filters if not currently setup
@@ -154,27 +154,26 @@ class SelectAccountTokenStore: ObservableObject {
     }
     let allVisibleUserAssets = assetManager.getAllVisibleAssetsInNetworkAssets(networks: allNetworks).flatMap { $0.tokens }
     guard !Task.isCancelled else { return }
-    self.accountSections = allKeyrings.flatMap { keyring in
-      let tokensForCoin = allVisibleUserAssets.filter { $0.coin == keyring.coin }
-      return keyring.accountInfos.map { account in
-        let tokenBalances = tokensForCoin.compactMap { token in
-          let tokenNetwork = allNetworks.first(where: { $0.chainId == token.chainId }) ?? .init()
-          if tokenNetwork.supportedKeyrings.contains(keyring.id.rawValue as NSNumber) {
-            return AccountSection.TokenBalance(
-              token: token,
-              network: allNetworks.first(where: { $0.chainId == token.chainId }) ?? .init(),
-              balance: cachedBalance(for: token, in: account),
-              price: cachedPrice(for: token, in: account),
-              nftMetadata: cachedMetadata(for: token)
-            )
-          }
-          return nil
+    let tokensGroupedByCoinType = Dictionary(grouping: allVisibleUserAssets, by: \.coin)
+    self.accountSections = allAccounts.accounts.map { account in
+      let tokensForAccountCoin = tokensGroupedByCoinType[account.coin] ?? []
+      let tokenBalances = tokensForAccountCoin.compactMap { token in
+        let tokenNetwork = allNetworks.first(where: { $0.chainId == token.chainId }) ?? .init()
+        if tokenNetwork.supportedKeyrings.contains(account.keyringId.rawValue as NSNumber) {
+          return AccountSection.TokenBalance(
+            token: token,
+            network: allNetworks.first(where: { $0.chainId == token.chainId }) ?? .init(),
+            balance: cachedBalance(for: token, in: account),
+            price: cachedPrice(for: token, in: account),
+            nftMetadata: cachedMetadata(for: token)
+          )
         }
-        return AccountSection(
-          account: account,
-          tokenBalances: tokenBalances
-        )
+        return nil
       }
+      return AccountSection(
+        account: account,
+        tokenBalances: tokenBalances
+      )
     }
     
     updateAccountBalances()

--- a/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
@@ -664,7 +664,7 @@ extension SendTokenStore: BraveWalletKeyringServiceObserver {
   public func keyringCreated(_ keyringId: BraveWallet.KeyringId) {
   }
 
-  public func keyringRestored(_ keyringId: BraveWallet.KeyringId) {
+  public func walletRestored() {
   }
 
   public func locked() {

--- a/Sources/BraveWallet/Crypto/Stores/SettingsStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SettingsStore.swift
@@ -170,7 +170,7 @@ extension SettingsStore: BraveWalletKeyringServiceObserver {
   public func keyringCreated(_ keyringId: BraveWallet.KeyringId) {
   }
   
-  public func keyringRestored(_ keyringId: BraveWallet.KeyringId) {
+  public func walletRestored() {
   }
   
   public func keyringReset() {

--- a/Sources/BraveWallet/Crypto/Stores/SwapTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SwapTokenStore.swift
@@ -890,7 +890,7 @@ extension SwapTokenStore: BraveWalletKeyringServiceObserver {
   public func keyringCreated(_ keyringId: BraveWallet.KeyringId) {
   }
 
-  public func keyringRestored(_ keyringId: BraveWallet.KeyringId) {
+  public func walletRestored() {
   }
 
   public func locked() {

--- a/Sources/BraveWallet/Crypto/Stores/TransactionDetailsStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/TransactionDetailsStore.swift
@@ -75,8 +75,6 @@ class TransactionDetailsStore: ObservableObject {
         return
       }
       self.network = network
-      let keringId = BraveWallet.KeyringId.keyringId(for: coin, on: transaction.chainId)
-      let keyring = await keyringService.keyringInfo(keringId)
       var allTokens: [BraveWallet.BlockchainToken] = await blockchainRegistry.allTokens(network.chainId, coin: network.coin) + tokenInfoCache.map(\.value)
       let userVisibleTokens: [BraveWallet.BlockchainToken] = assetManager.getAllUserAssetsInNetworkAssets(networks: [network]).flatMap { $0.tokens }
       let unknownTokenContractAddresses = transaction.tokenContractAddresses
@@ -105,9 +103,10 @@ class TransactionDetailsStore: ObservableObject {
       if transaction.coin == .sol {
         (solEstimatedTxFee, _, _) = await solanaTxManagerProxy.estimatedTxFee(network.chainId, txMetaId: transaction.id)
       }
+      let allAccounts = await keyringService.allAccounts().accounts
       guard let parsedTransaction = transaction.parsedTransaction(
         network: network,
-        accountInfos: keyring.accountInfos,
+        accountInfos: allAccounts,
         visibleTokens: userVisibleTokens,
         allTokens: allTokens,
         assetRatios: assetRatios,

--- a/Sources/BraveWallet/Crypto/Stores/TransactionsActivityStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/TransactionsActivityStore.swift
@@ -69,10 +69,8 @@ class TransactionsActivityStore: ObservableObject {
   func update() {
     updateTask?.cancel()
     updateTask = Task { @MainActor in
-      let allKeyrings = await self.keyringService.keyrings(
-        for: WalletConstants.supportedCoinTypes()
-      )
-      let allAccountInfos = allKeyrings.flatMap(\.accountInfos)
+      let allAccounts = await keyringService.allAccounts()
+      let allAccountInfos = allAccounts.accounts
       // setup network filters if not currently setup
       if self.networkFilters.isEmpty {
         self.networkFilters = await self.rpcService.allNetworksForSupportedCoins().map {
@@ -84,7 +82,7 @@ class TransactionsActivityStore: ObservableObject {
       let allNetworksAllCoins = networksForCoin.values.flatMap { $0 }
       
       let allTransactions = await txService.allTransactions(
-        networksForCoin: networksForCoin, for: allKeyrings
+        networksForCoin: networksForCoin, for: allAccountInfos
       ).filter { $0.txStatus != .rejected }
       let userVisibleTokens = assetManager.getAllVisibleAssetsInNetworkAssets(networks: allNetworksAllCoins).flatMap(\.tokens)
       let allTokens = await blockchainRegistry.allTokens(
@@ -188,7 +186,7 @@ class TransactionsActivityStore: ObservableObject {
 extension TransactionsActivityStore: BraveWalletKeyringServiceObserver {
   func keyringCreated(_ keyringId: BraveWallet.KeyringId) { }
   
-  func keyringRestored(_ keyringId: BraveWallet.KeyringId) { }
+  func walletRestored() { }
   
   func keyringReset() { }
   

--- a/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
@@ -239,7 +239,7 @@ extension UserAssetsStore: BraveWalletKeyringServiceObserver {
     update()
   }
   
-  public func keyringRestored(_ keyringId: BraveWallet.KeyringId) {
+  public func walletRestored() {
   }
   
   public func keyringReset() {

--- a/Sources/BraveWallet/Extensions/BraveWalletExtensions.swift
+++ b/Sources/BraveWallet/Extensions/BraveWalletExtensions.swift
@@ -220,7 +220,22 @@ extension BraveWallet.CoinType {
 
 extension BraveWallet.KeyringInfo {
   var coin: BraveWallet.CoinType? {
-    accountInfos.first?.coin
+    switch self.id {
+    case .default:
+      return .eth
+    case .solana:
+      return .sol
+    case .filecoin, .filecoinTestnet:
+      return .fil
+    case .bitcoin84, .bitcoin84Testnet:
+      return .btc
+    case .zCashMainnet:
+      return nil
+    case .zCashTestnet:
+      return nil
+    @unknown default:
+      return nil
+    }
   }
 }
 

--- a/Sources/BraveWallet/Extensions/KeyringServiceExtensions.swift
+++ b/Sources/BraveWallet/Extensions/KeyringServiceExtensions.swift
@@ -66,12 +66,11 @@ extension BraveWalletKeyringService {
   
   /// Check if any wallet account has been created given a coin type and a chain id
   @MainActor func isAccountAvailable(for coin: BraveWallet.CoinType, chainId: String) async -> Bool {
+    // KeyringId must be checked with chainId for Filecoin, BTC (2 keyring types).
     let keyringId = BraveWallet.KeyringId.keyringId(for: coin, on: chainId)
-    let keyringInfo = await keyringInfo(keyringId)
-    // If user restore a wallet, `BraveWallet.KeyringInfo.isKeyringCreated` can be true,
-    // but `BraveWallet.KeyringInfo.accountInfos` will be empty.
-    // Hence, we will have to check if `BraveWallet.KeyringInfo.accountInfos` is empty instead of
-    // checking the boolean of `BraveWallet.KeyringInfo.isKeyringCreated`
-    return !keyringInfo.accountInfos.isEmpty
+    // `KeyringInfo.isKeyringCreated` insufficient check as this value can
+    // be true with no accounts after wallet restore.
+    let allAccountsForKeyring = await allAccounts().accounts.filter { $0.keyringId == keyringId }
+    return !allAccountsForKeyring.isEmpty
   }
 }

--- a/Sources/BraveWallet/Panels/Connect/EditSiteConnectionView.swift
+++ b/Sources/BraveWallet/Panels/Connect/EditSiteConnectionView.swift
@@ -131,7 +131,7 @@ struct EditSiteConnectionView: View {
   }
   
   private var accountInfos: [BraveWallet.AccountInfo] {
-    keyringStore.allKeyrings.first(where: { $0.coin == coin })?.accountInfos ?? []
+    keyringStore.allAccounts.filter { $0.coin == coin }
   }
   
   var body: some View {

--- a/Sources/BraveWallet/Panels/Connect/NewSiteConnectionView.swift
+++ b/Sources/BraveWallet/Panels/Connect/NewSiteConnectionView.swift
@@ -41,7 +41,7 @@ public struct NewSiteConnectionView: View {
   @State private var isConfirmationViewVisible: Bool = false
   
   private var accountInfos: [BraveWallet.AccountInfo] {
-    let allAccounts = keyringStore.allKeyrings.first(where: { $0.coin == coin })?.accountInfos ?? []
+    let allAccounts = keyringStore.allAccounts.filter { $0.coin == coin }
     return allAccounts.filter { self.accounts.contains($0.address) }
   }
   
@@ -194,7 +194,7 @@ public struct NewSiteConnectionView: View {
   }
   
   private var accountsAddressesToConfirm: String {
-    keyringStore.defaultKeyring.accountInfos
+    accountInfos
       .filter { selectedAccounts.contains($0.id) }
       .map(\.address.truncatedAddress)
       .joined(separator: ", ")
@@ -228,7 +228,7 @@ public struct NewSiteConnectionView: View {
       }
       Section {
         Button {
-          let accounts = keyringStore.allKeyrings.flatMap(\.accountInfos)
+          let accounts = accountInfos
             .filter { selectedAccounts.contains($0.id) }
             .map(\.address)
           onConnect(accounts)

--- a/Tests/BraveWalletTests/AccountActivityStoreTests.swift
+++ b/Tests/BraveWalletTests/AccountActivityStoreTests.swift
@@ -55,6 +55,9 @@ class AccountActivityStoreTests: XCTestCase {
         completion(.mockDefaultKeyringInfo)
       }
     }
+    keyringService._allAccounts = {
+      $0(.mock)
+    }
 
     let rpcService = BraveWallet.TestJsonRpcService()
     rpcService._addObserver = { _ in }

--- a/Tests/BraveWalletTests/AssetDetailStoreTests.swift
+++ b/Tests/BraveWalletTests/AssetDetailStoreTests.swift
@@ -27,6 +27,9 @@ class AssetDetailStoreTests: XCTestCase {
     keyringService._keyringInfo = {
       $1(.mockDefaultKeyringInfo)
     }
+    keyringService._allAccounts = { completion in
+      completion(.mock)
+    }
     keyringService._addObserver = { _ in }
     
     let mockEthBalance: Double = 1
@@ -235,15 +238,10 @@ class AssetDetailStoreTests: XCTestCase {
     keyringService._keyringInfo = {
       $1(keyring)
     }
-    keyringService._addObserver = { _ in }
     keyringService._allAccounts = { completion in
-      completion(.init(
-        accounts: keyring.accountInfos,
-        selectedAccount: keyring.accountInfos.first,
-        ethDappSelectedAccount: keyring.accountInfos.first,
-        solDappSelectedAccount: nil
-      ))
+      completion(.mock)
     }
+    keyringService._addObserver = { _ in }
     
     let mockEthBalance: Double = 1
     let ethBalanceWei = formatter.weiString(
@@ -251,7 +249,6 @@ class AssetDetailStoreTests: XCTestCase {
       radix: .hex,
       decimals: Int(BraveWallet.BlockchainToken.previewToken.decimals)
     ) ?? ""
-    let formattedEthBalance = currencyFormatter.string(from: NSNumber(value: mockEthBalance)) ?? ""
     let rpcService = BraveWallet.TestJsonRpcService()
     rpcService._network = {
       $2(.mockMainnet)

--- a/Tests/BraveWalletTests/NetworkSelectionStoreTests.swift
+++ b/Tests/BraveWalletTests/NetworkSelectionStoreTests.swift
@@ -25,13 +25,11 @@ import Preferences
     
     let keyringService = BraveWallet.TestKeyringService()
     keyringService._keyringInfo = { keyringId, completion in
-      let isEthereumKeyringId = keyringId == BraveWallet.KeyringId.default
       let keyring: BraveWallet.KeyringInfo = .init(
         id: BraveWallet.KeyringId.default,
         isKeyringCreated: true,
         isLocked: false,
-        isBackedUp: true,
-        accountInfos: isEthereumKeyringId ? [.previewAccount] : []
+        isBackedUp: true
       )
       completion(keyring)
     }
@@ -217,23 +215,11 @@ import Preferences
     ]
     
     keyringService._keyringInfo = { keyringId, completion in
-      let accountInfos: [BraveWallet.AccountInfo]
-      switch keyringId {
-      case BraveWallet.KeyringId.default:
-        accountInfos = accountInfosDict[.eth, default: []]
-      case BraveWallet.KeyringId.solana:
-        accountInfos = accountInfosDict[.sol, default: []]
-      case BraveWallet.KeyringId.filecoin:
-        accountInfos = accountInfosDict[.fil, default: []]
-      default:
-        accountInfos = []
-      }
       let keyring: BraveWallet.KeyringInfo = .init(
         id: keyringId,
         isKeyringCreated: true,
         isLocked: false,
-        isBackedUp: false,
-        accountInfos: accountInfos
+        isBackedUp: false
       )
       completion(keyring)
     }

--- a/Tests/BraveWalletTests/NetworkStoreTests.swift
+++ b/Tests/BraveWalletTests/NetworkStoreTests.swift
@@ -31,13 +31,11 @@ import Preferences
     
     let keyringService = BraveWallet.TestKeyringService()
     keyringService._keyringInfo = { keyringId, completion in
-      let isEthereumKeyringId = keyringId == BraveWallet.KeyringId.default
       let keyring: BraveWallet.KeyringInfo = .init(
-        id: BraveWallet.KeyringId.default,
+        id: keyringId,
         isKeyringCreated: true,
         isLocked: false,
-        isBackedUp: true,
-        accountInfos: isEthereumKeyringId ? [.previewAccount] : []
+        isBackedUp: true
       )
       completion(keyring)
     }

--- a/Tests/BraveWalletTests/PortfolioStoreTests.swift
+++ b/Tests/BraveWalletTests/PortfolioStoreTests.swift
@@ -118,7 +118,6 @@ import Preferences
     let formatter = WeiFormatter(decimalFormatStyle: .decimals(precision: 18))
     
     // config filecoin on mainnet
-    let mockFilAccountInfos: [BraveWallet.AccountInfo] = [filAccount1, filAccount2]
     let mockFilUserAssets: [BraveWallet.BlockchainToken] = [
       BraveWallet.NetworkInfo.mockFilecoinMainnet.nativeToken.copy(asVisibleAsset: true)
     ]
@@ -128,7 +127,6 @@ import Preferences
       decimals: Int(BraveWallet.BlockchainToken.mockFilToken.decimals)
     ) ?? ""
     // config filecoin on testnet
-    let mockFilTestnetAccountInfos: [BraveWallet.AccountInfo] = [filTestnetAccount]
     let mockFilTestnetBalanceInWei = formatter.weiString(
       from: mockFILBalanceTestnet,
       radix: .decimal,
@@ -136,13 +134,11 @@ import Preferences
     ) ?? ""
     
     // config Solana
-    let mockSolAccountInfos: [BraveWallet.AccountInfo] = [solAccount1, solAccount2]
     let mockSolUserAssets: [BraveWallet.BlockchainToken] = [
       BraveWallet.NetworkInfo.mockSolana.nativeToken.copy(asVisibleAsset: true),
       .mockSpdToken // Verify non-visible assets not displayed #6386
     ]
     // config Ethereum
-    let mockEthAccountInfos: [BraveWallet.AccountInfo] = [ethAccount1, ethAccount2]
     let mockEthUserAssets: [BraveWallet.BlockchainToken] = [
       .previewToken.copy(asVisibleAsset: true),
       .previewDaiToken, // Verify non-visible assets not displayed #6386
@@ -172,35 +168,6 @@ import Preferences
       filTestnet.nativeToken.copy(asVisibleAsset: true)
     ]
     
-    let ethKeyring: BraveWallet.KeyringInfo = .init(
-      id: BraveWallet.KeyringId.default,
-      isKeyringCreated: true,
-      isLocked: false,
-      isBackedUp: true,
-      accountInfos: mockEthAccountInfos
-    )
-    let solKeyring: BraveWallet.KeyringInfo = .init(
-      id: BraveWallet.KeyringId.solana,
-      isKeyringCreated: true,
-      isLocked: false,
-      isBackedUp: true,
-      accountInfos: mockSolAccountInfos
-    )
-    let filKeyring: BraveWallet.KeyringInfo = .init(
-      id: .filecoin,
-      isKeyringCreated: true,
-      isLocked: false,
-      isBackedUp: true,
-      accountInfos: mockFilAccountInfos
-    )
-    let filTestnetKeyring: BraveWallet.KeyringInfo = .init(
-      id: .filecoinTestnet,
-      isKeyringCreated: true,
-      isLocked: false,
-      isBackedUp: true,
-      accountInfos: mockFilTestnetAccountInfos
-    )
-    
     // setup test services
     let keyringService = BraveWallet.TestKeyringService()
     keyringService._addObserver = { _ in }
@@ -210,10 +177,15 @@ import Preferences
     }
     keyringService._allAccounts = {
       $0(.init(
-        accounts: ethKeyring.accountInfos + solKeyring.accountInfos + filKeyring.accountInfos + filTestnetKeyring.accountInfos,
-        selectedAccount: ethKeyring.accountInfos.first,
-        ethDappSelectedAccount: ethKeyring.accountInfos.first,
-        solDappSelectedAccount: solKeyring.accountInfos.first
+        accounts: [
+          self.ethAccount1, self.ethAccount2,
+          self.solAccount1, self.solAccount2,
+          self.filAccount1, self.filAccount2,
+          self.filTestnetAccount
+        ],
+        selectedAccount: self.ethAccount1,
+        ethDappSelectedAccount: self.ethAccount1,
+        solDappSelectedAccount: self.solAccount1
       ))
     }
     let rpcService = BraveWallet.TestJsonRpcService()

--- a/Tests/BraveWalletTests/SelectAccountTokenStoreTests.swift
+++ b/Tests/BraveWalletTests/SelectAccountTokenStoreTests.swift
@@ -145,8 +145,7 @@ import Preferences
           id: BraveWallet.KeyringId.default,
           isKeyringCreated: true,
           isLocked: false,
-          isBackedUp: true,
-          accountInfos: [.mockEthAccount, self.mockEthAccount2]
+          isBackedUp: true
         )
         completion(keyring)
       case .solana:
@@ -154,8 +153,7 @@ import Preferences
           id: BraveWallet.KeyringId.solana,
           isKeyringCreated: true,
           isLocked: false,
-          isBackedUp: true,
-          accountInfos: [.mockSolAccount]
+          isBackedUp: true
         )
         completion(keyring)
       case .filecoin:
@@ -165,6 +163,20 @@ import Preferences
       default:
         completion(.mockDefaultKeyringInfo)
       }
+    }
+    keyringService._allAccounts = {
+      $0(.init(
+        accounts: [
+          .mockEthAccount,
+          self.mockEthAccount2,
+          .mockSolAccount,
+          .mockFilAccount,
+          .mockFilTestnetAccount
+        ],
+        selectedAccount: .mockEthAccount,
+        ethDappSelectedAccount: .mockEthAccount,
+        solDappSelectedAccount: .mockSolAccount
+      ))
     }
     let rpcService = BraveWallet.TestJsonRpcService()
     rpcService._allNetworks = { coin, completion in

--- a/Tests/BraveWalletTests/SettingsStoreTests.swift
+++ b/Tests/BraveWalletTests/SettingsStoreTests.swift
@@ -16,7 +16,6 @@ class SettingsStoreTests: XCTestCase {
   
   /// Sets up TestKeyringService, TestBraveWalletService and TestTxService with some default values.
   private func setupServices() -> (BraveWallet.TestKeyringService, BraveWallet.TestBraveWalletService, BraveWallet.TestJsonRpcService, BraveWallet.TestTxService, IpfsAPI) {
-    let mockAccountInfos: [BraveWallet.AccountInfo] = [.previewAccount]
     let mockUserAssets: [BraveWallet.BlockchainToken] = [.previewToken.copy(asVisibleAsset: true)]
     
     let keyringService = BraveWallet.TestKeyringService()
@@ -25,8 +24,8 @@ class SettingsStoreTests: XCTestCase {
         id: BraveWallet.KeyringId.default,
         isKeyringCreated: true,
         isLocked: false,
-        isBackedUp: true,
-        accountInfos: mockAccountInfos)
+        isBackedUp: true
+      )
       completion(keyring)
     }
     keyringService._addObserver = { _ in }

--- a/Tests/BraveWalletTests/TransactionConfirmationStoreTests.swift
+++ b/Tests/BraveWalletTests/TransactionConfirmationStoreTests.swift
@@ -114,16 +114,17 @@ import Preferences
         id: id,
         isKeyringCreated: true,
         isLocked: false,
-        isBackedUp: true,
-        accountInfos: [])
-      if id == BraveWallet.KeyringId.default {
-        keyring.accountInfos = accountInfos.filter { $0.coin == .eth }
-      } else if id == .solana {
-        keyring.accountInfos = accountInfos.filter { $0.coin == .sol }
-      } else {
-        keyring.accountInfos = accountInfos.filter { $0.coin == .fil }
-      }
+        isBackedUp: true
+      )
       completion(keyring)
+    }
+    keyringService._allAccounts = {
+      $0(.init(
+        accounts: accountInfos,
+        selectedAccount: accountInfos.first,
+        ethDappSelectedAccount: accountInfos.first(where: { $0.coin == .eth }),
+        solDappSelectedAccount: accountInfos.first(where: { $0.coin == .sol })
+      ))
     }
     
     let solTxManagerProxy = BraveWallet.TestSolanaTxManagerProxy()

--- a/Tests/BraveWalletTests/TransactionsActivityStoreTests.swift
+++ b/Tests/BraveWalletTests/TransactionsActivityStoreTests.swift
@@ -65,6 +65,9 @@ class TransactionsActivityStoreTests: XCTestCase {
         completion(.mockDefaultKeyringInfo)
       }
     }
+    keyringService._allAccounts = {
+      $0(.mock)
+    }
     
     let rpcService = BraveWallet.TestJsonRpcService()
     rpcService._allNetworks = { coin, completion in

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@mozilla/readability": "^0.4.2",
-        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.60.67/brave-core-ios-1.60.67.tgz",
+        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.60.81/brave-core-ios-1.60.81.tgz",
         "leo": "github:brave/leo#7f2dfddb70aff1501ef5a2f3c640a8c74a7343ee",
         "leo-sf-symbols": "github:brave/leo-sf-symbols#d6056328b8d6ef06e68996ff02a22e06f52590c3",
         "page-metadata-parser": "^1.1.3",
@@ -493,9 +493,9 @@
       }
     },
     "node_modules/brave-core-ios": {
-      "version": "1.60.67",
-      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.60.67/brave-core-ios-1.60.67.tgz",
-      "integrity": "sha512-1jojRJJmZZ/LgSNlG5lyhFYTjcUOOthvGkE9nDWnKLUebdAYeFGOCUSnE4XWJPd3/DVghiWdooldAd0+GE7x+Q==",
+      "version": "1.60.81",
+      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.60.81/brave-core-ios-1.60.81.tgz",
+      "integrity": "sha512-TXqECLiiXegyeXnVfUfZ9q8GtZT+3ErJ2AbGa4YFaI5Cl/rna0AzEfn8H3UgaOiIif8yULbjr7gdrCKCiPHtYA==",
       "license": "ISC"
     },
     "node_modules/browserslist": {
@@ -3171,8 +3171,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-browser/releases/download/v1.60.67/brave-core-ios-1.60.67.tgz",
-      "integrity": "sha512-1jojRJJmZZ/LgSNlG5lyhFYTjcUOOthvGkE9nDWnKLUebdAYeFGOCUSnE4XWJPd3/DVghiWdooldAd0+GE7x+Q=="
+      "version": "https://github.com/brave/brave-browser/releases/download/v1.60.81/brave-core-ios-1.60.81.tgz",
+      "integrity": "sha512-TXqECLiiXegyeXnVfUfZ9q8GtZT+3ErJ2AbGa4YFaI5Cl/rna0AzEfn8H3UgaOiIif8yULbjr7gdrCKCiPHtYA=="
     },
     "browserslist": {
       "version": "4.17.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "license": "MPL-2.0",
   "dependencies": {
     "@mozilla/readability": "^0.4.2",
-    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.60.67/brave-core-ios-1.60.67.tgz",
+    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.60.81/brave-core-ios-1.60.81.tgz",
     "leo": "github:brave/leo#7f2dfddb70aff1501ef5a2f3c640a8c74a7343ee",
     "leo-sf-symbols": "github:brave/leo-sf-symbols#d6056328b8d6ef06e68996ff02a22e06f52590c3",
     "page-metadata-parser": "^1.1.3",


### PR DESCRIPTION
## Summary of Changes
- `accountsInfo` was removed from `KeyringInfo`. We must fetch accounts using `GetAllAccounts` api on Keyring Service now.

This pull request fixes #8182

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Test setting up new wallet & wallet restore 
2. Verify Ethereum & Solana accounts shown on Accounts tab
3. Test creating a send transaction
4. Verify Transaction Confirmation displays as expected (accounts shown in header)
5. Verify transaction shows on Activity tab
6. Verify accounts for token coin type shown in Asset Detail, transaction created in step 3 shows up
7. Tap the transaction and verify transaction detail displays as expected


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
