### PR TITLE
Fix #8332: Allow proper caret selection on url bar in overlay mode

### DIFF
--- a/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
+++ b/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
@@ -273,12 +273,6 @@ class TabLocationView: UIView {
     contentView.snp.makeConstraints { make in
       make.leading.trailing.top.bottom.equalTo(self)
     }
-
-    // Setup UIDragInteraction to handle dragging the location
-    // bar for dropping its URL into other apps.
-    let dragInteraction = UIDragInteraction(delegate: self)
-    dragInteraction.allowsSimultaneousRecognitionDuringLift = true
-    self.addInteraction(dragInteraction)
     
     privateModeCancellable = privateBrowsingManager.$isPrivateBrowsing
       .removeDuplicates()
@@ -411,26 +405,6 @@ class TabLocationView: UIView {
   
   @objc func didTapWalletButton() {
     delegate?.tabLocationViewDidTapWalletButton(self)
-  }
-}
-
-// MARK: - UIDragInteractionDelegate
-
-extension TabLocationView: UIDragInteractionDelegate {
-  func dragInteraction(_ interaction: UIDragInteraction, itemsForBeginning session: UIDragSession) -> [UIDragItem] {
-    // Ensure we actually have a URL in the location bar and that the URL is not local.
-    guard let url = self.url, !InternalURL.isValid(url: url), let itemProvider = NSItemProvider(contentsOf: url),
-      !reloadButton.isHighlighted
-    else {
-      return []
-    }
-
-    let dragItem = UIDragItem(itemProvider: itemProvider)
-    return [dragItem]
-  }
-
-  func dragInteraction(_ interaction: UIDragInteraction, sessionWillBegin session: UIDragSession) {
-    delegate?.tabLocationViewDidBeginDragInteraction(self)
   }
 }
 


### PR DESCRIPTION
This cleans up the duplicate drag interactions as well as fixes the bug where you could no longer move the caret inside of the url bar text field. It also restores a missed delegate method and removes the drop delegate on the active text field so as to not crash

## Summary of Changes

This pull request fixes #8332 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

- Long press and drag the url bar on the NTP → nothing should happen 
- Visit a website, long press and drag on the url bar and drag → the url bar should lift and be droppable
- Tap on the URL bar and attempt to move the cursor via long-press → the cursor should be movable and shouldnt lift the entire url bar. Note: It is possible to start a drag session if you've selected a number of characters and long-press on the selected range which will show the text you've selected and not the url bar (this is unrelated)

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
