### PR TITLE
Fix #8205: Support NFT removal. Updates for NFT spam management new design

### DIFF
--- a/Sources/BraveWallet/Crypto/NFT/NFTDetailView.swift
+++ b/Sources/BraveWallet/Crypto/NFT/NFTDetailView.swift
@@ -51,6 +51,26 @@ struct NFTDetailView: View {
               .frame(maxWidth: .infinity, minHeight: 300)
           } else {
             nftImage
+              .overlay(alignment: .topLeading) {
+                if nftDetailStore.nft.isSpam {
+                  HStack(spacing: 4) {
+                    Text(Strings.Wallet.nftSpam)
+                      .padding(.vertical, 4)
+                      .padding(.leading, 6)
+                      .foregroundColor(Color(.braveErrorLabel))
+                    Image(braveSystemName: "leo.warning.triangle-outline")
+                      .padding(.vertical, 4)
+                      .padding(.trailing, 6)
+                      .foregroundColor(Color(.braveErrorBorder))
+                  }
+                  .font(.system(size: 13).weight(.semibold))
+                  .background(
+                    Color(uiColor: WalletV2Design.spamNFTLabelBackground)
+                      .cornerRadius(4)
+                  )
+                  .padding(12)
+                }
+              }
           }
           VStack(alignment: .leading, spacing: 8) {
             Text(nftDetailStore.nft.nftTokenTitle)

--- a/Sources/BraveWallet/Crypto/NFT/NFTView.swift
+++ b/Sources/BraveWallet/Crypto/NFT/NFTView.swift
@@ -205,17 +205,47 @@ struct NFTView: View {
                   .multilineTextAlignment(.leading)
               }
             }
+            .overlay(alignment: .topLeading) {
+              if nft.token.isSpam {
+                HStack(spacing: 4) {
+                  Text(Strings.Wallet.nftSpam)
+                    .padding(.vertical, 4)
+                    .padding(.leading, 6)
+                    .foregroundColor(Color(.braveErrorLabel))
+                  Image(braveSystemName: "leo.warning.triangle-outline")
+                    .padding(.vertical, 4)
+                    .padding(.trailing, 6)
+                    .foregroundColor(Color(.braveErrorBorder))
+                }
+                .font(.system(size: 13).weight(.semibold))
+                .background(
+                  Color(uiColor: WalletV2Design.spamNFTLabelBackground)
+                    .cornerRadius(4)
+                )
+                .padding(12)
+              }
+            }
           }
           .contextMenu {
             Button(action: {
-              nftStore.updateNFTStatus(nft.token, visible: isHiddenNFT(nft.token), isSpam: false)
+              if nft.token.visible { // a collected visible NFT
+                nftStore.updateNFTStatus(nft.token, visible: false, isDeletedByUser: false)
+              } else { // including hidden NFTs and junk NFTs
+                nftStore.updateNFTStatus(nft.token, visible: true, isDeletedByUser: false)
+              }
             }) {
-              Label(isHiddenNFT(nft.token) ? Strings.Wallet.nftUnhide : Strings.recentSearchHide, braveSystemImage: isHiddenNFT(nft.token) ? "leo.eye.on" : "leo.eye.off")
+              if nft.token.visible { // a collected visible NFT
+                Label(Strings.recentSearchHide, braveSystemImage: "leo.eye.off")
+              } else if nft.token.isSpam { // a spam NFT
+                Label(Strings.Wallet.nftUnspam, braveSystemImage: "leo.disable.outline")
+              } else { // a hidden but not spam NFT
+                Label(Strings.Wallet.nftUnhide, braveSystemImage: "leo.eye.on")
+              }
             }
             Button(action: {
-              nftStore.updateNFTStatus(nft.token, visible: isSpamNFT(nft.token), isSpam: !isSpamNFT(nft.token))
+              nftStore.updateNFTStatus(nft.token, visible: false, isDeletedByUser: true)
             }) {
-              Label(isSpamNFT(nft.token) ? Strings.Wallet.nftUnspam : Strings.Wallet.nftMoveToSpam, braveSystemImage: "leo.disable.outline")
+              Label(Strings.Wallet.nftRemoveFromWallet, braveSystemImage: "leo.trash")
             }
           }
         }
@@ -319,22 +349,6 @@ struct NFTView: View {
           self.isShowingNFTDiscoveryAlert = true
         }
       }
-    }
-  }
-  
-  private func isSpamNFT(_ nft: BraveWallet.BlockchainToken) -> Bool {
-    if nftStore.displayType == .spam {
-      return true
-    } else {
-      return nft.isSpam
-    }
-  }
-  
-  private func isHiddenNFT(_ nft: BraveWallet.BlockchainToken) -> Bool {
-    if nftStore.displayType == .spam {
-      return false
-    } else {
-      return !nft.visible
     }
   }
 }

