### PR TITLE
Fix #8209: Better message when tracking is disabled for the Privacy Hub.

### DIFF
--- a/Sources/Brave/Frontend/Browser/PrivacyHub/PrivacyHubLastWeekSection.swift
+++ b/Sources/Brave/Frontend/Browser/PrivacyHub/PrivacyHubLastWeekSection.swift
@@ -8,6 +8,7 @@ import Shared
 import BraveShared
 import BraveUI
 import Data
+import Preferences
 
 extension PrivacyReportsView {
   struct PrivacyHubLastWeekSection: View {
@@ -21,10 +22,14 @@ extension PrivacyReportsView {
       return mostFrequentTracker == nil && riskiestWebsite == nil
     }
     
-    private var noDataCalloutView: some View {
+    private var trackingDisabled: Bool {
+      !Preferences.PrivacyReports.captureShieldsData.value
+    }
+    
+    private func emptyCalloutView(text: String) -> some View {
       HStack {
         Image(systemName: "info.circle.fill")
-        Text(Strings.PrivacyHub.noDataCalloutBody)
+        Text(text)
       }
       .foregroundColor(Color.white)
       .frame(maxWidth: .infinity)
@@ -36,7 +41,13 @@ extension PrivacyReportsView {
     var body: some View {
       VStack(alignment: .leading, spacing: 8) {
         if noData {
-          noDataCalloutView
+          if trackingDisabled {
+            emptyCalloutView(text:
+                              String.localizedStringWithFormat(Strings.PrivacyHub.trackingDisabledCalloutBody,
+                                                               Strings.PrivacyHub.settingsEnableShieldsTitle))
+          } else {
+            emptyCalloutView(text: Strings.PrivacyHub.noDataCalloutBody)
+          } 
         }
         
         Text(Strings.PrivacyHub.lastWeekHeader.uppercased())

--- a/Sources/Brave/Frontend/Browser/PrivacyHub/PrivacyReportsView.swift
+++ b/Sources/Brave/Frontend/Browser/PrivacyHub/PrivacyReportsView.swift
@@ -67,18 +67,6 @@ struct PrivacyReportsView: View {
       .foregroundColor(Color(.braveBlurpleTint))
   }
   
-  private var noDataCalloutView: some View {
-    HStack {
-      Image(systemName: "info.circle.fill")
-      Text(Strings.PrivacyHub.noDataCalloutBody)
-    }
-    .foregroundColor(Color.white)
-    .frame(maxWidth: .infinity)
-    .padding()
-    .background(Color(.braveInfoLabel))
-    .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-  }
-  
   var body: some View {
     NavigationView {
       ScrollView(.vertical) {

--- a/Sources/BraveStrings/BraveStrings.swift
+++ b/Sources/BraveStrings/BraveStrings.swift
@@ -4365,6 +4365,11 @@ extension Strings {
       comment: "Text of a callout that tell user they need to browser some websites first in order to see privacy stats data"
     )
     
+    public static let trackingDisabledCalloutBody = NSLocalizedString("privacyHub.trackingDisabledCalloutBody", tableName: "BraveShared", bundle: .module,
+      value: "Enable '%@' to see data here",
+      comment: "Text of a callout that tells the user they shields tracking data is disabled. The %@ placeholder will name the setting that needs to be enabled"
+    )
+    
     public static let lastWeekHeader = NSLocalizedString("privacyHub.lastWeekHeader", tableName: "BraveShared", bundle: .module,
       value: "Last week",
       comment: "Header text, under it we display blocked items from last week"


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8209 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [x] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [x] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [x] Adequate unit test coverage exists to prevent regressions.
- [x] Adequate test plan exists for QA to validate (if applicable).
- [x] Issue and pull request is assigned to a milestone (should happen at merge time).
