### PR TITLE
Fix #8305 - Ref #8297: Allow Syncing All History - Update brave-core to 1.60.105

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+BraveTalk.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+BraveTalk.swift
@@ -26,7 +26,7 @@ extension BrowserViewController {
           var components = URLComponents()
           components.host = currentHost
           components.scheme = url.scheme
-          self.select(url: components.url!, visitType: .link)
+          self.select(components.url!)
         }
       }
     )

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+IPFSScheme.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+IPFSScheme.swift
@@ -10,12 +10,12 @@ import BraveCore
 import Data
 
 extension BrowserViewController: Web3IPFSScriptHandlerDelegate {
-  func web3IPFSDecisionHandler(_ proceed: Bool, originalURL: URL, visitType: VisitType) {
+  func web3IPFSDecisionHandler(_ proceed: Bool, originalURL: URL) {
     if proceed {
       if let resolvedUrl = braveCore.ipfsAPI.resolveGatewayUrl(for: originalURL) {
-        finishEditingAndSubmit(resolvedUrl, visitType: visitType)
+        finishEditingAndSubmit(resolvedUrl)
       } else {
-        finishEditingAndSubmit(originalURL, visitType: visitType)
+        finishEditingAndSubmit(originalURL)
       }
       Preferences.Wallet.resolveIPFSResources.value = Preferences.Wallet.Web3IPFSOption.enabled.rawValue
     } else {

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Menu.swift
@@ -108,7 +108,7 @@ extension BrowserViewController {
           guard let url = URL(string: "https://talk.brave.com/") else { return }
 
           self.popToBVC()
-          self.finishEditingAndSubmit(url, visitType: .typed)
+          self.finishEditingAndSubmit(url)
         }
       }
       

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+ReaderMode.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+ReaderMode.swift
@@ -7,20 +7,6 @@ import Shared
 import WebKit
 import Storage
 
-// MARK: VisitType
-
-enum VisitType: Int {
-  case unknown
-  /// Transition type where user followed a link and got a new top-level window
-  case link
-  /// Transition type where user typed the page's URL in the URL bar or selected it from URL bar autocomplete results.
-  case typed
-
-  /// Transition type where user opened a link from bookmarks.
-  case bookmark
-  case download
-}
-
 // MARK: - ReaderModeDelegate
 
 extension BrowserViewController: ReaderModeScriptHandlerDelegate {
@@ -210,9 +196,5 @@ extension BrowserViewController {
     self.readerModeStyleViewController(
       ReaderModeStyleViewController(selectedStyle: readerModeStyle),
       didConfigureStyle: readerModeStyle)
-  }
-
-  func recordNavigationInTab(_ url: URL, visitType: VisitType) {
-    typedNavigation[url] = visitType
   }
 }

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+UIDropInteractionDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+UIDropInteractionDelegate.swift
@@ -26,7 +26,7 @@ extension BrowserViewController: UIDropInteractionDelegate {
         return
       }
 
-      self.finishEditingAndSubmit(url, visitType: .typed)
+      self.finishEditingAndSubmit(url)
     }
   }
 }

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -204,7 +204,7 @@ extension BrowserViewController: WKNavigationDelegate {
     // handles IPFS URL schemes
     if requestURL.isIPFSScheme {
       if navigationAction.targetFrame?.isMainFrame == true {
-        handleIPFSSchemeURL(requestURL, visitType: .link)
+        handleIPFSSchemeURL(requestURL)
       }
       return (.cancel, preferences)
     }
@@ -220,11 +220,11 @@ extension BrowserViewController: WKNavigationDelegate {
       }
       switch result {
       case let .loadInterstitial(service):
-        showWeb3ServiceInterstitialPage(service: service, originalURL: requestURL, visitType: .link)
+        showWeb3ServiceInterstitialPage(service: service, originalURL: requestURL)
         return (.cancel, preferences)
       case let .load(resolvedURL):
         if resolvedURL.isIPFSScheme {
-          handleIPFSSchemeURL(resolvedURL, visitType: .link)
+          handleIPFSSchemeURL(resolvedURL)
           return (.cancel, preferences)
         } else { // non-ipfs, treat as normal url / link tapped
           requestURL = resolvedURL
@@ -513,13 +513,7 @@ extension BrowserViewController: WKNavigationDelegate {
 
       tab.mimeType = response.mimeType
     }
-    
-    // Record the navigation visit type for the URL after navigation actions
-    // this is done in decidePolicyFor to handle all the cases like redirects etc.
-    if let url = responseURL, let tab = tab, !url.isReaderModeURL, !url.isFileURL, url.isWebPage(), !tab.isPrivate {
-      recordNavigationInTab(url, visitType: lastEnteredURLVisitType)
-    }
-    
+ 
     // If none of our helpers are responsible for handling this response,
     // just let the webview handle it as normal.
     return .allow

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
@@ -135,7 +135,7 @@ extension BrowserViewController: BraveWalletDelegate {
       self.dismiss(animated: true)
     }
     if let url = tabManager.selectedTab?.url, InternalURL.isValid(url: url) {
-      select(url: destinationURL, visitType: .link)
+      select(url: destinationURL)
     } else {
       _ = tabManager.addTabAndSelect(
         URLRequest(url: destinationURL),

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Web3NameService.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Web3NameService.swift
@@ -23,11 +23,11 @@ extension BrowserViewController: Web3NameServiceScriptHandlerDelegate {
     )
   }
 
-  func web3NameServiceDecisionHandler(_ proceed: Bool, web3Service: Web3Service, originalURL: URL, visitType: VisitType) {
+  func web3NameServiceDecisionHandler(_ proceed: Bool, web3Service: Web3Service, originalURL: URL) {
     let isPrivateMode = privateBrowsingManager.isPrivateBrowsing
     guard let rpcService = BraveWallet.JsonRpcServiceFactory.get(privateMode: isPrivateMode),
           let decentralizedDNSHelper = self.decentralizedDNSHelperFor(url: originalURL) else {
-      finishEditingAndSubmit(originalURL, visitType: visitType)
+      finishEditingAndSubmit(originalURL)
       return
     }
     Task { @MainActor in
@@ -45,16 +45,16 @@ extension BrowserViewController: Web3NameServiceScriptHandlerDelegate {
       switch result {
       case let .load(resolvedURL):
         if resolvedURL.isIPFSScheme {
-          handleIPFSSchemeURL(resolvedURL, visitType: visitType)
+          handleIPFSSchemeURL(resolvedURL)
         } else {
-          finishEditingAndSubmit(resolvedURL, visitType: visitType)
+          finishEditingAndSubmit(resolvedURL)
         }
       case let .loadInterstitial(service):
         // ENS interstitial -> ENS Offchain interstitial possible
-        showWeb3ServiceInterstitialPage(service: service, originalURL: originalURL, visitType: visitType)
+        showWeb3ServiceInterstitialPage(service: service, originalURL: originalURL)
       case .none:
         // failed to resolve domain or disabled
-        finishEditingAndSubmit(originalURL, visitType: visitType)
+        finishEditingAndSubmit(originalURL)
       }
     }
   }

--- a/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarksViewController.swift
+++ b/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarksViewController.swift
@@ -489,7 +489,7 @@ class BookmarksViewController: SiteTableViewController, ToolbarUrlActionsProtoco
               ActivityShortcutManager.shared.donateCustomIntent(for: .openBookmarks, with: url.absoluteString)
             }
 
-            self.toolbarUrlActionsDelegate?.select(url: url, visitType: .bookmark)
+            self.toolbarUrlActionsDelegate?.select(url: url)
           }
 
           if presentingViewController is MenuViewController {

--- a/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/HistoryViewController.swift
+++ b/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/HistoryViewController.swift
@@ -274,7 +274,7 @@ class HistoryViewController: SiteTableViewController, ToolbarUrlActionsProtocol 
       }
       
       dismiss(animated: true) {
-        self.toolbarUrlActionsDelegate?.select(url: url, visitType: .typed)
+        self.toolbarUrlActionsDelegate?.select(url: url)
       }
     }
 

--- a/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/HistoryViewController.swift
+++ b/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/HistoryViewController.swift
@@ -188,8 +188,11 @@ class HistoryViewController: SiteTableViewController, ToolbarUrlActionsProtocol 
       UIAlertAction(
         title: Strings.History.historyClearActionTitle, style: .destructive,
         handler: { [weak self] _ in
-          guard let self = self else { return }
-          
+          guard let self = self, let allHistoryItems = historyFRC?.fetchedObjects  else {
+            return
+          }
+
+          // Deleting Local History
           self.historyAPI.deleteAll {
             // Clearing Tab History with entire history entry
             self.tabManager.clearTabHistory() {
@@ -198,6 +201,11 @@ class HistoryViewController: SiteTableViewController, ToolbarUrlActionsProtocol 
             
             // Clearing History should clear Recently Closed
             RecentlyClosed.removeAll()
+          }
+          
+          // Asking Sync Engine To Remove Visits
+          for historyItems in allHistoryItems {
+            self.historyAPI.removeHistory(historyItems)
           }
         }))
     alert.addAction(UIAlertAction(title: Strings.cancelButtonTitle, style: .cancel, handler: nil))

--- a/Sources/Brave/Frontend/Browser/Toolbars/ToolbarUrlActionsDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/Toolbars/ToolbarUrlActionsDelegate.swift
@@ -10,5 +10,5 @@ protocol ToolbarUrlActionsDelegate: AnyObject {
   func copy(_ url: URL)
   func share(_ url: URL)
   func batchOpen(_ urls: [URL])
-  func select(url: URL, visitType: VisitType)
+  func select(url: URL)
 }

--- a/Sources/Brave/Frontend/Sync/BraveCore/History/HistoryAPIExtensions.swift
+++ b/Sources/Brave/Frontend/Sync/BraveCore/History/HistoryAPIExtensions.swift
@@ -15,9 +15,9 @@ extension BraveHistoryAPI {
 
   // MARK: Internal
 
-  func add(url: URL, title: String, dateAdded: Date, isURLTyped: Bool = true) {
+  func add(url: URL, title: String, dateAdded: Date) {
     let historyNode = HistoryNode(url: url, title: title, dateAdded: dateAdded)
-    addHistory(historyNode, isURLTyped: isURLTyped)
+    addHistory(historyNode)
   }
 
   func frc() -> HistoryV2FetchResultsController? {

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Internal/Web3IPFSScriptHandler.swift
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Internal/Web3IPFSScriptHandler.swift
@@ -9,13 +9,12 @@ import WebKit
 import os.log
 
 protocol Web3IPFSScriptHandlerDelegate: AnyObject {
-  func web3IPFSDecisionHandler(_ proceed: Bool, originalURL: URL, visitType: VisitType)
+  func web3IPFSDecisionHandler(_ proceed: Bool, originalURL: URL)
 }
 
 class Web3IPFSScriptHandler: TabContentScript {
   weak var delegate: Web3IPFSScriptHandlerDelegate?
   var originalURL: URL?
-  var visitType: VisitType = .unknown
   fileprivate weak var tab: Tab?
   
   required init(tab: Tab) {
@@ -36,9 +35,9 @@ class Web3IPFSScriptHandler: TabContentScript {
     }
     
     if params["type"] == "IPFSDisable" {
-      delegate?.web3IPFSDecisionHandler(false, originalURL: originalURL, visitType: visitType)
+      delegate?.web3IPFSDecisionHandler(false, originalURL: originalURL)
     } else if params["type"] == "IPFSProceed" {
-      delegate?.web3IPFSDecisionHandler(true, originalURL: originalURL, visitType: visitType)
+      delegate?.web3IPFSDecisionHandler(true, originalURL: originalURL)
     } else {
       assertionFailure("Invalid message: \(message.body)")
     }

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Internal/Web3NameServiceScriptHandler.swift
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Internal/Web3NameServiceScriptHandler.swift
@@ -9,7 +9,7 @@ import os.log
 import BraveWallet
 
 protocol Web3NameServiceScriptHandlerDelegate: AnyObject {
-  func web3NameServiceDecisionHandler(_ proceed: Bool, web3Service: Web3Service, originalURL: URL, visitType: VisitType)
+  func web3NameServiceDecisionHandler(_ proceed: Bool, web3Service: Web3Service, originalURL: URL)
 }
 
 class Web3NameServiceScriptHandler: TabContentScript {
@@ -26,7 +26,6 @@ class Web3NameServiceScriptHandler: TabContentScript {
   
   weak var delegate: Web3NameServiceScriptHandlerDelegate?
   var originalURL: URL?
-  var visitType: VisitType = .unknown
   fileprivate weak var tab: Tab?
   
   required init(tab: Tab) {
@@ -49,11 +48,11 @@ class Web3NameServiceScriptHandler: TabContentScript {
     if params[ParamKey.buttonType.rawValue] == ParamValue.disable.rawValue,
        let serviceId = params[ParamKey.serviceId.rawValue],
        let service = Web3Service(rawValue: serviceId) {
-      delegate?.web3NameServiceDecisionHandler(false, web3Service: service, originalURL: originalURL, visitType: visitType)
+      delegate?.web3NameServiceDecisionHandler(false, web3Service: service, originalURL: originalURL)
     } else if params[ParamKey.buttonType.rawValue] == ParamValue.proceed.rawValue,
               let serviceId = params[ParamKey.serviceId.rawValue],
               let service = Web3Service(rawValue: serviceId) {
-      delegate?.web3NameServiceDecisionHandler(true, web3Service: service, originalURL: originalURL, visitType: visitType)
+      delegate?.web3NameServiceDecisionHandler(true, web3Service: service, originalURL: originalURL)
     } else {
       assertionFailure("Invalid message: \(message.body)")
     }

--- a/Sources/Brave/Shortcuts/ActivityShortcutManager.swift
+++ b/Sources/Brave/Shortcuts/ActivityShortcutManager.swift
@@ -165,7 +165,7 @@ public class ActivityShortcutManager: NSObject {
       } else {
         let controller = NewsSettingsViewController(dataSource: bvc.feedDataSource, openURL: { url in
           bvc.dismiss(animated: true)
-          bvc.select(url: url, visitType: .link)
+          bvc.select(url)
         })
         controller.viewDidDisappear = {
           if Preferences.Review.braveNewsCriteriaPassed.value {

--- a/Sources/Shared/Extensions/URLExtensions.swift
+++ b/Sources/Shared/Extensions/URLExtensions.swift
@@ -129,19 +129,6 @@ extension URL {
     }
   }
 
-  /// String suitable to detect the URL navigation type
-  /// This will return URL as a string without the scheme or ending "/" suffix limitation
-  /// This will be used as a key while storing navigation type of url before it is added to history
-  public var typedDisplayString: String {
-    var urlString = self.schemelessAbsoluteString
-
-    if urlString.hasSuffix("/") {
-      urlString.removeLast()
-    }
-
-    return urlString
-  }
-
   public var displayURL: URL? {
     if self.absoluteString.starts(with: "blob:") {
       return self.havingRemovedAuthorisationComponents()

--- a/Tests/BraveSharedTests/NSURLExtensionsTests.swift
+++ b/Tests/BraveSharedTests/NSURLExtensionsTests.swift
@@ -727,31 +727,6 @@ class NSURLExtensionsTests: XCTestCase {
       XCTAssertNil($0.bookmarkletCodeComponent)
     }
   }
-
-  func testTypedDisplayString() {
-    func checkDisplayURLString(testURL: URL?, displayString: String) {
-      if let actual = testURL?.typedDisplayString {
-        XCTAssertEqual(actual, displayString)
-      } else {
-        XCTFail("Actual url is nil")
-      }
-    }
-    
-    let urlMap = [
-      URL(string: "https://www.youtube.com"): "www.youtube.com",
-      URL(string: "http://google.com"): "google.com",
-      URL(string: "www.brave.com"): "www.brave.com",
-      URL(string: "http://brave.com/foo/"): "brave.com/foo",
-      URL(string: "http://brave.com/foo"): "brave.com/foo",
-      URL(string: "blob://http://brave.com/foo"): "http://brave.com/foo",
-      URL(string: "file:///Users/brave/documents/foo.txt"): "/Users/brave/documents/foo.txt",
-      URL(string: "file://http://brave.com/foo.txt"): "http://brave.com/foo.txt"
-    ]
-    
-    urlMap.forEach {
-      checkDisplayURLString(testURL: $0, displayString: $1)
-    }
-  }
   
   func testDisplayString() {
     func checkDisplayURLString(testURL: URL?, displayString: String) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@mozilla/readability": "^0.4.2",
-        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.60.104/brave-core-ios-1.60.104.tgz",
+        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.60.105/brave-core-ios-1.60.105.tgz",
         "leo": "github:brave/leo#7f2dfddb70aff1501ef5a2f3c640a8c74a7343ee",
         "leo-sf-symbols": "github:brave/leo-sf-symbols#d6056328b8d6ef06e68996ff02a22e06f52590c3",
         "page-metadata-parser": "^1.1.3",
@@ -493,9 +493,9 @@
       }
     },
     "node_modules/brave-core-ios": {
-      "version": "1.60.104",
-      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.60.104/brave-core-ios-1.60.104.tgz",
-      "integrity": "sha512-EwGu7HZ/7plhpkunyfFFDEyjxPhy1vhgVZjY3yAd3MhIW1t1E2zIWM6ivSHfEnLR4KdyqYKxnYj5Yl44zLkNsw==",
+      "version": "1.60.105",
+      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.60.105/brave-core-ios-1.60.105.tgz",
+      "integrity": "sha512-hejokYx3wTkR2iPeQVKWfYKAd4BqADQR4CRbE8ToWFHLqq2reVrghrIRaIjOXDIAJQU/lBzYr3fOq+YqjFcZLg==",
       "license": "ISC"
     },
     "node_modules/browserslist": {
@@ -3171,8 +3171,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-browser/releases/download/v1.60.104/brave-core-ios-1.60.104.tgz",
-      "integrity": "sha512-EwGu7HZ/7plhpkunyfFFDEyjxPhy1vhgVZjY3yAd3MhIW1t1E2zIWM6ivSHfEnLR4KdyqYKxnYj5Yl44zLkNsw=="
+      "version": "https://github.com/brave/brave-browser/releases/download/v1.60.105/brave-core-ios-1.60.105.tgz",
+      "integrity": "sha512-hejokYx3wTkR2iPeQVKWfYKAd4BqADQR4CRbE8ToWFHLqq2reVrghrIRaIjOXDIAJQU/lBzYr3fOq+YqjFcZLg=="
     },
     "browserslist": {
       "version": "4.17.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "license": "MPL-2.0",
   "dependencies": {
     "@mozilla/readability": "^0.4.2",
-    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.60.104/brave-core-ios-1.60.104.tgz",
+    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.60.105/brave-core-ios-1.60.105.tgz",
     "leo": "github:brave/leo#7f2dfddb70aff1501ef5a2f3c640a8c74a7343ee",
     "leo-sf-symbols": "github:brave/leo-sf-symbols#d6056328b8d6ef06e68996ff02a22e06f52590c3",
     "page-metadata-parser": "^1.1.3",


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8297
This pull request fixes #8305

This pull request is removing typedNavigation array and VisitType recording for navigation. This is necesserarry to allow all the History items to be synced properly.

https://github.com/brave/brave-core/pull/20654 CR119
1.60.105 brave-core has CR119 changes that includes Sync All History

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
Test History adding / deleting with or without Sync Chain and History type is enabled.
To have Sync History work both recipients should be 1.60+ for both desktop and mobile.

Important not for any OS: only those history entries are synced, which were created after enabling history sync. Entries visited before enabling history sync are not sent to server and are not synced.

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

![test2112](https://github.com/brave/brave-ios/assets/6643505/55e3475b-6b6f-4afc-877a-d297855d1604)


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
