### PR TITLE
Fix #8412: Dismiss NFT Discovery and NFT Removal popups when wallet is auto-locked

### DIFF
--- a/Sources/BraveWallet/Crypto/NFT/NFTView.swift
+++ b/Sources/BraveWallet/Crypto/NFT/NFTView.swift
@@ -416,6 +416,15 @@ struct NFTView: View {
         }
       })
     }
+    .onChange(of: keyringStore.isWalletLocked) { isLocked in
+      guard isLocked else { return }
+      if isShowingNFTDiscoveryAlert {
+        isShowingNFTDiscoveryAlert = false
+      }
+      if nftToBeRemoved != nil {
+        nftToBeRemoved = nil
+      }
+    }
     .onAppear {
       Task {
         isNFTDiscoveryEnabled = await nftStore.isNFTDiscoveryEnabled()


### PR DESCRIPTION
## Summary of Changes
- Dismiss the 2 NFT wallet popups (NFT Discovery and NFT Removal) when the wallet is auto-locked

This pull request fixes #8412

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

### NFT Auto-discovery
  1. Fresh install Brave and restore a wallet
  2. Update Auto-lock timer to 1 minute in Web3 Settings
  3. Visit Portfolio tab & Tap NFTs in segmented control
  4. Do not interact with popup, wait for auto-lock.
  5. Verify NFT auto-discovery popup is dismissed when wallet is locked.
  6. Unlock wallet, tap NFTs tab and verify popup is shown again.
  
### NFT Removal
  1. Update Auto-lock timer to 1 minute in Web3 Settings
  2. Tap & hold on an NFT and select `Don't show in wallet`
  3. Do not interact with popup, wait for auto-lock.
  4. Verify NFT removal popup is dismissed when wallet is locked.
  5. Unlock wallet, tap NFTs tab and try to remove the NFT again. Verify removal popup is shown again.
  


## Screenshots:

### NFT Auto-discovery

https://github.com/brave/brave-ios/assets/5314553/39d47358-442e-4e1a-bf69-752c3d47f25b


### NFT Removal

https://github.com/brave/brave-ios/assets/5314553/81dbdeb2-de0d-4ff4-90e0-7593a29bd540



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
