### PR TITLE
Fix #8263: use `String` as `rawValue` for `BraveCertificateUtilError`

### DIFF
--- a/Sources/CertificateUtilities/BraveCertificateUtils.swift
+++ b/Sources/CertificateUtilities/BraveCertificateUtils.swift
@@ -166,21 +166,14 @@ public extension BraveCertificateUtils {
   }
 }
 
-public enum BraveCertificateUtilError: LocalizedError {
-  case noCertificatesProvided
-  case cannotCreateServerTrust
-  case trustEvaluationFailed
-  
-  public var errorDescription: String? {
-    switch self {
-    case .noCertificatesProvided:
-      return "Cannot Create Server Trust - No Certificates Provided"
-    case .cannotCreateServerTrust:
-      return "Cannot Create Server Trust"
-    case .trustEvaluationFailed:
-      return "Trust Evaluation Failed"
+public enum BraveCertificateUtilError: String, LocalizedError {
+    case noCertificatesProvided = "Cannot Create Server Trust - No Certificates Provided"
+    case cannotCreateServerTrust = "Cannot Create Server Trust"
+    case trustEvaluationFailed = "Trust Evaluation Failed"
+
+    public var errorDescription: String? {
+        rawValue
     }
-  }
 }
 
 public extension BraveCertificateUtils {


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #8263 
I used `String` as `rawValue` to shorten `BraveCertificateUtilError.errorDescription`

## Submitter Checklist:

I only refactored a small chunk of code without breaking changes. As a newcomer, I'm not yet familiar with this template's semantics. That's why I check them all. Sorry if it's inconvenient for you.

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
