### PR TITLE
Fix #8357: Disable button to create wallet when wallet is already being created

### DIFF
--- a/Sources/BraveWallet/Crypto/Onboarding/CreateWalletView.swift
+++ b/Sources/BraveWallet/Crypto/Onboarding/CreateWalletView.swift
@@ -78,7 +78,7 @@ private struct CreateWalletView: View {
       }
     } else {
       keyringStore.createWallet(password: password) { mnemonic in
-        if !mnemonic.isEmpty {
+        if let mnemonic, !mnemonic.isEmpty {
           isNewWalletCreated = true
         }
       }
@@ -144,6 +144,11 @@ private struct CreateWalletView: View {
     )
     .hidden(isHidden: error == nil)
   }
+  
+  private var isContinueDisabled: Bool {
+    validationError != nil || password.isEmpty || repeatedPassword.isEmpty ||
+    keyringStore.isCreatingWallet || keyringStore.isRestoringWallet
+  }
 
   var body: some View {
     VStack(spacing: 16) {
@@ -200,7 +205,7 @@ private struct CreateWalletView: View {
           .frame(maxWidth: .infinity)
       }
       .buttonStyle(BraveFilledButtonStyle(size: .large))
-      .disabled(validationError != nil || password.isEmpty || repeatedPassword.isEmpty)
+      .disabled(isContinueDisabled)
       .padding(.top, 60)
     }
     .padding(.horizontal, 20)

--- a/Sources/BraveWallet/Crypto/Onboarding/RestoreWalletView.swift
+++ b/Sources/BraveWallet/Crypto/Onboarding/RestoreWalletView.swift
@@ -46,7 +46,7 @@ private struct RestoreWalletView: View {
   }
   
   private var isContinueDisabled: Bool {
-    !recoveryWords.allSatisfy({ !$0.isEmpty })
+    !recoveryWords.allSatisfy({ !$0.isEmpty }) || keyringStore.isRestoringWallet
   }
   
   private var errorLabel: some View {


### PR DESCRIPTION
## Summary of Changes
- Disable the `Continue` button when a wallet is being created to prevent double taps. This can cause 2 ethereum / solana accounts to be created during new wallet flow.
- `isCreatingWallet` / `isRestoringWallet` are now used to disable the `Continue` button. `isOnboarding` added for iPad multi-window protection against duplicate onboarding.

This pull request fixes #8357

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
### Disabled Continue button
1. Open Wallet onboarding
2. Proceed through `Need a new wallet?` / fresh wallet flow.
3. On `Create a Password` step, double-tap `Continue` button (note: pressing enter/return in 2nd password field counts as tapping the `Continue` button)
4. Confirm continue was disabled (might be too quick to verify), verify only 1 Ethereum account & 1 Solana account in Accounts tab.
5. Reset your wallet
6. Open Wallet onboarding and proceed through `Already have a wallet?` / restore wallet flow.
7. On `Create a Password` step, double-tap `Continue button (note: pressing enter/return in 2nd password field counts as tapping the `Continue` button)
8. Verify continue was disabled, verify only 1 Ethereum account & 1 Solana account in Accounts tab (duplicate accounts should only be possible during create new wallet flow).

### New wallet onboarding - Split View verification
1. Open 2 new instances of Brave in Split View on iPad. 
2. Open Wallet in both, you should see onboarding in each window.
3. In one window, proceed through `Need a new wallet?` / fresh wallet flow.
4. After `Create a Password` step, verify active window continues with onboarding as normal, while onboarding is dismissed in the other window.

### Restore wallet onboarding - Split View verification
1. Open 2 new instances of Brave in Split View on iPad. 
2. Open Wallet in both, you should see onboarding in each window.
3. In one window, proceed through `Already have a wallet?` / restore wallet flow.
4. After `Create a Password` step, verify active window continues with onboarding as normal, while onboarding is dismissed in the other window.


## Screenshots:

Double-tap `Continue` during create wallet:

https://github.com/brave/brave-ios/assets/5314553/27f1034b-4097-4556-878f-76bdefbfe203

Double-tap `Continue` during restore wallet:

https://github.com/brave/brave-ios/assets/5314553/d4f12293-0a40-429c-b355-dd676020e2d2


New wallet onboarding - iPad Split View

https://github.com/brave/brave-ios/assets/5314553/5ed26edd-0d0f-4715-93e2-81a19ad2e2ec

Restore wallet onboarding - iPad Split View

https://github.com/brave/brave-ios/assets/5314553/3d254e9d-7a7b-402b-8db9-64344800f74a


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
