### PR TITLE
Fix #8393: Update the progress & url correctly when cancelling a load

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController.swift
@@ -1699,6 +1699,10 @@ public class BrowserViewController: UIViewController {
     case .loading:
       if tab === tabManager.selectedTab {
         topToolbar.locationView.loading = tab.loading
+        // There is a bug in WebKit where if you cancel a load on a request the progress can stick to 0.1
+        if !tab.loading, webView.estimatedProgress != 1 {
+          topToolbar.updateProgressBar(1)
+        }
       }
     case .URL:
       guard let tab = tabManager[webView] else { break }
@@ -1720,6 +1724,8 @@ public class BrowserViewController: UIViewController {
         // Catch history pushState navigation, but ONLY for same origin navigation,
         // for reasons above about URL spoofing risk.
         navigateInTab(tab: tab)
+      } else {
+        updateURLBar()
       }
 
       // Rewards reporting


### PR DESCRIPTION
If you return `cancel` in one of the `decidePolicy*` methods the progress bar gets stuck at 10%. When that load happens on NTP, the url shown also gets stuck showing the cancelled url.

## Summary of Changes

This pull request fixes #8393 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
