### PR TITLE
Fix #8261: performance issue of `BraveCertificateUtils.formatDate(_:)`

### DIFF
--- a/Sources/CertificateUtilities/BraveCertificateUtils.swift
+++ b/Sources/CertificateUtilities/BraveCertificateUtils.swift
@@ -23,10 +23,14 @@ public struct BraveCertificateUtils {
     return result
   }
 
-  public static func formatDate(_ date: Date) -> String {
+  private static let dateFormatter: DateFormatter = {
     let dateFormatter = DateFormatter()
     dateFormatter.dateStyle = .full
     dateFormatter.timeStyle = .full
+    return dateFormatter
+  }()
+
+  public static func formatDate(_ date: Date) -> String {
     return dateFormatter.string(from: date)
   }
 }


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #8261 

I move the initialization of `DateFormmater` to make `BraveCertificateUtils.formatDate(_:)` 100x faster. You can read the details of measurement in #8261.

## Submitter Checklist:

I only refactored a small chunk of code without breaking changes. As a newcomer, I'm not yet familiar with this template's semantics. That's why I check them all. Sorry if it's inconvenient for you.

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
