### PR TITLE
Fix #8228: Switch to UIScene notifications

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController.swift
@@ -687,7 +687,11 @@ public class BrowserViewController: UIViewController {
     displayedPopoverController?.dismiss(animated: true)
   }
 
-  @objc func appDidEnterBackgroundNotification() {
+  @objc func sceneDidEnterBackgroundNotification(_ notification: NSNotification) {
+    guard let scene = notification.object as? UIScene, scene == currentScene else {
+      return
+    }
+    
     displayedPopoverController?.dismiss(animated: false) {
       self.updateDisplayedPopoverProperties = nil
       self.displayedPopoverController = nil
@@ -711,7 +715,11 @@ public class BrowserViewController: UIViewController {
     toolbarVisibilityViewModel.toolbarState = .expanded
   }
 
-  @objc func appWillResignActiveNotification() {
+  @objc func sceneWillResignActiveNotification(_ notification: NSNotification) {
+    guard let scene = notification.object as? UIScene, scene == currentScene else {
+      return
+    }
+    
     tabManager.saveAllTabs()
     
     // Dismiss any popovers that might be visible
@@ -746,7 +754,11 @@ public class BrowserViewController: UIViewController {
     }
   }
 
-  @objc func appDidBecomeActiveNotification() {
+  @objc func sceneDidBecomeActiveNotification(_ notification: NSNotification) {
+    guard let scene = notification.object as? UIScene, scene == currentScene else {
+      return
+    }
+    
     guard let tab = tabManager.selectedTab, tab.isPrivate else {
       return
     }
@@ -832,14 +844,14 @@ public class BrowserViewController: UIViewController {
     
     NotificationCenter.default.do {
       $0.addObserver(
-        self, selector: #selector(appWillResignActiveNotification),
-        name: UIApplication.willResignActiveNotification, object: nil)
+        self, selector: #selector(sceneWillResignActiveNotification(_:)),
+        name: UIScene.willDeactivateNotification, object: nil)
       $0.addObserver(
-        self, selector: #selector(appDidBecomeActiveNotification),
-        name: UIApplication.didBecomeActiveNotification, object: nil)
+        self, selector: #selector(sceneDidBecomeActiveNotification(_:)),
+        name: UIScene.didActivateNotification, object: nil)
       $0.addObserver(
-        self, selector: #selector(appDidEnterBackgroundNotification),
-        name: UIApplication.didEnterBackgroundNotification, object: nil)
+        self, selector: #selector(sceneDidEnterBackgroundNotification),
+        name: UIScene.didEnterBackgroundNotification, object: nil)
       $0.addObserver(
         self, selector: #selector(appWillTerminateNotification),
         name: UIApplication.willTerminateNotification, object: nil)


### PR DESCRIPTION
## Summary of Changes
- Switch to scene notifications instead of UIApplication. This allows us to determine which logic runs **Per Scene** vs. Per Application. UI logic that isn't shared across all windows should be scene specific.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8228

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes


## Screenshots:
<img width="357" alt="image" src="https://github.com/brave/brave-ios/assets/1530031/b40a713e-6f5a-476f-a2fb-862861cb7129">

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
