### PR TITLE
Fix 8064: Some v2 updates in NFT details

### DIFF
--- a/Sources/BraveWallet/Crypto/NFT/NFTDetailView.swift
+++ b/Sources/BraveWallet/Crypto/NFT/NFTDetailView.swift
@@ -130,14 +130,8 @@ struct NFTDetailView: View {
           }
           NFTDetailRow(title: nftDetailStore.nft.isErc721 ? Strings.Wallet.contractAddressAccessibilityLabel : Strings.Wallet.tokenMintAddress) {
             Button {
-              if nftDetailStore.nft.isErc721 {
-                if let url = nftDetailStore.networkInfo.erc721TokenBlockExplorerURL(nftDetailStore.nft) {
-                  openWalletURL(url)
-                }
-              } else {
-                if let url = nftDetailStore.networkInfo.splTokenBlockExplorerURL(nftDetailStore.nft) {
-                  openWalletURL(url)
-                }
+              if let url = nftDetailStore.networkInfo.nftBlockExplorerURL(nftDetailStore.nft) {
+                openWalletURL(url)
               }
             } label: {
               HStack {
@@ -162,7 +156,6 @@ struct NFTDetailView: View {
         .listRowBackground(Color(.secondaryBraveGroupedBackground))
       } header: {
         Text(Strings.Wallet.nftDetailOverview)
-          .listRowInsets(.zero)
       }
       if let nftMetadata = nftDetailStore.nftMetadata, let description = nftMetadata.description, !description.isEmpty {
         Section {
@@ -170,9 +163,16 @@ struct NFTDetailView: View {
             .font(.subheadline)
             .foregroundColor(Color(.braveLabel))
             .listRowBackground(Color(.secondaryBraveGroupedBackground))
+            .osAvailabilityModifiers({
+              if #unavailable(iOS 16) {
+                // iOS 15 missing default row insect in section
+                $0.listRowInsets(EdgeInsets(top: 16, leading: 16, bottom: 16, trailing: 16))
+              } else {
+                $0
+              }
+            })
         } header: {
           Text(Strings.Wallet.nftDetailDescription)
-            .listRowInsets(.zero)
         }
       }
       if let attributes = nftDetailStore.nftMetadata?.attributes {
@@ -189,7 +189,6 @@ struct NFTDetailView: View {
           .listRowBackground(Color(.secondaryBraveGroupedBackground))
         } header: {
           Text(Strings.Wallet.nftDetailProperties)
-            .listRowInsets(.zero)
         }
       }
     }

--- a/Sources/BraveWallet/Crypto/NFT/NFTDetailView.swift
+++ b/Sources/BraveWallet/Crypto/NFT/NFTDetailView.swift
@@ -13,13 +13,30 @@ struct NFTDetailView: View {
   @ObservedObject var nftDetailStore: NFTDetailStore
   @Binding var buySendSwapDestination: BuySendSwapDestination? 
   var onNFTMetadataRefreshed: ((NFTMetadata) -> Void)?
+  var onNFTStatusUpdated: (() -> Void)?
   
   @Environment(\.openURL) private var openWalletURL
+  @Environment(\.presentationMode) @Binding private var presentationMode
+  
+  @State private var isPresentingRemoveAlert: Bool = false
   
   @ViewBuilder private var noImageView: some View {
     Text(Strings.Wallet.nftDetailImageNotAvailable)
       .foregroundColor(Color(.secondaryBraveLabel))
       .frame(maxWidth: .infinity, minHeight: 300)
+  }
+  
+  @ViewBuilder private var nftLogo: some View {
+    if let image = nftDetailStore.networkInfo.nativeTokenLogoImage, !nftDetailStore.isLoading {
+      Image(uiImage: image)
+        .resizable()
+        .frame(width: 32, height: 32)
+        .overlay {
+          Circle()
+            .stroke(lineWidth: 2)
+            .foregroundColor(Color(braveSystemName: .containerBackground))
+        }
+    }
   }
   
   @ViewBuilder private var nftImage: some View {
@@ -36,9 +53,9 @@ struct NFTDetailView: View {
   }
   
   var body: some View {
-    ScrollView(.vertical) {
-      VStack(alignment: .leading, spacing: 24) {
-        VStack(spacing: 8) {
+    Form {
+      Section {
+        VStack(alignment: .leading, spacing: 16) {
           nftImage
             .overlay(alignment: .topLeading) {
               if nftDetailStore.nft.isSpam {
@@ -60,119 +77,131 @@ struct NFTDetailView: View {
                 .padding(12)
               }
             }
+            .overlay(alignment: .bottomTrailing) {
+              ZStack {
+                if let owner = nftDetailStore.owner {
+                  Blockie(address: owner.address, shape: .rectangle)
+                    .overlay(
+                      RoundedRectangle(cornerRadius: 4)
+                        .stroke(lineWidth: 2)
+                        .foregroundColor(Color(braveSystemName: .containerBackground))
+                    )
+                    .frame(width: 32, height: 32)
+                    .zIndex(1)
+                    .offset(x: -28)
+                }
+                nftLogo
+              }
+              .offset(y: 16)
+            }
           VStack(alignment: .leading, spacing: 8) {
             Text(nftDetailStore.nft.nftTokenTitle)
               .font(.title3.weight(.semibold))
               .foregroundColor(Color(.braveLabel))
             Text(nftDetailStore.nft.name)
               .foregroundColor(Color(.secondaryBraveLabel))
-            Button(action: {
-              buySendSwapDestination = BuySendSwapDestination(
-                kind: .send,
-                initialToken: nftDetailStore.nft
-              )
-            }) {
-              Text(Strings.Wallet.nftDetailSendNFTButtonTitle)
-                .frame(maxWidth: .infinity)
-            }
-            .buttonStyle(BraveFilledButtonStyle(size: .large))
           }
         }
-        if let nftMetadata = nftDetailStore.nftMetadata, let description = nftMetadata.description, !description.isEmpty {
-          VStack(alignment: .leading, spacing: 8) {
-            Text(Strings.Wallet.nftDetailDescription)
-              .font(.headline.weight(.semibold))
-              .foregroundColor(Color(.braveLabel))
-            Text(description)
-              .foregroundColor(Color(.braveLabel))
+        .listRowInsets(.zero)
+        .listRowBackground(Color.clear)
+      }
+      Section {
+        List {
+          if let owner = nftDetailStore.owner {
+            NFTDetailRow(title: Strings.Wallet.nftDetailOwnedBy) {
+              AddressView(address: owner.address) {
+                HStack {
+                  Text(owner.name)
+                    .foregroundColor(Color(.braveBlurpleTint))
+                  Text(owner.address.truncatedAddress)
+                    .foregroundColor(Color(.braveLabel))
+                }
+                .font(.subheadline)
+              }
+            }
           }
-        }
-        VStack(spacing: 16) {
-          Group {
-            HStack {
-              Text(Strings.Wallet.nftDetailBlockchain)
-                .font(.headline.weight(.semibold))
-              Spacer()
-              Text(nftDetailStore.networkInfo.chainName)
+          if nftDetailStore.nft.isErc721, let tokenId = Int(nftDetailStore.nft.tokenId.removingHexPrefix, radix: 16) {
+            NFTDetailRow(title: Strings.Wallet.nftDetailTokenID) {
+              Text("\(tokenId)")
+                .font(.subheadline)
+                .foregroundColor(Color(.braveLabel))
             }
-            HStack {
-              Text(Strings.Wallet.nftDetailTokenStandard)
-                .font(.headline.weight(.semibold))
-              Spacer()
-              Text(nftDetailStore.nft.isErc721 ? Strings.Wallet.nftDetailERC721 : Strings.Wallet.nftDetailSPL)
-            }
-            if nftDetailStore.nft.isErc721 {
-              HStack {
-                Text(Strings.Wallet.nftDetailTokenID)
-                  .font(.headline.weight(.semibold))
-                Spacer()
-                Button(action: {
-                  if let explorerURL = nftDetailStore.networkInfo.blockExplorerUrls.first {
-                    let baseURL = "\(explorerURL)/token/\(nftDetailStore.nft.contractAddress)"
-                    var nftURL = URL(string: baseURL)
-                    if let tokenId = Int(nftDetailStore.nft.tokenId.removingHexPrefix, radix: 16) {
-                      nftURL = URL(string: "\(baseURL)?a=\(tokenId)")
-                    }
-                    
-                    if let url = nftURL {
-                      openWalletURL(url)
-                    }
-                  }
-                }) {
+          }
+          NFTDetailRow(title: nftDetailStore.nft.isErc721 ? Strings.Wallet.contractAddressAccessibilityLabel : Strings.Wallet.tokenMintAddress) {
+            Button {
+              if nftDetailStore.nft.isErc721 {
+                if let explorerURL = nftDetailStore.networkInfo.blockExplorerUrls.first {
+                  let baseURL = "\(explorerURL)/token/\(nftDetailStore.nft.contractAddress)"
+                  var nftURL = URL(string: baseURL)
                   if let tokenId = Int(nftDetailStore.nft.tokenId.removingHexPrefix, radix: 16) {
-                    HStack {
-                      Text(verbatim: "#\(tokenId)")
-                      Image(systemName: "arrow.up.forward.square")
-                    }
-                    .foregroundColor(Color(.braveBlurple))
-                  } else {
-                    HStack {
-                      Text("\(nftDetailStore.nft.name) #\(nftDetailStore.nft.tokenId)")
-                      Image(systemName: "arrow.up.forward.square")
-                    }
-                    .foregroundColor(Color(.braveBlurple))
+                    nftURL = URL(string: "\(baseURL)?a=\(tokenId)")
+                  }
+                  
+                  if let url = nftURL {
+                    openWalletURL(url)
                   }
                 }
-              }
-            } else {
-              HStack {
-                Text(Strings.Wallet.tokenMintAddress)
-                  .font(.headline.weight(.semibold))
-                Spacer()
-                Button(action: {
-                  if WalletConstants.supportedTestNetworkChainIds.contains(nftDetailStore.networkInfo.chainId) {
-                    if let components = nftDetailStore.networkInfo.blockExplorerUrls.first?.separatedBy("/?cluster="), let baseURL = components.first {
-                      let cluster = components.last ?? ""
-                      if let nftURL = URL(string: "\(baseURL)/address/\(nftDetailStore.nft.contractAddress)/?cluster=\(cluster)") {
-                        openWalletURL(nftURL)
-                      }
-                    }
-                  } else {
-                    if let explorerURL = nftDetailStore.networkInfo.blockExplorerUrls.first, let nftURL = URL(string: "\(explorerURL)/address/\(nftDetailStore.nft.contractAddress)") {
+              } else {
+                if WalletConstants.supportedTestNetworkChainIds.contains(nftDetailStore.networkInfo.chainId) {
+                  if let components = nftDetailStore.networkInfo.blockExplorerUrls.first?.separatedBy("/?cluster="), let baseURL = components.first {
+                    let cluster = components.last ?? ""
+                    if let nftURL = URL(string: "\(baseURL)/address/\(nftDetailStore.nft.contractAddress)/?cluster=\(cluster)") {
                       openWalletURL(nftURL)
                     }
                   }
-                }) {
-                  HStack {
-                    Text("\(nftDetailStore.nft.contractAddress.truncatedAddress)")
-                    Image(systemName: "arrow.up.forward.square")
+                } else {
+                  if let explorerURL = nftDetailStore.networkInfo.blockExplorerUrls.first, let nftURL = URL(string: "\(explorerURL)/address/\(nftDetailStore.nft.contractAddress)") {
+                    openWalletURL(nftURL)
                   }
-                  .foregroundColor(Color(.braveBlurple))
                 }
+              }
+            } label: {
+              Text(nftDetailStore.nft.contractAddress.truncatedAddress)
+                .font(.subheadline)
+                .foregroundColor(Color(.braveBlurpleTint))
+            }
+          }
+          NFTDetailRow(title: Strings.Wallet.nftDetailBlockchain) {
+            Text(nftDetailStore.networkInfo.chainName)
+              .font(.subheadline)
+              .foregroundColor(Color(.braveLabel))
+          }
+          NFTDetailRow(title: Strings.Wallet.nftDetailTokenStandard) {
+            Text(nftDetailStore.nft.isErc721 ? Strings.Wallet.nftDetailERC721 : Strings.Wallet.nftDetailSPL)
+              .font(.subheadline)
+              .foregroundColor(Color(.braveLabel))
+          }
+        }
+      } header: {
+        Text(Strings.Wallet.nftDetailOverview)
+          .listRowInsets(.zero)
+      }
+      if let nftMetadata = nftDetailStore.nftMetadata, let description = nftMetadata.description, !description.isEmpty {
+        Section {
+          Text(description)
+            .font(.subheadline)
+            .foregroundColor(Color(.braveLabel))
+        } header: {
+          Text(Strings.Wallet.nftDetailDescription)
+            .listRowInsets(.zero)
+        }
+      }
+      if let attributes = nftDetailStore.nftMetadata?.attributes {
+        Section {
+          List {
+            ForEach(attributes) { attribute in
+              NFTDetailRow(title: attribute.type) {
+                Text(attribute.value)
+                  .font(.subheadline)
+                  .foregroundColor(Color(.braveLabel))
               }
             }
           }
-          .foregroundColor(Color(.braveLabel))
-        }
-        if isSVGImage {
-          Text(Strings.Wallet.nftDetailSVGImageDisclaimer)
-            .multilineTextAlignment(.center)
-            .font(.footnote)
-            .foregroundColor(Color(.secondaryBraveLabel))
-            .frame(maxWidth: .infinity)
+        } header: {
+          Text(Strings.Wallet.nftDetailProperties)
+            .listRowInsets(.zero)
         }
       }
-      .padding()
     }
     .onChange(of: nftDetailStore.nftMetadata, perform: { newValue in
       if let newMetadata = newValue {
@@ -183,6 +212,105 @@ struct NFTDetailView: View {
       nftDetailStore.update()
     }
     .background(Color(UIColor.braveGroupedBackground).ignoresSafeArea())
-    .navigationBarTitle(Strings.Wallet.nftDetailTitle)
+    .navigationBarTitle(nftDetailStore.nft.nftTokenTitle)
+    .toolbar {
+      ToolbarItemGroup(placement: .navigationBarTrailing) {
+        Menu {
+          if nftDetailStore.nft.visible {
+            Button(action: {
+              buySendSwapDestination = BuySendSwapDestination(
+                kind: .send,
+                initialToken: nftDetailStore.nft
+              )
+            }) {
+              Label(Strings.Wallet.nftDetailSendNFTButtonTitle, braveSystemImage: "leo.send")
+            }
+            .buttonStyle(BraveFilledButtonStyle(size: .large))
+          }
+          Button(action: {
+            if nftDetailStore.nft.visible { // a collected visible NFT, mark as hidden
+              nftDetailStore.updateNFTStatus(visible: false, isSpam: false, isDeletedByUser: false, completion: {
+                onNFTStatusUpdated?()
+              })
+            } else { // either a hidden NFT or a junk NFT, mark as visible
+              nftDetailStore.updateNFTStatus(visible: true, isSpam: false, isDeletedByUser: false, completion: {
+                onNFTStatusUpdated?()
+              })
+            }
+          }) {
+            if nftDetailStore.nft.visible { // a collected visible NFT
+              Label(Strings.recentSearchHide, braveSystemImage: "leo.eye.off")
+            } else if nftDetailStore.nft.isSpam { // a spam NFT
+              Label(Strings.Wallet.nftUnspam, braveSystemImage: "leo.disable.outline")
+            } else { // a hidden but not spam NFT
+              Label(Strings.Wallet.nftUnhide, braveSystemImage: "leo.eye.on")
+            }
+          }
+          Button(action: {
+            isPresentingRemoveAlert = true
+          }) {
+            Label(Strings.Wallet.nftRemoveFromWallet, braveSystemImage: "leo.trash")
+          }
+        } label: {
+          Label(Strings.Wallet.otherWalletActionsAccessibilityTitle, braveSystemImage: "leo.more.horizontal")
+            .labelStyle(.iconOnly)
+            .foregroundColor(Color(.braveBlurpleTint))
+        }
+      }
+    }
+    .background(
+      WalletPromptView(
+        isPresented: $isPresentingRemoveAlert,
+        primaryButton: .init(
+          title: Strings.Wallet.manageSiteConnectionsConfirmAlertRemove,
+          action: { _ in
+            nftDetailStore.updateNFTStatus(visible: false, isSpam: nftDetailStore.nft.isSpam, isDeletedByUser: true, completion: {
+              onNFTStatusUpdated?()
+              presentationMode.dismiss()
+            })
+            isPresentingRemoveAlert = false
+          }
+        ),
+        secondaryButton: .init(
+          title: Strings.CancelString,
+          action: { _ in
+            isPresentingRemoveAlert = false
+          }
+        ),
+        showCloseButton: false,
+        content: {
+          VStack(spacing: 16) {
+            Text(Strings.Wallet.nftRemoveFromWalletAlertTitle)
+              .font(.headline)
+              .foregroundColor(Color(.bravePrimary))
+            Text(Strings.Wallet.nftRemoveFromWalletAlertDescription)
+              .font(.footnote)
+              .foregroundStyle(Color(.secondaryBraveLabel))
+          }
+        })
+    )
+  }
+}
+
+struct NFTDetailRow<ValueContent: View>: View {
+  var title: String
+  var valueContent: () -> ValueContent
+  
+  init(
+    title: String,
+    @ViewBuilder valueContent: @escaping () -> ValueContent
+  ) {
+    self.title = title
+    self.valueContent = valueContent
+  }
+  var body: some View {
+    HStack {
+      Text(title)
+        .font(.subheadline)
+        .foregroundColor(Color(.secondaryLabel))
+      Spacer()
+      valueContent()
+        .multilineTextAlignment(.trailing)
+    }
   }
 }

--- a/Sources/BraveWallet/Crypto/NFT/NFTDetailView.swift
+++ b/Sources/BraveWallet/Crypto/NFT/NFTDetailView.swift
@@ -103,6 +103,10 @@ struct NFTDetailView: View {
             Text(nftDetailStore.nft.name)
               .foregroundColor(Color(.secondaryBraveLabel))
           }
+          .transaction { transaction in
+            transaction.animation = nil
+            transaction.disablesAnimations = true
+          }
         }
         .listRowInsets(.zero)
         .listRowBackground(Color.clear)

--- a/Sources/BraveWallet/Crypto/NFT/NFTDetailView.swift
+++ b/Sources/BraveWallet/Crypto/NFT/NFTDetailView.swift
@@ -172,6 +172,7 @@ struct NFTDetailView: View {
               .foregroundColor(Color(.braveLabel))
           }
         }
+        .listRowBackground(Color(.secondaryBraveGroupedBackground))
       } header: {
         Text(Strings.Wallet.nftDetailOverview)
           .listRowInsets(.zero)
@@ -181,6 +182,7 @@ struct NFTDetailView: View {
           Text(description)
             .font(.subheadline)
             .foregroundColor(Color(.braveLabel))
+            .listRowBackground(Color(.secondaryBraveGroupedBackground))
         } header: {
           Text(Strings.Wallet.nftDetailDescription)
             .listRowInsets(.zero)
@@ -197,12 +199,14 @@ struct NFTDetailView: View {
               }
             }
           }
+          .listRowBackground(Color(.secondaryBraveGroupedBackground))
         } header: {
           Text(Strings.Wallet.nftDetailProperties)
             .listRowInsets(.zero)
         }
       }
     }
+    .listBackgroundColor(Color(.braveGroupedBackground))
     .onChange(of: nftDetailStore.nftMetadata, perform: { newValue in
       if let newMetadata = newValue {
         onNFTMetadataRefreshed?(newMetadata)

--- a/Sources/BraveWallet/Crypto/NFT/NFTDetailView.swift
+++ b/Sources/BraveWallet/Crypto/NFT/NFTDetailView.swift
@@ -18,6 +18,7 @@ struct NFTDetailView: View {
   
   @Environment(\.openURL) private var openWalletURL
   @Environment(\.presentationMode) @Binding private var presentationMode
+  @Environment(\.horizontalSizeClass) private var horizontalSizeClass
   
   @State private var isPresentingRemoveAlert: Bool = false
   
@@ -164,8 +165,7 @@ struct NFTDetailView: View {
             .foregroundColor(Color(.braveLabel))
             .listRowBackground(Color(.secondaryBraveGroupedBackground))
             .osAvailabilityModifiers({
-              if #unavailable(iOS 16) {
-                // iOS 15 missing default row insect in section
+              if horizontalSizeClass == .regular {
                 $0.listRowInsets(EdgeInsets(top: 16, leading: 16, bottom: 16, trailing: 16))
               } else {
                 $0

--- a/Sources/BraveWallet/Crypto/NFT/NFTView.swift
+++ b/Sources/BraveWallet/Crypto/NFT/NFTView.swift
@@ -301,6 +301,7 @@ struct NFTView: View {
         destination: {
           if let nftViewModel = selectedNFTViewModel {
             NFTDetailView(
+              keyringStore: keyringStore,
               nftDetailStore: cryptoStore.nftDetailStore(for: nftViewModel.token, nftMetadata: nftViewModel.nftMetadata, owner: nftStore.owner(for: nftViewModel.token)),
               buySendSwapDestination: buySendSwapDestination,
               onNFTMetadataRefreshed: {  nftMetadata in

--- a/Sources/BraveWallet/Crypto/NFT/NFTView.swift
+++ b/Sources/BraveWallet/Crypto/NFT/NFTView.swift
@@ -289,6 +289,9 @@ struct NFTView: View {
         }
       }
     }
+    .introspectViewController { vc in
+      vc.navigationItem.backButtonDisplayMode = .minimal
+    }
     .background(
       NavigationLink(
         isActive: Binding(
@@ -298,11 +301,15 @@ struct NFTView: View {
         destination: {
           if let nftViewModel = selectedNFTViewModel {
             NFTDetailView(
-              nftDetailStore: cryptoStore.nftDetailStore(for: nftViewModel.token, nftMetadata: nftViewModel.nftMetadata),
-              buySendSwapDestination: buySendSwapDestination
-            ) { nftMetadata in
-              nftStore.updateNFTMetadataCache(for: nftViewModel.token, metadata: nftMetadata)
-            }
+              nftDetailStore: cryptoStore.nftDetailStore(for: nftViewModel.token, nftMetadata: nftViewModel.nftMetadata, owner: nftStore.owner(for: nftViewModel.token)),
+              buySendSwapDestination: buySendSwapDestination,
+              onNFTMetadataRefreshed: {  nftMetadata in
+                nftStore.updateNFTMetadataCache(for: nftViewModel.token, metadata: nftMetadata)
+              },
+              onNFTStatusUpdated: {
+                nftStore.update()
+              }
+            )
             .onDisappear {
               cryptoStore.closeNFTDetailStore(for: nftViewModel.token)
             }

--- a/Sources/BraveWallet/Crypto/NFTImageView.swift
+++ b/Sources/BraveWallet/Crypto/NFTImageView.swift
@@ -84,7 +84,7 @@ struct LoadingNFTView: View {
             .preference(key: SizePreferenceKey.self, value: geometryProxy.size)
         }
       )
-      .frame(minHeight: viewSize.width)
+      .frame(minHeight: viewSize.width, maxHeight: 172)
       .onPreferenceChange(SizePreferenceKey.self) { newSize in
         viewSize = newSize
       }

--- a/Sources/BraveWallet/Crypto/Search/AssetSearchView.swift
+++ b/Sources/BraveWallet/Crypto/Search/AssetSearchView.swift
@@ -139,7 +139,7 @@ struct AssetSearchView: View {
             if let selectedToken {
               if selectedToken.isErc721 || selectedToken.isNft {
                 NFTDetailView(
-                  nftDetailStore: cryptoStore.nftDetailStore(for: selectedToken, nftMetadata: allNFTMetadata[selectedToken.id]),
+                  nftDetailStore: cryptoStore.nftDetailStore(for: selectedToken, nftMetadata: allNFTMetadata[selectedToken.id], owner: nil),
                   buySendSwapDestination: .constant(nil)
                 ) { metadata in
                   allNFTMetadata[selectedToken.id] = metadata

--- a/Sources/BraveWallet/Crypto/Search/AssetSearchView.swift
+++ b/Sources/BraveWallet/Crypto/Search/AssetSearchView.swift
@@ -139,6 +139,7 @@ struct AssetSearchView: View {
             if let selectedToken {
               if selectedToken.isErc721 || selectedToken.isNft {
                 NFTDetailView(
+                  keyringStore: keyringStore,
                   nftDetailStore: cryptoStore.nftDetailStore(for: selectedToken, nftMetadata: allNFTMetadata[selectedToken.id], owner: nil),
                   buySendSwapDestination: .constant(nil)
                 ) { metadata in

--- a/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -516,6 +516,7 @@ public class CryptoStore: ObservableObject, WalletObserverStore {
     }
     let store = NFTDetailStore(
       assetManager: userAssetManager,
+      keyringService: keyringService,
       rpcService: rpcService,
       ipfsApi: ipfsApi,
       nft: nft,

--- a/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -510,15 +510,17 @@ public class CryptoStore: ObservableObject, WalletObserverStore {
   }
   
   private var nftDetailStore: NFTDetailStore?
-  func nftDetailStore(for nft: BraveWallet.BlockchainToken, nftMetadata: NFTMetadata?) -> NFTDetailStore {
+  func nftDetailStore(for nft: BraveWallet.BlockchainToken, nftMetadata: NFTMetadata?, owner: BraveWallet.AccountInfo?) -> NFTDetailStore {
     if let store = nftDetailStore, store.nft.id == nft.id {
       return store
     }
     let store = NFTDetailStore(
+      assetManager: userAssetManager,
       rpcService: rpcService,
       ipfsApi: ipfsApi,
       nft: nft,
-      nftMetadata: nftMetadata
+      nftMetadata: nftMetadata,
+      owner: owner
     )
     nftDetailStore = store
     return store

--- a/Sources/BraveWallet/Crypto/Stores/NFTDetailStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/NFTDetailStore.swift
@@ -9,11 +9,13 @@ struct NFTMetadata: Codable, Equatable {
   var imageURLString: String?
   var name: String?
   var description: String?
+  var attributes: [NFTAttribute]?
 
   enum CodingKeys: String, CodingKey {
     case imageURLString = "image"
     case name
     case description
+    case attributes
   }
   
   init(from decoder: Decoder) throws {
@@ -21,25 +23,29 @@ struct NFTMetadata: Codable, Equatable {
     self.imageURLString = try container.decodeIfPresent(String.self, forKey: .imageURLString)
     self.name = try container.decodeIfPresent(String.self, forKey: .name)
     self.description = try container.decodeIfPresent(String.self, forKey: .description)
+    let test = try container.decodeIfPresent([NFTAttribute].self, forKey: .attributes)
+    self.attributes = test
   }
   
   init(
     imageURLString: String?,
     name: String?,
-    description: String?
+    description: String?,
+    attributes: [NFTAttribute]?
   ) {
     self.imageURLString = imageURLString
     self.name = name
     self.description = description
+    self.attributes = attributes
   }
 
   func httpfyIpfsUrl(ipfsApi: IpfsAPI) -> NFTMetadata {
     guard let imageURLString,
           imageURLString.hasPrefix("ipfs://"),
           let url = URL(string: imageURLString) else {
-      return NFTMetadata(imageURLString: self.imageURLString, name: self.name, description: self.description)
+      return NFTMetadata(imageURLString: self.imageURLString, name: self.name, description: self.description, attributes: self.attributes)
     }
-    return NFTMetadata(imageURLString: ipfsApi.resolveGatewayUrl(for: url)?.absoluteString, name: self.name, description: self.description)
+    return NFTMetadata(imageURLString: ipfsApi.resolveGatewayUrl(for: url)?.absoluteString, name: self.name, description: self.description, attributes: self.attributes)
   }
   
   var imageURL: URL? {
@@ -48,10 +54,23 @@ struct NFTMetadata: Codable, Equatable {
   }
 }
 
+struct NFTAttribute: Codable, Equatable, Identifiable {
+  var type: String
+  var value: String
+  var id: String { type }
+  
+  enum CodingKeys: String, CodingKey {
+    case type = "trait_type"
+    case value
+  }
+}
+
 class NFTDetailStore: ObservableObject, WalletObserverStore {
+  private let assetManager: WalletUserAssetManagerType
   private let rpcService: BraveWalletJsonRpcService
   private let ipfsApi: IpfsAPI
-  let nft: BraveWallet.BlockchainToken
+  let owner: BraveWallet.AccountInfo?
+  @Published var nft: BraveWallet.BlockchainToken
   @Published var isLoading: Bool = false
   @Published var nftMetadata: NFTMetadata?
   @Published var networkInfo: BraveWallet.NetworkInfo = .init()
@@ -59,15 +78,19 @@ class NFTDetailStore: ObservableObject, WalletObserverStore {
   var isObserving: Bool = false
 
   init(
+    assetManager: WalletUserAssetManagerType,
     rpcService: BraveWalletJsonRpcService,
     ipfsApi: IpfsAPI,
     nft: BraveWallet.BlockchainToken,
-    nftMetadata: NFTMetadata?
+    nftMetadata: NFTMetadata?,
+    owner: BraveWallet.AccountInfo?
   ) {
+    self.assetManager = assetManager
     self.rpcService = rpcService
     self.ipfsApi = ipfsApi
     self.nft = nft
     self.nftMetadata = nftMetadata?.httpfyIpfsUrl(ipfsApi: ipfsApi)
+    self.owner = owner
   }
   
   func update() {
@@ -82,6 +105,26 @@ class NFTDetailStore: ObservableObject, WalletObserverStore {
         nftMetadata = await rpcService.fetchNFTMetadata(for: nft, ipfsApi: self.ipfsApi)
         isLoading = false
       }
+    }
+  }
+  
+  func updateNFTStatus(
+    visible: Bool,
+    isSpam: Bool,
+    isDeletedByUser: Bool,
+    completion: @escaping () -> Void
+  ) {
+    assetManager.updateUserAsset(
+      for: nft,
+      visible: visible,
+      isSpam: isSpam,
+      isDeletedByUser: isDeletedByUser
+    ) { [weak self] in
+      guard let self else { return }
+      if let newNFT = self.assetManager.getUserAsset(self.nft)?.blockchainToken {
+        self.nft = newNFT
+      }
+      completion()
     }
   }
 }

--- a/Sources/BraveWallet/Crypto/Stores/NFTStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/NFTStore.swift
@@ -610,6 +610,15 @@ public class NFTStore: ObservableObject, WalletObserverStore {
       isShowingNFTLoadingState = false
     }
   }
+  
+  func owner(for nft: BraveWallet.BlockchainToken) -> BraveWallet.AccountInfo? {
+    guard let allBalances = nftBalancesCache[nft.id],
+          let address = allBalances.first(where: { address, balance in
+            balance > 0
+          })?.key
+    else { return nil }
+    return allAccounts.first { $0.address.caseInsensitiveCompare(address) == .orderedSame }
+  }
 }
 
 extension NFTStore: PreferencesObserver {

--- a/Sources/BraveWallet/Crypto/Stores/NFTStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/NFTStore.swift
@@ -303,42 +303,44 @@ public class NFTStore: ObservableObject, WalletObserverStore {
       for networkAssets in [userVisibleNFTs, userHiddenNFTs, unionedSpamNFTs] {
         allNFTs.append(contentsOf: networkAssets.flatMap(\.tokens))
       }
-      // fetch balance for all NFTs
-      let allAccounts = filters.accounts.map(\.model)
-      nftBalancesCache = await withTaskGroup(
-        of: [String: [String: Int]].self,
-        body: { @MainActor [nftBalancesCache, rpcService] group in
-          for nft in allNFTs { // for each NFT
-            guard let networkForNFT = allNetworks.first(where: { $0.chainId == nft.chainId }) else {
-              continue
-            }
-            group.addTask { @MainActor in
-              let updatedBalances = await withTaskGroup(
-                of: [String: Int].self,
-                body: { @MainActor group in
-                  for account in allAccounts where account.coin == nft.coin {
-                    group.addTask { @MainActor in
-                      let balanceForToken = await rpcService.balance(
-                        for: nft,
-                        in: account,
-                        network: networkForNFT
-                      )
-                      return [account.address: Int(balanceForToken ?? 0)]
+      // if we're not hiding unowned or grouping by account, balance isn't needed
+      if filters.isHidingUnownedNFTs {
+        let allAccounts = filters.accounts.map(\.model)
+        nftBalancesCache = await withTaskGroup(
+          of: [String: [String: Int]].self,
+          body: { @MainActor [nftBalancesCache, rpcService] group in
+            for nft in allNFTs { // for each NFT
+              guard let networkForNFT = allNetworks.first(where: { $0.chainId == nft.chainId }) else {
+                continue
+              }
+              group.addTask { @MainActor in
+                let updatedBalances = await withTaskGroup(
+                  of: [String: Int].self,
+                  body: { @MainActor group in
+                    for account in allAccounts where account.coin == nft.coin {
+                      group.addTask { @MainActor in
+                        let balanceForToken = await rpcService.balance(
+                          for: nft,
+                          in: account,
+                          network: networkForNFT
+                        )
+                        return [account.address: Int(balanceForToken ?? 0)]
+                      }
                     }
-                  }
-                  return await group.reduce(into: [String: Int](), { partialResult, new in
-                    partialResult.merge(with: new)
+                    return await group.reduce(into: [String: Int](), { partialResult, new in
+                      partialResult.merge(with: new)
+                    })
                   })
-                })
-              var tokenBalances = nftBalancesCache[nft.id] ?? [:]
-              tokenBalances.merge(with: updatedBalances)
-              return [nft.id: tokenBalances]
+                var tokenBalances = nftBalancesCache[nft.id] ?? [:]
+                tokenBalances.merge(with: updatedBalances)
+                return [nft.id: tokenBalances]
+              }
             }
-          }
-          return await group.reduce(into: [String: [String: Int]](), { partialResult, new in
-            partialResult.merge(with: new)
+            return await group.reduce(into: [String: [String: Int]](), { partialResult, new in
+              partialResult.merge(with: new)
+            })
           })
-        })
+      }
       
       guard !Task.isCancelled else { return }
       userNFTGroups = buildNFTGroupModels(

--- a/Sources/BraveWallet/Crypto/Stores/NFTStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/NFTStore.swift
@@ -304,7 +304,7 @@ public class NFTStore: ObservableObject, WalletObserverStore {
         allNFTs.append(contentsOf: networkAssets.flatMap(\.tokens))
       }
       // if we're not hiding unowned or grouping by account, balance isn't needed
-      if filters.isHidingUnownedNFTs {
+      if filters.isHidingUnownedNFTs || filters.groupBy == .accounts {
         let allAccounts = filters.accounts.map(\.model)
         nftBalancesCache = await withTaskGroup(
           of: [String: [String: Int]].self,

--- a/Sources/BraveWallet/Extensions/BraveWalletExtensions.swift
+++ b/Sources/BraveWallet/Extensions/BraveWalletExtensions.swift
@@ -288,7 +288,7 @@ extension BraveWallet.BlockchainToken {
   
   var nftTokenTitle: String {
     if isErc721, let tokenId = Int(tokenId.removingHexPrefix, radix: 16) {
-      return "\(name) #\(tokenId)"
+      return "\(symbol) #\(tokenId)"
     } else {
       return name
     }

--- a/Sources/BraveWallet/Extensions/BraveWalletExtensions.swift
+++ b/Sources/BraveWallet/Extensions/BraveWalletExtensions.swift
@@ -262,33 +262,31 @@ extension BraveWallet.NetworkInfo {
     return nil
   }
   
-  /// Generate the explorer link for the given ERC721 token with the current NetworkInfo
-  func erc721TokenBlockExplorerURL(_ token: BraveWallet.BlockchainToken) -> URL? {
-    guard token.isErc721,
-          let explorerURL = blockExplorerUrls.first
-    else { return nil }
-    
-    let baseURL = "\(explorerURL)/token/\(token.contractAddress)"
-    var tokenURL = URL(string: baseURL)
-    if let tokenId = Int(token.tokenId.removingHexPrefix, radix: 16) {
-      tokenURL = URL(string: "\(baseURL)?a=\(tokenId)")
-    }
-    return tokenURL
-  }
-  
-  /// Generate the explorer link for the given SPL token with the current NetworkInfo
-  func splTokenBlockExplorerURL(_ token: BraveWallet.BlockchainToken) -> URL? {
-    guard !token.isErc721, !token.isErc20, !token.isErc1155 else { return nil }
-    if WalletConstants.supportedTestNetworkChainIds.contains(chainId) {
-      if let components = blockExplorerUrls.first?.separatedBy("/?cluster="), let baseURL = components.first {
-        let cluster = components.last ?? ""
-        if let tokenURL = URL(string: "\(baseURL)/address/\(token.contractAddress)/?cluster=\(cluster)") {
+  /// Generate the explorer link for the given NFT token with the current NetworkInfo
+  func nftBlockExplorerURL(_ token: BraveWallet.BlockchainToken) -> URL? {
+    if token.isErc721 { // when NFT is ERC721 token standard
+      guard let explorerURL = blockExplorerUrls.first else { return nil }
+      
+      let baseURL = "\(explorerURL)/token/\(token.contractAddress)"
+      var tokenURL = URL(string: baseURL)
+      if let tokenId = Int(token.tokenId.removingHexPrefix, radix: 16) {
+        tokenURL = URL(string: "\(baseURL)?a=\(tokenId)")
+      }
+      return tokenURL
+    } else if token.isErc1155 {
+      return nil // ERC1155 is not yet supported
+    } else if token.isNft { // when NFT is a SPL NFT
+      if WalletConstants.supportedTestNetworkChainIds.contains(chainId) {
+        if let components = blockExplorerUrls.first?.separatedBy("/?cluster="), let baseURL = components.first {
+          let cluster = components.last ?? ""
+          if let tokenURL = URL(string: "\(baseURL)/address/\(token.contractAddress)/?cluster=\(cluster)") {
+            return tokenURL
+          }
+        }
+      } else {
+        if let explorerURL = blockExplorerUrls.first, let tokenURL = URL(string: "\(explorerURL)/address/\(token.contractAddress)") {
           return tokenURL
         }
-      }
-    } else {
-      if let explorerURL = blockExplorerUrls.first, let tokenURL = URL(string: "\(explorerURL)/address/\(token.contractAddress)") {
-        return tokenURL
       }
     }
     return nil

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -3684,13 +3684,6 @@ extension Strings {
       value: "%@ on %@",
       comment: "The description displayed below the token name on each row for the user assets. The first '%@' will be the token symbol, and the second '%@' will be the token's network name."
     )
-    public static let nftDetailTitle = NSLocalizedString(
-      "wallet.nftDetailTitle",
-      tableName: "BraveWallet",
-      bundle: .module,
-      value: "NFT Detail",
-      comment: "The navigation title for NFT detail screen."
-    )
     public static let nftDetailTokenID = NSLocalizedString(
       "wallet.nftDetailTokenID",
       tableName: "BraveWallet",
@@ -3716,7 +3709,7 @@ extension Strings {
       "wallet.nftDetailTokenStandard",
       tableName: "BraveWallet",
       bundle: .module,
-      value: "Token standard",
+      value: "Token Standard",
       comment: "The title an entry that will be displayed in NFT detail. This entry to display this NFT's token standard"
     )
     public static let nftDetailBlockchain = NSLocalizedString(
@@ -3753,6 +3746,27 @@ extension Strings {
       bundle: .module,
       value: "The image rendered above may not exactly match the NFT",
       comment: "A disclaimer that appears at the bottom of a NFT detail screen which shows NFT image and other information."
+    )
+    public static let nftDetailOverview = NSLocalizedString(
+      "wallet.nftDetailOverview",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Overview",
+      comment: "The section header that displays the overview information of this NFT."
+    )
+    public static let nftDetailProperties = NSLocalizedString(
+      "wallet.nftDetailProperties",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Properties",
+      comment: "The section header that displays the all the properties/attributes information of this NFT."
+    )
+    public static let nftDetailOwnedBy = NSLocalizedString(
+      "wallet.nftDetailOwnedBy",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Owned by",
+      comment: "The section header that displays the all the properties/attributes information of this NFT."
     )
     public static let signTransactionSignRisk = NSLocalizedString(
       "wallet.signTransactionSignRisk",

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -3766,7 +3766,7 @@ extension Strings {
       tableName: "BraveWallet",
       bundle: .module,
       value: "Owned by",
-      comment: "The section header that displays the all the properties/attributes information of this NFT."
+      comment: "The title of the row under `Overview` section in NFT details screen. When this NFT has an owner."
     )
     public static let signTransactionSignRisk = NSLocalizedString(
       "wallet.signTransactionSignRisk",

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -3765,7 +3765,7 @@ extension Strings {
       "wallet.nftDetailOwnedBy",
       tableName: "BraveWallet",
       bundle: .module,
-      value: "Owned by",
+      value: "Owned By",
       comment: "The title of the row under `Overview` section in NFT details screen. When this NFT has an owner."
     )
     public static let signTransactionSignRisk = NSLocalizedString(

--- a/Tests/BraveWalletTests/AccountActivityStoreTests.swift
+++ b/Tests/BraveWalletTests/AccountActivityStoreTests.swift
@@ -131,7 +131,7 @@ class AccountActivityStoreTests: XCTestCase {
     let mockNFTBalance: Double = 1
     let mockERC721BalanceWei = formatter.weiString(from: mockNFTBalance, radix: .hex, decimals: 0) ?? ""
     
-    let mockERC721Metadata: NFTMetadata = .init(imageURLString: "mock.image.url", name: "mock nft name", description: "mock nft description")
+    let mockERC721Metadata: NFTMetadata = .init(imageURLString: "mock.image.url", name: "mock nft name", description: "mock nft description", attributes: nil)
     
     let ethSendTxCopy = BraveWallet.TransactionInfo.previewConfirmedSend.copy() as! BraveWallet.TransactionInfo // default in mainnet
     let goerliSwapTxCopy = BraveWallet.TransactionInfo.previewConfirmedSwap.copy() as! BraveWallet.TransactionInfo
@@ -259,7 +259,7 @@ class AccountActivityStoreTests: XCTestCase {
       BraveWallet.BlockchainToken.mockSolanaNFTToken.contractAddress: "\(mockSolanaNFTTokenBalance)"
     ]
     
-    let mockSolMetadata: NFTMetadata = .init(imageURLString: "sol.mock.image.url", name: "sol mock nft name", description: "sol mock nft description")
+    let mockSolMetadata: NFTMetadata = .init(imageURLString: "sol.mock.image.url", name: "sol mock nft name", description: "sol mock nft description", attributes: nil)
     
     let solSendTxCopy = BraveWallet.TransactionInfo.previewConfirmedSolSystemTransfer.copy() as! BraveWallet.TransactionInfo // default in mainnet
     let solTestnetSendTxCopy = BraveWallet.TransactionInfo.previewConfirmedSolTokenTransfer.copy() as! BraveWallet.TransactionInfo

--- a/Tests/BraveWalletTests/NFTStoreTests.swift
+++ b/Tests/BraveWalletTests/NFTStoreTests.swift
@@ -32,8 +32,8 @@ class NFTStoreTests: XCTestCase {
   let solNetwork: BraveWallet.NetworkInfo = .mockSolana
   let solAccount: BraveWallet.AccountInfo = .mockSolAccount
   
-  let mockERC721Metadata: NFTMetadata = .init(imageURLString: "mock.image.url", name: "mock nft name", description: "mock nft description")
-  let mockSolMetadata: NFTMetadata = .init(imageURLString: "sol.mock.image.url", name: "sol mock nft name", description: "sol mock nft description")
+  let mockERC721Metadata: NFTMetadata = .init(imageURLString: "mock.image.url", name: "mock nft name", description: "mock nft description", attributes: nil)
+  let mockSolMetadata: NFTMetadata = .init(imageURLString: "sol.mock.image.url", name: "sol mock nft name", description: "sol mock nft description", attributes: nil)
   
   let spamEthNFT = (BraveWallet.BlockchainToken.mockERC721NFTToken.copy() as! BraveWallet.BlockchainToken).then {
     $0.contractAddress = "0xbbbbbbbbbb222222222233333333336666666666"

--- a/Tests/BraveWalletTests/SelectAccountTokenStoreTests.swift
+++ b/Tests/BraveWalletTests/SelectAccountTokenStoreTests.swift
@@ -104,7 +104,8 @@ import Preferences
     let mockNFTMetadata: NFTMetadata = .init(
       imageURLString: "sol.mock.image.url",
       name: "sol mock nft name",
-      description: "sol mock nft description"
+      description: "sol mock nft description",
+      attributes: nil
     )
     let mockFILBalance: Double = 1
     let mockFILPrice: String = "4.06" // FIL value = $4.06

--- a/Tests/BraveWalletTests/SendTokenStoreTests.swift
+++ b/Tests/BraveWalletTests/SendTokenStoreTests.swift
@@ -660,7 +660,7 @@ class SendTokenStoreTests: XCTestCase {
     ethTxManagerProxy._makeErc721TransferFromData = { _, _, _, _, completion in
       completion(true, .init())
     }
-    let mockERC721Metadata: NFTMetadata = .init(imageURLString: "mock.image.url", name: "mock nft name", description: "mock nft description")
+    let mockERC721Metadata: NFTMetadata = .init(imageURLString: "mock.image.url", name: "mock nft name", description: "mock nft description", attributes: nil)
     
     let store = SendTokenStore(
       keyringService: keyringService,
@@ -704,7 +704,7 @@ class SendTokenStoreTests: XCTestCase {
     ethTxManagerProxy._makeErc721TransferFromData = { _, _, _, _, completion in
       completion(true, .init())
     }
-    let mockSolMetadata: NFTMetadata = .init(imageURLString: "sol.mock.image.url", name: "sol mock nft name", description: "sol mock nft description")
+    let mockSolMetadata: NFTMetadata = .init(imageURLString: "sol.mock.image.url", name: "sol mock nft name", description: "sol mock nft description", attributes: nil)
     
     let store = SendTokenStore(
       keyringService: keyringService,


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8064

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Set up wallet and make sure add or auto-discover some NFTs
2. Click any NFT to go to its details screen 
3. The NFT image now has a network icon and an account blockie that owns this NFT (This is missing when you come from asset search list. Not listed in the figma, if this is required we can add later)
4. On top right there is a 3-dot button which will give you the same options when you long-press the NFT grid in the previous screen + a new option `Send` if this NFT is visible 
5. Click send will bring you to the send screen
6. Click hide will update NFT visible status which will change the options of the 3-dot, and move the NFT to the `Hide` selection if you go back to the previous screen
7. Click unhide will update NFT visible status which will change the options of the 3-dot, and move the NFT to the `Collected` selection if you go back to the previous screen.
8. Click mark as not junk will update NFT spam status which will change the options of the 3-dot, and move the NFT to the `Collected` selection if you go back to the previous screen
9. Click Don't show in wallet will remove NFT from the wallet after you confirm to remove it. You will be pop-off from the details screen and NFT will be remove from the wallet entirely. 
10. Below the image, we have `Overview`, `Description` and `Properties` sections(optional), if we have information from NFT's metadata. 

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

![Simulator Screenshot - iPhone 15 Pro - 2023-11-14 at 17 47 09](https://github.com/brave/brave-ios/assets/1187676/99988829-19ea-4932-ae40-083a2f700313) | ![Simulator Screenshot - iPhone 15 Pro - 2023-11-14 at 17 47 44](https://github.com/brave/brave-ios/assets/1187676/30ed8a83-50e1-4078-a8e3-35a4adc5b245)
--- | ---
![Simulator Screenshot - iPhone 15 Pro - 2023-11-14 at 17 47 13](https://github.com/brave/brave-ios/assets/1187676/e416ff2d-7a4d-4a08-a418-9ace7842960d) | ![Simulator Screenshot - iPhone 15 Pro - 2023-11-14 at 17 47 47](https://github.com/brave/brave-ios/assets/1187676/0fd870da-568b-4a70-afa8-28b635f5bd29)
![Simulator Screenshot - iPhone 15 Pro - 2023-11-14 at 17 47 19](https://github.com/brave/brave-ios/assets/1187676/f959f8cb-4f14-4936-92a6-5e88c33edcf5) | ![Simulator Screenshot - iPhone 15 Pro - 2023-11-14 at 17 47 41](https://github.com/brave/brave-ios/assets/1187676/4c4829dd-ee95-4311-8393-65cc5e897afa)
![Simulator Screenshot - iPhone 15 Pro - 2023-11-14 at 17 48 49](https://github.com/brave/brave-ios/assets/1187676/1cd38e94-238f-46e0-8452-e01f55a10bfd) | ![Simulator Screenshot - iPhone 15 Pro - 2023-11-14 at 21 09 57](https://github.com/brave/brave-ios/assets/1187676/76440802-4bc7-492e-84ad-5567f2ee2d47)

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
