### PR TITLE
Fix #8236: Adding export fail case and alert for success

### DIFF
--- a/Sources/BraveStrings/BraveStrings.swift
+++ b/Sources/BraveStrings/BraveStrings.swift
@@ -3227,7 +3227,7 @@ extension Strings {
       NSLocalizedString("sync.syncV1DeprecationText", tableName: "BraveShared", bundle: .module,
         value: "A new Brave Sync is coming and will affect your setup. Get ready for the upgrade.",
         comment: "Text that informs a user about Brave Sync service deprecation.")
-    public static let bookmarksImportPopupErrorTitle =
+    public static let bookmarksImportExportPopupTitle =
       NSLocalizedString("sync.bookmarksImportPopupErrorTitle", tableName: "BraveShared", bundle: .module,
         value: "Bookmarks",
         comment: "Title of the bookmark import popup.")
@@ -3235,6 +3235,14 @@ extension Strings {
       NSLocalizedString("sync.bookmarksImportPopupSuccessMessage", tableName: "BraveShared", bundle: .module,
         value: "Bookmarks Imported Successfully",
         comment: "Message of the popup if bookmark import succeeds.")
+    public static let bookmarksExportPopupSuccessMessage =
+      NSLocalizedString("sync.bookmarksExportPopupSuccessMessage", tableName: "BraveShared", bundle: .module,
+        value: "Bookmarks Exported Successfully",
+        comment: "Message of the popup if bookmark export succeeds.")
+    public static let bookmarksExportPopupFailureMessage =
+      NSLocalizedString("sync.bookmarksIExportPopupFailureMessage", tableName: "BraveShared", bundle: .module,
+        value: "Bookmark Export Failed",
+        comment: "Message of the popup if bookmark export fails.")
     public static let bookmarksImportPopupFailureMessage =
       NSLocalizedString("sync.bookmarksImportPopupFailureMessage", tableName: "BraveShared", bundle: .module,
         value: "Bookmark Import Failed",


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

Adding export fail case and alert for success
<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8236

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->

- [ ] Launch Brave
- [ ] Three-dot menu > Bookmarks
- [ ] Tap the Import/Export button in the bottom left corner
- [ ] Export Bookmarks > Save to Files
- [ ] Choose a folder, for example, Downloads
- [ ] Tap Save in the top right corner > Observe there is no confirmation message

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


https://github.com/brave/brave-ios/assets/6643505/bcc7a1c3-bc00-48f4-8038-4fdc72be2d51


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
