### PR TITLE
Fix #8266: Disable rpc url selection in view mode from dapp request

### DIFF
--- a/Sources/BraveWallet/Settings/CustomNetworkDetailsView.swift
+++ b/Sources/BraveWallet/Settings/CustomNetworkDetailsView.swift
@@ -547,7 +547,7 @@ struct NetworkRadioButton: View {
   var body: some View {
     Image(braveSystemName: checked ? "leo.check.circle-outline" : "leo.radio.unchecked")
       .renderingMode(.template)
-      .foregroundColor(Color(checked ? .braveBlurpleTint : .braveDisabled))
+      .foregroundColor(Color((checked && !isDisabled) ? .braveBlurpleTint : .braveDisabled))
       .font(.title3)
       .onTapGesture {
         if !self.isDisabled && !checked {


### PR DESCRIPTION

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
tap gesture is already disabled. update colour so that users won't get the feeling of rpc url is configurable via dapp request. 

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8266

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
1. set up wallet
2. go to chainlist.org to add a network that is not reloaded from wallet
3. in the prompt request, click view detail to see the network detail 
4. observe the rpc url radio button's colours are all in disable colour 

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

![Simulator Screenshot - iPhone 15 Pro - 2023-11-17 at 17 21 53](https://github.com/brave/brave-ios/assets/1187676/4afc2f90-482e-488a-8db0-825a8b6f59bd)


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
