### PR TITLE
Fix #8349: Transaction Activity v2 UI

### DIFF
--- a/Sources/BraveUI/Buttons/LoaderView.swift
+++ b/Sources/BraveUI/Buttons/LoaderView.swift
@@ -21,6 +21,7 @@ private class LoaderLayer: CALayer {
 public class LoaderView: UIView {
   /// The size of the indicator
   public enum Size {
+    case mini
     case small
     case normal
     case large
@@ -30,6 +31,8 @@ public class LoaderView: UIView {
 
     fileprivate var size: CGSize {
       switch self {
+      case .mini:
+        return CGSize(width: 8, height: 8)
       case .small:
         return CGSize(width: 16, height: 16)
       case .normal:
@@ -41,6 +44,8 @@ public class LoaderView: UIView {
 
     fileprivate var lineWidth: CGFloat {
       switch self {
+      case .mini:
+        return 1.0
       case .small:
         return 2.0
       case .normal:

--- a/Sources/BraveWallet/Crypto/AssetIconView.swift
+++ b/Sources/BraveWallet/Crypto/AssetIconView.swift
@@ -6,6 +6,7 @@
 import SwiftUI
 import BraveCore
 import BraveUI
+import DesignSystem
 
 /// Displays an asset's icon from the token registry
 ///
@@ -36,26 +37,10 @@ struct AssetIconView: View {
       )
   }
 
-  private var localImage: Image? {
-    if network.isNativeAsset(token), let uiImage = network.nativeTokenLogoImage {
-      return Image(uiImage: uiImage)
-    }
-    
-    for logo in [token.logo, token.symbol.lowercased()] {
-      if let baseURL = BraveWallet.TokenRegistryUtils.tokenLogoBaseURL,
-        case let imageURL = baseURL.appendingPathComponent(logo),
-        let image = UIImage(contentsOfFile: imageURL.path) {
-        return Image(uiImage: image)
-      }
-    }
-    
-    return nil
-  }
-
   var body: some View {
     Group {
-      if let image = localImage {
-        image
+      if let uiImage = token.localImage(network: network) {
+        Image(uiImage: uiImage)
           .resizable()
           .aspectRatio(contentMode: .fit)
       } else if let url = URL(string: token.logo) {
@@ -176,5 +161,154 @@ struct NFTIconView: View {
     .overlay(tokenLogo, alignment: .bottomTrailing)
     .allowsHitTesting(false)
     .accessibilityHidden(true)
+  }
+}
+
+/// Displays 2 asset icons stacked on top of one another, with the token's network logo on top.
+/// `bottomToken` is displayed in the top-right, `topToken` is displayed in the bottom-left,
+/// and the network logo is displayed in the bottom-right.
+struct StackedAssetIconsView: View {
+  
+  var bottomToken: BraveWallet.BlockchainToken?
+  var topToken: BraveWallet.BlockchainToken?
+  var network: BraveWallet.NetworkInfo
+
+  /// Length of entire view
+  @ScaledMetric var length: CGFloat = 40
+  /// Max length of entire view
+  var maxLength: CGFloat?
+  @ScaledMetric var networkSymbolLength: CGFloat = 15
+  var maxNetworkSymbolLength: CGFloat?
+  
+  /// Size of padding applied to bottom/top icon so they can overlap
+  private var iconPadding: CGFloat {
+    length / 5
+  }
+  
+  /// Size of asset icon
+  private var assetIconLength: CGFloat {
+    length - iconPadding
+  }
+  
+  /// Max size of asset icon
+  private var maxAssetIconLength: CGFloat? {
+    guard let maxLength else { return nil }
+    return maxLength - iconPadding
+  }
+  
+  var body: some View {
+    ZStack {
+      Group {
+        if let bottomToken {
+          AssetIconView(
+            token: bottomToken,
+            network: network,
+            shouldShowNetworkIcon: false,
+            length: assetIconLength,
+            maxLength: maxAssetIconLength
+          )
+        } else { // nil token possible for Solana Swaps
+          GenericAssetIconView(
+            backgroundColor: Color(braveSystemName: .gray40),
+            iconColor: Color.white,
+            length: assetIconLength,
+            maxLength: maxAssetIconLength
+          )
+        }
+      }
+      .padding(.leading, iconPadding)
+      .padding(.bottom, iconPadding)
+      .zIndex(0)
+      
+      Group {
+        if let topToken {
+          AssetIconView(
+            token: topToken,
+            network: network,
+            shouldShowNetworkIcon: false,
+            length: assetIconLength,
+            maxLength: maxAssetIconLength
+          )
+        } else { // nil token possible for Solana Swaps
+          GenericAssetIconView(
+            backgroundColor: Color(braveSystemName: .gray20),
+            iconColor: Color.black,
+            length: assetIconLength,
+            maxLength: maxAssetIconLength
+          )
+        }
+      }
+      .padding(.top, iconPadding)
+      .padding(.trailing, iconPadding)
+      .zIndex(1)
+      
+      if let networkLogoImage = network.networkLogoImage {
+        Group {
+          Image(uiImage: networkLogoImage)
+            .resizable()
+            .overlay(
+              Circle()
+                .stroke(lineWidth: 2)
+                .foregroundColor(Color(braveSystemName: .containerBackground))
+            )
+            .frame(
+              width: min(networkSymbolLength, maxNetworkSymbolLength ?? networkSymbolLength),
+              height: min(networkSymbolLength, maxNetworkSymbolLength ?? networkSymbolLength)
+            )
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
+        .zIndex(2)
+      }
+    }
+    .frame(
+      width: min(length, maxLength ?? length),
+      height: min(length, maxLength ?? length)
+    )
+  }
+}
+
+#if DEBUG
+struct StackedAssetIconsView_Previews: PreviewProvider {
+  static var previews: some View {
+    StackedAssetIconsView(
+      bottomToken: nil,
+      topToken: nil,
+      network: .mockSolana
+    )
+    .previewLayout(.sizeThatFits)
+  }
+}
+#endif
+
+struct GenericAssetIconView: View {
+  
+  let backgroundColor: Color
+  let iconColor: Color
+  @ScaledMetric var length: CGFloat
+  let maxLength: CGFloat?
+  
+  init(
+    backgroundColor: Color = Color(braveSystemName: .gray20),
+    iconColor: Color = Color.black,
+    length: CGFloat = 40,
+    maxLength: CGFloat? = nil
+  ) {
+    self.backgroundColor = backgroundColor
+    self.iconColor = iconColor
+    self._length = .init(wrappedValue: length)
+    self.maxLength = maxLength
+  }
+  
+  var body: some View {
+    Circle()
+      .fill(backgroundColor)
+      .frame(width: min(length, maxLength ?? length), height: min(length, maxLength ?? length))
+      .overlay {
+        Image(braveSystemName: "leo.crypto.wallets")
+          .resizable()
+          .aspectRatio(contentMode: .fit)
+          .padding(6)
+          .foregroundColor(iconColor)
+      }
   }
 }

--- a/Sources/BraveWallet/Crypto/Transaction Confirmations/SwapTransactionConfirmationView.swift
+++ b/Sources/BraveWallet/Crypto/Transaction Confirmations/SwapTransactionConfirmationView.swift
@@ -266,7 +266,7 @@ struct SwapTransactionConfirmationView_Previews: PreviewProvider {
       fromAddress: BraveWallet.AccountInfo.previewAccount.address,
       namedToAddress: "0x Exchange",
       toAddress: "0x1111111111222222222233333333334444444444",
-      networkSymbol: "ETH",
+      network: .mockMainnet,
       details: .ethSwap(.init(
         fromToken: .mockUSDCToken,
         fromValue: "1.000004",

--- a/Sources/BraveWallet/Crypto/Transactions/TransactionSummaryViews.swift
+++ b/Sources/BraveWallet/Crypto/Transactions/TransactionSummaryViews.swift
@@ -205,9 +205,17 @@ struct SendTransactionSummaryView: View {
         
         if let valueSent, let fiatValueSent {
           VStack(alignment: .trailing) {
-            Text("-\(valueSent)")
-              .font(primaryFont)
-              .foregroundColor(primaryTextColor)
+            Group {
+              if let symbol = token?.symbol {
+                Text("-\(valueSent) \(symbol)")
+                  .font(primaryFont)
+                  .foregroundColor(primaryTextColor)
+              } else {
+                Text("-\(valueSent)")
+              }
+            }
+            .font(primaryFont)
+            .foregroundColor(primaryTextColor)
             Text(fiatValueSent)
               .font(secondaryFont)
               .foregroundColor(secondaryTextColor)

--- a/Sources/BraveWallet/Crypto/Transactions/TransactionSummaryViews.swift
+++ b/Sources/BraveWallet/Crypto/Transactions/TransactionSummaryViews.swift
@@ -76,7 +76,7 @@ struct TransactionSummaryViewContainer: View {
     case .solDappTransaction:
       SendTransactionSummaryView(
         sentFromAccountName: parsedTransaction.namedFromAddress,
-        token: nil,
+        token: parsedTransaction.network.nativeToken,
         network: parsedTransaction.network,
         valueSent: nil,
         fiatValueSent: nil,
@@ -203,7 +203,7 @@ struct SendTransactionSummaryView: View {
         
         Spacer()
         
-        if let valueSent, let fiatValueSent {
+        if let valueSent {
           VStack(alignment: .trailing) {
             Group {
               if let symbol = token?.symbol {
@@ -216,7 +216,7 @@ struct SendTransactionSummaryView: View {
             }
             .font(primaryFont)
             .foregroundColor(primaryTextColor)
-            Text(fiatValueSent)
+            Text(fiatValueSent ?? "")
               .font(secondaryFont)
               .foregroundColor(secondaryTextColor)
           }

--- a/Sources/BraveWallet/Crypto/Transactions/TransactionSummaryViews.swift
+++ b/Sources/BraveWallet/Crypto/Transactions/TransactionSummaryViews.swift
@@ -512,63 +512,69 @@ struct ApprovalTransactionSummaryView: View {
 struct TransactionSummaryRow_Previews: PreviewProvider {
   static var previews: some View {
     VStack {
-      SendTransactionSummaryView(
-        sentFromAccountName: "Account 1",
-        token: .mockUSDCToken,
-        network: .mockMainnet,
-        valueSent: "37.8065",
-        fiatValueSent: "$37.80",
-        status: .unapproved,
-        time: Date()
-      )
+      Group {
+        SendTransactionSummaryView(
+          sentFromAccountName: "Account 1",
+          token: .mockUSDCToken,
+          network: .mockMainnet,
+          valueSent: "37.8065",
+          fiatValueSent: "$37.80",
+          status: .unapproved,
+          time: Date()
+        )
+        Divider()
+        SendTransactionSummaryView(
+          sentFromAccountName: "Account 1",
+          token: .mockERC721NFTToken,
+          network: .mockMainnet,
+          valueSent: nil,
+          fiatValueSent: nil,
+          status: .submitted,
+          time: Date()
+        )
+      }
       Divider()
-      SendTransactionSummaryView(
-        sentFromAccountName: "Account 1",
-        token: .mockERC721NFTToken,
-        network: .mockMainnet,
-        valueSent: nil,
-        fiatValueSent: nil,
-        status: .submitted,
-        time: Date()
-      )
+      Group {
+        SwapTransactionSummaryView(
+          swappedOnAccountName: "Account 1",
+          fromToken: .previewToken,
+          toToken: .previewDaiToken,
+          network: .mockMainnet,
+          fromValue: "0.02",
+          toValue: "189.301",
+          status: .confirmed,
+          time: Date()
+        )
+        Divider()
+        SolanaSwapTransactionSummaryView(
+          swappedOnAccountName: "Account 1",
+          network: .mockMainnet,
+          status: .error,
+          time: Date()
+        )
+      }
       Divider()
-      SwapTransactionSummaryView(
-        swappedOnAccountName: "Account 1",
-        fromToken: .previewToken,
-        toToken: .previewDaiToken,
-        network: .mockMainnet,
-        fromValue: "0.02",
-        toValue: "189.301",
-        status: .confirmed,
-        time: Date()
-      )
-      Divider()
-      SolanaSwapTransactionSummaryView(
-        swappedOnAccountName: "Account 1",
-        network: .mockMainnet,
-        status: .error,
-        time: Date()
-      )
-      Divider()
-      ApprovalTransactionSummaryView(
-        fromAccountName: "Account 1",
-        token: .previewToken,
-        network: .mockMainnet,
-        valueApproved: "Unlimited",
-        fiatValueApproved: "Unlimited",
-        status: .submitted,
-        time: Date()
-      )
-      Divider()
-      ApprovalTransactionSummaryView(
-        fromAccountName: "Account 1",
-        token: .mockUSDCToken,
-        network: .mockMainnet,
-        valueApproved: "1",
-        fiatValueApproved: "$1,500",
-        status: .submitted,
-        time: Date()
-      )
+      Group {
+        ApprovalTransactionSummaryView(
+          fromAccountName: "Account 1",
+          token: .previewToken,
+          network: .mockMainnet,
+          valueApproved: "Unlimited",
+          fiatValueApproved: "Unlimited",
+          status: .submitted,
+          time: Date()
+        )
+        Divider()
+        ApprovalTransactionSummaryView(
+          fromAccountName: "Account 1",
+          token: .mockUSDCToken,
+          network: .mockMainnet,
+          valueApproved: "1",
+          fiatValueApproved: "$1,500",
+          status: .submitted,
+          time: Date()
+        )
+      }
     }
     .previewLayout(.sizeThatFits)
   }

--- a/Sources/BraveWallet/Crypto/Transactions/TransactionSummaryViews.swift
+++ b/Sources/BraveWallet/Crypto/Transactions/TransactionSummaryViews.swift
@@ -84,7 +84,15 @@ struct TransactionSummaryViewContainer: View {
         time: parsedTransaction.transaction.createdTime
       )
     case .other:
-      EmptyView()
+      SendTransactionSummaryView(
+        sentFromAccountName: parsedTransaction.namedFromAddress,
+        token: nil,
+        network: parsedTransaction.network,
+        valueSent: nil,
+        fiatValueSent: nil,
+        status: parsedTransaction.transaction.txStatus,
+        time: parsedTransaction.transaction.createdTime
+      )
     }
   }
 }

--- a/Sources/BraveWallet/Crypto/Transactions/TransactionSummaryViews.swift
+++ b/Sources/BraveWallet/Crypto/Transactions/TransactionSummaryViews.swift
@@ -1,0 +1,496 @@
+/* Copyright 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import BraveCore
+import SwiftUI
+
+struct TransactionSummaryViewContainer: View {
+  
+  let parsedTransaction: ParsedTransaction
+  
+  var body: some View { // TODO: tx statuses?
+    switch parsedTransaction.details {
+    case .ethSend(let details),
+      .erc20Transfer(let details),
+      .solSystemTransfer(let details),
+      .solSplTokenTransfer(let details):
+      SendTransactionSummaryView(
+        sentFromAccountName: parsedTransaction.namedFromAddress,
+        token: details.fromToken,
+        network: parsedTransaction.network,
+        valueSent: details.fromAmount,
+        fiatValueSent: details.fromFiat ?? "",
+        time: parsedTransaction.transaction.createdTime
+      )
+    case .filSend(let details):
+      SendTransactionSummaryView(
+        sentFromAccountName: parsedTransaction.namedFromAddress,
+        token: details.sendToken,
+        network: parsedTransaction.network,
+        valueSent: details.sendAmount,
+        fiatValueSent: details.sendFiat ?? "",
+        time: parsedTransaction.transaction.createdTime
+      )
+    case .ethSwap(let details):
+      SwapTransactionSummaryView(
+        swappedOnAccountName: parsedTransaction.namedFromAddress,
+        fromToken: details.fromToken,
+        toToken: details.toToken,
+        network: parsedTransaction.network,
+        fromValue: details.fromAmount,
+        toValue: details.minBuyAmount,
+        time: parsedTransaction.transaction.createdTime
+      )
+    case .solSwapTransaction:
+      SolanaSwapTransactionSummaryView(
+        swappedOnAccountName: parsedTransaction.namedFromAddress,
+        network: parsedTransaction.network,
+        time: parsedTransaction.transaction.createdTime
+      )
+    case .ethErc20Approve(let details):
+      ApprovalTransactionSummaryView(
+        fromAccountName: parsedTransaction.namedFromAddress,
+        token: details.token,
+        network: parsedTransaction.network,
+        valueApproved: details.approvalAmount,
+        fiatValueApproved: details.approvalFiat,
+        time: parsedTransaction.transaction.createdTime
+      )
+    case .erc721Transfer(let details):
+      SendTransactionSummaryView(
+        sentFromAccountName: parsedTransaction.namedFromAddress,
+        token: details.fromToken,
+        network: parsedTransaction.network,
+        valueSent: nil,
+        fiatValueSent: nil,
+        time: parsedTransaction.transaction.createdTime
+      )
+    case .solDappTransaction:
+      SendTransactionSummaryView(
+        sentFromAccountName: parsedTransaction.namedFromAddress,
+        token: nil,
+        network: parsedTransaction.network,
+        valueSent: nil,
+        fiatValueSent: nil,
+        time: parsedTransaction.transaction.createdTime
+      )
+    case .other:
+      EmptyView()
+    }
+  }
+}
+
+struct SendTransactionSummaryView: View {
+  
+  let sentFromAccountName: String
+  let token: BraveWallet.BlockchainToken?
+  let network: BraveWallet.NetworkInfo
+  let valueSent: String?
+  let fiatValueSent: String?
+  let time: Date
+  
+  init(
+    sentFromAccountName: String,
+    token: BraveWallet.BlockchainToken?,
+    network: BraveWallet.NetworkInfo,
+    valueSent: String?,
+    fiatValueSent: String?,
+    time: Date
+  ) {
+    self.sentFromAccountName = sentFromAccountName
+    self.token = token
+    self.network = network
+    self.valueSent = valueSent
+    self.fiatValueSent = fiatValueSent
+    self.time = time
+  }
+  
+  private let primaryFont: Font = .callout.weight(.semibold)
+  private let primaryTextColor = Color(braveSystemName: .textPrimary)
+  private let secondaryFont: Font = .footnote
+  private let secondaryTextColor = Color(braveSystemName: .textTertiary)
+  
+  @ScaledMetric private var length: CGFloat = 32
+  private let maxLength: CGFloat = 48
+  @ScaledMetric private var networkSymbolLength: CGFloat = 15
+  private let maxNetworkSymbolLength: CGFloat = 30
+  
+  var body: some View {
+    VStack {
+      HStack { // header
+        Text(time, style: .time)
+        Image(braveSystemName: "leo.send")
+          .imageScale(.small)
+          .foregroundColor(Color(braveSystemName: .iconDefault))
+        Text("Send from ") + Text(sentFromAccountName).bold()
+      }
+      .font(secondaryFont)
+      .foregroundColor(secondaryTextColor)
+      .frame(maxWidth: .infinity, alignment: .leading)
+      
+      HStack {
+        if let token {
+          if token.isNft || token.isErc721 {
+            NFTIconView(
+              token: token,
+              network: network,
+              url: nil,
+              shouldShowNetworkIcon: true,
+              length: length,
+              maxLength: maxLength,
+              tokenLogoLength: networkSymbolLength,
+              maxTokenLogoLength: maxNetworkSymbolLength
+            )
+          } else {
+            AssetIconView(
+              token: token,
+              network: network,
+              shouldShowNetworkIcon: true,
+              length: length,
+              maxLength: maxLength,
+              networkSymbolLength: networkSymbolLength,
+              maxNetworkSymbolLength: maxNetworkSymbolLength
+            )
+          }
+        } else {
+          GenericAssetIconView(
+            length: length,
+            maxLength: maxLength
+          )
+        }
+        VStack(alignment: .leading) {
+          Text(token?.name ?? "")
+            .font(primaryFont)
+            .foregroundColor(primaryTextColor)
+          Text(token?.symbol ?? "")
+            .font(secondaryFont)
+            .foregroundColor(secondaryTextColor)
+        }
+        
+        Spacer()
+        
+        if let valueSent, let fiatValueSent {
+          VStack(alignment: .trailing) {
+            Text("-\(valueSent)")
+              .font(primaryFont)
+              .foregroundColor(primaryTextColor)
+            Text(fiatValueSent)
+              .font(secondaryFont)
+              .foregroundColor(secondaryTextColor)
+          }
+          .multilineTextAlignment(.trailing)
+        }
+      }
+    }
+    .multilineTextAlignment(.leading)
+    .padding(8)
+    .frame(maxWidth: .infinity)
+  }
+}
+
+struct SwapTransactionSummaryView: View {
+  
+  let swappedOnAccountName: String
+  let fromToken: BraveWallet.BlockchainToken?
+  let toToken: BraveWallet.BlockchainToken?
+  let network: BraveWallet.NetworkInfo
+  let fromValue: String
+  let toValue: String
+  let time: Date
+  
+  init(
+    swappedOnAccountName: String,
+    fromToken: BraveWallet.BlockchainToken?,
+    toToken: BraveWallet.BlockchainToken?,
+    network: BraveWallet.NetworkInfo,
+    fromValue: String,
+    toValue: String,
+    time: Date
+  ) {
+    self.swappedOnAccountName = swappedOnAccountName
+    self.fromToken = fromToken
+    self.toToken = toToken
+    self.network = network
+    self.fromValue = fromValue
+    self.toValue = toValue
+    self.time = time
+  }
+  
+  private let primaryFont: Font = .callout.weight(.semibold)
+  private let primaryTextColor = Color(braveSystemName: .textPrimary)
+  private let secondaryFont: Font = .footnote
+  private let secondaryTextColor = Color(braveSystemName: .textTertiary)
+  
+  @ScaledMetric private var length: CGFloat = 32
+  private let maxLength: CGFloat = 48
+  @ScaledMetric private var networkSymbolLength: CGFloat = 15
+  private let maxNetworkSymbolLength: CGFloat = 30
+  
+  var body: some View {
+    VStack {
+      HStack { // header
+        Text(time, style: .time)
+        Image(braveSystemName: "leo.currency.exchange")
+          .imageScale(.small)
+          .foregroundColor(Color(braveSystemName: .iconDefault))
+        Text("Swap on ") + Text(swappedOnAccountName).bold()
+      }
+      .font(secondaryFont)
+      .foregroundColor(secondaryTextColor)
+      .frame(maxWidth: .infinity, alignment: .leading)
+      
+      HStack {
+        StackedAssetIconsView(
+          bottomToken: fromToken,
+          topToken: toToken,
+          network: network,
+          length: length,
+          maxLength: maxLength,
+          networkSymbolLength: networkSymbolLength,
+          maxNetworkSymbolLength: maxNetworkSymbolLength
+        )
+        HStack {
+          Text(fromToken?.symbol ?? "")
+            .font(primaryFont)
+          Image(braveSystemName: "leo.carat.right")
+            .resizable()
+            .aspectRatio(contentMode: .fit)
+            .padding(4)
+            .frame(width: 16, height: 16)
+            .foregroundColor(Color(braveSystemName: .iconDefault))
+            .background(Color(braveSystemName: .containerHighlight).clipShape(Circle()))
+          Text(toToken?.symbol ?? "")
+            .font(primaryFont)
+        }
+        .foregroundColor(primaryTextColor)
+        
+        Spacer()
+        
+        VStack(alignment: .trailing) {
+          Text("-\(fromValue) \(fromToken?.symbol ?? "")")
+            .font(secondaryFont)
+            .foregroundColor(secondaryTextColor)
+          Text("+\(toValue) \(toToken?.symbol ?? "")")
+            .font(primaryFont)
+            .foregroundColor(primaryTextColor)
+        }
+        .multilineTextAlignment(.trailing)
+      }
+    }
+    .multilineTextAlignment(.leading)
+    .padding(8)
+    .frame(maxWidth: .infinity)
+  }
+}
+
+struct SolanaSwapTransactionSummaryView: View {
+  
+  let swappedOnAccountName: String
+  let network: BraveWallet.NetworkInfo
+  let time: Date
+  
+  init(
+    swappedOnAccountName: String,
+    network: BraveWallet.NetworkInfo,
+    time: Date
+  ) {
+    self.swappedOnAccountName = swappedOnAccountName
+    self.network = network
+    self.time = time
+  }
+  
+  private let primaryFont: Font = .callout.weight(.semibold)
+  private let primaryTextColor = Color(braveSystemName: .textPrimary)
+  private let secondaryFont: Font = .footnote
+  private let secondaryTextColor = Color(braveSystemName: .textTertiary)
+  
+  @ScaledMetric private var length: CGFloat = 32
+  private let maxLength: CGFloat = 48
+  @ScaledMetric private var networkSymbolLength: CGFloat = 15
+  private let maxNetworkSymbolLength: CGFloat = 30
+  
+  var body: some View {
+    VStack {
+      HStack { // header
+        Text(time, style: .time)
+        Image(braveSystemName: "leo.currency.exchange")
+          .imageScale(.small)
+          .foregroundColor(Color(braveSystemName: .iconDefault))
+        Text("Swap on ") + Text(swappedOnAccountName).bold()
+      }
+      .font(secondaryFont)
+      .foregroundColor(secondaryTextColor)
+      .frame(maxWidth: .infinity, alignment: .leading)
+      
+      HStack {
+        StackedAssetIconsView(
+          bottomToken: nil,
+          topToken: nil,
+          network: network,
+          length: length,
+          maxLength: maxLength,
+          networkSymbolLength: networkSymbolLength,
+          maxNetworkSymbolLength: maxNetworkSymbolLength
+        )
+        HStack {
+          Text("Solana Swap")
+            .font(primaryFont)
+        }
+        .foregroundColor(primaryTextColor)
+        
+        Spacer()
+      }
+    }
+    .multilineTextAlignment(.leading)
+    .padding(.horizontal, 8)
+    .padding(.vertical, 10)
+    .frame(maxWidth: .infinity)
+  }
+}
+
+struct ApprovalTransactionSummaryView: View {
+  
+  let fromAccountName: String
+  let token: BraveWallet.BlockchainToken?
+  let network: BraveWallet.NetworkInfo
+  let valueApproved: String
+  let fiatValueApproved: String
+  let time: Date
+  
+  init(
+    fromAccountName: String,
+    token: BraveWallet.BlockchainToken?,
+    network: BraveWallet.NetworkInfo,
+    valueApproved: String,
+    fiatValueApproved: String,
+    time: Date
+  ) {
+    self.fromAccountName = fromAccountName
+    self.token = token
+    self.network = network
+    self.valueApproved = valueApproved
+    self.fiatValueApproved = fiatValueApproved
+    self.time = time
+  }
+  
+  private let primaryFont: Font = .callout.weight(.semibold)
+  private let primaryTextColor = Color(braveSystemName: .textPrimary)
+  private let secondaryFont: Font = .footnote
+  private let secondaryTextColor = Color(braveSystemName: .textTertiary)
+  
+  @ScaledMetric private var length: CGFloat = 32
+  private let maxLength: CGFloat = 48
+  @ScaledMetric private var networkSymbolLength: CGFloat = 15
+  private let maxNetworkSymbolLength: CGFloat = 30
+  
+  var body: some View {
+    VStack {
+      HStack { // header
+        Text(time, style: .time)
+        Image(braveSystemName: "leo.check.normal")
+          .imageScale(.small)
+          .foregroundColor(Color(braveSystemName: .iconDefault))
+        Text("Approved from ") + Text(fromAccountName).bold()
+      }
+      .font(secondaryFont)
+      .foregroundColor(secondaryTextColor)
+      .frame(maxWidth: .infinity, alignment: .leading)
+      
+      HStack {
+        if let token {
+          AssetIconView(
+            token: token,
+            network: network,
+            shouldShowNetworkIcon: true,
+            length: length,
+            maxLength: maxLength,
+            networkSymbolLength: networkSymbolLength,
+            maxNetworkSymbolLength: maxNetworkSymbolLength
+          )
+        } else {
+          GenericAssetIconView(
+            length: length,
+            maxLength: maxLength
+          )
+        }
+        VStack(alignment: .leading) {
+          Text(token?.name ?? "")
+            .font(primaryFont)
+            .foregroundColor(primaryTextColor)
+          Text(token?.symbol ?? "")
+            .font(secondaryFont)
+            .foregroundColor(secondaryTextColor)
+        }
+        
+        Spacer()
+        
+        VStack(alignment: .trailing) {
+          Text(valueApproved)
+            .font(primaryFont)
+            .foregroundColor(primaryTextColor)
+          Text(fiatValueApproved)
+            .font(secondaryFont)
+            .foregroundColor(secondaryTextColor)
+        }
+        .multilineTextAlignment(.trailing)
+      }
+    }
+    .multilineTextAlignment(.leading)
+    .padding(8)
+    .frame(maxWidth: .infinity)
+  }
+}
+
+#if DEBUG
+struct TransactionSummaryViews_Previews: PreviewProvider {
+  static var previews: some View {
+    VStack {
+      SendTransactionSummaryView(
+        sentFromAccountName: "Account 1",
+        token: .mockUSDCToken,
+        network: .mockMainnet,
+        valueSent: "37.8065",
+        fiatValueSent: "$37.80",
+        time: Date()
+      )
+      Divider()
+      SendTransactionSummaryView(
+        sentFromAccountName: "Account 1",
+        token: .mockERC721NFTToken,
+        network: .mockMainnet,
+        valueSent: nil,
+        fiatValueSent: nil,
+        time: Date()
+      )
+      Divider()
+      SwapTransactionSummaryView(
+        swappedOnAccountName: "Account 1",
+        fromToken: .previewToken,
+        toToken: .previewDaiToken,
+        network: .mockMainnet,
+        fromValue: "0.02",
+        toValue: "189.301",
+        time: Date()
+      )
+      Divider()
+      SolanaSwapTransactionSummaryView(
+        swappedOnAccountName: "Account 1",
+        network: .mockMainnet,
+        time: Date()
+      )
+      Divider()
+      ApprovalTransactionSummaryView(
+        fromAccountName: "Account 1",
+        token: .previewToken,
+        network: .mockMainnet,
+        valueApproved: "Unlimited",
+        fiatValueApproved: "Unlimited",
+        time: Date()
+      )
+    }
+    .previewLayout(.sizeThatFits)
+  }
+}
+#endif

--- a/Sources/BraveWallet/Crypto/Transactions/TransactionSummaryViews.swift
+++ b/Sources/BraveWallet/Crypto/Transactions/TransactionSummaryViews.swift
@@ -135,6 +135,13 @@ struct SendTransactionSummaryView: View {
   @ScaledMetric private var networkSymbolLength: CGFloat = 15
   private let maxNetworkSymbolLength: CGFloat = 30
   
+  private var sendTitle: String {
+    String.localizedStringWithFormat(
+      Strings.Wallet.transactionSummaryIntentLabel,
+      Strings.Wallet.sent
+    )
+  }
+  
   var body: some View {
     VStack {
       HStack { // header
@@ -142,7 +149,7 @@ struct SendTransactionSummaryView: View {
         Image(braveSystemName: "leo.send")
           .imageScale(.small)
           .foregroundColor(Color(braveSystemName: .iconDefault))
-        Text("Send from ") + Text(sentFromAccountName).bold()
+        Text(sendTitle) + Text(" " + sentFromAccountName).bold()
       }
       .font(secondaryFont)
       .foregroundColor(secondaryTextColor)
@@ -263,7 +270,7 @@ struct SwapTransactionSummaryView: View {
         Image(braveSystemName: "leo.currency.exchange")
           .imageScale(.small)
           .foregroundColor(Color(braveSystemName: .iconDefault))
-        Text("Swap on ") + Text(swappedOnAccountName).bold()
+        Text(Strings.Wallet.transactionSummarySwapOn) + Text(" " + swappedOnAccountName).bold()
       }
       .font(secondaryFont)
       .foregroundColor(secondaryTextColor)
@@ -354,7 +361,7 @@ struct SolanaSwapTransactionSummaryView: View {
         Image(braveSystemName: "leo.currency.exchange")
           .imageScale(.small)
           .foregroundColor(Color(braveSystemName: .iconDefault))
-        Text("Swap on ") + Text(swappedOnAccountName).bold()
+        Text(Strings.Wallet.transactionSummarySwapOn) + Text(" " + swappedOnAccountName).bold()
       }
       .font(secondaryFont)
       .foregroundColor(secondaryTextColor)
@@ -376,7 +383,7 @@ struct SolanaSwapTransactionSummaryView: View {
           }
         }
         HStack {
-          Text("Solana Swap")
+          Text(Strings.Wallet.transactionSummarySolanaSwap)
             .font(primaryFont)
         }
         .foregroundColor(primaryTextColor)
@@ -429,6 +436,13 @@ struct ApprovalTransactionSummaryView: View {
   @ScaledMetric private var networkSymbolLength: CGFloat = 15
   private let maxNetworkSymbolLength: CGFloat = 30
   
+  private var approvedTitle: String {
+    String.localizedStringWithFormat(
+      Strings.Wallet.transactionSummaryIntentLabel,
+      Strings.Wallet.transactionTypeApprove
+    )
+  }
+  
   var body: some View {
     VStack {
       HStack { // header
@@ -436,7 +450,7 @@ struct ApprovalTransactionSummaryView: View {
         Image(braveSystemName: "leo.check.normal")
           .imageScale(.small)
           .foregroundColor(Color(braveSystemName: .iconDefault))
-        Text("Approved from ") + Text(fromAccountName).bold()
+        Text(approvedTitle) + Text(" " + fromAccountName).bold()
       }
       .font(secondaryFont)
       .foregroundColor(secondaryTextColor)
@@ -542,6 +556,16 @@ struct TransactionSummaryRow_Previews: PreviewProvider {
         network: .mockMainnet,
         valueApproved: "Unlimited",
         fiatValueApproved: "Unlimited",
+        status: .submitted,
+        time: Date()
+      )
+      Divider()
+      ApprovalTransactionSummaryView(
+        fromAccountName: "Account 1",
+        token: .mockUSDCToken,
+        network: .mockMainnet,
+        valueApproved: "1",
+        fiatValueApproved: "$1,500",
         status: .submitted,
         time: Date()
       )

--- a/Sources/BraveWallet/Crypto/Transactions/TransactionsListView.swift
+++ b/Sources/BraveWallet/Crypto/Transactions/TransactionsListView.swift
@@ -1,0 +1,181 @@
+/* Copyright 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import BraveCore
+import SwiftUI
+
+struct TransactionSection: Equatable, Identifiable {
+  var id: Date { date }
+  let date: Date
+  
+  let transactions: [ParsedTransaction]
+}
+
+/// List of transactions separated by date with a search bar and filter button.
+/// Used in Activity tab, Asset Details (#8137), etc.
+struct TransactionsListView: View {
+  
+  /// All `TransactionSection` items, unfiltered.
+  let transactionSections: [TransactionSection]
+  /// Query displayed in the search bar above the transactions.
+  @Binding var query: String
+  /// Called when the filters button beside the search bar is tapped/
+  let filtersButtonTapped: () -> Void
+  /// Called when a transaction is tapped.
+  let transactionTapped: (BraveWallet.TransactionInfo) -> Void
+  
+  /// Returns `transactionSections` filtered using the `filter` value.
+  var filteredTransactionSections: [TransactionSection] {
+    if query.isEmpty {
+      return transactionSections
+    }
+    return transactionSections.compactMap { transactionSection in
+      // check for transactions matching `filter`
+      let filteredTransactions = transactionSection.transactions.filter { parsedTransaction in
+        parsedTransaction.matches(query)
+      }
+      if filteredTransactions.isEmpty {
+        // don't return section if no transactions
+        return nil
+      }
+      return TransactionSection(date: transactionSection.date, transactions: filteredTransactions)
+    }
+  }
+  
+  var body: some View {
+    ScrollView {
+      LazyVStack(pinnedViews: [.sectionHeaders]) { // pin search bar + filters
+        Section(content: {
+          LazyVStack { // don't pin date headers
+            if filteredTransactionSections.isEmpty {
+              emptyState
+                .listRowBackground(Color.clear)
+            } else {
+              ForEach(filteredTransactionSections) { section in
+                Section(content: {
+                  ForEach(section.transactions, id: \.transaction.id) { parsedTransaction in
+                    Button(action: {
+                      transactionTapped(parsedTransaction.transaction)
+                    }) {
+                      TransactionSummaryViewContainer(
+                        parsedTransaction: parsedTransaction
+                      )
+                    }
+                    .listRowInsets(.zero)
+                  }
+                }, header: {
+                  Text(section.date, style: .date)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundColor(Color(braveSystemName: .textTertiary))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                })
+              }
+            }
+          }
+          .padding(.horizontal)
+        }, header: {
+          searchBarAndFiltersContainer
+        })
+      }
+    }
+    .background(Color(braveSystemName: .containerBackground))
+  }
+  
+  private var searchBarAndFiltersContainer: some View {
+    VStack(spacing: 0) {
+      HStack(spacing: 10) {
+        SearchBar(text: $query, placeholder: "Search")
+        AssetButton(braveSystemName: "leo.filter.settings", action: filtersButtonTapped)
+      }
+      .padding(.vertical, 8)
+      Divider()
+    }
+    .padding(.horizontal, 8)
+    .frame(maxWidth: .infinity)
+    .background(Color(braveSystemName: .containerBackground))
+  }
+  
+  private var emptyState: some View {
+    VStack(alignment: .center, spacing: 10) {
+      Text(Strings.Wallet.activityPageEmptyTitle)
+        .font(.headline.weight(.semibold))
+        .foregroundColor(Color(.braveLabel))
+      Text(Strings.Wallet.activityPageEmptyDescription)
+        .font(.subheadline.weight(.semibold))
+        .foregroundColor(Color(.secondaryLabel))
+    }
+    .multilineTextAlignment(.center)
+    .frame(maxWidth: .infinity)
+    .padding(.vertical, 60)
+    .padding(.horizontal, 32)
+  }
+}
+
+private struct SearchBar: UIViewRepresentable {
+  
+  @Binding var text: String
+  var placeholder = ""
+  
+  func makeUIView(context: Context) -> UISearchBar {
+    let searchBar = UISearchBar(frame: .zero)
+    searchBar.text = text
+    searchBar.placeholder = placeholder
+    // remove black divider lines above/below field
+    searchBar.searchBarStyle = .minimal
+    // don't disable 'Search' when field empty
+    searchBar.enablesReturnKeyAutomatically = false
+    return searchBar
+  }
+  
+  func updateUIView(_ uiView: UISearchBar, context: Context) {
+    uiView.text = text
+    uiView.placeholder = placeholder
+    uiView.delegate = context.coordinator
+  }
+  
+  func makeCoordinator() -> Coordinator {
+    Coordinator(text: $text)
+  }
+  
+  class Coordinator: NSObject, UISearchBarDelegate {
+    @Binding var text: String
+    
+    init(text: Binding<String>) {
+      _text = text
+    }
+    
+    func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
+      text = searchText
+    }
+    
+    func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
+      // dismiss keyboard when 'Search' / return key tapped
+      searchBar.resignFirstResponder()
+    }
+  }
+}
+
+#if DEBUG
+struct TransactionsListView_Previews: PreviewProvider {
+  @State private static var query: String = ""
+  static var previews: some View {
+    TransactionsListView(
+      transactionSections: [
+        .init(
+          date: Date(),
+          transactions: [
+            .previewConfirmedSend,
+            .previewConfirmedSwap,
+            .previewConfirmedERC20Approve
+          ].compactMap { $0 }
+        )
+      ],
+      query: $query,
+      filtersButtonTapped: {},
+      transactionTapped: { _ in }
+    )
+  }
+}
+#endif

--- a/Sources/BraveWallet/Crypto/Transactions/TransactionsListView.swift
+++ b/Sources/BraveWallet/Crypto/Transactions/TransactionsListView.swift
@@ -86,7 +86,7 @@ struct TransactionsListView: View {
   private var searchBarAndFiltersContainer: some View {
     VStack(spacing: 0) {
       HStack(spacing: 10) {
-        SearchBar(text: $query, placeholder: "Search")
+        SearchBar(text: $query, placeholder: Strings.Wallet.search)
         AssetButton(braveSystemName: "leo.filter.settings", action: filtersButtonTapped)
       }
       .padding(.vertical, 8)

--- a/Sources/BraveWallet/Crypto/TransactionsActivityView.swift
+++ b/Sources/BraveWallet/Crypto/TransactionsActivityView.swift
@@ -14,14 +14,19 @@ struct TransactionsActivityView: View {
   @State private var isPresentingNetworkFilter = false
   @State private var transactionDetails: TransactionDetailsStore?
   
-  private var networkFilterButton: some View {
-    Button(action: {
-      self.isPresentingNetworkFilter = true
-    }) {
-      Image(braveSystemName: "leo.tune")
-        .font(.footnote.weight(.medium))
-        .foregroundColor(Color(.braveBlurpleTint))
-        .clipShape(Rectangle())
+  var body: some View {
+    TransactionsListView(
+      transactionSections: store.transactionSections,
+      query: $store.query,
+      filtersButtonTapped: {
+        isPresentingNetworkFilter = true
+      },
+      transactionTapped: {
+        transactionDetails = store.transactionDetailsStore(for: $0)
+      }
+    )
+    .onAppear {
+      store.update()
     }
     .sheet(isPresented: $isPresentingNetworkFilter) {
       NavigationView {
@@ -38,41 +43,6 @@ struct TransactionsActivityView: View {
         networkStore.closeNetworkSelectionStore()
       }
     }
-  }
-  
-  var body: some View {
-    List {
-      Section {
-        if store.transactionSummaries.isEmpty {
-          emptyState
-            .listRowBackground(Color.clear)
-        } else {
-          Group {
-            ForEach(store.transactionSummaries) { txSummary in
-              Button(action: {
-                self.transactionDetails = store.transactionDetailsStore(for: txSummary.txInfo)
-              }) {
-                TransactionSummaryView(summary: txSummary)
-              }
-            }
-          }
-          .listRowBackground(Color(.secondaryBraveGroupedBackground))
-        }
-      } header: {
-        HStack {
-          Text(Strings.Wallet.assetsTitle)
-          Spacer()
-          networkFilterButton
-        }
-        .textCase(nil)
-        .padding(.horizontal, -8)
-        .frame(maxWidth: .infinity, alignment: .leading)
-      }
-    }
-    .listBackgroundColor(Color(UIColor.braveGroupedBackground))
-    .onAppear {
-      store.update()
-    }
     .sheet(
       isPresented: Binding(
         get: { self.transactionDetails != nil },
@@ -87,25 +57,10 @@ struct TransactionsActivityView: View {
       }
     }
   }
-  
-  private var emptyState: some View {
-    VStack(alignment: .center, spacing: 10) {
-      Text(Strings.Wallet.activityPageEmptyTitle)
-        .font(.headline.weight(.semibold))
-        .foregroundColor(Color(.braveLabel))
-      Text(Strings.Wallet.activityPageEmptyDescription)
-        .font(.subheadline.weight(.semibold))
-        .foregroundColor(Color(.secondaryLabel))
-    }
-    .multilineTextAlignment(.center)
-    .frame(maxWidth: .infinity)
-    .padding(.vertical, 60)
-    .padding(.horizontal, 32)
-  }
 }
 
 #if DEBUG
-struct TransactionsActivityViewView_Previews: PreviewProvider {
+struct TransactionsActivityView_Previews: PreviewProvider {
   static var previews: some View {
     TransactionsActivityView(
       store: .preview,

--- a/Sources/BraveWallet/Extensions/BraveWalletExtensions.swift
+++ b/Sources/BraveWallet/Extensions/BraveWalletExtensions.swift
@@ -293,6 +293,23 @@ extension BraveWallet.BlockchainToken {
       return name
     }
   }
+  
+  /// Returns the local image asset for the `BlockchainToken`.
+  func localImage(network: BraveWallet.NetworkInfo) -> UIImage? {
+    if network.isNativeAsset(self), let uiImage = network.nativeTokenLogoImage {
+      return uiImage
+    }
+    
+    for logo in [logo, symbol.lowercased()] {
+      if let baseURL = BraveWallet.TokenRegistryUtils.tokenLogoBaseURL,
+         case let imageURL = baseURL.appendingPathComponent(logo),
+         let image = UIImage(contentsOfFile: imageURL.path) {
+        return image
+      }
+    }
+    
+    return nil
+  }
 }
 
 extension BraveWallet.OnRampProvider {

--- a/Sources/BraveWallet/Preview Content/MockContent.swift
+++ b/Sources/BraveWallet/Preview Content/MockContent.swift
@@ -437,6 +437,26 @@ extension TransactionSummary {
   }
 }
 
+extension ParsedTransaction {
+  
+  static var previewConfirmedSend = previewParsedTransaction(from: .previewConfirmedSend)
+  static var previewConfirmedSwap = previewParsedTransaction(from: .previewConfirmedSwap)
+  static var previewConfirmedERC20Approve = previewParsedTransaction(from: .previewConfirmedERC20Approve)
+
+  static func previewParsedTransaction(from txInfo: BraveWallet.TransactionInfo) -> Self? {
+    TransactionParser.parseTransaction(
+      transaction: txInfo,
+      network: .mockMainnet,
+      accountInfos: [.previewAccount],
+      userAssets: [.previewToken, .previewDaiToken],
+      allTokens: [],
+      assetRatios: [BraveWallet.BlockchainToken.previewToken.assetRatioId.lowercased(): 1],
+      solEstimatedTxFee: nil,
+      currencyFormatter: .usdCurrencyFormatter
+    )
+  }
+}
+
 extension BraveWallet.CoinMarket {
   static var mockCoinMarketBitcoin: BraveWallet.CoinMarket {
     .init(

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -1563,8 +1563,8 @@ extension Strings {
       value: "Approved %@ %@",
       comment: "The title shown for ERC20 approvals. The first '%@' becomes the  amount, the second '%@' becomes the symbol for the cryptocurrency. For example: \"Approved 150.0 BAT\""
     )
-    public static let transactionUnknownApprovalTitle = NSLocalizedString(
-      "wallet.transactionUnknownApprovalTitle",
+    public static let transactionApprovalTitle = NSLocalizedString(
+      "wallet.transactionApprovalTitle",
       tableName: "BraveWallet",
       bundle: .module,
       value: "Approved",
@@ -4751,6 +4751,34 @@ extension Strings {
       bundle: .module,
       value: "Details",
       comment: "The title of the details view for Sign In With Ethereum/Brave Wallet requests."
+    )
+    public static let transactionSummaryIntentLabel = NSLocalizedString(
+      "wallet.transactionSummarySendType",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "%@ from",
+      comment: "The label used to describe a transaction type. Used like 'Send from' or 'Approved from'."
+    )
+    public static let transactionSummarySwapOn = NSLocalizedString(
+      "wallet.transactionSummarySwapOn",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Swap on",
+      comment: "The label to describe an Swap transaction."
+    )
+    public static let transactionSummarySolanaSwap = NSLocalizedString(
+      "wallet.transactionSummarySolanaSwap",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Solana Swap",
+      comment: "The label to describe an Solana Swap transaction."
+    )
+    public static let search = NSLocalizedString(
+      "wallet.search",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Search",
+      comment: "The label as a placeholder in search fields."
     )
   }
 }

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -4753,7 +4753,7 @@ extension Strings {
       comment: "The title of the details view for Sign In With Ethereum/Brave Wallet requests."
     )
     public static let transactionSummaryIntentLabel = NSLocalizedString(
-      "wallet.transactionSummarySendType",
+      "wallet.transactionSummaryIntentLabel",
       tableName: "BraveWallet",
       bundle: .module,
       value: "%@ from",

--- a/Sources/DesignSystem/Icons/Symbols.xcassets/leo.carat.right.symbolset/Contents.json
+++ b/Sources/DesignSystem/Icons/Symbols.xcassets/leo.carat.right.symbolset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "symbols" : [
+    {
+      "idiom" : "universal"
+    }
+  ]
+}

--- a/Sources/DesignSystem/Icons/Symbols.xcassets/leo.crypto.wallets.symbolset/Contents.json
+++ b/Sources/DesignSystem/Icons/Symbols.xcassets/leo.crypto.wallets.symbolset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "symbols" : [
+    {
+      "idiom" : "universal"
+    }
+  ]
+}

--- a/Sources/DesignSystem/Icons/Symbols.xcassets/leo.loading.spinner.symbolset/Contents.json
+++ b/Sources/DesignSystem/Icons/Symbols.xcassets/leo.loading.spinner.symbolset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "symbols" : [
+    {
+      "idiom" : "universal"
+    }
+  ]
+}

--- a/Tests/BraveWalletTests/TransactionParserTests.swift
+++ b/Tests/BraveWalletTests/TransactionParserTests.swift
@@ -124,7 +124,7 @@ class TransactionParserTests: XCTestCase {
       fromAddress: accountInfos[0].address,
       namedToAddress: "Ethereum Account 2",
       toAddress: "0x0987654321098765432109876543210987654321",
-      networkSymbol: "ETH",
+      network: .mockMainnet,
       details: .ethSend(
         .init(
           fromToken: network.nativeToken,
@@ -219,7 +219,7 @@ class TransactionParserTests: XCTestCase {
       fromAddress: accountInfos[0].address,
       namedToAddress: "Ethereum Account 2",
       toAddress: "0x0987654321098765432109876543210987654321",
-      networkSymbol: "ETH",
+      network: .mockMainnet,
       details: .erc20Transfer(
         .init(
           fromToken: .previewDaiToken,
@@ -305,7 +305,7 @@ class TransactionParserTests: XCTestCase {
       fromAddress: accountInfos[0].address,
       namedToAddress: "0x Exchange Proxy",
       toAddress: "0xDef1C0ded9bec7F1a1670819833240f027b25EfF",
-      networkSymbol: "ETH",
+      network: .mockMainnet,
       details: .ethSwap(
         .init(
           fromToken: .previewToken,
@@ -395,7 +395,7 @@ class TransactionParserTests: XCTestCase {
       fromAddress: accountInfos[0].address,
       namedToAddress: "0x Exchange Proxy",
       toAddress: "0xDef1C0ded9bec7F1a1670819833240f027b25EfF",
-      networkSymbol: "ETH",
+      network: .mockMainnet,
       details: .ethSwap(
         .init(
           fromToken: .mockUSDCToken,
@@ -481,13 +481,14 @@ class TransactionParserTests: XCTestCase {
       fromAddress: accountInfos[0].address,
       namedToAddress: BraveWallet.BlockchainToken.previewDaiToken.contractAddress.truncatedAddress,
       toAddress: BraveWallet.BlockchainToken.previewDaiToken.contractAddress,
-      networkSymbol: "ETH",
+      network: .mockMainnet,
       details: .ethErc20Approve(
         .init(
           token: .previewDaiToken,
           tokenContractAddress: BraveWallet.BlockchainToken.previewDaiToken.contractAddress,
           approvalValue: "0x2386f26fc10000",
           approvalAmount: "0.01",
+          approvalFiat: "$0.02",
           isUnlimited: false,
           spenderAddress: "",
           gasFee: .init(
@@ -565,13 +566,14 @@ class TransactionParserTests: XCTestCase {
       fromAddress: accountInfos[0].address,
       namedToAddress: BraveWallet.BlockchainToken.previewDaiToken.contractAddress.truncatedAddress,
       toAddress: BraveWallet.BlockchainToken.previewDaiToken.contractAddress,
-      networkSymbol: "ETH",
+      network: .mockMainnet,
       details: .ethErc20Approve(
         .init(
           token: .previewDaiToken,
           tokenContractAddress: BraveWallet.BlockchainToken.previewDaiToken.contractAddress,
           approvalValue: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
           approvalAmount: "Unlimited",
+          approvalFiat: "Unlimited",
           isUnlimited: true,
           spenderAddress: "",
           gasFee: .init(
@@ -653,7 +655,7 @@ class TransactionParserTests: XCTestCase {
       fromAddress: accountInfos[0].address,
       namedToAddress: "Ethereum Account 2",
       toAddress: "0x0987654321098765432109876543210987654321",
-      networkSymbol: "ETH",
+      network: .mockMainnet,
       details: .erc721Transfer(
         .init(
           fromToken: .previewDaiToken,
@@ -737,7 +739,7 @@ class TransactionParserTests: XCTestCase {
       fromAddress: accountInfos[2].accountId.address,
       namedToAddress: accountInfos[3].name,
       toAddress: accountInfos[3].accountId.address,
-      networkSymbol: "SOL",
+      network: .mockSolana,
       details: .solSystemTransfer(
         .init(
           fromToken: .mockSolToken,
@@ -834,7 +836,7 @@ class TransactionParserTests: XCTestCase {
       fromAddress: accountInfos[2].accountId.address,
       namedToAddress: accountInfos[3].name,
       toAddress: accountInfos[3].accountId.address,
-      networkSymbol: "SOL",
+      network: .mockSolana,
       details: .solSplTokenTransfer(
         .init(
           fromToken: .mockSpdToken,
@@ -918,7 +920,7 @@ class TransactionParserTests: XCTestCase {
       fromAddress: accountInfos[2].accountId.address,
       namedToAddress: accountInfos[3].name,
       toAddress: accountInfos[3].accountId.address,
-      networkSymbol: "SOL",
+      network: .mockSolana,
       details: .solSplTokenTransfer(
         .init(
           fromToken: .mockSolanaNFTToken,
@@ -1129,7 +1131,7 @@ class TransactionParserTests: XCTestCase {
       fromAddress: accountInfos[4].address,
       namedToAddress: accountInfos[5].name,
       toAddress: accountInfos[5].address,
-      networkSymbol: "FIL",
+      network: .mockFilecoinTestnet,
       details: .filSend(
         .init(
           sendToken: .mockFilToken,


### PR DESCRIPTION
## Summary of Changes
- Integrates v2 UI for Activity tab, including search/filter transactions. Whole lot of UI!
- Created a new `TransactionSummaryViewContainer` that can be passed a `ParsedTransaction` for display. Different subview used for each tx type as appropriate.
- Created a `TransactionsListView` to contain the UI. The intention is for this to be re-usable for Asset Details v2 & Account Details transaction list. Activity tab has a wrapper around this view.
- Some smaller changes / improvements:
    - ERC20 Approve transaction fiat now calculated in `ParsedTransaction`
    - Added `mini` size to `LoaderView` / brave circlular loading indicator
    - `func localImage(network: BraveWallet.NetworkInfo) -> UIImage?` moved to `BlockchainToken` extension for re-use.
    - Added `NetworkInfo` to `ParsedTransaction` (previously only stored network symbol.

This pull request fixes #8349

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
- Verify all transaction types show up as expected, should be similar to desktop Nightly. Send on EVM, send on Solana, send on Filecoin, Swap on EVM, Swap on Solana (no icon information available to show), ERC20 Approval, dapp transactions.
- Verify transaction types are grouped by the day (date header vs time headers)
- Verify search / filtering works. Search supports account names, addresses, token name, token symbol, token contract address and transaction hash.


## Screenshots:

![activity empty - light](https://github.com/brave/brave-ios/assets/5314553/7d445682-4178-444c-80bb-732b9be12fea) | ![activity empty - dark](https://github.com/brave/brave-ios/assets/5314553/76a7dc49-7afa-4296-8501-1a361c6b8e21)
--|--
![activity - light](https://github.com/brave/brave-ios/assets/5314553/79284170-1c1c-4fa6-b985-692695b5488f) | ![activity - dark](https://github.com/brave/brave-ios/assets/5314553/41237521-15fc-4ddc-b545-76e4d38aa5b3)


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
