### PR TITLE
Fix #8364: Add missing footer constraint when bottom toolbar is hidden

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController.swift
@@ -1301,6 +1301,9 @@ public class BrowserViewController: UIViewController {
     footer.snp.remakeConstraints { make in
       make.bottom.equalTo(toolbarLayoutGuide)
       make.leading.trailing.equalTo(self.view)
+      if toolbar == nil {
+        make.height.equalTo(0)
+      }
     }
 
     bottomBarKeyboardBackground.snp.remakeConstraints {


### PR DESCRIPTION
Missing this constraint would cause the web view container view to have ambiguous height and result in a 0-height web page.

## Summary of Changes

This pull request fixes #8364 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
