### PR TITLE
Fix #8272: Add setting to ensure YouTube links always load in Brave

### DIFF
--- a/App/iOS/Delegates/AppDelegate.swift
+++ b/App/iOS/Delegates/AppDelegate.swift
@@ -198,6 +198,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
       // To avoid unexpected problems we clear all vpn keychain items.
       // New set of keychain items will be created on purchase or iap restoration.
       BraveVPN.clearCredentials()
+      
+      // Always load YouTube in Brave for new users
+      Preferences.General.keepYouTubeInBrave.value = true
     }
 
     if UserReferralProgram.shared != nil {

--- a/Sources/Brave/Frontend/ClientPreferences.swift
+++ b/Sources/Brave/Frontend/ClientPreferences.swift
@@ -73,6 +73,9 @@ extension Preferences {
 
     /// Whether or not the app (in regular browsing mode) will follow universal links
     static let followUniversalLinks = Option<Bool>(key: "general.follow-universal-links", default: true)
+    
+    /// Whether or not the app will always load YouTube in Brave
+    public static let keepYouTubeInBrave = Option<Bool>(key: "general.follow-universal-links.youtube", default: false)
 
     /// Whether or not the pull-to-refresh control is added to web views
     static let enablePullToRefresh = Option<Bool>(key: "general.enable-pull-to-refresh", default: true)

--- a/Sources/Brave/Frontend/Settings/Display/MediaSettingsView.swift
+++ b/Sources/Brave/Frontend/Settings/Display/MediaSettingsView.swift
@@ -10,6 +10,7 @@ import BraveUI
 
 struct MediaSettingsView: View {
   @ObservedObject var enableBackgroundAudio = Preferences.General.mediaAutoBackgrounding
+  @ObservedObject var keepYouTubeInBrave = Preferences.General.keepYouTubeInBrave
   
   var body: some View {
     Form {
@@ -22,6 +23,10 @@ struct MediaSettingsView: View {
       .listRowBackground(Color(.secondaryBraveGroupedBackground))
       
       Section(header: Text(Strings.Settings.youtube)) {
+        Toggle(isOn: $keepYouTubeInBrave.value) {
+          Text(Strings.Settings.openYouTubeInBrave)
+        }
+        .toggleStyle(SwitchToggleStyle(tint: .accentColor))
         NavigationLink(destination: QualitySettingsView()) {
           VStack(alignment: .leading) {
             Text(Strings.Settings.highestQualityPlayback)

--- a/Sources/BraveStrings/BraveStrings.swift
+++ b/Sources/BraveStrings/BraveStrings.swift
@@ -858,6 +858,15 @@ extension Strings {
       comment: "Header for the Youtube settings section"
     )
     
+    public static let openYouTubeInBrave =
+    NSLocalizedString(
+      "settings.openYouTubeInBrave",
+      tableName: "BraveShared",
+      bundle: .module,
+      value: "Open YouTube links in Brave",
+      comment: "A toggle label which lets the user always open YouTube urls in Brave"
+    )
+    
     public static let highestQualityPlayback =
     NSLocalizedString(
       "settings.highestQualityPlayback",


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #8272 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

Prefix: Install the YouTube app, ensure clicking on YouTube links open the YouTube app prior

### Fresh install path:
- Fresh install, verify Settings > Media > Open YouTube links in Brave is enabled by default
- Query a video in Brave Search that results in YouTube links
- Click on a YouTube link
- Verify it loads the video in Brave
- Disable the setting
- Verify clicking the same link loads the YouTube app

### Upgrade path:
- Upgrade, verify Settings > Media > Open YouTube links in Brave is disabled since you are not a new user

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
