### PR TITLE
Fix #7592: Alternative - New Keyboard Shortcuts for tabs "reopen" and "reverse navigation" And Zoom In Zoom Out 

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController.swift
@@ -461,7 +461,8 @@ public class BrowserViewController: UIViewController {
       self?.tabManager.allTabs.forEach({
         guard let url = $0.webView?.url else { return }
         let zoomLevel = self?.privateBrowsingManager.isPrivateBrowsing == true ? 1.0 : Domain.getPersistedDomain(for: url)?.zoom_level?.doubleValue ?? Preferences.General.defaultPageZoomLevel.value
-        $0.webView?.setValue(zoomLevel, forKey: PageZoomView.propertyName)
+        
+        $0.webView?.setValue(zoomLevel, forKey: PageZoomHandler.propertyName)
       })
     }
     
@@ -2285,9 +2286,10 @@ public class BrowserViewController: UIViewController {
       return
     }
     
-    guard let webView = tabManager.selectedTab?.webView else { return }
-    let pageZoomBar = UIHostingController(rootView: PageZoomView(webView: webView, isPrivateBrowsing: privateBrowsingManager.isPrivateBrowsing))
-    
+    guard let selectTab = tabManager.selectedTab else { return }
+    let zoomHandler = PageZoomHandler(tab: selectTab, isPrivateBrowsing: privateBrowsingManager.isPrivateBrowsing)
+    let pageZoomBar = UIHostingController(rootView: PageZoomView(zoomHandler: zoomHandler))
+
     pageZoomBar.rootView.dismiss = { [weak self] in
       guard let self = self else { return }
       pageZoomBar.view.removeFromSuperview()
@@ -2324,7 +2326,7 @@ public class BrowserViewController: UIViewController {
       let domain = Domain.getPersistedDomain(for: currentURL)
       
       let zoomLevel = privateBrowsingManager.isPrivateBrowsing ? 1.0 : domain?.zoom_level?.doubleValue ?? Preferences.General.defaultPageZoomLevel.value
-      tab.webView?.setValue(zoomLevel, forKey: PageZoomView.propertyName)
+      tab.webView?.setValue(zoomLevel, forKey: PageZoomHandler.propertyName)
     }
   }
   
