### PR TITLE
Fix #8229: Disable save changes until changes made

### DIFF
--- a/Sources/BraveWallet/Crypto/FiltersDisplaySettingsView.swift
+++ b/Sources/BraveWallet/Crypto/FiltersDisplaySettingsView.swift
@@ -115,6 +115,8 @@ struct FiltersDisplaySettingsView: View {
   let networkStore: NetworkStore
   let save: (Filters) -> Void
   
+  private let originalFilters: Filters
+  
   /// Returns true if all accounts are selected
   var allAccountsSelected: Bool {
     accounts.allSatisfy(\.isSelected)
@@ -157,6 +159,7 @@ struct FiltersDisplaySettingsView: View {
     self.isNFTFilters = isNFTFilters
     self.networkStore = networkStore
     self.save = save
+    self.originalFilters = filters
   }
   
   var body: some View {
@@ -341,6 +344,16 @@ struct FiltersDisplaySettingsView: View {
     .buttonStyle(FadeButtonStyle())
   }
   
+  private var isSaveChangesDisabled: Bool {
+    originalFilters.groupBy == groupBy &&
+    originalFilters.sortOrder == sortOrder &&
+    originalFilters.isHidingSmallBalances == isHidingSmallBalances &&
+    originalFilters.isHidingUnownedNFTs == isHidingUnownedNFTs &&
+    originalFilters.isShowingNFTNetworkLogo == isShowingNFTNetworkLogo &&
+    originalFilters.accounts == accounts &&
+    originalFilters.networks == networks
+  }
+  
   private var saveChangesContainer: some View {
     VStack {
       Button(action: {
@@ -362,6 +375,7 @@ struct FiltersDisplaySettingsView: View {
           .padding(.vertical, 4)
       }
       .buttonStyle(BraveFilledButtonStyle(size: .large))
+      .disabled(isSaveChangesDisabled)
       
       Button(action: { dismiss() }) {
         Text(Strings.CancelString)


### PR DESCRIPTION
## Summary of Changes
- Disable Save Changes button until changes made to selected filters

This pull request fixes #8229

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Open Portfolio
2. Open filters on Portfolio Assets tab
3. Verify `Save Changes` only enabled when changes are made to any filter
4. Switch to NFT tab & open filters
5. Verify `Save Changes` only enabled when changes are made to any filter


## Screenshots:

https://github.com/brave/brave-ios/assets/5314553/1124587f-a93c-424f-858c-ac555c8de3c1


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
