### PR TITLE
Fix #8421: Update the toolbar layout on `viewWillAppear`

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController.swift
@@ -1108,6 +1108,12 @@ public class BrowserViewController: UIViewController {
 
   override public func viewWillAppear(_ animated: Bool) {
     super.viewWillAppear(animated)
+    if #available(iOS 17, *) {
+      // On iOS 17 rotating the device with a full screen modal presented (e.g. Playlist, Tab Tray)
+      // to landscape then back to portrait does not trigger `traitCollectionDidChange`/`willTransition`/etc
+      // calls and so the toolbar remains in the wrong state.
+      updateToolbarStateForTraitCollection(traitCollection)
+    }
     updateToolbarUsingTabManager(tabManager)
 
     if let tabId = tabManager.selectedTab?.rewardsId, rewards.rewardsAPI?.selectedTabId == 0 {


### PR DESCRIPTION
On iOS 17 rotating the device with a full screen modal presented (e.g. Playlist, Tab Tray) to landscape then back to portrait does not trigger `traitCollectionDidChange`/`willTransition`/etc calls and so the toolbar remains in the wrong state.

## Summary of Changes

This pull request fixes #8421 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
