### PR TITLE
Fix #7945: NFTs displayed in Portfolio when grouped by accounts

### DIFF
--- a/Tests/BraveWalletTests/PortfolioStoreTests.swift
+++ b/Tests/BraveWalletTests/PortfolioStoreTests.swift
@@ -146,7 +146,8 @@ import Preferences
     let mockEthUserAssets: [BraveWallet.BlockchainToken] = [
       .previewToken.copy(asVisibleAsset: true),
       .previewDaiToken, // Verify non-visible assets not displayed #6386
-      .mockUSDCToken.copy(asVisibleAsset: true)
+      .mockUSDCToken.copy(asVisibleAsset: true),
+      .mockERC721NFTToken.copy(asVisibleAsset: true) // Verify NFTs not used in Portfolio #7945
     ]
     let ethBalanceWei = formatter.weiString(
       from: mockETHBalanceAccount1,
@@ -259,6 +260,10 @@ import Preferences
       } else {
         completion(usdcAccount2BalanceWei, .success, "")
       }
+    }
+    rpcService._erc721TokenBalance = { _, _, _, _, completion in
+      // should not be fetching NFT balance in Portfolio
+      completion("", .internalError, "Error Message")
     }
     rpcService._solanaBalance = { accountAddress, chainId, completion in
       // sol balance
@@ -662,6 +667,12 @@ import Preferences
         XCTAssertEqual(group.assets[safe: 4]?.quantity, String(format: "%.04f", 0))
         // SOL (value = $0, SOL networks hidden)
         XCTAssertNil(group.assets[safe: 5])
+        
+        // Verify NFTs not used in Portfolio #7945
+        let noAssetsAreNFTs = lastUpdatedAssetGroups.flatMap(\.assets).allSatisfy({
+          !($0.token.isNft || $0.token.isErc721)
+        })
+        XCTAssertTrue(noAssetsAreNFTs)
       }.store(in: &cancellables)
     store.saveFilters(.init(
       groupBy: store.filters.groupBy,
@@ -778,6 +789,12 @@ import Preferences
         XCTAssertEqual(filAccount2Group.assets[safe: 0]?.token.symbol,
                        BraveWallet.BlockchainToken.mockFilToken.symbol)
         XCTAssertEqual(filAccount2Group.assets[safe: 0]?.quantity, String(format: "%.04f", 0))
+        
+        // Verify NFTs not used in Portfolio #7945
+        let noAssetsAreNFTs = lastUpdatedAssetGroups.flatMap(\.assets).allSatisfy({
+          !($0.token.isNft || $0.token.isErc721)
+        })
+        XCTAssertTrue(noAssetsAreNFTs)
       }
       .store(in: &cancellables)
     store.saveFilters(.init(
@@ -942,6 +959,12 @@ import Preferences
         XCTAssertEqual(ethGoerliGroup.assets[safe: 0]?.token.symbol,
                        BraveWallet.BlockchainToken.previewToken.symbol)
         XCTAssertEqual(ethGoerliGroup.assets[safe: 0]?.quantity, String(format: "%.04f", 0))
+        
+        // Verify NFTs not used in Portfolio #7945
+        let noAssetsAreNFTs = lastUpdatedAssetGroups.flatMap(\.assets).allSatisfy({
+          !($0.token.isNft || $0.token.isErc721)
+        })
+        XCTAssertTrue(noAssetsAreNFTs)
       }
       .store(in: &cancellables)
     store.saveFilters(.init(


### PR DESCRIPTION
## Summary of Changes
- NFTs were filtered out when grouping by none, or by network but not when grouping by accounts. 
- If an owned NFT (balance >0) has an [`assetRatioId`](https://github.com/brave/brave-ios/blob/be1d1929867d4d2c7c2323d0287595a1d46b3317/Sources/BraveWallet/Extensions/BraveWalletExtensions.swift#L287-L297) with history available, it could result in graph issues ('disappearing' if only 1 historical price available for example).
- Added an NFT to `PortfolioStoreTests` user assets + verify it's not displayed in any `AssetGroupViewModel`.

This pull request fixes #7945

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Have an owned NFT added for a network displayed in Portfolio (you must own the NFT)
2. Open Portfolio and open Filters
3. Change `Group By` to `Accounts`, verify owned NFT's network is selected (test networks not selected by default)
4. Tap `Save Changes`
5. Verify NFT not displayed in Portfolio group for the owning account.
6. Verify graph does not change drastically (likely some minor differences between initial data fetch and updating filters)


## Screenshots:

https://github.com/brave/brave-ios/assets/5314553/7b16822f-5951-4846-a72a-d05ee9b64c26


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
