### PR TITLE
Fix #8353: Add Subscription Custom Offer Codes Interaction

### DIFF
--- a/Sources/Brave/Frontend/Settings/SettingsViewController.swift
+++ b/Sources/Brave/Frontend/Settings/SettingsViewController.swift
@@ -623,7 +623,18 @@ class SettingsViewController: TableViewController {
         }()
 
         guard let vcToShow = vc else { return }
-        self.navigationController?.pushViewController(vcToShow, animated: true)
+        
+        if VPNProductInfo.isComplete {
+          self.navigationController?.pushViewController(vcToShow, animated: true)
+        } else {
+          let alert = UIAlertController(
+            title: Strings.VPN.errorCantGetPricesTitle,
+            message: Strings.VPN.errorCantGetPricesBody,
+            preferredStyle: .alert)
+
+          alert.addAction(UIAlertAction(title: Strings.OKString, style: .default, handler: nil))
+          self.present(alert, animated: true, completion: nil)
+        }
       },
       image: Preferences.VPN.vpnReceiptStatus.value == BraveVPN.ReceiptResponse.Status.retryPeriod.rawValue
         ? UIImage(braveSystemNamed: "leo.warning.triangle-filled")?

--- a/Sources/Brave/Frontend/Settings/SettingsViewController.swift
+++ b/Sources/Brave/Frontend/Settings/SettingsViewController.swift
@@ -612,7 +612,7 @@ class SettingsViewController: TableViewController {
           case .notPurchased, .expired:
             return BraveVPN.vpnState.enableVPNDestinationVC
           case .purchased:
-            let vc = BraveVPNSettingsViewController()
+            let vc = BraveVPNSettingsViewController(iapObserver: BraveVPN.iapObserver)
             vc.openURL = { [unowned self] url in
               self.settingsDelegate?.settingsOpenURLInNewTab(url)
               self.dismiss(animated: true)

--- a/Sources/BraveStrings/BraveStrings.swift
+++ b/Sources/BraveStrings/BraveStrings.swift
@@ -2820,6 +2820,11 @@ extension Strings {
         value: "Manage Subscription",
         comment: "Button to manage your VPN subscription")
     
+    public static let settingsRedeemOfferCode =
+      NSLocalizedString("vpn.settingsManageSubscription", tableName: "BraveShared", bundle: .module,
+        value: "Redeem Offer Code",
+        comment: "Button to redeem offer code subscription")
+    
     public static let settingsLinkReceipt =
       NSLocalizedString("vpn.settingsLinkReceipt", tableName: "BraveShared", bundle: .module,
         value: "Link purchase to your Brave account",
@@ -2929,6 +2934,11 @@ extension Strings {
       NSLocalizedString("vpn.vpnErrorPurchaseFailedBody", tableName: "BraveShared", bundle: .module,
         value: "Unable to complete purchase. Please try again, or check your payment details on Apple and try again.",
         comment: "Message for error when VPN could not be purchased.")
+    
+    public static let vpnErrorOfferCodeFailedBody =
+      NSLocalizedString("vpn.vpnErrorOfferCodeFailedBody", tableName: "BraveShared", bundle: .module,
+        value: "Unable to redeem offer code. Please try again, or check your offer code details and try again.",
+        comment: "Message for error when VPN offer code could not be redeemed.")
 
     public static let vpnResetAlertTitle =
       NSLocalizedString("vpn.vpnResetAlertTitle", tableName: "BraveShared", bundle: .module,

--- a/Sources/BraveStrings/BraveStrings.swift
+++ b/Sources/BraveStrings/BraveStrings.swift
@@ -2909,6 +2909,11 @@ extension Strings {
       NSLocalizedString("vpn.vpnConfigPermissionDeniedErrorTitle", tableName: "BraveShared", bundle: .module,
         value: "Permission denied",
         comment: "Title for an alert when the user didn't allow to install VPN profile")
+    
+    public static let vpnRedeemCodeButtonActionTitle =
+      NSLocalizedString("vpn.vpnRedeemCodeButtonActionTitle", tableName: "BraveShared", bundle: .module,
+        value: "Redeem Code",
+        comment: "Title for a button for enabling the Redeem Code flow")
 
     public static let vpnConfigPermissionDeniedErrorBody =
       NSLocalizedString("vpn.vpnConfigPermissionDeniedErrorBody", tableName: "BraveShared", bundle: .module,

--- a/Sources/BraveVPN/BuyVPNViewController.swift
+++ b/Sources/BraveVPN/BuyVPNViewController.swift
@@ -68,8 +68,8 @@ class BuyVPNViewController: VPNSetupLoadingController {
     }
     
     let redeemButton = UIButton().then {
-      $0.setTitle("Redeem Code", for: .normal)
-      $0.titleLabel?.font = .systemFont(ofSize: 15, weight: .semibold)
+      $0.setTitle(Strings.VPN.vpnRedeemCodeButtonActionTitle, for: .normal)
+      $0.titleLabel?.font = .systemFont(ofSize: 13, weight: .medium)
       $0.titleLabel?.textAlignment = .center
       
       $0.addTarget(self, action: #selector(redeemOfferSubscriptionCode), for: .touchUpInside)

--- a/Sources/BraveVPN/BuyVPNViewController.swift
+++ b/Sources/BraveVPN/BuyVPNViewController.swift
@@ -44,15 +44,15 @@ class BuyVPNViewController: VPNSetupLoadingController {
       title: Strings.VPN.restorePurchases, style: .done,
       target: self, action: #selector(restorePurchasesAction))
     
-    let actionTitle = Preferences.VPN.freeTrialUsed.value
+    let buyTitle = Preferences.VPN.freeTrialUsed.value
       ? Strings.VPN.activateSubscriptionAction.capitalized
       : Strings.VPN.freeTrialPeriodAction.capitalized
     
-    let actionButton = BraveGradientButton(gradient: .backgroundGradient1).then {
+    let buyButton = BraveGradientButton(gradient: .backgroundGradient1).then {
       $0.titleLabel?.font = .systemFont(ofSize: 15, weight: .bold)
       $0.titleLabel?.textAlignment = .center
        
-      $0.setTitle(actionTitle, for: .normal)
+      $0.setTitle(buyTitle, for: .normal)
       
       $0.snp.makeConstraints {
         $0.height.equalTo(50)
@@ -66,7 +66,15 @@ class BuyVPNViewController: VPNSetupLoadingController {
       
       $0.addTarget(self, action: #selector(startSubscriptionAction), for: .touchUpInside)
     }
-  
+    
+    let redeemButton = UIButton().then {
+      $0.setTitle("Redeem Code", for: .normal)
+      $0.titleLabel?.font = .systemFont(ofSize: 15, weight: .semibold)
+      $0.titleLabel?.textAlignment = .center
+      
+      $0.addTarget(self, action: #selector(redeemOfferSubscriptionCode), for: .touchUpInside)
+    }
+    
     let seperator = UIView().then {
       $0.backgroundColor = UIColor.white.withAlphaComponent(0.1)
       $0.snp.makeConstraints { make in
@@ -76,7 +84,8 @@ class BuyVPNViewController: VPNSetupLoadingController {
         
     view.addSubview(buyVPNView)
     view.addSubview(seperator)
-    view.addSubview(actionButton)
+    view.addSubview(buyButton)
+    view.addSubview(redeemButton)
     
     buyVPNView.snp.makeConstraints {
       $0.leading.trailing.top.equalToSuperview()
@@ -87,9 +96,15 @@ class BuyVPNViewController: VPNSetupLoadingController {
       $0.leading.trailing.equalToSuperview()
     }
     
-    actionButton.snp.makeConstraints() {
+    buyButton.snp.makeConstraints() {
       $0.top.equalTo(seperator.snp.bottom).inset(-12)
-      $0.leading.trailing.bottom.equalToSuperview().inset(24)
+      $0.leading.trailing.equalToSuperview().inset(24)
+    }
+    
+    redeemButton.snp.makeConstraints() {
+      $0.top.equalTo(buyButton.snp.bottom).inset(-12)
+      $0.bottom.equalToSuperview().inset(24)
+      $0.centerX.equalToSuperview()
     }
 
     buyVPNView.monthlySubButton
@@ -152,6 +167,11 @@ class BuyVPNViewController: VPNSetupLoadingController {
   
   @objc func startSubscriptionAction() {
     addPaymentForSubcription(type: activeSubcriptionChoice)
+  }
+  
+  @objc func redeemOfferSubscriptionCode() {
+    // Open the redeem code sheet
+    SKPaymentQueue.default().presentCodeRedemptionSheet()
   }
   
   private func addPaymentForSubcription(type: SubscriptionType) {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8353

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->

Currently, we can not test offer codes with a sandbox environment. ([Source](https://developer.apple.com/documentation/storekit/in-app_purchase/testing_at_all_stages_of_development_with_xcode_and_the_sandbox))

One option to test offer code, other than in a production environment, is to use [Storekit testing](https://developer.apple.com/documentation/xcode/setting-up-storekit-testing-in-xcode/).

However this is development testing so For QA to test this they have to a real production offer code has to be created and they have purchase the VPN.

However going over this simple interaction will be sufficient. 

- Load the link for an offer in NTP and check if it is directed to open external which will open AppStore Reedem
- Go to VPN Buy Screen and click Redeem Code action.

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

New Redeem Flow

https://github.com/brave/brave-ios/assets/6643505/ea9809d1-0655-4967-83db-6df081ccc55c

Redeeming Browser:


https://github.com/brave/brave-ios/assets/6643505/a60b46fa-a951-49fe-8c7e-5b901ad33d53


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
