### PR TITLE
Fix #8232: Display 0 for send amount for all percentage if selected token balanc…

### DIFF
--- a/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
@@ -232,7 +232,7 @@ public class SendTokenStore: ObservableObject, WalletObserverStore {
       decimalPoint = Int(selectedSendToken?.decimals ?? 18)
       rounded = false
     }
-    sendAmount = ((selectedSendTokenBalance ?? 0) * amount.rawValue).decimalExpansion(precisionAfterDecimalPoint: decimalPoint, rounded: rounded)
+    sendAmount = selectedSendTokenBalance == 0 ? "0" : ((selectedSendTokenBalance ?? 0) * amount.rawValue).decimalExpansion(precisionAfterDecimalPoint: decimalPoint, rounded: rounded)
   }
   
   func didSelect(account: BraveWallet.AccountInfo, token: BraveWallet.BlockchainToken) {

--- a/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SendTokenStore.swift
@@ -232,7 +232,7 @@ public class SendTokenStore: ObservableObject, WalletObserverStore {
       decimalPoint = Int(selectedSendToken?.decimals ?? 18)
       rounded = false
     }
-    sendAmount = selectedSendTokenBalance == 0 ? "0" : ((selectedSendTokenBalance ?? 0) * amount.rawValue).decimalExpansion(precisionAfterDecimalPoint: decimalPoint, rounded: rounded)
+    sendAmount = ((selectedSendTokenBalance ?? 0) * amount.rawValue).decimalExpansion(precisionAfterDecimalPoint: decimalPoint, rounded: rounded).trimmingTrailingZeros
   }
   
   func didSelect(account: BraveWallet.AccountInfo, token: BraveWallet.BlockchainToken) {

--- a/Sources/BraveWallet/Crypto/Stores/SwapTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SwapTokenStore.swift
@@ -915,7 +915,7 @@ public class SwapTokenStore: ObservableObject, WalletObserverStore {
       rounded = false
     }
     sellAmount = ((selectedFromTokenBalance ?? 0) * amount.rawValue)
-      .decimalExpansion(precisionAfterDecimalPoint: decimalPoint, rounded: rounded)
+      .decimalExpansion(precisionAfterDecimalPoint: decimalPoint, rounded: rounded).trimmingTrailingZeros
   }
 
   #if DEBUG


### PR DESCRIPTION
 Display 0 for send amount for all percentage if selected token balance is zero

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8232

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
please refer to the issue

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
