### PR TITLE
No Bug: Fix flakey `ManageSiteConnectionsStoreTests`

### DIFF
--- a/Tests/BraveWalletTests/ManageSiteConnectionsStoreTests.swift
+++ b/Tests/BraveWalletTests/ManageSiteConnectionsStoreTests.swift
@@ -6,7 +6,7 @@
 import Combine
 import XCTest
 import BraveCore
-import Data
+@testable import Data
 import TestHelpers
 @testable import BraveWallet
 
@@ -79,6 +79,8 @@ class ManageSiteConnectionsStoreTests: CoreDataTestCase {
     backgroundSaveAndWaitForExpectation {
       store.removeAllPermissions(from: [siteConnectionToRemove])
     }
+    DataController.viewContext.refreshAllObjects()
+    
     // verify `siteConnections` is updated
     XCTAssertEqual(store.siteConnections.count, 2)
     XCTAssertNotEqual(store.siteConnections[0].url, siteConnectionToRemove.url)
@@ -101,6 +103,7 @@ class ManageSiteConnectionsStoreTests: CoreDataTestCase {
     backgroundSaveAndWaitForExpectation {
       store.removePermissions(for: .eth, from: [walletAccount], url: URL(string: siteConnectionToRemoveAccount.url)!)
     }
+    DataController.viewContext.refreshAllObjects()
     
     // verify `siteConnections` is updated to remove specific accounts from the `SiteConnection`
     XCTAssertEqual(store.siteConnections.count, 3)
@@ -125,11 +128,14 @@ class ManageSiteConnectionsStoreTests: CoreDataTestCase {
     backgroundSaveAndWaitForExpectation {
       store.removePermissions(for: .eth, from: [walletAccount], url: URL(string: siteConnectionToRemove.url)!)
     }
+    DataController.viewContext.refreshAllObjects()
+    
     // remove `walletAccount2` permissions for this `SiteConnection`
     XCTAssertEqual(store.siteConnections[0].connectedAddresses.count, 1)
     backgroundSaveAndWaitForExpectation {
       store.removePermissions(for: .eth, from: [walletAccount2], url: URL(string: siteConnectionToRemove.url)!)
     }
+    DataController.viewContext.refreshAllObjects()
     
     // verify `siteConnections` is updated to remove the `SiteConnection` as all `connectedAddresses` are removed
     XCTAssertEqual(store.siteConnections.count, 2)


### PR DESCRIPTION
## Summary of Changes
- Fixes a flakey wallet test. Test is (still) not run on CI due to using CoreData and flakiness on CI, but this resolves flakiness locally.

This pull request fixes #<number>

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
Run `ManageSiteConnectionsStoreTests` repeatedly 100+ times, verify no failure.


## Screenshots:

1000 runs:
<img width="772" alt="Screenshot 2023-11-07 at 11 46 41 AM" src="https://github.com/brave/brave-ios/assets/5314553/3b16958c-6a37-4113-9334-4e7d71025e02">


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
