### PR TITLE
Fix #8073: Add NFT grouping by none/accounts/networks

### DIFF
--- a/Sources/BraveWallet/Crypto/FiltersDisplaySettingsView.swift
+++ b/Sources/BraveWallet/Crypto/FiltersDisplaySettingsView.swift
@@ -156,7 +156,7 @@ struct FiltersDisplaySettingsView: View {
     self._isHidingSmallBalances = State(initialValue: filters.isHidingSmallBalances)
     self._isHidingUnownedNFTs = State(initialValue: filters.groupBy == .accounts ? true : filters.isHidingUnownedNFTs)
     self._isShowingNFTNetworkLogo = State(initialValue: filters.isShowingNFTNetworkLogo)
-    self._isHidingUnownedNFTsDisabled = State(initialValue: filters.groupBy == .accounts ? true : false)
+    self._isHidingUnownedNFTsDisabled = State(initialValue: filters.groupBy == .accounts)
     self._accounts = State(initialValue: filters.accounts)
     self._networks = State(initialValue: filters.networks)
     self.isNFTFilters = isNFTFilters

--- a/Sources/BraveWallet/Crypto/FiltersDisplaySettingsView.swift
+++ b/Sources/BraveWallet/Crypto/FiltersDisplaySettingsView.swift
@@ -105,6 +105,8 @@ struct FiltersDisplaySettingsView: View {
   @State var isHidingUnownedNFTs: Bool
   /// If we are showing the network logo on NFTs. Default is true.
   @State var isShowingNFTNetworkLogo: Bool
+  /// If we should disable `Hide Unowned`
+  @State var isHidingUnownedNFTsDisabled: Bool
   
   /// All accounts and if they are currently selected. Default is all accounts selected.
   @State var accounts: [Selectable<BraveWallet.AccountInfo>]
@@ -152,8 +154,9 @@ struct FiltersDisplaySettingsView: View {
     self._groupBy = State(initialValue: filters.groupBy)
     self._sortOrder = State(initialValue: filters.sortOrder)
     self._isHidingSmallBalances = State(initialValue: filters.isHidingSmallBalances)
-    self._isHidingUnownedNFTs = State(initialValue: filters.isHidingUnownedNFTs)
+    self._isHidingUnownedNFTs = State(initialValue: filters.groupBy == .accounts ? true : filters.isHidingUnownedNFTs)
     self._isShowingNFTNetworkLogo = State(initialValue: filters.isShowingNFTNetworkLogo)
+    self._isHidingUnownedNFTsDisabled = State(initialValue: filters.groupBy == .accounts ? true : false)
     self._accounts = State(initialValue: filters.accounts)
     self._networks = State(initialValue: filters.networks)
     self.isNFTFilters = isNFTFilters
@@ -167,6 +170,9 @@ struct FiltersDisplaySettingsView: View {
       ScrollView {
         LazyVStack(spacing: 0) {
           if isNFTFilters {
+            groupByRow
+              .padding(.vertical, rowPadding)
+            
             showNFTNetworkLogo
               .padding(.vertical, rowPadding)
             
@@ -194,6 +200,16 @@ struct FiltersDisplaySettingsView: View {
         }
         .padding(.horizontal)
       }
+      .onChange(of: groupBy, perform: { newValue in
+        if isNFTFilters {
+          if newValue == .accounts {
+            isHidingUnownedNFTs = true
+            isHidingUnownedNFTsDisabled = true
+          } else {
+            isHidingUnownedNFTsDisabled = false
+          }
+        }
+      })
       .background(Color(uiColor: WalletV2Design.containerBackground))
       .safeAreaInset(edge: .bottom, content: {
         saveChangesContainer
@@ -268,6 +284,7 @@ struct FiltersDisplaySettingsView: View {
       )
     }
     .tint(Color(.braveBlurpleTint))
+    .disabled(isHidingUnownedNFTsDisabled)
   }
   
   private var showNFTNetworkLogo: some View {

--- a/Sources/BraveWallet/Crypto/NFT/NFTView.swift
+++ b/Sources/BraveWallet/Crypto/NFT/NFTView.swift
@@ -113,28 +113,40 @@ struct NFTView: View {
   
   private var nftHeaderView: some View {
     HStack {
-      Text(Strings.Wallet.assetsTitle)
-        .font(.title3.weight(.semibold))
-        .foregroundColor(Color(braveSystemName: .textPrimary))
+      Menu {
+        Picker("", selection: $nftStore.displayType) {
+          ForEach(NFTStore.NFTDisplayType.allCases) { type in
+            Text(type.dropdownTitle)
+              .foregroundColor(Color(.secondaryBraveLabel))
+              .tag(type)
+          }
+        }
+        .pickerStyle(.inline)
+      } label: {
+        HStack(spacing: 12) {
+          Text(nftStore.displayType.dropdownTitle)
+            .font(.subheadline.weight(.semibold))
+          Text("\(nftStore.totalDisplayNFTCounter)")
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .font(.caption2.weight(.semibold))
+            .background(
+              Color(uiColor: WalletV2Design.displayNFTCounterColor)
+                .cornerRadius(4)
+            )
+          Image(braveSystemName: "leo.carat.down")
+            .font(.subheadline.weight(.semibold))
+        }
+        .foregroundColor(Color(.braveBlurpleTint))
+      }
       if nftStore.isLoadingDiscoverAssets && isNFTDiscoveryEnabled {
         ProgressView()
           .padding(.leading, 5)
       }
       Spacer()
-      Picker(selection: $nftStore.displayType) {
-        ForEach(NFTStore.NFTDisplayType.allCases) { type in
-          Text(type.dropdownTitle)
-            .foregroundColor(Color(.secondaryBraveLabel))
-            .tag(type)
-        }
-      } label: {
-        Text(nftStore.displayType.dropdownTitle)
-          .font(.footnote)
-          .foregroundColor(Color(.braveLabel))
-      }
-      filtersButton
-        .padding(.trailing, 10)
       addCustomAssetButton
+        .padding(.trailing, 10)
+      filtersButton
     }
     .padding(.horizontal)
     .frame(maxWidth: .infinity, alignment: .leading)
@@ -236,50 +248,25 @@ struct NFTView: View {
       EmptyView()
     } else {
       WalletDisclosureGroup(
+        isNFTGroup: true,
         isExpanded: Binding(
           get: { groupToggleState[group.id, default: true] },
           set: { groupToggleState[group.id] = $0 }
         ),
         content: {
           nftGridsPlainView(group)
+            .padding(.top)
         },
         label: {
           if case let .account(account) = group.groupType {
             AddressView(address: account.address) {
-              groupHeader(for: group)
+              PortfolioAssetGroupHeaderView(group: group)
             }
           } else {
-            groupHeader(for: group)
+            PortfolioAssetGroupHeaderView(group: group)
           }
         }
       )
-    }
-  }
-  
-  /// Builds the in-section header for an NFTGroupViewModel that is shown in expanded and non-expanded state. Not used for ungrouped assets.
-  private func groupHeader(for group: NFTGroupViewModel) -> some View {
-    VStack(spacing: 0) {
-      HStack {
-        if case let .network(networkInfo) = group.groupType {
-          NetworkIcon(network: networkInfo, length: 32)
-        } else if case let .account(accountInfo) = group.groupType {
-          Blockie(address: accountInfo.address, shape: .rectangle)
-            .frame(width: 32, height: 32)
-            .clipShape(RoundedRectangle(cornerRadius: 4))
-        }
-        VStack(alignment: .leading) {
-          Text(group.title)
-            .font(.callout.weight(.semibold))
-            .foregroundColor(Color(WalletV2Design.textPrimary))
-          if let description = group.description {
-            Text(description)
-              .font(.footnote)
-              .foregroundColor(Color(WalletV2Design.textSecondary))
-          }
-        }
-        .multilineTextAlignment(.leading)
-      }
-      .padding(.vertical, 4)
     }
   }
   

--- a/Sources/BraveWallet/Crypto/NFT/NFTView.swift
+++ b/Sources/BraveWallet/Crypto/NFT/NFTView.swift
@@ -126,12 +126,12 @@ struct NFTView: View {
         HStack(spacing: 12) {
           Text(nftStore.displayType.dropdownTitle)
             .font(.subheadline.weight(.semibold))
-          Text("\(nftStore.totalDisplayNFTCounter)")
+          Text("\(nftStore.totalDisplayedNFTCount)")
             .padding(.horizontal, 8)
             .padding(.vertical, 4)
             .font(.caption2.weight(.semibold))
             .background(
-              Color(uiColor: WalletV2Design.displayNFTCounterColor)
+              Color(braveSystemName: .primary20)
                 .cornerRadius(4)
             )
           Image(braveSystemName: "leo.carat.down")

--- a/Sources/BraveWallet/Crypto/Portfolio/PortfolioAssetsView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/PortfolioAssetsView.swift
@@ -166,6 +166,7 @@ struct PortfolioAssetsView: View {
   /// Builds the expandable/collapseable (expanded by default) section content for a given group.
   @ViewBuilder private func groupedAssetsSection(for group: AssetGroupViewModel) -> some View {
     WalletDisclosureGroup(
+      isNFTGroup: false,
       isExpanded: Binding(
         get: { groupToggleState[group.id, default: true] },
         set: { isExpanded in
@@ -196,44 +197,12 @@ struct PortfolioAssetsView: View {
       label: {
         if case let .account(account) = group.groupType {
           AddressView(address: account.address) {
-            groupHeader(for: group)
+            PortfolioAssetGroupHeaderView(group: group)
           }
         } else {
-          groupHeader(for: group)
+          PortfolioAssetGroupHeaderView(group: group)
         }
       }
     )
-  }
-  
-  /// Builds the in-section header for an AssetGroupViewModel that is shown in expanded and non-expanded state. Not used for ungrouped assets.
-  private func groupHeader(for group: AssetGroupViewModel) -> some View {
-    VStack(spacing: 0) {
-      HStack {
-        if case let .network(networkInfo) = group.groupType {
-          NetworkIcon(network: networkInfo, length: 32)
-        } else if case let .account(accountInfo) = group.groupType {
-          Blockie(address: accountInfo.address, shape: .rectangle)
-            .frame(width: 32, height: 32)
-            .clipShape(RoundedRectangle(cornerRadius: 4))
-        }
-        VStack(alignment: .leading) {
-          Text(group.title)
-            .font(.callout.weight(.semibold))
-            .foregroundColor(Color(WalletV2Design.textPrimary))
-          if let description = group.description {
-            Text(description)
-              .font(.footnote)
-              .foregroundColor(Color(WalletV2Design.textSecondary))
-          }
-        }
-        .multilineTextAlignment(.leading)
-        Spacer()
-        Text(isShowingBalances.value ? portfolioStore.currencyFormatter.string(from: NSNumber(value: group.totalFiatValue)) ?? "" : "****")
-          .font(.callout.weight(.semibold))
-          .foregroundColor(Color(WalletV2Design.textPrimary))
-          .multilineTextAlignment(.trailing)
-      }
-      .padding(.vertical, 4)
-    }
   }
 }

--- a/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
@@ -91,6 +91,37 @@ struct PortfolioView: View {
   }
 }
 
+/// Builds the in-section header for `Assets`/`NFT` that is shown in expanded and non-expanded state. Not used for ungrouped assets.
+struct PortfolioAssetGroupHeaderView: View {
+  let group: any WalletAssetGroupViewModel
+  
+  var body: some View {
+    VStack(spacing: 0) {
+      HStack {
+        if case let .network(networkInfo) = group.groupType {
+          NetworkIcon(network: networkInfo, length: 32)
+        } else if case let .account(accountInfo) = group.groupType {
+          Blockie(address: accountInfo.address, shape: .rectangle)
+            .frame(width: 32, height: 32)
+            .clipShape(RoundedRectangle(cornerRadius: 4))
+        }
+        VStack(alignment: .leading) {
+          Text(group.title)
+            .font(.callout.weight(.semibold))
+            .foregroundColor(Color(WalletV2Design.textPrimary))
+          if let description = group.description {
+            Text(description)
+              .font(.footnote)
+              .foregroundColor(Color(WalletV2Design.textSecondary))
+          }
+        }
+        .multilineTextAlignment(.leading)
+      }
+      .padding(.vertical, 4)
+    }
+  }
+}
+
 #if DEBUG
 struct PortfolioViewController_Previews: PreviewProvider {
   static var previews: some View {

--- a/Sources/BraveWallet/Crypto/Stores/AccountActivityStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/AccountActivityStore.swift
@@ -150,6 +150,7 @@ class AccountActivityStore: ObservableObject, WalletObserverStore {
           if token.isErc721 || token.isNft {
             updatedUserNFTs.append(
               NFTAssetViewModel(
+                groupType: .none,
                 token: token,
                 network: networkAssets.network,
                 balanceForAccounts: [:]
@@ -225,6 +226,7 @@ class AccountActivityStore: ObservableObject, WalletObserverStore {
           if token.isErc721 || token.isNft {
             updatedUserNFTs.append(
               NFTAssetViewModel(
+                groupType: .none,
                 token: token,
                 network: networkAssets.network,
                 balanceForAccounts: [account.address: Int(totalBalances[token.assetBalanceId] ?? 0)],

--- a/Sources/BraveWallet/Crypto/Stores/NFTStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/NFTStore.swift
@@ -263,8 +263,8 @@ public class NFTStore: ObservableObject, WalletObserverStore {
         .map { networkAssets in
           NetworkAssets(
             network: networkAssets.network,
-            tokens: networkAssets.tokens.filter { $0.isNft || $0.isErc721 }
-            , sortOrder: networkAssets.sortOrder
+            tokens: networkAssets.tokens.filter { $0.isNft || $0.isErc721 },
+            sortOrder: networkAssets.sortOrder
           )
         }
       // user hidden NFTs
@@ -272,8 +272,8 @@ public class NFTStore: ObservableObject, WalletObserverStore {
         .map { networkAssets in
           NetworkAssets(
             network: networkAssets.network,
-            tokens: networkAssets.tokens.filter { $0.isNft || $0.isErc721 }
-            , sortOrder: networkAssets.sortOrder
+            tokens: networkAssets.tokens.filter { $0.isNft || $0.isErc721 },
+            sortOrder: networkAssets.sortOrder
           )
         }
       // all spam NFTs marked by SimpleHash

--- a/Sources/BraveWallet/Crypto/Stores/NFTStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/NFTStore.swift
@@ -163,6 +163,10 @@ public class NFTStore: ObservableObject, WalletObserverStore {
     return displayNFTGroups.isEmpty
   }
   
+  var totalDisplayNFTCounter: Int {
+    displayNFTGroups.reduce(0) { $0 + $1.assets.count }
+  }
+  
   public init(
     keyringService: BraveWalletKeyringService,
     rpcService: BraveWalletJsonRpcService,
@@ -191,6 +195,7 @@ public class NFTStore: ObservableObject, WalletObserverStore {
     Preferences.Wallet.isHidingUnownedNFTsFilter.observe(from: self)
     Preferences.Wallet.isShowingNFTNetworkLogoFilter.observe(from: self)
     Preferences.Wallet.nonSelectedNetworksFilter.observe(from: self)
+    Preferences.Wallet.groupByFilter.observe(from: self)
   }
   
   func tearDown() {

--- a/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
@@ -26,10 +26,14 @@ public enum AssetGroupType: Equatable, Identifiable {
   }
 }
 
-public struct AssetGroupViewModel: Identifiable, Equatable {
-  let groupType: AssetGroupType
-  let assets: [AssetViewModel]
-  
+/// A protocol for both fungible and non-fungible asset group's view model
+protocol WalletAssetGroupViewModel {
+  associatedtype ViewModel
+  var groupType: AssetGroupType { get }
+  var assets: [ViewModel] { get }
+}
+
+extension WalletAssetGroupViewModel {
   var title: String {
     switch groupType {
     case .none:
@@ -40,6 +44,7 @@ public struct AssetGroupViewModel: Identifiable, Equatable {
       return account.name
     }
   }
+  
   var description: String? {
     switch groupType {
     case .none, .network:
@@ -48,6 +53,15 @@ public struct AssetGroupViewModel: Identifiable, Equatable {
       return account.address.truncatedAddress
     }
   }
+}
+
+public struct AssetGroupViewModel: WalletAssetGroupViewModel, Identifiable, Equatable {
+  typealias ViewModel = AssetViewModel
+  
+  public var groupType: AssetGroupType
+  public var assets: [AssetViewModel]
+  public var id: String { "\(groupType.id) \(title)" }
+  
   var totalFiatValue: Double {
     assets.reduce(0) { partialResult, asset in
       let balance: Double
@@ -61,7 +75,6 @@ public struct AssetGroupViewModel: Identifiable, Equatable {
       return partialResult + assetValue
     }
   }
-  public var id: String { "\(groupType.id) \(title)" }
 }
 
 public struct AssetViewModel: Identifiable, Equatable {

--- a/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
@@ -353,6 +353,7 @@ public class PortfolioStore: ObservableObject, WalletObserverStore {
     Preferences.Wallet.isHidingSmallBalancesFilter.observe(from: self)
     Preferences.Wallet.nonSelectedAccountsFilter.observe(from: self)
     Preferences.Wallet.nonSelectedNetworksFilter.observe(from: self)
+    Preferences.Wallet.groupByFilter.observe(from: self)
   }
   
   func tearDown() {

--- a/Sources/BraveWallet/Crypto/WalletDisclosureGroup.swift
+++ b/Sources/BraveWallet/Crypto/WalletDisclosureGroup.swift
@@ -6,6 +6,7 @@
 import SwiftUI
 
 struct WalletDisclosureGroup<Label: View, Content: View>: View {
+  var isNFTGroup: Bool
   @Binding var isExpanded: Bool
   @ViewBuilder var content: () -> Content
   @ViewBuilder var label: () -> Label
@@ -44,7 +45,7 @@ struct WalletDisclosureGroup<Label: View, Content: View>: View {
       if isExpanded {
         Divider()
           .padding(.top, 6)
-          .padding(.horizontal, 8)
+          .padding(.horizontal, isNFTGroup ? nil : 8)
         content()
           .padding(.horizontal)
       }
@@ -52,10 +53,14 @@ struct WalletDisclosureGroup<Label: View, Content: View>: View {
     // when collapsed, padding is applied to `header`
     .padding(.vertical, isExpanded ? 6 : 0)
     .osAvailabilityModifiers {
-      if isExpanded {
-        $0.overlay {
-          RoundedRectangle(cornerRadius: 16)
-            .stroke(Color(braveSystemName: .dividerSubtle), lineWidth: 1)
+      if !isNFTGroup {
+        if isExpanded {
+          $0.overlay {
+            RoundedRectangle(cornerRadius: 16)
+              .stroke(Color(braveSystemName: .dividerSubtle), lineWidth: 1)
+          }
+        } else {
+          $0
         }
       } else {
         $0

--- a/Sources/BraveWallet/Extensions/WalletColors.swift
+++ b/Sources/BraveWallet/Extensions/WalletColors.swift
@@ -257,11 +257,4 @@ enum WalletV2Design {
     blue: 207 / 255,
     alpha: 1
   )
-  
-  static let displayNFTCounterColor = UIColor(
-    red: 213 / 255,
-    green: 220 / 255,
-    blue: 1,
-    alpha: 1
-  )
 }

--- a/Sources/BraveWallet/Extensions/WalletColors.swift
+++ b/Sources/BraveWallet/Extensions/WalletColors.swift
@@ -257,4 +257,11 @@ enum WalletV2Design {
     blue: 207 / 255,
     alpha: 1
   )
+  
+  static let displayNFTCounterColor = UIColor(
+    red: 213 / 255,
+    green: 220 / 255,
+    blue: 1,
+    alpha: 1
+  )
 }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
Same as Portfolio, NFTs can be grouped by `None`/`Accounts`/Networks 
`None`: no grouping no expandable feature 
`Accounts`: grouping by wallet accounts and each group can be collapsed or expanded  
`Networks`: grouping by networks and each group can be collapsed or expanded 

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8073

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
1. Go to brave wallet and unlock your wallet 
2. Tap NFT in portfolio
3. Keep the dropdown as `Collected`
4. Open filter button in the header
5. Observe there is a new option called `Group By` with default value `None`
6. Adjust other parts inside this settings and save the changes. The filtering should work exactly as before. 
7. Click on this toggle to observer there are three options: None/Accounts/Networks
8. Choose `Accounts`
9. Observe that `Hide Unowned` will be changed to `On` (if it was not initially) and disabled 
10. Click `Save Changes`
11. Observe NFTs are now being displayed in groups by `Accounts` and there should be no unowned NFT in any groups. Any group/account that does not have any NFT will be hidden. Check all NFTs should be visible assets since its under `Collected`
12. Open filter then choose `Networks` for `Group By`
13. Observe `Hide Unowned` is now enabled 
14. Click `Save Changed`
15. Observe NFTs are now being displayed in groups by `Network` and there should be no unowned NFT in any groups. Any group/network that does not have any NFT will be hidden.
16. Let's change the dropdown in the header from `Collected` to `Hidden`
17. Repeat step 7-10 and step 12 - 14
18. Observe each `Group By` is applied correctly. and only hidden or spam NFTs are being grouped and displayed. 
19. Make sure hide or unhide NFTs still work in groups


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->
![simulator_screenshot_115AFC85-C1EA-4573-9E06-73D170A2326B](https://github.com/brave/brave-ios/assets/1187676/87cf0187-7b93-4c7e-b6d0-1a6e47b9ff7b) | ![simulator_screenshot_5F1FFB16-2D12-4CE9-8E64-71AB89C837B1](https://github.com/brave/brave-ios/assets/1187676/ea5ebfb5-43ee-4f9c-a732-751580303347) | ![simulator_screenshot_93131FF7-451F-4C19-BEE5-8471B38300E9](https://github.com/brave/brave-ios/assets/1187676/92a311aa-20c0-4bdc-9f23-8ecfc651d5a5)
--- | --- | ---
![simulator_screenshot_61F43603-C53D-474F-9662-FCA53558F6F6](https://github.com/brave/brave-ios/assets/1187676/635c0fb5-5e26-4036-b9f2-64ad578774a2) | ![simulator_screenshot_22D48BED-6299-428F-A2A8-56858E4407E8](https://github.com/brave/brave-ios/assets/1187676/fdcb77f2-0016-4ba8-b801-c66a149ba4a6) | ![simulator_screenshot_386D4FDE-C3B3-44B4-B904-CEDF4F0FF3BB](https://github.com/brave/brave-ios/assets/1187676/9f5ba62a-a264-4485-ad75-07a026d16ea3)

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
