### PR TITLE
Fix #8291: Onboarding can get stuck if crashed before keyring saved

### DIFF
--- a/Sources/BraveWallet/Crypto/Stores/KeyringStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/KeyringStore.swift
@@ -304,6 +304,10 @@ public class KeyringStore: ObservableObject, WalletObserverStore {
         self.defaultKeyring = defaultKeyring
         self.isDefaultKeyringLoaded = true
         self.isDefaultKeyringCreated = defaultKeyring.isKeyringCreated
+        // fallback case where user completed front-end onboarding, but has no keyring created/accounts.
+        if !defaultKeyring.isKeyringCreated && Preferences.Wallet.isOnboardingCompleted.value {
+          Preferences.Wallet.isOnboardingCompleted.reset()
+        }
       }
       self.allKeyrings = allKeyrings
       if let selectedAccountKeyring = allKeyrings.first(where: { $0.id == selectedAccount?.keyringId }) {


### PR DESCRIPTION
## Summary of Changes
- Add fallback case to reset `isOnboardingCompleted` value when true, but `isKeyringCreated` is false.

This pull request fixes #8291

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
  1. Build BraveCore locally (`1.59.x`, `1.60.x`, or `master`)
  2. Fresh install the app
  3. Restore a wallet and immediately lock it.
  4. App crashes.
  5. Re-open app, open Wallet
  6. Verify onboarding is shown again, as keyring was not saved / wallet not restored successfully.


## Screenshots:


https://github.com/brave/brave-ios/assets/5314553/ae8206f8-1fb8-4b43-aac5-6cea278032e7




## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
