### PR TITLE
Fix #8190: Add in-page search to the debug histograms controller

### DIFF
--- a/Sources/Brave/Frontend/Settings/SettingsViewController.swift
+++ b/Sources/Brave/Frontend/Settings/SettingsViewController.swift
@@ -780,6 +780,22 @@ class SettingsViewController: TableViewController {
             let histogramsController = self.p3aUtilities.histogramsController().then {
               $0.title = "Histograms (p3a)"
             }
+            if #available(iOS 16.0, *) {
+              // TODO: Replace this with property access when exposed from brave-core side
+              let webView = histogramsController.value(forKey: "_webView") as! WKWebView // swiftlint:disable:this force_cast
+              webView.isFindInteractionEnabled = true
+              histogramsController.navigationItem.rightBarButtonItem = UIBarButtonItem(
+                systemItem: .search,
+                primaryAction: .init { [weak webView] _ in
+                  guard let findInteraction = webView?.findInteraction,
+                        !findInteraction.isFindNavigatorVisible else {
+                    return
+                  }
+                  findInteraction.searchText = ""
+                  findInteraction.presentFindNavigator(showingReplace: false)
+                }
+              )
+            }
             self.navigationController?.pushViewController(histogramsController, animated: true)
           }, accessory: .disclosureIndicator, cellClass: MultilineValue1Cell.self),
         Row(


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #8190 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Screenshots:

![image](https://github.com/brave/brave-ios/assets/529104/ea449360-d269-407b-ad1f-031f7c6a0243)

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
