### PR TITLE
Fix #8242: Fix bug in menu seeing private browsing as false

### DIFF
--- a/Sources/Brave/Frontend/Browser/Tabs/TabBar/TabsBarViewController.swift
+++ b/Sources/Brave/Frontend/Browser/Tabs/TabBar/TabsBarViewController.swift
@@ -103,8 +103,9 @@ class TabsBarViewController: UIViewController {
       make.right.equalTo(view).inset(UX.TabsBar.buttonWidth)
     }
 
-    updatePlusButtonMenu()
-    updateColors()
+    let isPrivateBrowsing = tabManager?.privateBrowsingManager.isPrivateBrowsing == true
+    updatePlusButtonMenu(isPrivateBrowsing)
+    updateColors(isPrivateBrowsing)
     
     privateModeCancellable = tabManager?.privateBrowsingManager
       .$isPrivateBrowsing
@@ -112,8 +113,8 @@ class TabsBarViewController: UIViewController {
       .receive(on: RunLoop.main)
       .sink(receiveValue: { [weak self] isPrivateBrowsing in
         guard let self = self else { return }
-        self.updatePlusButtonMenu()
-        self.updateColors()
+        self.updatePlusButtonMenu(isPrivateBrowsing)
+        self.updateColors(isPrivateBrowsing)
       })
   }
   
@@ -183,10 +184,8 @@ class TabsBarViewController: UIViewController {
     }
   }
   
-  func updatePlusButtonMenu() {
+  func updatePlusButtonMenu(_ isPrivateBrowsing: Bool) {
     var newTabMenu: [UIAction] = []
-    let isPrivateBrowsing = tabManager?.privateBrowsingManager.isPrivateBrowsing == true
-    
     let openNewTab = UIAction(
       title: isPrivateBrowsing ? Strings.Hotkey.newPrivateTabTitle : Strings.Hotkey.newTabTitle,
       image: isPrivateBrowsing ? UIImage(systemName: "plus.square.fill.on.square.fill") : UIImage(systemName: "plus.square.on.square"),


### PR DESCRIPTION
## Summary of Changes
- The publisher for `isPrivateBrowsing` does not update the value immediately before being triggered, so it causes a bug sometimes where the menu isn't updated correctly

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8242

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

![image](https://github.com/brave/brave-ios/assets/1530031/1d3c8e9f-af69-49d1-90cb-5c8267de0394)

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
