### PR TITLE
Fix 8431: Copy mistake in confirmation message after resetting VPN config

### DIFF
--- a/Sources/BraveStrings/BraveStrings.swift
+++ b/Sources/BraveStrings/BraveStrings.swift
@@ -3082,7 +3082,7 @@ extension Strings {
 
     public static let resetVPNSuccessBody =
       NSLocalizedString("vpn.resetVPNSuccessBody", tableName: "BraveShared", bundle: .module,
-        value: "VPN Configuration is resetted successfully.",
+        value: "VPN Configuration is reset successfully.",
         comment: "Message to show when vpn configuration reset succeeds.")
 
     public static let contactFormDoNotEditText =


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->
Grammatical Error with Confirmation is fixed

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8431

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
