### PR TITLE
Fix #8169: Count and open all subfolder urls with Open All (#)

### DIFF
--- a/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarksViewController.swift
+++ b/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarksViewController.swift
@@ -551,22 +551,15 @@ class BookmarksViewController: SiteTableViewController, ToolbarUrlActionsProtoco
 
     if bookmarkItem.isFolder {
       var actionChildren: [UIAction] = []
-
-      let children = bookmarkManager.getChildren(forFolder: bookmarkItem, includeFolders: false) ?? []
-
-      let urls: [URL] = children.compactMap { bookmark in
-        guard let url = bookmark.url else { return nil }
-        return URL(string: url)
-      }
-
-      let openBatchURLAction = UIAction(
-        title: String(format: Strings.openAllBookmarks, children.count),
-        image: UIImage(systemName: "arrow.up.forward.app"),
-        handler: UIAction.deferredActionHandler { _ in
-          self.toolbarUrlActionsDelegate?.batchOpen(urls)
-        })
-
-      if children.count > 0 {
+      let urls: [URL] = self.getAllURLS(forFolder: bookmarkItem)
+      
+      if urls.count > 0 {
+        let openBatchURLAction = UIAction(
+          title: String(format: Strings.openAllBookmarks, urls.count),
+          image: UIImage(systemName: "arrow.up.forward.app"),
+          handler: UIAction.deferredActionHandler { _ in
+            self.toolbarUrlActionsDelegate?.batchOpen(urls)
+          })
         actionChildren.append(openBatchURLAction)
       }
 
@@ -628,6 +621,23 @@ class BookmarksViewController: SiteTableViewController, ToolbarUrlActionsProtoco
     return UIContextMenuConfiguration(identifier: indexPath as NSCopying, previewProvider: nil) { _ in
       return actionItemsMenu
     }
+  }
+  
+  private func getAllURLS(forFolder rootFolder: Bookmarkv2) -> [URL] {
+    var urls: [URL] = []
+    guard rootFolder.isFolder else { return urls }
+    var children = bookmarkManager.getChildren(forFolder: rootFolder, includeFolders: true) ?? []
+    
+    while !children.isEmpty {
+      let bookmarkItem = children.removeFirst()
+      if bookmarkItem.isFolder {
+        // Follow the order of bookmark manager
+        children.insert(contentsOf: bookmarkManager.getChildren(forFolder: bookmarkItem, includeFolders: true) ?? [], at: 0)
+      } else if let bookmarkItemURL = URL(string: bookmarkItem.url ?? "") {
+        urls.append(bookmarkItemURL)
+      }
+    }
+    return urls
   }
 }
 


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

1. Add private method `getAllURLS` in `BookmarksViewController` to transverse all urls in the order of bookmark manager from a root folder.
2. Update the counter with `urls.count`.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8169 

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
1.  Add multiple urls in nested subfolders.
3. Validate the counter of open all matching the number of urls in the selected folder.
4. Validate all urls are opened with `Open All` in selected folder, and the opened tabs follow the order shown in bookmark manager.


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

https://github.com/brave/brave-ios/assets/22326503/9b8516f4-bf4d-42cf-a7fc-b62fd71b95f5




## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
