### PR TITLE
Fix #8221: Cleanup logs for ad-block

### DIFF
--- a/Sources/Brave/Frontend/Browser/UserScriptManager.swift
+++ b/Sources/Brave/Frontend/Browser/UserScriptManager.swift
@@ -280,16 +280,15 @@ class UserScriptManager {
       return
     }
     
-    #if DEBUG
-    ContentBlockerManager.log.debug("Loaded \(userScripts.count + customScripts.count) scripts:")
-    userScripts.sorted(by: { $0.rawValue < $1.rawValue}).forEach { scriptType in
-      ContentBlockerManager.log.debug(" \(scriptType.debugDescription)")
-    }
-    customScripts.sorted(by: { $0.order < $1.order}).forEach { scriptType in
-      ContentBlockerManager.log.debug(" #\(scriptType.order) \(scriptType.debugDescription)")
-    }
-    #endif
-    
+    let logComponents = [
+      userScripts.sorted(by: { $0.rawValue < $1.rawValue}).map { scriptType in
+        " \(scriptType.debugDescription)"
+      }.joined(separator: "\n"),
+      customScripts.sorted(by: { $0.order < $1.order}).map { scriptType in
+        " #\(scriptType.order) \(scriptType.debugDescription)"
+      }.joined(separator: "\n")
+    ]
+    ContentBlockerManager.log.debug("Loaded \(userScripts.count + customScripts.count) script(s): \n\(logComponents.joined(separator: "\n"))")    
     loadScripts(into: webView, scripts: userScripts)
     
     webView.configuration.userContentController.do { scriptController in

--- a/Sources/Brave/WebFilters/AdblockResourceDownloader.swift
+++ b/Sources/Brave/WebFilters/AdblockResourceDownloader.swift
@@ -47,7 +47,6 @@ public actor AdblockResourceDownloader: Sendable {
         // .blockAds is special because it can be replaced by a downloaded file.
         // Hence we need to first check if it already exists.
         if await ContentBlockerManager.shared.hasRuleList(for: blocklistType, mode: mode) {
-          ContentBlockerManager.log.debug("Rule list already compiled for `\(blocklistType.makeIdentifier(for: mode))`")
           return false
         } else {
           return true
@@ -154,7 +153,7 @@ public actor AdblockResourceDownloader: Sendable {
         )
       } catch {
         ContentBlockerManager.log.error(
-          "Failed to compile downloaded content blocker resource: \(error.localizedDescription)"
+          "Failed to compile rule lists for `\(blocklistType.debugDescription)`: \(error.localizedDescription)"
         )
       }
       

--- a/Sources/Brave/WebFilters/ContentBlocker/ContentBlockerHelper.swift
+++ b/Sources/Brave/WebFilters/ContentBlocker/ContentBlockerHelper.swift
@@ -67,29 +67,29 @@ class ContentBlockerHelper {
   
   @MainActor func set(ruleLists: Set<WKContentRuleList>) {
     guard ruleLists != setRuleLists else { return }
-    #if DEBUG
-    ContentBlockerManager.log.debug("Set rule lists:")
-    #endif
+    var addedIds: [String] = []
+    var removedIds: [String] = []
     
     // Remove unwanted rule lists
     for ruleList in setRuleLists.subtracting(ruleLists) {
       // It's added but we don't want it. So we remove it.
       tab?.webView?.configuration.userContentController.remove(ruleList)
       setRuleLists.remove(ruleList)
-      
-      #if DEBUG
-      ContentBlockerManager.log.debug(" - \(ruleList.identifier)")
-      #endif
+      removedIds.append(ruleList.identifier)
     }
     
     // Add missing rule lists
     for ruleList in ruleLists.subtracting(setRuleLists) {
       tab?.webView?.configuration.userContentController.add(ruleList)
       setRuleLists.insert(ruleList)
-      
-      #if DEBUG
-      ContentBlockerManager.log.debug(" + \(ruleList.identifier)")
-      #endif
+      addedIds.append(ruleList.identifier)
     }
+    
+    let parts = [
+      addedIds.sorted(by: { $0 < $1 }).map({ " + \($0)" }).joined(separator: "\n"),
+      removedIds.sorted(by: { $0 < $1 }).map({ " - \($0)" }).joined(separator: "\n")
+    ]
+    
+    ContentBlockerManager.log.debug("Set rule lists:\n\(parts.joined(separator: "\n"))")
   }
 }

--- a/Sources/Brave/WebFilters/FilterListResourceDownloader.swift
+++ b/Sources/Brave/WebFilters/FilterListResourceDownloader.swift
@@ -298,13 +298,8 @@ public actor FilterListResourceDownloader {
         }
       } catch {
         ContentBlockerManager.log.error(
-          "Failed to create content blockers for `\(componentId)` v\(version): \(error)"
+          "Failed to create content blockers for `\(blocklistType.debugDescription)` v\(version): \(error)"
         )
-        #if DEBUG
-        ContentBlockerManager.log.debug(
-          "`\(componentId)`: \(filterListURL.absoluteString)"
-        )
-        #endif
       }
     }
   }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
This PR just cleans up some of the logging so its cleaner on Xcode 15 and doesn't spit out as much useless information.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8221

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Not testable

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
