### PR TITLE
Remove dislike ad button

### DIFF
--- a/Sources/Brave/Frontend/Brave Rewards/Ads/AdView.swift
+++ b/Sources/Brave/Frontend/Brave Rewards/Ads/AdView.swift
@@ -20,7 +20,7 @@ public class AdView: UIView {
 
     addSubview(adContentButton)
     //    addSubview(openSwipeButton)
-    addSubview(dislikeSwipeButton)
+    //    addSubview(dislikeSwipeButton)
 
     adContentButton.snp.makeConstraints {
       $0.edges.equalTo(self)


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8211

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Confirm user cannot dislike a notification ad by swiping

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
