### PR TITLE
Fix #8241: Fix Menu not updating when the private-mode changes

### DIFF
--- a/Sources/Brave/Frontend/Browser/Tabs/TabBar/TabsBarViewController.swift
+++ b/Sources/Brave/Frontend/Browser/Tabs/TabBar/TabsBarViewController.swift
@@ -103,46 +103,17 @@ class TabsBarViewController: UIViewController {
       make.right.equalTo(view).inset(UX.TabsBar.buttonWidth)
     }
 
-    var newTabMenu: [UIAction] = []
-    let isPrivateBrowsing = tabManager?.privateBrowsingManager.isPrivateBrowsing == true
-
-    if !isPrivateBrowsing {
-      let openNewPrivateTab = UIAction(
-        title: Strings.Hotkey.newPrivateTabTitle,
-        image: UIImage(systemName: "plus.square.fill.on.square.fill"),
-        handler: UIAction.deferredActionHandler { [unowned self] _ in
-          self.delegate?.tabsBarDidSelectAddNewTab(true)
-        })
-
-      newTabMenu.append(openNewPrivateTab)
-    }
-
-    let openNewTab = UIAction(
-      title: isPrivateBrowsing ? Strings.Hotkey.newPrivateTabTitle : Strings.Hotkey.newTabTitle,
-      image: isPrivateBrowsing ? UIImage(systemName: "plus.square.fill.on.square.fill") : UIImage(systemName: "plus.square.on.square"),
-      handler: UIAction.deferredActionHandler { [unowned self] _ in
-        self.delegate?.tabsBarDidSelectAddNewTab(isPrivateBrowsing)
-      })
-
-    newTabMenu.append(openNewTab)
-    
-    newTabMenu.append(UIAction(title: Strings.newWindowTitle, image: UIImage(braveSystemNamed: "leo.window"), handler: UIAction.deferredActionHandler { [unowned self] _ in
-      self.delegate?.tabsBarDidSelectAddNewWindow(false)
-    }))
-        
-    newTabMenu.append(UIAction(title: Strings.newPrivateWindowTitle, image: UIImage(braveSystemNamed: "leo.window.tab-private"), handler: UIAction.deferredActionHandler { [unowned self] _ in
-      self.delegate?.tabsBarDidSelectAddNewWindow(true)
-    }))
-
+    updatePlusButtonMenu()
     updateColors()
     
-    plusButton.menu = UIMenu(title: "", identifier: nil, children: newTabMenu)
     privateModeCancellable = tabManager?.privateBrowsingManager
       .$isPrivateBrowsing
       .removeDuplicates()
       .receive(on: RunLoop.main)
       .sink(receiveValue: { [weak self] isPrivateBrowsing in
-        self?.updateColors()
+        guard let self = self else { return }
+        self.updatePlusButtonMenu()
+        self.updateColors()
       })
   }
   
@@ -210,6 +181,41 @@ class TabsBarViewController: UIViewController {
     if longPress.state == .began {
       delegate?.tabsBarDidLongPressAddTab(self, button: plusButton)
     }
+  }
+  
+  func updatePlusButtonMenu() {
+    var newTabMenu: [UIAction] = []
+    let isPrivateBrowsing = tabManager?.privateBrowsingManager.isPrivateBrowsing == true
+    
+    let openNewTab = UIAction(
+      title: isPrivateBrowsing ? Strings.Hotkey.newPrivateTabTitle : Strings.Hotkey.newTabTitle,
+      image: isPrivateBrowsing ? UIImage(systemName: "plus.square.fill.on.square.fill") : UIImage(systemName: "plus.square.on.square"),
+      handler: UIAction.deferredActionHandler { [unowned self] _ in
+        self.delegate?.tabsBarDidSelectAddNewTab(isPrivateBrowsing)
+      })
+    
+    newTabMenu.append(openNewTab)
+    
+    if !isPrivateBrowsing {
+      let openNewPrivateTab = UIAction(
+        title: Strings.Hotkey.newPrivateTabTitle,
+        image: UIImage(systemName: "plus.square.fill.on.square.fill"),
+        handler: UIAction.deferredActionHandler { [unowned self] _ in
+          self.delegate?.tabsBarDidSelectAddNewTab(true)
+        })
+      
+      newTabMenu.append(openNewPrivateTab)
+    }
+    
+    newTabMenu.append(UIAction(title: Strings.newWindowTitle, image: UIImage(braveSystemNamed: "leo.window"), handler: UIAction.deferredActionHandler { [unowned self] _ in
+      self.delegate?.tabsBarDidSelectAddNewWindow(false)
+    }))
+        
+    newTabMenu.append(UIAction(title: Strings.newPrivateWindowTitle, image: UIImage(braveSystemNamed: "leo.window.tab-private"), handler: UIAction.deferredActionHandler { [unowned self] _ in
+      self.delegate?.tabsBarDidSelectAddNewWindow(true)
+    }))
+    
+    plusButton.menu = UIMenu(title: "", identifier: nil, children: newTabMenu)
   }
 
   func updateData(reloadingCollectionView: Bool = true) {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Update the plus button menu items when the private browsing mode changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8241

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
