### PR TITLE
Ref #8078: Fix collapsed URL bar background color

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController.swift
@@ -2441,7 +2441,7 @@ public class BrowserViewController: UIViewController {
           topToolbar.locationContainer.alpha = 1
           topToolbar.actionButtons.forEach { $0.alpha = topToolbar.locationContainer.alpha }
           header.collapsedBarContainerView.alpha = 1 - topToolbar.locationContainer.alpha
-          tabsBar.view.subviews.forEach { $0.alpha = topToolbar.locationContainer.alpha }
+          tabsBar.view.alpha = topToolbar.locationContainer.alpha
           toolbar?.actionButtons.forEach { $0.alpha = topToolbar.locationContainer.alpha }
         }
         animator.startAnimation()
@@ -2464,7 +2464,7 @@ public class BrowserViewController: UIViewController {
         toolbarBottomConstraint?.update(offset: min(footerHeight, max(0, footerHeight * (1 - progress))))
       }
       topToolbar.actionButtons.forEach { $0.alpha = topToolbar.locationContainer.alpha }
-      tabsBar.view.subviews.forEach { $0.alpha = topToolbar.locationContainer.alpha }
+      tabsBar.view.alpha = topToolbar.locationContainer.alpha
       header.collapsedBarContainerView.alpha = 1 - topToolbar.locationContainer.alpha
       toolbar?.actionButtons.forEach { $0.alpha = topToolbar.locationContainer.alpha }
       return
@@ -2479,7 +2479,7 @@ public class BrowserViewController: UIViewController {
       topToolbar.locationContainer.alpha = 0
       toolbarBottomConstraint?.update(offset: footerHeight)
     }
-    tabsBar.view.subviews.forEach { $0.alpha = topToolbar.locationContainer.alpha }
+    tabsBar.view.alpha = topToolbar.locationContainer.alpha
     topToolbar.actionButtons.forEach { $0.alpha = topToolbar.locationContainer.alpha }
     header.collapsedBarContainerView.alpha = 1 - topToolbar.locationContainer.alpha
     toolbar?.actionButtons.forEach { $0.alpha = topToolbar.locationContainer.alpha }


### PR DESCRIPTION
The tabs bar now has a background and in general colors around these have changed so we can now just set the alpha of the tabs bar entirely instead of the subviews alone

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
