### PR TITLE
Fix #8350: Fix Playlist not working on Youtube at all

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController.swift
@@ -3150,11 +3150,9 @@ extension BrowserViewController: PreferencesObserver {
       Preferences.Rewards.rewardsToggledOnce.key:
       updateRewardsButtonState()
     case Preferences.Playlist.webMediaSourceCompatibility.key:
-      if UIDevice.isIpad {
-        tabManager.allTabs.forEach {
-          $0.setScript(script: .playlistMediaSource, enabled: Preferences.Playlist.webMediaSourceCompatibility.value)
-          $0.webView?.reload()
-        }
+      tabManager.allTabs.forEach {
+        $0.setScript(script: .playlistMediaSource, enabled: Preferences.Playlist.webMediaSourceCompatibility.value)
+        $0.webView?.reload()
       }
     case Preferences.General.mediaAutoBackgrounding.key:
       tabManager.allTabs.forEach {

--- a/Sources/Brave/Frontend/Browser/Tab.swift
+++ b/Sources/Brave/Frontend/Browser/Tab.swift
@@ -398,7 +398,8 @@ class Tab: NSObject {
         .cookieBlocking: Preferences.Privacy.blockAllCookies.value,
         .mediaBackgroundPlay: Preferences.General.mediaAutoBackgrounding.value,
         .nightMode: Preferences.General.nightModeEnabled.value,
-        .deAmp: Preferences.Shields.autoRedirectAMPPages.value
+        .deAmp: Preferences.Shields.autoRedirectAMPPages.value,
+        .playlistMediaSource: Preferences.Playlist.webMediaSourceCompatibility.value,
       ]
       
       userScripts = Set(scriptPreferences.filter({ $0.value }).map({ $0.key }))

--- a/Sources/Brave/Frontend/Settings/Features/PlaylistSettingsViewController.swift
+++ b/Sources/Brave/Frontend/Settings/Features/PlaylistSettingsViewController.swift
@@ -156,17 +156,15 @@ class PlaylistSettingsViewController: TableViewController {
       dataSource.sections.append(sideSelectionSection)
     }
 
-    if UIDevice.isIpad {
-      dataSource.sections.append(
-        Section(
-          rows: [
-            .boolRow(
-              title: Strings.PlayList.playlistWebCompatibilityTitle,
-              detailText: Strings.PlayList.playlistWebCompatibilityDescription,
-              option: Preferences.Playlist.webMediaSourceCompatibility)
-          ])
-      )
-    }
+    dataSource.sections.append(
+      Section(
+        rows: [
+          .boolRow(
+            title: Strings.PlayList.playlistWebCompatibilityTitle,
+            detailText: Strings.PlayList.playlistWebCompatibilityDescription,
+            option: Preferences.Playlist.webMediaSourceCompatibility)
+        ])
+    )
     
     dataSource.sections.append(
       Section(

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Paged/PlaylistSwizzlerScript.js
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Paged/PlaylistSwizzlerScript.js
@@ -4,12 +4,18 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 // Stub out the MediaSource API so video players do not attempt to use `blob` for streaming
-if (window.MediaSource || window.WebKitMediaSource || window.HTMLMediaElement && HTMLMediaElement.prototype.webkitSourceAddId) {
-  window.MediaSource = null;
-  window.WebKitMediaSource = null;
-  //HTMLMediaElement.prototype.webkitSourceAddId = null;
-  //window.SourceBuffer = null;
-  
+
+if (window.MediaSource || window.WebKitMediaSource || window.ManagedMediaSource || (window.HTMLMediaElement && HTMLMediaElement.prototype.webkitSourceAddId)) {
   delete window.MediaSource;
   delete window.WebKitMediaSource;
+  
+  // This API is only availale in iOS 17.1+ and only available in WebKit atm. The proposal to get it in all browsers is currently still open.
+  delete window.ManagedMediaSource;
+  
+//  window.MediaSource = undefined;
+//  window.WebKitMediaSource = undefined;
+//  window.ManagedMediaSource = undefined;
+//
+//  HTMLMediaElement.prototype.webkitSourceAddId = undefined;
+//  window.SourceBuffer = undefined;
 }

--- a/Sources/Playlist/PlaylistPreferences.swift
+++ b/Sources/Playlist/PlaylistPreferences.swift
@@ -38,7 +38,7 @@ extension Preferences {
     /// The Option to download video yes / no / only wi-fi
     public static let autoDownloadVideo = Option<String>(key: "playlist.autoDownload", default: PlayListDownloadType.on.rawValue)
     /// The Option to disable playlist MediaSource web-compatibility
-    public static let webMediaSourceCompatibility = Option<Bool>(key: "playlist.webMediaSourceCompatibility", default: UIDevice.isIpad)
+    public static let webMediaSourceCompatibility = Option<Bool>(key: "playlist.webMediaSourceCompatibility", default: false)
     /// The option to start the playback where user left-off
     public static let playbackLeftOff = Option<Bool>(key: "playlist.playbackLeftOff", default: true)
     /// The option to disable long-press-to-add-to-playlist gesture.


### PR DESCRIPTION
## Summary of Changes
- Update the Playlist Swizzling scripts to run on iPhone and not just iPad
- Update the Playlist Swizzling scripts to handle ManagedMediaSource
- Update WebKit error handling code to allow WebKit to automatically refresh the frame whenever it fails and continue on like normal (gets rid of the unnecessary/false alert that something went wrong)

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8350

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
- Test adding videos to Playlist from Youtube
- Test adding 4K videos to Playlist from Youtube


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
