### PR TITLE
Fix #8396: Use correct text color for Brave VPN menu button

### DIFF
--- a/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/VPNMenuButton.swift
+++ b/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/VPNMenuButton.swift
@@ -136,7 +136,6 @@ struct VPNMenuButton: View {
         .padding(.vertical, 2)
       VStack(alignment: .leading, spacing: 3) {
         Text(verbatim: description == nil ? "Brave VPN" : Strings.OptionsMenu.braveVPNItemTitle)
-          .foregroundColor(Color(.bravePrimary))
         if let subTitle = description {
           Text(retryStateActive ? Strings.VPN.vpnUpdatePaymentMethodDescriptionText : subTitle)
             .font(.subheadline)


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #8396 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Screenshots:

| NTP | Website |
| --- | --- |
| ![Simulator Screenshot - iPhone 15 - 2023-11-16 at 12 36 18](https://github.com/brave/brave-ios/assets/529104/78dc56d6-29a9-4e4d-b2c4-7b2141171be3) | ![Simulator Screenshot - iPhone 15 - 2023-11-16 at 12 36 14](https://github.com/brave/brave-ios/assets/529104/43d1805a-4df2-4636-997d-2f040bf439e6) |

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
