### PR TITLE
Fix #8268: UIGraphicsBeginImageContextWithOptions causing Intermittent crash while taking Tab Screenshot

### DIFF
--- a/Sources/Brave/Extensions/UIViewExtensions.swift
+++ b/Sources/Brave/Extensions/UIViewExtensions.swift
@@ -15,8 +15,8 @@ extension UIView {
     let offset = offset ?? .zero
 
     // Temporary check to handle _UIGraphicsBeginImageContextWithOptions zero size error
-    // Shiould be replaced with UIGraphicsImageRenderer
-    if size.width <= 0 || size.height <= 0 {
+    // Should be replaced with UIGraphicsImageRenderer
+    guard size.width > 0, size.height > 0 else {
       return nil
     }
     

--- a/Sources/Brave/Extensions/UIViewExtensions.swift
+++ b/Sources/Brave/Extensions/UIViewExtensions.swift
@@ -14,6 +14,12 @@ extension UIView {
 
     let offset = offset ?? .zero
 
+    // Temporary check to handle _UIGraphicsBeginImageContextWithOptions zero size error
+    // Shiould be replaced with UIGraphicsImageRenderer
+    if size.width <= 0 || size.height <= 0 {
+      return nil
+    }
+    
     UIGraphicsBeginImageContextWithOptions(size, false, UIScreen.main.scale * quality)
     drawHierarchy(in: CGRect(origin: offset, size: frame.size), afterScreenUpdates: false)
     let image = UIGraphicsGetImageFromCurrentImageContext()

--- a/Sources/Favicon/BundledFaviconRenderer.swift
+++ b/Sources/Favicon/BundledFaviconRenderer.swift
@@ -77,14 +77,13 @@ public class BundledFaviconRenderer {
     } else if let name = url.baseDomain, let icon = Self.bundledIcons[name] {
       bundleIcon = icon
     }
-    guard let icon = bundleIcon, let image = UIImage(contentsOfFile: icon.url) else {
+    guard let icon = bundleIcon,
+          let image = UIImage(contentsOfFile: icon.url),
+          let scaledImage = image.createScaled(CGSize(width: 40.0, height: 40.0)) else {
       return nil
     }
 
-    return (
-      image.createScaled(CGSize(width: 40.0, height: 40.0)),
-      icon.color
-    )
+    return (scaledImage, icon.color)
   }
 
   private static let multiRegionDomains = ["craigslist", "google", "amazon"]

--- a/Sources/Favicon/UIImage+FaviconRenderer.swift
+++ b/Sources/Favicon/UIImage+FaviconRenderer.swift
@@ -49,7 +49,7 @@ extension UIImage {
       return false
     }
 
-    guard let cgImage = createScaled(CGSize(width: 48.0, height: 48.0)).cgImage else {
+    guard let cgImage = createScaled(CGSize(width: 48.0, height: 48.0))?.cgImage else {
       return false
     }
 

--- a/Sources/Onboarding/Callouts/OnboardingPlaylistView.swift
+++ b/Sources/Onboarding/Callouts/OnboardingPlaylistView.swift
@@ -395,9 +395,9 @@ extension OnboardingPlaylistView {
         .trimmingCharacters(in: .whitespaces)
       // The icon, which is a PDF since it is multicoloured and has special alpha, needs to scale with
       // the text, so we need to create a UIImage version of it, scale that, then adjust the baseline offset
+      let addIcon = UIImage(sharedNamed: "leo.playlist.bold.add")!
       let icon = Image(
-        uiImage: UIImage(sharedNamed: "leo.playlist.bold.add")!
-          .createScaled(CGSize(width: tryItOutIconSize, height: tryItOutIconSize))
+        uiImage: addIcon.createScaled(CGSize(width: tryItOutIconSize, height: tryItOutIconSize)) ?? addIcon
       )
       let iconText = Text(icon).baselineOffset(tryItOutIconBaselineOffset)
       

--- a/Sources/Shared/Extensions/UIImageExtensions.swift
+++ b/Sources/Shared/Extensions/UIImageExtensions.swift
@@ -27,7 +27,11 @@ extension UIImage {
     return image
   }
 
-  public func createScaled(_ size: CGSize) -> UIImage {
+  public func createScaled(_ size: CGSize) -> UIImage? {
+    guard size.width > 0, size.height > 0 else {
+      return nil
+    }
+    
     UIGraphicsBeginImageContextWithOptions(size, false, 0)
     draw(in: CGRect(size: size))
     let scaledImage = UIGraphicsGetImageFromCurrentImageContext()
@@ -59,6 +63,10 @@ extension UIImage {
   }
 
   public func textToImage(drawText text: String, textFont: UIFont? = nil, textColor: UIColor? = nil, atPoint point: CGPoint) -> UIImage? {
+    guard size.width > 0, size.height > 0 else {
+      return nil
+    }
+    
     let paragraphStyle = NSMutableParagraphStyle()
     paragraphStyle.alignment = .center
 
@@ -80,6 +88,10 @@ extension UIImage {
   }
   
   public func imageWithInsets(insets: UIEdgeInsets) -> UIImage? {
+    guard size.width > 0, size.height > 0 else {
+      return nil
+    }
+    
     UIGraphicsBeginImageContextWithOptions(
       CGSize(width: self.size.width + insets.left + insets.right,
              height: self.size.height + insets.top + insets.bottom), false, self.scale)


### PR DESCRIPTION
Adding Temporary if check to take care UIGraphicsBeginImageContextWithOptions zero size error

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8268

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
- Check screenshotting tab view for different devices and sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
