### PR TITLE
Fix #7755: Reinsert the favs overlay when bottom bar mode changes

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController.swift
@@ -600,6 +600,11 @@ public class BrowserViewController: UIViewController {
     traitCollection.horizontalSizeClass == .compact &&
     traitCollection.verticalSizeClass == .regular &&
     traitCollection.userInterfaceIdiom == .phone
+    
+    // Reinserts the fav controller whos parent is based on bottom bar
+    if let favoritesController {
+      insertFavoritesControllerView(favoritesController: favoritesController)
+    }
   }
 
   public override func viewSafeAreaInsetsDidChange() {

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
@@ -661,6 +661,18 @@ extension BrowserViewController: TopToolbarDelegate {
     
     favoritesController?.view.isHidden = true
   }
+  
+  func insertFavoritesControllerView(favoritesController: FavoritesViewController) {
+    if let ntpController = self.activeNewTabPageViewController, ntpController.parent != nil {
+      view.insertSubview(favoritesController.view, aboveSubview: ntpController.view)
+    } else {
+      // Two different behaviors here:
+      // 1. For bottom bar we do not want to show the status bar color
+      // 2. For top bar we do so it matches the address bar background
+      let subview = isUsingBottomBar ? statusBarOverlay : footer
+      view.insertSubview(favoritesController.view, aboveSubview: subview)
+    }
+  }
 
   private func displayFavoritesController() {
     if favoritesController == nil {
@@ -730,15 +742,7 @@ extension BrowserViewController: TopToolbarDelegate {
       self.favoritesController = favoritesController
 
       addChild(favoritesController)
-      if let ntpController = self.activeNewTabPageViewController, ntpController.parent != nil {
-        view.insertSubview(favoritesController.view, aboveSubview: ntpController.view)
-      } else {
-        // Two different behaviors here:
-        // 1. For bottom bar we do not want to show the status bar color
-        // 2. For top bar we do so it matches the address bar background
-        let subview = isUsingBottomBar ? statusBarOverlay : footer
-        view.insertSubview(favoritesController.view, aboveSubview: subview)
-      }
+      insertFavoritesControllerView(favoritesController: favoritesController)
       favoritesController.didMove(toParent: self)
 
       favoritesController.view.snp.makeConstraints {


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #7755 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