--- a/Sources/BraveWallet/Crypto/NFT/NFTView.swift
+++ b/Sources/BraveWallet/Crypto/NFT/NFTView.swift
@@ -228,10 +228,10 @@ struct NFTView: View {
           }
           .contextMenu {
             Button(action: {
-              if nft.token.visible { // a collected visible NFT
-                nftStore.updateNFTStatus(nft.token, visible: false, isDeletedByUser: false)
-              } else { // including hidden NFTs and junk NFTs
-                nftStore.updateNFTStatus(nft.token, visible: true, isDeletedByUser: false)
+              if nft.token.visible { // a collected visible NFT, mark as hidden
+                nftStore.updateNFTStatus(nft.token, visible: false, isSpam: false, isDeletedByUser: false)
+              } else { // either a hidden NFT or a junk NFT, mark as visible
+                nftStore.updateNFTStatus(nft.token, visible: true, isSpam: false, isDeletedByUser: false)
               }
             }) {
               if nft.token.visible { // a collected visible NFT
@@ -243,7 +243,7 @@ struct NFTView: View {
               }
             }
             Button(action: {
-              nftStore.updateNFTStatus(nft.token, visible: false, isDeletedByUser: true)
+              nftStore.updateNFTStatus(nft.token, visible: false, isSpam: nft.token.isSpam, isDeletedByUser: true)
             }) {
               Label(Strings.Wallet.nftRemoveFromWallet, braveSystemImage: "leo.trash")
             }

--- a/Sources/BraveWallet/Crypto/NFT/NFTView.swift
+++ b/Sources/BraveWallet/Crypto/NFT/NFTView.swift
@@ -20,6 +20,7 @@ struct NFTView: View {
   @State private var isShowingNFTDiscoveryAlert: Bool = false
   @State private var isShowingAddCustomNFT: Bool = false
   @State private var isNFTDiscoveryEnabled: Bool = false
+  @State private var nftToBeRemoved: NFTAssetViewModel?
   
   @Environment(\.buySendSwapDestination)
   private var buySendSwapDestination: Binding<BuySendSwapDestination?>
@@ -243,7 +244,7 @@ struct NFTView: View {
               }
             }
             Button(action: {
-              nftStore.updateNFTStatus(nft.token, visible: false, isSpam: nft.token.isSpam, isDeletedByUser: true)
+              nftToBeRemoved = nft
             }) {
               Label(Strings.Wallet.nftRemoveFromWallet, braveSystemImage: "leo.trash")
             }
@@ -330,6 +331,38 @@ struct NFTView: View {
           }
         }
       )
+    )
+    .background(
+      WalletPromptView(
+        isPresented: Binding(
+          get: { nftToBeRemoved != nil },
+          set: { if !$0 { nftToBeRemoved = nil } }
+        ),
+        primaryButton: .init(
+          title: Strings.Wallet.manageSiteConnectionsConfirmAlertRemove,
+          action: { _ in
+            guard let nft = nftToBeRemoved else { return }
+            nftStore.updateNFTStatus(nft.token, visible: false, isSpam: nft.token.isSpam, isDeletedByUser: true)
+            nftToBeRemoved = nil
+          }
+        ),
+        secondaryButton: .init(
+          title: Strings.CancelString,
+          action: { _ in
+            nftToBeRemoved = nil
+          }
+        ),
+        showCloseButton: false,
+        content: {
+          VStack(spacing: 16) {
+            Text(Strings.Wallet.nftRemoveFromWalletAlertTitle)
+              .font(.headline)
+              .foregroundColor(Color(.bravePrimary))
+            Text(Strings.Wallet.nftRemoveFromWalletAlertDescription)
+              .font(.footnote)
+              .foregroundStyle(Color(.secondaryBraveLabel))
+          }
+        })
     )
     .sheet(isPresented: $isShowingAddCustomNFT) {
       AddCustomAssetView(

--- a/Sources/BraveWallet/Crypto/Stores/AccountActivityStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/AccountActivityStore.swift
@@ -141,7 +141,7 @@ class AccountActivityStore: ObservableObject, WalletObserverStore {
         let tokens: [BraveWallet.BlockchainToken]
         let sortOrder: Int
       }
-      let allUserAssets = assetManager.getAllUserAssetsInNetworkAssets(networks: networksForAccount, includingSpam: true)
+      let allUserAssets = assetManager.getAllUserAssetsInNetworkAssets(networks: networksForAccount, includingUserDeleted: true)
       let allTokens = await blockchainRegistry.allTokens(in: networksForAccountCoin).flatMap(\.tokens)
       var updatedUserAssets: [AssetViewModel] = []
       var updatedUserNFTs: [NFTAssetViewModel] = []

--- a/Sources/BraveWallet/Crypto/Stores/AssetDetailStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/AssetDetailStore.swift
@@ -317,7 +317,7 @@ class AssetDetailStore: ObservableObject, WalletObserverStore {
   ) async -> [TransactionSummary] {
     guard case let .blockchainToken(token) = assetDetailType
     else { return [] }
-    let userAssets = assetManager.getAllUserAssetsInNetworkAssets(networks: [network], includingSpam: true).flatMap { $0.tokens }
+    let userAssets = assetManager.getAllUserAssetsInNetworkAssets(networks: [network], includingUserDeleted: true).flatMap { $0.tokens }
     let allTokens = await blockchainRegistry.allTokens(network.chainId, coin: network.coin)
     let allTransactions = await withTaskGroup(of: [BraveWallet.TransactionInfo].self) { @MainActor group -> [BraveWallet.TransactionInfo] in
       for account in keyring.accountInfos {

--- a/Sources/BraveWallet/Crypto/Stores/NFTStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/NFTStore.swift
@@ -384,8 +384,18 @@ public class NFTStore: ObservableObject, WalletObserverStore {
     walletService.setNftDiscoveryEnabled(true)
   }
   
-  func updateNFTStatus(_ token: BraveWallet.BlockchainToken, visible: Bool, isDeletedByUser: Bool) {
-    assetManager.updateUserAsset(for: token, visible: visible, isDeletedByUser: isDeletedByUser) { [weak self] in
+  func updateNFTStatus(
+    _ token: BraveWallet.BlockchainToken,
+    visible: Bool,
+    isSpam: Bool,
+    isDeletedByUser: Bool
+  ) {
+    assetManager.updateUserAsset(
+      for: token,
+      visible: visible,
+      isSpam: isSpam,
+      isDeletedByUser: isDeletedByUser
+    ) { [weak self] in
       guard let self else { return }
       let selectedAccounts = self.filters.accounts.filter(\.isSelected).map(\.model)
       let selectedNetworks = self.filters.networks.filter(\.isSelected).map(\.model)

--- a/Sources/BraveWallet/Crypto/Stores/NFTStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/NFTStore.swift
@@ -30,9 +30,7 @@ public class NFTStore: ObservableObject, WalletObserverStore {
     case .visible:
       return userNFTs.filter(\.token.visible)
     case .hidden:
-      return userNFTs.filter { !$0.token.visible && !$0.token.isSpam }
-    case .spam:
-      return userNFTs.filter(\.token.isSpam)
+      return userNFTs.filter { !$0.token.visible }
     }
   }
   /// All User Accounts
@@ -75,7 +73,6 @@ public class NFTStore: ObservableObject, WalletObserverStore {
   enum NFTDisplayType: Int, CaseIterable, Identifiable {
     case visible
     case hidden
-    case spam
     
     var id: Int {
       rawValue
@@ -84,11 +81,9 @@ public class NFTStore: ObservableObject, WalletObserverStore {
     var dropdownTitle: String {
       switch self {
       case .visible:
-        return Strings.Wallet.nftsTitle
+        return Strings.Wallet.nftCollected
       case .hidden:
         return Strings.Wallet.nftHidden
-      case .spam:
-        return Strings.Wallet.nftSpam
       }
     }
     
@@ -98,8 +93,6 @@ public class NFTStore: ObservableObject, WalletObserverStore {
         return Strings.Wallet.nftPageEmptyTitle
       case .hidden:
         return Strings.Wallet.nftInvisiblePageEmptyTitle
-      case .spam:
-        return Strings.Wallet.nftSpamPageEmptyTitle
       }
     }
     
@@ -107,7 +100,7 @@ public class NFTStore: ObservableObject, WalletObserverStore {
       switch self {
       case .visible:
         return Strings.Wallet.nftPageEmptyDescription
-      case .hidden, .spam:
+      case .hidden:
         return nil
       }
     }
@@ -344,17 +337,21 @@ public class NFTStore: ObservableObject, WalletObserverStore {
     selectedAccounts: [BraveWallet.AccountInfo],
     simpleHashSpamNFTs: [NetworkAssets]
   ) -> [NetworkAssets] {
+    // all user marked deleted NFTs
+    let allUserMarkedDeletedNFTs = assetManager.getAllUserDeletedNFTs()
     // all spam NFTs marked by user
     let allUserMarkedSpamNFTs = assetManager.getAllUserNFTs(networks: selectedNetworks, isSpam: true)
     // filter out any spam NFTs from `simpleHashSpamNFTs` that are marked
-    // not-spam by user
+    // not-spam or deleted by user
     var updatedSimpleHashSpamNFTs: [NetworkAssets] = []
     for simpleHashSpamNFTsOnNetwork in simpleHashSpamNFTs {
       let userMarkedNotSpamTokensOnNetwork = assetManager.getAllUserNFTs(networks: [simpleHashSpamNFTsOnNetwork.network], isSpam: false).flatMap(\.tokens)
       let filteredSimpleHashSpamTokens = simpleHashSpamNFTsOnNetwork.tokens.filter { simpleHashSpamToken in
-        !userMarkedNotSpamTokensOnNetwork.contains { token in
+        return !userMarkedNotSpamTokensOnNetwork.contains { token in
           token.id == simpleHashSpamToken.id
-        }
+        } && !allUserMarkedDeletedNFTs.contains(where: { deletedNFT in
+          deletedNFT.contractAddress == simpleHashSpamToken.contractAddress && deletedNFT.chainId == simpleHashSpamToken.chainId && deletedNFT.tokenId == simpleHashSpamToken.tokenId
+        })
       }
       updatedSimpleHashSpamNFTs.append(NetworkAssets(network: simpleHashSpamNFTsOnNetwork.network, tokens: filteredSimpleHashSpamTokens, sortOrder: simpleHashSpamNFTsOnNetwork.sortOrder))
     }
@@ -387,8 +384,8 @@ public class NFTStore: ObservableObject, WalletObserverStore {
     walletService.setNftDiscoveryEnabled(true)
   }
   
-  func updateNFTStatus(_ token: BraveWallet.BlockchainToken, visible: Bool, isSpam: Bool) {
-    assetManager.updateUserAsset(for: token, visible: visible, isSpam: isSpam) { [weak self] in
+  func updateNFTStatus(_ token: BraveWallet.BlockchainToken, visible: Bool, isDeletedByUser: Bool) {
+    assetManager.updateUserAsset(for: token, visible: visible, isDeletedByUser: isDeletedByUser) { [weak self] in
       guard let self else { return }
       let selectedAccounts = self.filters.accounts.filter(\.isSelected).map(\.model)
       let selectedNetworks = self.filters.networks.filter(\.isSelected).map(\.model)

--- a/Sources/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
@@ -277,7 +277,7 @@ public class TransactionConfirmationStore: ObservableObject, WalletObserverStore
     let transactionNetworks: [BraveWallet.NetworkInfo] = Set(allTxs.map(\.chainId))
       .compactMap { chainId in allNetworks.first(where: { $0.chainId == chainId }) }
     for network in transactionNetworks {
-      let userAssets = assetManager.getAllUserAssetsInNetworkAssets(networks: [network], includingSpam: true).flatMap { $0.tokens }
+      let userAssets = assetManager.getAllUserAssetsInNetworkAssets(networks: [network], includingUserDeleted: true).flatMap { $0.tokens }
       await fetchAssetRatios(for: userAssets)
     }
     await fetchUnknownTokens(for: unapprovedTxs)
@@ -307,7 +307,7 @@ public class TransactionConfirmationStore: ObservableObject, WalletObserverStore
         return
       }
       let allTokens = await blockchainRegistry.allTokens(network.chainId, coin: coin) + tokenInfoCache.map(\.value)
-      let userAssets = assetManager.getAllUserAssetsInNetworkAssets(networks: [network], includingSpam: true).flatMap { $0.tokens }
+      let userAssets = assetManager.getAllUserAssetsInNetworkAssets(networks: [network], includingUserDeleted: true).flatMap { $0.tokens }
       let solEstimatedTxFee: UInt64? = solEstimatedTxFeeCache[transaction.id]
       
       if transaction.isEIP1559Transaction {
@@ -431,7 +431,7 @@ public class TransactionConfirmationStore: ObservableObject, WalletObserverStore
     guard let network = allNetworks.first(where: { $0.chainId == BraveWallet.MainnetChainId }) else {
       return
     }
-    let userAssets = assetManager.getAllUserAssetsInNetworkAssets(networks: [network], includingSpam: true).flatMap { $0.tokens }
+    let userAssets = assetManager.getAllUserAssetsInNetworkAssets(networks: [network], includingUserDeleted: true).flatMap { $0.tokens }
     let allTokens = await blockchainRegistry.allTokens(network.chainId, coin: network.coin)
     let unknownTokenContractAddresses = mainnetTransactions.flatMap(\.tokenContractAddresses)
       .filter { contractAddress in

--- a/Sources/BraveWallet/Crypto/Stores/TransactionDetailsStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/TransactionDetailsStore.swift
@@ -80,7 +80,7 @@ class TransactionDetailsStore: ObservableObject, WalletObserverStore {
       let keringId = BraveWallet.KeyringId.keyringId(for: coin, on: transaction.chainId)
       let keyring = await keyringService.keyringInfo(keringId)
       var allTokens: [BraveWallet.BlockchainToken] = await blockchainRegistry.allTokens(network.chainId, coin: network.coin) + tokenInfoCache.map(\.value)
-      let userAssets: [BraveWallet.BlockchainToken] = assetManager.getAllUserAssetsInNetworkAssets(networks: [network], includingSpam: true).flatMap { $0.tokens }
+      let userAssets: [BraveWallet.BlockchainToken] = assetManager.getAllUserAssetsInNetworkAssets(networks: [network], includingUserDeleted: true).flatMap { $0.tokens }
       let unknownTokenContractAddresses = transaction.tokenContractAddresses
         .filter { contractAddress in
           !userAssets.contains(where: { $0.contractAddress(in: network).caseInsensitiveCompare(contractAddress) == .orderedSame })

--- a/Sources/BraveWallet/Crypto/Stores/TransactionsActivityStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/TransactionsActivityStore.swift
@@ -138,7 +138,7 @@ class TransactionsActivityStore: ObservableObject, WalletObserverStore {
       let allTransactions = await txService.allTransactions(
         networksForCoin: networksForCoin, for: allKeyrings
       ).filter { $0.txStatus != .rejected }
-      let userAssets = assetManager.getAllUserAssetsInNetworkAssets(networks: allNetworksAllCoins, includingSpam: true).flatMap(\.tokens)
+      let userAssets = assetManager.getAllUserAssetsInNetworkAssets(networks: allNetworksAllCoins, includingUserDeleted: true).flatMap(\.tokens)
       let allTokens = await blockchainRegistry.allTokens(
         in: allNetworksAllCoins
       ).flatMap(\.tokens)

--- a/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
@@ -137,7 +137,7 @@ public class UserAssetsStore: ObservableObject, WalletObserverStore {
         }
       }
       let networks: [BraveWallet.NetworkInfo] = self.networkFilters.filter(\.isSelected).map(\.model)
-      let allUserAssets = assetManager.getAllUserAssetsInNetworkAssets(networks: networks, includingSpam: true)
+      let allUserAssets = assetManager.getAllUserAssetsInNetworkAssets(networks: networks, includingUserDeleted: false)
       var allTokens = await self.blockchainRegistry.allTokens(in: networks)
       // Filter `allTokens` to remove any tokens existing in `allUserAssets`. This is possible for ERC721 tokens in the registry without a `tokenId`, which requires the user to add as a custom token
       let allUserTokens = allUserAssets.flatMap(\.tokens)
@@ -233,7 +233,7 @@ public class UserAssetsStore: ObservableObject, WalletObserverStore {
   
   @MainActor func allAssets() async -> [AssetViewModel] {
     let allNetworks = await rpcService.allNetworksForSupportedCoins()
-    let allUserAssets = assetManager.getAllUserAssetsInNetworkAssets(networks: allNetworks, includingSpam: true)
+    let allUserAssets = assetManager.getAllUserAssetsInNetworkAssets(networks: allNetworks, includingUserDeleted: false)
     // Filter `allTokens` to remove any tokens existing in `allUserAssets`. This is possible for ERC721 tokens in the registry without a `tokenId`, which requires the user to add as a custom token
     let allUserTokens = allUserAssets.flatMap(\.tokens)
     let allBlockchainTokens = await blockchainRegistry.allTokens(in: allNetworks)
@@ -262,7 +262,7 @@ public class UserAssetsStore: ObservableObject, WalletObserverStore {
   
   @MainActor func allNFTMetadata() async -> [String: NFTMetadata] {
     let allNetworks = await rpcService.allNetworksForSupportedCoins()
-    let allUserAssets = assetManager.getAllUserAssetsInNetworkAssets(networks: allNetworks, includingSpam: true)
+    let allUserAssets = assetManager.getAllUserAssetsInNetworkAssets(networks: allNetworks, includingUserDeleted: true)
     // Filter `allTokens` to remove any tokens existing in `allUserAssets`. This is possible for ERC721 tokens in the registry without a `tokenId`, which requires the user to add as a custom token
     let allUserTokens = allUserAssets.flatMap(\.tokens)
     

--- a/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
@@ -13,7 +13,7 @@ public class AssetStore: ObservableObject, Equatable, WalletObserverStore {
   @Published var token: BraveWallet.BlockchainToken
   @Published var isVisible: Bool {
     didSet {
-      assetManager.updateUserAsset(for: token, visible: isVisible, isSpam: false, completion: nil)
+      assetManager.updateUserAsset(for: token, visible: isVisible, isDeletedByUser: false, completion: nil)
     }
   }
   var network: BraveWallet.NetworkInfo
@@ -183,7 +183,7 @@ public class UserAssetsStore: ObservableObject, WalletObserverStore {
     _ asset: BraveWallet.BlockchainToken,
     completion: @escaping (_ success: Bool) -> Void
   ) {
-    if assetManager.getUserAsset(asset) != nil {
+    if let existedAsset = assetManager.getUserAsset(asset), !existedAsset.isDeletedByUser {
       completion(false)
     } else {
       assetManager.addUserAsset(asset) { [weak self] in

--- a/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
@@ -13,7 +13,7 @@ public class AssetStore: ObservableObject, Equatable, WalletObserverStore {
   @Published var token: BraveWallet.BlockchainToken
   @Published var isVisible: Bool {
     didSet {
-      assetManager.updateUserAsset(for: token, visible: isVisible, isDeletedByUser: false, completion: nil)
+      assetManager.updateUserAsset(for: token, visible: isVisible, isSpam: false, isDeletedByUser: false, completion: nil)
     }
   }
   var network: BraveWallet.NetworkInfo

--- a/Sources/BraveWallet/Extensions/WalletColors.swift
+++ b/Sources/BraveWallet/Extensions/WalletColors.swift
@@ -250,4 +250,11 @@ enum WalletV2Design {
   static let passwordMediumYellow = UIColor(rgb: 0xbd9600)
   
   static let passwordStrongGreen = UIColor(rgb: 0x31803e)
+  
+  static let spamNFTLabelBackground = UIColor(
+    red: 255 / 255,
+    green: 209 / 255,
+    blue: 207 / 255,
+    alpha: 1
+  )
 }

--- a/Sources/BraveWallet/Extensions/WalletColors.swift
+++ b/Sources/BraveWallet/Extensions/WalletColors.swift
@@ -252,7 +252,7 @@ enum WalletV2Design {
   static let passwordStrongGreen = UIColor(rgb: 0x31803e)
   
   static let spamNFTLabelBackground = UIColor(
-    red: 255 / 255,
+    red: 1,
     green: 209 / 255,
     blue: 207 / 255,
     alpha: 1

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -4371,7 +4371,7 @@ extension Strings {
       "wallet.nftUnspam",
       tableName: "BraveWallet",
       bundle: .module,
-      value: "Mark As Not Junk",
+      value: "Mark as Not Junk",
       comment: "The title of context button for user to unspam a NFT."
     )
     public static let nftRemoveFromWallet = NSLocalizedString(

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -4234,13 +4234,6 @@ extension Strings {
       value: "No hidden NFTs here yet.",
       comment: "The title of the empty state inside NFT tab under Hidden group."
     )
-    public static let nftSpamPageEmptyTitle = NSLocalizedString(
-      "wallet.nftSpamPageEmptyTitle",
-      tableName: "BraveWallet",
-      bundle: .module,
-      value: "No NFTs have been marked as spam.",
-      comment: "The title of the empty state inside NFT tab under Spam group."
-    )
     public static let nftPageEmptyDescription = NSLocalizedString(
       "wallet.nftPageEmptyDescription",
       tableName: "BraveWallet",
@@ -4346,6 +4339,13 @@ extension Strings {
       value: "Import NFT",
       comment: "The title of the button that user clicks to add his/her first NFT"
     )
+    public static let nftCollected = NSLocalizedString(
+      "wallet.nftCollected",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Collected",
+      comment: "The title of one of the dropdown options to group NFTs. This group will display all user's visible NFTs."
+    )
     public static let nftHidden = NSLocalizedString(
       "wallet.nftHidden",
       tableName: "BraveWallet",
@@ -4357,8 +4357,8 @@ extension Strings {
       "wallet.nftSpam",
       tableName: "BraveWallet",
       bundle: .module,
-      value: "Spam",
-      comment: "The title of one of the dropdown options to group NFTs. This group will display all user's marked spam NFTs and SimpleHash marked spam NFTs."
+      value: "Junk",
+      comment: "The title of an overlay on top left of the junk NFT grid."
     )
     public static let nftUnhide = NSLocalizedString(
       "wallet.nftUnhide",
@@ -4367,19 +4367,19 @@ extension Strings {
       value: "Unhide",
       comment: "The title of context button for user to unhide visible NFT."
     )
-    public static let nftMoveToSpam = NSLocalizedString(
-      "wallet.nftMoveToSpam",
-      tableName: "BraveWallet",
-      bundle: .module,
-      value: "Move to Spam",
-      comment: "The title of context button for user to move a NFT to the `Spam` group."
-    )
     public static let nftUnspam = NSLocalizedString(
       "wallet.nftUnspam",
       tableName: "BraveWallet",
       bundle: .module,
-      value: "Unspam",
+      value: "Mark as not junk",
       comment: "The title of context button for user to unspam a NFT."
+    )
+    public static let nftRemoveFromWallet = NSLocalizedString(
+      "wallet.nftRemoveFromWallet",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Don't show in wallet",
+      comment: "The title of context button for user to do not show a NFT in wallet at all."
     )
     public static let selectTokenToSendTitle = NSLocalizedString(
       "wallet.selectTokenToSendTitle",

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -4371,14 +4371,14 @@ extension Strings {
       "wallet.nftUnspam",
       tableName: "BraveWallet",
       bundle: .module,
-      value: "Mark as not junk",
+      value: "Mark As Not Junk",
       comment: "The title of context button for user to unspam a NFT."
     )
     public static let nftRemoveFromWallet = NSLocalizedString(
       "wallet.nftRemoveFromWallet",
       tableName: "BraveWallet",
       bundle: .module,
-      value: "Don't show in wallet",
+      value: "Don't Show in Wallet",
       comment: "The title of context button for user to do not show a NFT in wallet at all."
     )
     public static let nftRemoveFromWalletAlertTitle = NSLocalizedString(

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -4381,6 +4381,20 @@ extension Strings {
       value: "Don't show in wallet",
       comment: "The title of context button for user to do not show a NFT in wallet at all."
     )
+    public static let nftRemoveFromWalletAlertTitle = NSLocalizedString(
+      "wallet.nftRemoveFromWalletAlertTitle",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Remove from Brave Wallet?",
+      comment: "The title of the alert when user attempts to remove an NFT from wallet."
+    )
+    public static let nftRemoveFromWalletAlertDescription = NSLocalizedString(
+      "wallet.nftRemoveFromWalletAlertDescription",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "NFT will be removed from Brave Wallet but will remain on the blockchain. If you remove it, then change your mind, you'll need to import it again manually.",
+      comment: "The description of the alert when user attempts to remove an NFT from wallet."
+    )
     public static let selectTokenToSendTitle = NSLocalizedString(
       "wallet.selectTokenToSendTitle",
       tableName: "BraveWallet",

--- a/Sources/BraveWallet/WalletUserAssetManager.swift
+++ b/Sources/BraveWallet/WalletUserAssetManager.swift
@@ -28,8 +28,8 @@ public protocol WalletUserAssetManagerType: AnyObject {
   func removeUserAsset(_ asset: BraveWallet.BlockchainToken, completion: (() -> Void)?)
   /// Remove an entire `WalletUserAssetGroup` with a given `groupId`
   func removeGroup(for groupId: String, completion: (() -> Void)?)
-  /// Update a `WalletUserAsset`'s `visible` and `isDeletedByUser` status
-  func updateUserAsset(for asset: BraveWallet.BlockchainToken, visible: Bool, isDeletedByUser: Bool, completion: (() -> Void)?)
+  /// Update a `WalletUserAsset`'s `visible`, `isSpam`, and `isDeletedByUser` status
+  func updateUserAsset(for asset: BraveWallet.BlockchainToken, visible: Bool, isSpam: Bool, isDeletedByUser: Bool, completion: (() -> Void)?)
 }
 
 public class WalletUserAssetManager: WalletUserAssetManagerType {
@@ -113,7 +113,7 @@ public class WalletUserAssetManager: WalletUserAssetManagerType {
   public func addUserAsset(_ asset: BraveWallet.BlockchainToken, completion: (() -> Void)?) {
     if let existedAsset = WalletUserAsset.getUserAsset(asset: asset) {
       if existedAsset.isDeletedByUser { // this asset was added before but user marked as deleted after
-        WalletUserAsset.updateUserAsset(for: asset, visible: true, isDeletedByUser: false, completion: completion)
+        WalletUserAsset.updateUserAsset(for: asset, visible: true, isSpam: false, isDeletedByUser: false, completion: completion)
       } else { // this asset exists, either in `Collected` or `Hidden` based on its `visible` value
         completion?()
         return
@@ -130,12 +130,14 @@ public class WalletUserAssetManager: WalletUserAssetManagerType {
   public func updateUserAsset(
     for asset: BraveWallet.BlockchainToken,
     visible: Bool,
+    isSpam: Bool,
     isDeletedByUser: Bool,
     completion: (() -> Void)?
   ) {
     WalletUserAsset.updateUserAsset(
       for: asset,
       visible: visible,
+      isSpam: isSpam,
       isDeletedByUser: isDeletedByUser,
       completion: completion
     )
@@ -238,6 +240,7 @@ public class TestableWalletUserAssetManager: WalletUserAssetManagerType {
   public func updateUserAsset(
     for asset: BraveWallet.BlockchainToken,
     visible: Bool,
+    isSpam: Bool,
     isDeletedByUser: Bool,
     completion: (() -> Void)?
   ) {

--- a/Sources/Data/models/Model.xcdatamodeld/.xccurrentversion
+++ b/Sources/Data/models/Model.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>Model23.xcdatamodel</string>
+	<string>Model24.xcdatamodel</string>
 </dict>
 </plist>

--- a/Sources/Data/models/Model.xcdatamodeld/Model24.xcdatamodel/contents
+++ b/Sources/Data/models/Model.xcdatamodeld/Model24.xcdatamodel/contents
@@ -1,0 +1,234 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22222" systemVersion="23A344" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="BlockedResource" representedClassName="Data.BlockedResource" syncable="YES">
+        <attribute name="domain" optional="YES" attributeType="String"/>
+        <attribute name="faviconUrl" optional="YES" attributeType="String"/>
+        <attribute name="host" optional="YES" attributeType="String"/>
+        <attribute name="timestamp" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <fetchIndex name="byHost">
+            <fetchIndexElement property="host" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <fetchIndex name="byDomain">
+            <fetchIndexElement property="domain" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="Bookmark" representedClassName="Data.Favorite" syncable="YES">
+        <attribute name="created" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="customTitle" optional="YES" attributeType="String"/>
+        <attribute name="isFavorite" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="isFolder" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="lastVisited" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="order" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="syncDisplayUUID" optional="YES" attributeType="String"/>
+        <attribute name="syncOrder" optional="YES" attributeType="String"/>
+        <attribute name="syncParentDisplayUUID" optional="YES" attributeType="String"/>
+        <attribute name="tags" optional="YES" attributeType="Transformable"/>
+        <attribute name="title" optional="YES" attributeType="String"/>
+        <attribute name="url" optional="YES" attributeType="String"/>
+        <attribute name="visits" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="domain" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Domain" inverseName="bookmarks" inverseEntity="Domain"/>
+        <fetchIndex name="byLastVisitedIndex">
+            <fetchIndexElement property="lastVisited" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <fetchIndex name="byUrlIndex">
+            <fetchIndexElement property="url" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <fetchIndex name="byVisitsIndex">
+            <fetchIndexElement property="visits" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="BraveVPNAlert" representedClassName="Data.BraveVPNAlert" syncable="YES">
+        <attribute name="action" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="category" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="host" optional="YES" attributeType="String"/>
+        <attribute name="message" optional="YES" attributeType="String"/>
+        <attribute name="timestamp" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="title" optional="YES" attributeType="String"/>
+        <attribute name="uuid" optional="YES" attributeType="String"/>
+        <fetchIndex name="byUUID">
+            <fetchIndexElement property="uuid" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="uuid"/>
+            </uniquenessConstraint>
+            <uniquenessConstraint>
+                <constraint value="timestamp"/>
+                <constraint value="host"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="CustomFilterListSetting" representedClassName="Data.CustomFilterListSetting" syncable="YES">
+        <attribute name="externalURL" optional="YES" attributeType="URI"/>
+        <attribute name="isEnabled" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="uuid" optional="YES" attributeType="String"/>
+    </entity>
+    <entity name="DataSaved" representedClassName="Data.DataSaved" syncable="YES">
+        <attribute name="amount" optional="YES" attributeType="String"/>
+        <attribute name="savedUrl" optional="YES" attributeType="String"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="savedUrl"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="Domain" representedClassName="Data.Domain" syncable="YES">
+        <attribute name="blockedFromTopSites" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="shield_adblockAndTp" optional="YES" attributeType="Boolean" usesScalarValueType="NO"/>
+        <attribute name="shield_allOff" optional="YES" attributeType="Boolean" usesScalarValueType="NO"/>
+        <attribute name="shield_fpProtection" optional="YES" attributeType="Boolean" usesScalarValueType="NO"/>
+        <attribute name="shield_httpse" optional="YES" attributeType="Boolean" usesScalarValueType="NO"/>
+        <attribute name="shield_noScript" optional="YES" attributeType="Boolean" usesScalarValueType="NO"/>
+        <attribute name="shield_safeBrowsing" optional="YES" attributeType="Boolean" usesScalarValueType="NO"/>
+        <attribute name="topsite" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="url" optional="YES" attributeType="String"/>
+        <attribute name="visits" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="wallet_permittedAccounts" optional="YES" attributeType="String"/>
+        <attribute name="wallet_solanaPermittedAcccounts" optional="YES" attributeType="String"/>
+        <attribute name="zoom_level" optional="YES" attributeType="Double" usesScalarValueType="NO"/>
+        <relationship name="bookmarks" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Bookmark" inverseName="domain" inverseEntity="Bookmark"/>
+        <fetchIndex name="byBlockedFromTopSitesIndex">
+            <fetchIndexElement property="blockedFromTopSites" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <fetchIndex name="byUrlIndex">
+            <fetchIndexElement property="url" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <fetchIndex name="byVisitsIndex">
+            <fetchIndexElement property="visits" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="FeedSourceOverride" representedClassName="Data.FeedSourceOverride" syncable="YES">
+        <attribute name="enabled" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="publisherID" attributeType="String"/>
+        <fetchIndex name="byPublisherID">
+            <fetchIndexElement property="publisherID" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="publisherID"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="FilterListSetting" representedClassName="Data.FilterListSetting" syncable="YES">
+        <attribute name="componentId" optional="YES" attributeType="String"/>
+        <attribute name="folderPath" optional="YES" attributeType="String"/>
+        <attribute name="isAlwaysAggressive" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="isEnabled" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="order" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="uuid" attributeType="String"/>
+    </entity>
+    <entity name="PlaylistFolder" representedClassName="Data.PlaylistFolder" syncable="YES">
+        <attribute name="creatorLink" optional="YES" attributeType="String"/>
+        <attribute name="creatorName" optional="YES" attributeType="String"/>
+        <attribute name="dateAdded" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="order" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="sharedFolderETag" optional="YES" attributeType="String"/>
+        <attribute name="sharedFolderId" optional="YES" attributeType="String"/>
+        <attribute name="sharedFolderUrl" optional="YES" attributeType="String"/>
+        <attribute name="title" attributeType="String"/>
+        <attribute name="uuid" attributeType="String"/>
+        <relationship name="playlistItems" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="PlaylistItem" inverseName="playlistFolder" inverseEntity="PlaylistItem"/>
+    </entity>
+    <entity name="PlaylistItem" representedClassName="Data.PlaylistItem" syncable="YES">
+        <attribute name="cachedData" optional="YES" attributeType="Binary"/>
+        <attribute name="dateAdded" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="duration" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="lastPlayedOffset" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="mediaSrc" attributeType="String"/>
+        <attribute name="mimeType" attributeType="String"/>
+        <attribute name="name" attributeType="String"/>
+        <attribute name="order" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="pageSrc" attributeType="String"/>
+        <attribute name="pageTitle" optional="YES" attributeType="String"/>
+        <attribute name="uuid" optional="YES" attributeType="String"/>
+        <relationship name="playlistFolder" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="PlaylistFolder" inverseName="playlistItems" inverseEntity="PlaylistFolder"/>
+    </entity>
+    <entity name="RecentlyClosed" representedClassName="Data.RecentlyClosed" syncable="YES">
+        <attribute name="dateAdded" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="historyIndex" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="historyList" optional="YES" attributeType="Transformable"/>
+        <attribute name="interactionState" optional="YES" attributeType="Binary"/>
+        <attribute name="title" optional="YES" attributeType="String"/>
+        <attribute name="url" attributeType="String"/>
+    </entity>
+    <entity name="RecentSearch" representedClassName="Data.RecentSearch" syncable="YES">
+        <attribute name="dateAdded" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="searchType" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="text" optional="YES" attributeType="String"/>
+        <attribute name="websiteUrl" optional="YES" attributeType="String"/>
+    </entity>
+    <entity name="RSSFeedSource" representedClassName="Data.RSSFeedSource" syncable="YES">
+        <attribute name="feedUrl" attributeType="String"/>
+        <attribute name="title" optional="YES" attributeType="String"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="feedUrl"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="SessionTab" representedClassName="Data.SessionTab" syncable="YES">
+        <attribute name="index" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="interactionState" attributeType="Binary"/>
+        <attribute name="isPrivate" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="isSelected" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="lastUpdated" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="screenshotData" attributeType="Binary"/>
+        <attribute name="tabId" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="title" attributeType="String"/>
+        <attribute name="url" attributeType="URI"/>
+        <relationship name="sessionTabGroup" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SessionTabGroup" inverseName="sessionTabs" inverseEntity="SessionTabGroup"/>
+        <relationship name="sessionWindow" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SessionWindow" inverseName="sessionTabs" inverseEntity="SessionWindow"/>
+    </entity>
+    <entity name="SessionTabGroup" representedClassName="Data.SessionTabGroup" syncable="YES">
+        <attribute name="groupId" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="index" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="title" attributeType="String"/>
+        <relationship name="sessionTabs" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="SessionTab" inverseName="sessionTabGroup" inverseEntity="SessionTab"/>
+        <relationship name="sessionWindow" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SessionWindow" inverseName="sessionTabGroups" inverseEntity="SessionWindow"/>
+    </entity>
+    <entity name="SessionWindow" representedClassName="Data.SessionWindow" syncable="YES">
+        <attribute name="index" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="isPrivate" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="isSelected" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="windowId" attributeType="UUID" usesScalarValueType="NO"/>
+        <relationship name="sessionTabGroups" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="SessionTabGroup" inverseName="sessionWindow" inverseEntity="SessionTabGroup"/>
+        <relationship name="sessionTabs" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="SessionTab" inverseName="sessionWindow" inverseEntity="SessionTab"/>
+    </entity>
+    <entity name="TabMO" representedClassName="Data.TabMO" syncable="YES">
+        <attribute name="color" optional="YES" attributeType="String"/>
+        <attribute name="isPrivate" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="isSelected" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="lastUpdate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="order" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="screenshot" optional="YES" attributeType="Binary" allowsExternalBinaryDataStorage="YES"/>
+        <attribute name="screenshotUUID" optional="YES" attributeType="String"/>
+        <attribute name="syncUUID" optional="YES" attributeType="String"/>
+        <attribute name="title" optional="YES" attributeType="String"/>
+        <attribute name="url" optional="YES" attributeType="String"/>
+        <attribute name="urlHistoryCurrentIndex" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="urlHistorySnapshot" optional="YES" attributeType="Transformable"/>
+    </entity>
+    <entity name="WalletUserAsset" representedClassName="Data.WalletUserAsset" syncable="YES">
+        <attribute name="chainId" optional="YES" attributeType="String"/>
+        <attribute name="coin" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="coingeckoId" optional="YES" attributeType="String"/>
+        <attribute name="contractAddress" optional="YES" attributeType="String"/>
+        <attribute name="decimals" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="isDeletedByUser" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="isERC20" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="isERC721" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="isERC1155" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="isNFT" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="isSpam" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="logo" optional="YES" attributeType="String"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="symbol" optional="YES" attributeType="String"/>
+        <attribute name="tokenId" optional="YES" attributeType="String"/>
+        <attribute name="visible" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <relationship name="walletUserAssetGroup" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="WalletUserAssetGroup" inverseName="walletUserAssets" inverseEntity="WalletUserAssetGroup"/>
+    </entity>
+    <entity name="WalletUserAssetGroup" representedClassName="Data.WalletUserAssetGroup" syncable="YES">
+        <attribute name="groupId" optional="YES" attributeType="String"/>
+        <relationship name="walletUserAssets" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="WalletUserAsset" inverseName="walletUserAssetGroup" inverseEntity="WalletUserAsset"/>
+    </entity>
+</model>

--- a/Sources/Data/models/WalletUserAsset.swift
+++ b/Sources/Data/models/WalletUserAsset.swift
@@ -25,6 +25,7 @@ public final class WalletUserAsset: NSManagedObject, CRUD {
   @NSManaged public var coingeckoId: String
   @NSManaged public var chainId: String
   @NSManaged public var coin: Int16
+  @NSManaged public var isDeletedByUser: Bool
   @NSManaged public var walletUserAssetGroup: WalletUserAssetGroup?
   
   public var blockchainToken: BraveWallet.BlockchainToken {
@@ -80,6 +81,7 @@ public final class WalletUserAsset: NSManagedObject, CRUD {
     self.coingeckoId = asset.coingeckoId
     self.chainId = asset.chainId
     self.coin = Int16(asset.coin.rawValue)
+    // `isDeletedByUser` has a default value `NO`
   }
   
   public static func getUserAsset(asset: BraveWallet.BlockchainToken, context: NSManagedObjectContext? = nil) -> WalletUserAsset? {
@@ -87,7 +89,11 @@ public final class WalletUserAsset: NSManagedObject, CRUD {
   }
   
   public static func getAllVisibleUserAssets(context: NSManagedObjectContext? = nil) -> [WalletUserAsset]? {
-    WalletUserAsset.all(where: NSPredicate(format: "visible = true"), context: context ?? DataController.viewContext)
+    WalletUserAsset.all(where: NSPredicate(format: "visible = true AND isDeletedByUser == false"), context: context ?? DataController.viewContext)
+  }
+  
+  public static func getAllUserDeletedUserAssets(context: NSManagedObjectContext? = nil) -> [WalletUserAsset]? {
+    WalletUserAsset.all(where: NSPredicate(format: "isDeletedByUser == true"), context: context ?? DataController.viewContext)
   }
   
   public static func migrateVisibleAssets(_ assets: [String: [BraveWallet.BlockchainToken]], completion: (() -> Void)? = nil) {
@@ -111,19 +117,19 @@ public final class WalletUserAsset: NSManagedObject, CRUD {
   public static func updateUserAsset(
     for asset: BraveWallet.BlockchainToken,
     visible: Bool,
-    isSpam: Bool,
+    isDeletedByUser: Bool,
     completion: (() -> Void)? = nil
   ) {
     DataController.perform(context: .new(inMemory: false), save: false) { context in
       if let asset = WalletUserAsset.first(where: NSPredicate(format: "contractAddress == %@ AND chainId == %@ AND symbol == %@ AND tokenId == %@", asset.contractAddress, asset.chainId, asset.symbol, asset.tokenId), context: context) {
         asset.visible = visible
-        asset.isSpam = isSpam
+        asset.isDeletedByUser = isDeletedByUser
       } else {
         let groupId = asset.walletUserAssetGroupId
         let group = WalletUserAssetGroup.getGroup(groupId: groupId, context: context) ?? WalletUserAssetGroup(context: context, groupId: groupId)
         let visibleAsset = WalletUserAsset(context: context, asset: asset)
         visibleAsset.visible = visible
-        visibleAsset.isSpam = isSpam
+        visibleAsset.isDeletedByUser = isDeletedByUser
         visibleAsset.walletUserAssetGroup = group
       }
       
@@ -140,7 +146,7 @@ public final class WalletUserAsset: NSManagedObject, CRUD {
       let groupId = asset.walletUserAssetGroupId
       let group = WalletUserAssetGroup.getGroup(groupId: groupId, context: context) ?? WalletUserAssetGroup(context: context, groupId: groupId)
       let visibleAsset = WalletUserAsset(context: context, asset: asset)
-      visibleAsset.visible = true
+      visibleAsset.visible = true // (`isSpam` and `isDeletedByUser` have a default value `NO`)
       visibleAsset.walletUserAssetGroup = group
       
       WalletUserAsset.saveContext(context)

--- a/Sources/Data/models/WalletUserAsset.swift
+++ b/Sources/Data/models/WalletUserAsset.swift
@@ -117,18 +117,21 @@ public final class WalletUserAsset: NSManagedObject, CRUD {
   public static func updateUserAsset(
     for asset: BraveWallet.BlockchainToken,
     visible: Bool,
+    isSpam: Bool,
     isDeletedByUser: Bool,
     completion: (() -> Void)? = nil
   ) {
     DataController.perform(context: .new(inMemory: false), save: false) { context in
       if let asset = WalletUserAsset.first(where: NSPredicate(format: "contractAddress == %@ AND chainId == %@ AND symbol == %@ AND tokenId == %@", asset.contractAddress, asset.chainId, asset.symbol, asset.tokenId), context: context) {
         asset.visible = visible
+        asset.isSpam = isSpam
         asset.isDeletedByUser = isDeletedByUser
       } else {
         let groupId = asset.walletUserAssetGroupId
         let group = WalletUserAssetGroup.getGroup(groupId: groupId, context: context) ?? WalletUserAssetGroup(context: context, groupId: groupId)
         let visibleAsset = WalletUserAsset(context: context, asset: asset)
         visibleAsset.visible = visible
+        visibleAsset.isSpam = isSpam
         visibleAsset.isDeletedByUser = isDeletedByUser
         visibleAsset.walletUserAssetGroup = group
       }

--- a/Sources/DesignSystem/Icons/Symbols.xcassets/leo.warning.triangle-outline.symbolset/Contents.json
+++ b/Sources/DesignSystem/Icons/Symbols.xcassets/leo.warning.triangle-outline.symbolset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "symbols" : [
+    {
+      "idiom" : "universal"
+    }
+  ]
+}

--- a/Tests/DataTests/WalletUserAssetTests.swift
+++ b/Tests/DataTests/WalletUserAssetTests.swift
@@ -38,9 +38,10 @@ class WalletUserAssetTests: CoreDataTestCase {
     
     XCTAssertTrue(userAsset.visible)
     XCTAssertFalse(userAsset.isSpam)
+    XCTAssertFalse(userAsset.isDeletedByUser)
     
     backgroundSaveAndWaitForExpectation {
-      WalletUserAsset.updateUserAsset(for: asset, visible: false, isDeletedByUser: true)
+      WalletUserAsset.updateUserAsset(for: asset, visible: false, isSpam: true, isDeletedByUser: true)
     }
     
     DataController.viewContext.refreshAllObjects()
@@ -48,6 +49,7 @@ class WalletUserAssetTests: CoreDataTestCase {
     XCTAssertEqual(try! DataController.viewContext.count(for: fetchRequest), 1)
     
     XCTAssertFalse(userAsset.visible)
+    XCTAssertTrue(userAsset.isSpam)
     XCTAssertTrue(userAsset.isDeletedByUser)
   }
   
@@ -57,7 +59,7 @@ class WalletUserAssetTests: CoreDataTestCase {
     createAndWait(asset: asset3)
     
     backgroundSaveAndWaitForExpectation {
-      WalletUserAsset.updateUserAsset(for: asset2, visible: false, isDeletedByUser: false)
+      WalletUserAsset.updateUserAsset(for: asset2, visible: false, isSpam: false, isDeletedByUser: false)
     }
     
     DataController.viewContext.refreshAllObjects()
@@ -71,7 +73,7 @@ class WalletUserAssetTests: CoreDataTestCase {
     createAndWait(asset: asset2)
     
     backgroundSaveAndWaitForExpectation {
-      WalletUserAsset.updateUserAsset(for: asset2, visible: false, isDeletedByUser: true)
+      WalletUserAsset.updateUserAsset(for: asset2, visible: false, isSpam: false, isDeletedByUser: true)
     }
     
     DataController.viewContext.refreshAllObjects()

--- a/Tests/DataTests/WalletUserAssetTests.swift
+++ b/Tests/DataTests/WalletUserAssetTests.swift
@@ -40,7 +40,7 @@ class WalletUserAssetTests: CoreDataTestCase {
     XCTAssertFalse(userAsset.isSpam)
     
     backgroundSaveAndWaitForExpectation {
-      WalletUserAsset.updateUserAsset(for: asset, visible: false, isSpam: true)
+      WalletUserAsset.updateUserAsset(for: asset, visible: false, isDeletedByUser: true)
     }
     
     DataController.viewContext.refreshAllObjects()
@@ -48,7 +48,7 @@ class WalletUserAssetTests: CoreDataTestCase {
     XCTAssertEqual(try! DataController.viewContext.count(for: fetchRequest), 1)
     
     XCTAssertFalse(userAsset.visible)
-    XCTAssertTrue(userAsset.isSpam)
+    XCTAssertTrue(userAsset.isDeletedByUser)
   }
   
   func testGetAllVisibleAssets() {
@@ -57,13 +57,27 @@ class WalletUserAssetTests: CoreDataTestCase {
     createAndWait(asset: asset3)
     
     backgroundSaveAndWaitForExpectation {
-      WalletUserAsset.updateUserAsset(for: asset2, visible: false, isSpam: false)
+      WalletUserAsset.updateUserAsset(for: asset2, visible: false, isDeletedByUser: false)
     }
     
     DataController.viewContext.refreshAllObjects()
     let allAssets = WalletUserAsset.getAllVisibleUserAssets()
     XCTAssertNotNil(allAssets)
     XCTAssertEqual(allAssets!.count, 2)
+  }
+  
+  func testGetAllVisibleAssetsAfterDeletion() {
+    createAndWait(asset: asset)
+    createAndWait(asset: asset2)
+    
+    backgroundSaveAndWaitForExpectation {
+      WalletUserAsset.updateUserAsset(for: asset2, visible: false, isDeletedByUser: true)
+    }
+    
+    DataController.viewContext.refreshAllObjects()
+    let allDeletedAssets = WalletUserAsset.getAllUserDeletedUserAssets()
+    XCTAssertNotNil(allDeletedAssets)
+    XCTAssertEqual(allDeletedAssets!.count, 1)
   }
   
   // MARK: - Deleting


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
User now can remove NFTs from the wallet, not just hide and unhide. 
Some new updates for NFT spam management please refer to the issue itself. 

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8205

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
1. Set up a wallet and go to wallet/portfolio/NFT
2. Check if the dropdown now has two options: 
    * Collected
    * Hidden
3. If you have auto-discovered NFTs and auto-discovery is enabled, check if 
    * auto-discovered NFTs are being displayed under `Collected`
    * any junk auto-discovered NFTs are being displayed under `Hidden`
    * check junk NFT has a `Junk` label on the top left.
4. Check if NFTs under `Collected` have context menu with options: 
    * Hide 
    * Don't show in wallet
5. Check clicking `Hide` in step 4 will move NFT to `Hidden`
6. Check clicking `Don't show in wallet` in step 4 will remove NFT which you can't see it in neither `Collected` nor `Hidden`
7. Check if NFTs that are not junk under `Hidden` have context menu with options:
    * Unhide
    * Don't show in wallet
8. Check clicking `Unhide` in step 7 will move NFT to `Collected`
9. Check clicking `Don't show in wallet` in step 7 will remove NFT which you can't see it in neither `Collected` nor `Hidden`
10. Check if NFTs that are junk under `Hidden` have context menu with options:
     * Mark as not junk
     * Don't show in wallet
11. Check clicking `Mark as not junk` in step 10 will move NFT to `Collected`, the junk label will be gone
12. Check clicking `Don't show in wallet` in step 10 will remove NFT which you can't see it in neither `Collected` nor `Hidden`
13. Repeat step 5 on the NFT that was moved from `Hidden` to `Collected` from step 11. Now this NFT will be moved to `Hidden` but this time there is no `Junk` label 
14. Try to re-add any deleted NFTs with the same `contractAddress`, network, `symbol` and `tokenId`(if there is one), this NFT will re-appear under `Collected`
## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->

- Check if a dropdown is available in the header beside filter button in NFT tab
- Check if dropdown selection will display correct group of NFTs
1. Test spam NFTs only come from SimpleHash. This should happen if you never add a custom NFT and manually marked as a spam before. If you have some NFTs are supposed to be auto-discovered but not being displayed under `NFTs` group, they are most likely being displayed under `Spam`
2. Test moving a NFT under `NFTs` to `Spam` by long pressing the NFT then select `Move to Spam`
3. Test hide a NFT under `NFTs` by long pressing the NFT then select `Hide`, this will move NFT to `Hidden`
4. Test unspam a NFT under `Spam` by long pressing the NFT then select `Unspam`, this will move NFT to `NFTs` group
5. Test hide a NFT under `Spam` by long pressing the NFT then select `Hide`, this will move NFT to `Hidden`
6. Test moving a NFT under `Hidden` to `Spam` by long pressing the NFT then select `Move to Spam`
7. Test unhide a NFT under `Hidden` by long pressing the NFT then select `Unhide`, this will move NFT to `NFTs`
- Check no duplication spam NFTs under `Spam`

Test token list:
1. Hide a user asset in Portfolio and make sure this token is from the token registry 

Screens token is hidden | Screens token is not hidden
--- | ---
Portfolio, Send | Token search, Edit visible Asset, Account Details, Swap

1. Add a custom token that it cannot be found from the token registry
2. Hide this custom token in Portfolio 

Screens token is hidden | Screens token is not hidden
--- | ---
Portfolio, Send | Token search, Edit visible Asset, Account Details
Note: transaction summary should also display the token name even though this token is hidden


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->
![Simulator Screenshot - iPhone 15 Pro - 2023-10-11 at 16 15 25](https://github.com/brave/brave-ios/assets/1187676/3ab618d0-2364-46ef-a61d-24fbdb3f068b) | ![Simulator Screenshot - iPhone 15 Pro - 2023-10-11 at 16 15 44](https://github.com/brave/brave-ios/assets/1187676/ce0c435c-7b8a-4db5-97c6-61c8e304f469) | ![simulator_screenshot_4B0FB612-2F05-4D11-AEE8-6237B4B12106](https://github.com/brave/brave-ios/assets/1187676/3000bec0-5729-435a-8b05-faa91a8e26b1)
--- | --- | --- 
![Simulator Screenshot - iPhone 15 Pro - 2023-10-11 at 16 15 55](https://github.com/brave/brave-ios/assets/1187676/41a716e2-e6d1-4fc7-9427-9c902eb7bc9e) | ![Simulator Screenshot - iPhone 15 Pro - 2023-10-11 at 16 16 01](https://github.com/brave/brave-ios/assets/1187676/c81bf899-5fb0-44bd-bd28-72d3c54f2d8c) | ![Simulator Screenshot - iPhone 15 Pro - 2023-10-11 at 16 16 06](https://github.com/brave/brave-ios/assets/1187676/60a750d4-8eb2-4b59-b35e-f27efb87bb6e) 


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
