### PR TITLE
Fix #8255: Reordering Favourites shows duplicated items 

### DIFF
--- a/Sources/Brave/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
+++ b/Sources/Brave/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
@@ -1232,13 +1232,21 @@ extension NewTabPageViewController: UICollectionViewDragDelegate, UICollectionVi
 
     if coordinator.proposal.operation == .move {
       guard let item = coordinator.items.first else { return }
+      _ = coordinator.drop(item.dragItem, toItemAt: destinationIndexPath)
 
+      guard let favouritesSection = sections.firstIndex(where: { $0 is FavoritesSectionProvider }) else {
+        return
+      }
+      
       Favorite.reorder(
         sourceIndexPath: sourceIndexPath,
         destinationIndexPath: destinationIndexPath,
         isInteractiveDragReorder: true
       )
-      _ = coordinator.drop(item.dragItem, toItemAt: destinationIndexPath)
+      
+      UIView.performWithoutAnimation {
+        self.collectionView.reloadSections(IndexSet(integer: favouritesSection))
+      }
 
     }
   }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8255

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
NTP fresh open
Move and order favourites randomly and continuously
Check all is placed proper

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


https://github.com/brave/brave-ios/assets/6643505/90ae348a-1d93-4f68-8864-ff9de463772b



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
