### PR TITLE
Fix #8254, Fix #8251: Ensure Brave News uses the correct Ads instance

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController.swift
@@ -346,7 +346,11 @@ public class BrowserViewController: UIViewController {
       }
     }
 
-    self.feedDataSource.ads = rewards.ads
+    self.feedDataSource.getAdsAPI = {
+      // The ads object gets re-recreated when shutdown, so we need to make sure News fetches it out of
+      // the BraveRewards container
+      return rewards.ads
+    }
     
     // Observer watching tab information is sent by another device
     openTabsModelStateListener = braveCore.sendTabAPI.add(

--- a/Sources/BraveNews/Composer/FeedDataSource.swift
+++ b/Sources/BraveNews/Composer/FeedDataSource.swift
@@ -106,7 +106,7 @@ public class FeedDataSource: ObservableObject {
   }
 
   /// An ads object to handle inserting Inline Content Ads within the Brave News sequence
-  public var ads: BraveAds?
+  public var getAdsAPI: (() -> BraveAds)?
   public var historyAPI: BraveHistoryAPI?
 
   private let todayQueue = DispatchQueue(label: "com.brave.today")
@@ -939,7 +939,7 @@ public class FeedDataSource: ObservableObject {
         followedSources: followedSources,
         hiddenSources: hiddenSources,
         followedChannels: followedChannels.mapValues(Set.init),
-        ads: ads
+        ads: getAdsAPI?()
       )
       // Move to OSSignposter when we're 15+
       let log = OSLog(subsystem: Bundle.main.bundleIdentifier ?? "com.brave.ios", category: "Brave News")

--- a/Sources/BraveNews/Customize/NewsSettingsView.swift
+++ b/Sources/BraveNews/Customize/NewsSettingsView.swift
@@ -271,7 +271,7 @@ public struct NewsSettingsView: View {
       OptInView { @MainActor in
         Preferences.BraveNews.isShowingOptIn.value = false
         // Initialize ads if it hasn't already been done
-        await dataSource.ads?.initialize()
+        await dataSource.getAdsAPI?().initialize()
         if dataSource.isSourcesExpired {
           await withCheckedContinuation { c in
             dataSource.load {


### PR DESCRIPTION
When Rewards or Brave News is turned off the `BraveAds` instance is replaced, however `FeedDataSource` could still hold onto a reference to the old instance which could cause a crash if opting into News via Brave News settings and if opted in via the NTP it could cause ads to not appear since the old ads instance is not initialized.

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8254 
This pull request fixes #8251 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