@@ -3127,7 +3129,7 @@ extension BrowserViewController: PreferencesObserver {
       tabManager.allTabs.forEach({
         guard let url = $0.webView?.url else { return }
         let zoomLevel = $0.isPrivate ? 1.0 : Domain.getPersistedDomain(for: url)?.zoom_level?.doubleValue ?? Preferences.General.defaultPageZoomLevel.value
-        $0.webView?.setValue(zoomLevel, forKey: PageZoomView.propertyName)
+        $0.webView?.setValue(zoomLevel, forKey: PageZoomHandler.propertyName)
       })
     case Preferences.Shields.httpsEverywhere.key:
       tabManager.reset()

--- a/Sources/Brave/Frontend/Browser/PageZoom/PageZoomHandler.swift
+++ b/Sources/Brave/Frontend/Browser/PageZoom/PageZoomHandler.swift
@@ -1,0 +1,84 @@
+// Copyright 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import Shared
+import Data
+import Preferences
+
+class PageZoomHandler: ObservableObject {
+  
+  enum ChangeStatus {
+    case increment, decrement
+  }
+  
+  private weak var webView: BraveWebView?
+  let isPrivateBrowsing: Bool
+  
+  static let steps = [0.5, 0.75, 0.85,
+                       1.0, 1.15, 1.25,
+                       1.50, 1.75, 2.00,
+                       2.50, 3.0]
+  static let propertyName = "viewScale"
+  @Published var currentValue: Double = 1.0
+
+  required init(tab: Tab, isPrivateBrowsing: Bool) {
+    self.webView = tab.webView
+    self.isPrivateBrowsing = isPrivateBrowsing
+    
+    // Private Browsing on Safari iOS always defaults to 100%, and isn't persistently saved.
+    if isPrivateBrowsing {
+      currentValue = 1.0
+      return
+    }
+    
+    if let webView = webView {
+      // Fetch the current value for zoom
+      if let url = webView.url, let domain = Domain.getPersistedDomain(for: url) {
+        currentValue = domain.zoom_level?.doubleValue ?? Preferences.General.defaultPageZoomLevel.value
+      } else {
+        currentValue = webView.value(forKey: Self.propertyName) as? Double ?? Preferences.General.defaultPageZoomLevel.value
+      }
+    }
+  }
+  
+  func changeZoomLevel(_ status: ChangeStatus) {
+    switch status {
+    case .increment:
+      guard let index = Self.steps.firstIndex(of: currentValue),
+            index + 1 < Self.steps.count else { return }
+      
+      currentValue = Self.steps[index + 1]
+    case .decrement:
+      guard let index = Self.steps.firstIndex(of: currentValue),
+            index - 1 >= 0 else { return }
+      currentValue = Self.steps[index - 1]
+    }
+    
+    // Setting the value
+    storeChanges()
+  }
+  
+  func reset() {
+    currentValue = Preferences.General.defaultPageZoomLevel.value
+    storeChanges()
+  }
+  
+  private func storeChanges() {
+    guard let webView = webView,
+          let url = webView.url else { return }
+    
+    webView.setValue(currentValue, forKey: PageZoomHandler.propertyName)
+    
+    // Do NOT store the changes in the Domain
+    if !isPrivateBrowsing {
+      let domain = Domain.getPersistedDomain(for: url)?.then {
+        $0.zoom_level = currentValue == $0.zoom_level?.doubleValue ? nil : NSNumber(value: currentValue)
+      }
+      
+      try? domain?.managedObjectContext?.save()
+    }
+  }
+}

--- a/Sources/Brave/Frontend/Browser/PageZoom/PageZoomHandler.swift
+++ b/Sources/Brave/Frontend/Browser/PageZoom/PageZoomHandler.swift
@@ -24,8 +24,8 @@ class PageZoomHandler: ObservableObject {
   static let propertyName = "viewScale"
   @Published var currentValue: Double = 1.0
 
-  required init(tab: Tab, isPrivateBrowsing: Bool) {
-    self.webView = tab.webView
+  required init(tab: Tab?, isPrivateBrowsing: Bool) {
+    self.webView = tab?.webView
     self.isPrivateBrowsing = isPrivateBrowsing
     
     // Private Browsing on Safari iOS always defaults to 100%, and isn't persistently saved.

--- a/Sources/Brave/Frontend/Browser/PageZoom/PageZoomSettingsView.swift
+++ b/Sources/Brave/Frontend/Browser/PageZoom/PageZoomSettingsView.swift
@@ -64,7 +64,7 @@ struct PageZoomSettingsView: View {
           .font(.subheadline)
           .foregroundColor(Color(.secondaryBraveLabel))
       ) {
-        ForEach(PageZoomView.steps, id: \.self) { step in
+        ForEach(PageZoomHandler.steps, id: \.self) { step in
           Button(action: {
             resetDefaultZoomLevel(zoomLevel: step)
           }, label: {

--- a/Sources/Brave/Frontend/Browser/PageZoom/PageZoomView.swift
+++ b/Sources/Brave/Frontend/Browser/PageZoom/PageZoomView.swift
@@ -18,15 +18,13 @@ private struct ZoomView: View {
   var maxValue: Double
   @Binding var value: Double
   
-  var onDecrement: ()
-  var onReset: ()
-  var onIncrement: ()
+  var onDecrement: () -> Void
+  var onReset: () -> Void
+  var onIncrement: () -> Void
   
   var body: some View {
     HStack(spacing: 0.0) {
-      Button(action: {
-        onDecrement
-      }) {
+      Button(action: onDecrement) {
         Image(systemName: "minus")
           .font(.system(.footnote).weight(.medium))
           .foregroundColor(value == minValue ? .accentColor : Color(UIColor.braveLabel))
@@ -47,9 +45,7 @@ private struct ZoomView: View {
       
       Divider()
       
-      Button(action: {
-        onIncrement
-      }) {
+      Button(action: onIncrement) {
         Image(systemName: "plus")
           .font(.system(.footnote).weight(.medium))
           .foregroundColor(value == maxValue ? .accentColor : Color(UIColor.braveLabel))
@@ -64,9 +60,7 @@ private struct ZoomView: View {
   }
   
   private var resetZoomButton: some View {
-    Button(action: {
-      onReset
-    }) {
+    Button(action: onReset) {
       Text(NSNumber(value: value), formatter: PageZoomView.percentFormatter)
         .font(.system(.footnote).weight(.medium))
         .foregroundColor((value == (isPrivateBrowsing ? 1.0 : Preferences.General.defaultPageZoomLevel.value)) ? .accentColor : Color(UIColor.braveLabel))
@@ -116,9 +110,9 @@ struct PageZoomView: View {
           minValue: minValue,
           maxValue: maxValue,
           value: $zoomHandler.currentValue,
-          onDecrement: zoomHandler.changeZoomLevel(.decrement),
-          onReset: zoomHandler.reset(),
-          onIncrement: zoomHandler.changeZoomLevel(.increment))
+          onDecrement: decrement,
+          onReset: reset,
+          onIncrement: increment)
         .frame(maxWidth: .infinity)
         Button {
           dismiss?()
@@ -134,14 +128,25 @@ struct PageZoomView: View {
     }
     .background(Color(UIColor.braveBackground))
   }
+  
+  private func increment() {
+    zoomHandler.changeZoomLevel(.increment)
+  }
+
+  private func reset() {
+    zoomHandler.reset()
+  }
+
+  private func decrement() {
+    zoomHandler.changeZoomLevel(.decrement)
+  }
 }
 
-//
-//#if DEBUG
-//struct PageZoomView_Previews: PreviewProvider {
-//  static var previews: some View {
-//    PageZoomView(zoomHandler: nil)
-//      .previewLayout(PreviewLayout.sizeThatFits)
-//  }
-//}
-//#endif
+#if DEBUG
+struct PageZoomView_Previews: PreviewProvider {
+  static var previews: some View {
+    PageZoomView(zoomHandler: PageZoomHandler(tab: nil, isPrivateBrowsing: false))
+      .previewLayout(PreviewLayout.sizeThatFits)
+  }
+}
+#endif

--- a/Sources/Brave/Frontend/Browser/PageZoom/PageZoomView.swift
+++ b/Sources/Brave/Frontend/Browser/PageZoom/PageZoomView.swift
@@ -18,13 +18,15 @@ private struct ZoomView: View {
   var maxValue: Double
   @Binding var value: Double
   
-  var onDecrement: () -> Void
-  var onReset: () -> Void
-  var onIncrement: () -> Void
+  var onDecrement: ()
+  var onReset: ()
+  var onIncrement: ()
   
   var body: some View {
     HStack(spacing: 0.0) {
-      Button(action: onDecrement) {
+      Button(action: {
+        onDecrement
+      }) {
         Image(systemName: "minus")
           .font(.system(.footnote).weight(.medium))
           .foregroundColor(value == minValue ? .accentColor : Color(UIColor.braveLabel))
@@ -45,7 +47,9 @@ private struct ZoomView: View {
       
       Divider()
       
-      Button(action: onIncrement) {
+      Button(action: {
+        onIncrement
+      }) {
         Image(systemName: "plus")
           .font(.system(.footnote).weight(.medium))
           .foregroundColor(value == maxValue ? .accentColor : Color(UIColor.braveLabel))
@@ -60,7 +64,9 @@ private struct ZoomView: View {
   }
   
   private var resetZoomButton: some View {
-    Button(action: onReset) {
+    Button(action: {
+      onReset
+    }) {
       Text(NSNumber(value: value), formatter: PageZoomView.percentFormatter)
         .font(.system(.footnote).weight(.medium))
         .foregroundColor((value == (isPrivateBrowsing ? 1.0 : Preferences.General.defaultPageZoomLevel.value)) ? .accentColor : Color(UIColor.braveLabel))
@@ -75,11 +81,10 @@ private struct ZoomView: View {
 struct PageZoomView: View {
   @Environment(\.managedObjectContext) private var context
   
-  private var webView: WKWebView?
+  @ObservedObject private var zoomHandler: PageZoomHandler
   private let isPrivateBrowsing: Bool
   @State private var minValue = 0.5
   @State private var maxValue = 3.0
-  @State private var currentValue: Double
   
   public static let percentFormatter = NumberFormatter().then {
     $0.numberStyle = .percent
@@ -89,35 +94,14 @@ struct PageZoomView: View {
     $0.minimumFractionDigits = 0
   }
   
-  public static let propertyName = "viewScale"
   public static let notificationName = Notification.Name(rawValue: "com.brave.pagezoom-change")
-  
-  public static let steps = [0.5, 0.75, 0.85,
-                             1.0, 1.15, 1.25,
-                             1.50, 1.75, 2.00,
-                             2.50, 3.0]
   
   var dismiss: (() -> Void)?
   
-  init(webView: WKWebView?, isPrivateBrowsing: Bool) {
-    self.webView = webView
-    self.isPrivateBrowsing = isPrivateBrowsing
+  init(zoomHandler: PageZoomHandler) {
+    self.zoomHandler = zoomHandler
+    self.isPrivateBrowsing = zoomHandler.isPrivateBrowsing
     
-    // Private Browsing on Safari iOS always defaults to 100%, and isn't persistently saved.
-    if isPrivateBrowsing {
-      _currentValue = State(initialValue: 1.0)
-      return
-    }
-    
-    // We never re-init, so
-    // it is okay to initialize state here.
-    if let url = webView?.url,
-       let domain = Domain.getPersistedDomain(for: url) {
-      
-      _currentValue = State(initialValue: domain.zoom_level?.doubleValue ?? Preferences.General.defaultPageZoomLevel.value)
-    } else {
-      _currentValue = State(initialValue: webView?.value(forKey: PageZoomView.propertyName) as? Double ?? Preferences.General.defaultPageZoomLevel.value)
-    }
   }
   
   var body: some View {
@@ -127,17 +111,15 @@ struct PageZoomView: View {
         Text(Strings.PageZoom.zoomViewText)
           .font(.system(.subheadline))
           .frame(maxWidth: .infinity, alignment: .leading)
-        
         ZoomView(
           isPrivateBrowsing: isPrivateBrowsing,
           minValue: minValue,
           maxValue: maxValue,
-          value: $currentValue,
-          onDecrement: decrement,
-          onReset: reset,
-          onIncrement: increment)
-          .frame(maxWidth: .infinity)
-        
+          value: $zoomHandler.currentValue,
+          onDecrement: zoomHandler.changeZoomLevel(.decrement),
+          onReset: zoomHandler.reset(),
+          onIncrement: zoomHandler.changeZoomLevel(.increment))
+        .frame(maxWidth: .infinity)
         Button {
           dismiss?()
         } label: {
@@ -152,48 +134,14 @@ struct PageZoomView: View {
     }
     .background(Color(UIColor.braveBackground))
   }
-  
-  private func storeChanges() {
-    guard let webView = webView,
-          let url = webView.url else { return }
-    
-    webView.setValue(currentValue, forKey: PageZoomView.propertyName)
-    
-    // Do NOT store the changes in the Domain
-    if !isPrivateBrowsing {
-      let domain = Domain.getPersistedDomain(for: url)?.then {
-        $0.zoom_level = currentValue == $0.zoom_level?.doubleValue ? nil : NSNumber(value: currentValue)
-      }
-      
-      try? domain?.managedObjectContext?.save()
-    }
-  }
-  
-  private func increment() {
-    guard let index = PageZoomView.steps.firstIndex(of: currentValue),
-          index + 1 < PageZoomView.steps.count else { return }
-    currentValue = PageZoomView.steps[index + 1]
-    storeChanges()
-  }
-  
-  private func reset() {
-    currentValue = Preferences.General.defaultPageZoomLevel.value
-    storeChanges()
-  }
-  
-  private func decrement() {
-    guard let index = PageZoomView.steps.firstIndex(of: currentValue),
-          index - 1 >= 0 else { return }
-    currentValue = PageZoomView.steps[index - 1]
-    storeChanges()
-  }
 }
 
-#if DEBUG
-struct PageZoomView_Previews: PreviewProvider {
-  static var previews: some View {
-    PageZoomView(webView: nil, isPrivateBrowsing: false)
-      .previewLayout(PreviewLayout.sizeThatFits)
-  }
-}
-#endif
+//
+//#if DEBUG
+//struct PageZoomView_Previews: PreviewProvider {
+//  static var previews: some View {
+//    PageZoomView(zoomHandler: nil)
+//      .previewLayout(PreviewLayout.sizeThatFits)
+//  }
+//}
+//#endif

--- a/Sources/BraveStrings/BraveStrings.swift
+++ b/Sources/BraveStrings/BraveStrings.swift
@@ -4928,6 +4928,8 @@ extension Strings {
     public static let reloadPageTitle = NSLocalizedString("ReloadPageTitle", bundle: .module, value: "Reload Page", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
     public static let backTitle = NSLocalizedString("BackTitle", bundle: .module, value: "Back", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
     public static let forwardTitle = NSLocalizedString("ForwardTitle", bundle: .module, value: "Forward", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
+    public static let zoomInTitle = NSLocalizedString("ZoomInTitle", bundle: .module, value: "Zoom In", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
+    public static let zoomOutTitle = NSLocalizedString("ZoomOutTitle", bundle: .module, value: "Zoom Out", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
     public static let selectLocationBarTitle = NSLocalizedString("SelectLocationBarTitle", bundle: .module, value: "Select Location Bar", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
     public static let newTabTitle = NSLocalizedString("NewTabTitle", bundle: .module, value: "New Tab", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")
     public static let newPrivateTabTitle = NSLocalizedString("NewPrivateTabTitle", bundle: .module, value: "New Private Tab", comment: "Label to display in the Discoverability overlay for keyboard shortcuts")


### PR DESCRIPTION
Adding Zoom In + Zoom Out shortcuts and adding alternatives for previous tab and reopen switched off tab key command

This also includes separating the Zoom In - Out Handling outside the view.

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7592

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
- Open Brave 
- Test Key combinations for short*cuts

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

![Simulator Screenshot - iPad mini (6th generation) - 2023-11-09 at 17 42 38](https://github.com/brave/brave-ios/assets/6643505/85094fb4-f078-421d-b1b8-b86a4253598b)

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
