### PR TITLE
Fix #8228: Use specific Scene resign functions when dealing with UI only

### DIFF
--- a/App/iOS/Delegates/SceneDelegate.swift
+++ b/App/iOS/Delegates/SceneDelegate.swift
@@ -202,9 +202,19 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
     
     BraveSkusManager.refreshSKUCredential(isPrivate: scene.browserViewController?.privateBrowsingManager.isPrivateBrowsing == true)
+    
+    scene.browserViewControllers.forEach({
+      $0.sceneDidBecomeActive(scene)
+    })
   }
 
   func sceneWillResignActive(_ scene: UIScene) {
+    if let scene = scene as? UIWindowScene {
+      scene.browserViewControllers.forEach({
+        $0.sceneWillResignActive(scene)
+      })
+    }
+    
     Preferences.AppState.backgroundedCleanly.value = true
     scene.userActivity?.resignCurrent()
   }

--- a/Sources/Brave/Frontend/Browser/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController.swift
@@ -710,8 +710,8 @@ public class BrowserViewController: UIViewController {
   @objc func tappedTopArea() {
     toolbarVisibilityViewModel.toolbarState = .expanded
   }
-
-  @objc func appWillResignActiveNotification() {
+  
+  public func sceneWillResignActive(_ scene: UIScene) {
     tabManager.saveAllTabs()
     
     // Dismiss any popovers that might be visible
@@ -746,7 +746,7 @@ public class BrowserViewController: UIViewController {
     }
   }
 
-  @objc func appDidBecomeActiveNotification() {
+  public func sceneDidBecomeActive(_ scene: UIScene) {
     guard let tab = tabManager.selectedTab, tab.isPrivate else {
       return
     }
@@ -831,12 +831,6 @@ public class BrowserViewController: UIViewController {
     footer.isHidden = false
     
     NotificationCenter.default.do {
-      $0.addObserver(
-        self, selector: #selector(appWillResignActiveNotification),
-        name: UIApplication.willResignActiveNotification, object: nil)
-      $0.addObserver(
-        self, selector: #selector(appDidBecomeActiveNotification),
-        name: UIApplication.didBecomeActiveNotification, object: nil)
       $0.addObserver(
         self, selector: #selector(appDidEnterBackgroundNotification),
         name: UIApplication.didEnterBackgroundNotification, object: nil)


### PR DESCRIPTION
## Summary of Changes
- Do not ever use applicationWillResignActive for **SCENE** specific stuff.
- applicationWillResignActive is called for **EVERY SCENE**, but sceneWillResignActive is called only for the one scene that will resignActive.

- To fix the issue, we must only update UI for the one scene inside of the scene specific delegate. If updating UI for all scenes (or doing logic that applies to all windows), then we can do it inside applicationWillResignActive.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8228

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
