### PR TITLE
Fix #8435: NFT images failing to show in Activity tab Send transactions

### DIFF
--- a/Sources/BraveWallet/Crypto/AssetIconView.swift
+++ b/Sources/BraveWallet/Crypto/AssetIconView.swift
@@ -147,7 +147,10 @@ struct NFTIconView: View {
   }
   
   var body: some View {
-    NFTImageView(urlString: url?.absoluteString ?? "", isLoading: isLoadingMetadata) {
+    NFTImageView( // logo populated for auto-discovered NFTs
+      urlString: url?.absoluteString ?? token.logo,
+      isLoading: isLoadingMetadata
+    ) {
       LoadingNFTView(shimmer: false)
     }
     .cornerRadius(5)

--- a/Sources/BraveWallet/Crypto/Stores/AccountActivityStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/AccountActivityStore.swift
@@ -304,6 +304,7 @@ class AccountActivityStore: ObservableObject, WalletObserverStore {
           userAssets: userAssets,
           allTokens: allTokens,
           assetRatios: assetRatios,
+          nftMetadata: [:],
           solEstimatedTxFee: solEstimatedTxFees[transaction.id],
           currencyFormatter: currencyFormatter
         )

--- a/Sources/BraveWallet/Crypto/Stores/AssetDetailStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/AssetDetailStore.swift
@@ -376,6 +376,7 @@ class AssetDetailStore: ObservableObject, WalletObserverStore {
           userAssets: userAssets,
           allTokens: allTokens,
           assetRatios: assetRatios,
+          nftMetadata: [:],
           solEstimatedTxFee: solEstimatedTxFees[transaction.id],
           currencyFormatter: self.currencyFormatter
         )

--- a/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -190,6 +190,7 @@ public class CryptoStore: ObservableObject, WalletObserverStore {
       blockchainRegistry: blockchainRegistry,
       txService: txService,
       solTxManagerProxy: solTxManagerProxy,
+      ipfsApi: ipfsApi,
       userAssetManager: userAssetManager
     )
     self.marketStore = .init(

--- a/Sources/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
@@ -319,6 +319,7 @@ public class TransactionConfirmationStore: ObservableObject, WalletObserverStore
         userAssets: userAssets,
         allTokens: allTokens,
         assetRatios: assetRatios,
+        nftMetadata: [:],
         solEstimatedTxFee: solEstimatedTxFee,
         currencyFormatter: currencyFormatter
       ) else {

--- a/Sources/BraveWallet/Crypto/Stores/TransactionDetailsStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/TransactionDetailsStore.swift
@@ -112,6 +112,7 @@ class TransactionDetailsStore: ObservableObject, WalletObserverStore {
         userAssets: userAssets,
         allTokens: allTokens,
         assetRatios: assetRatios,
+        nftMetadata: [:],
         solEstimatedTxFee: solEstimatedTxFee,
         currencyFormatter: currencyFormatter
       ) else {

--- a/Sources/BraveWallet/Crypto/Transactions/TransactionParser+TransactionSummary.swift
+++ b/Sources/BraveWallet/Crypto/Transactions/TransactionParser+TransactionSummary.swift
@@ -44,6 +44,7 @@ extension TransactionParser {
     userAssets: [BraveWallet.BlockchainToken],
     allTokens: [BraveWallet.BlockchainToken],
     assetRatios: [String: Double],
+    nftMetadata: [String: NFTMetadata],
     solEstimatedTxFee: UInt64?,
     currencyFormatter: NumberFormatter
   ) -> TransactionSummary {
@@ -54,6 +55,7 @@ extension TransactionParser {
       userAssets: userAssets,
       allTokens: allTokens,
       assetRatios: assetRatios,
+      nftMetadata: nftMetadata,
       solEstimatedTxFee: solEstimatedTxFee,
       currencyFormatter: currencyFormatter,
       decimalFormatStyle: .balance // use 4 digit precision for summary

--- a/Sources/BraveWallet/Crypto/Transactions/TransactionSummaryViews.swift
+++ b/Sources/BraveWallet/Crypto/Transactions/TransactionSummaryViews.swift
@@ -19,6 +19,7 @@ struct TransactionSummaryViewContainer: View {
       SendTransactionSummaryView(
         sentFromAccountName: parsedTransaction.namedFromAddress,
         token: details.fromToken,
+        nftMetadata: details.fromTokenMetadata,
         network: parsedTransaction.network,
         valueSent: details.fromAmount,
         fiatValueSent: details.fromFiat ?? "",
@@ -67,6 +68,7 @@ struct TransactionSummaryViewContainer: View {
       SendTransactionSummaryView(
         sentFromAccountName: parsedTransaction.namedFromAddress,
         token: details.fromToken,
+        nftMetadata: details.nftMetadata,
         network: parsedTransaction.network,
         valueSent: nil,
         fiatValueSent: nil,
@@ -101,6 +103,7 @@ struct SendTransactionSummaryView: View {
   
   let sentFromAccountName: String
   let token: BraveWallet.BlockchainToken?
+  let nftMetadata: NFTMetadata?
   let network: BraveWallet.NetworkInfo
   let valueSent: String?
   let fiatValueSent: String?
@@ -110,6 +113,7 @@ struct SendTransactionSummaryView: View {
   init(
     sentFromAccountName: String,
     token: BraveWallet.BlockchainToken?,
+    nftMetadata: NFTMetadata? = nil,
     network: BraveWallet.NetworkInfo,
     valueSent: String?,
     fiatValueSent: String?,
@@ -117,6 +121,7 @@ struct SendTransactionSummaryView: View {
     time: Date
   ) {
     self.sentFromAccountName = sentFromAccountName
+    self.nftMetadata = nftMetadata
     self.token = token
     self.network = network
     self.valueSent = valueSent
@@ -162,7 +167,7 @@ struct SendTransactionSummaryView: View {
               NFTIconView(
                 token: token,
                 network: network,
-                url: nil,
+                url: nftMetadata?.imageURL,
                 shouldShowNetworkIcon: true,
                 length: length,
                 maxLength: maxLength,

--- a/Sources/BraveWallet/Preview Content/MockContent.swift
+++ b/Sources/BraveWallet/Preview Content/MockContent.swift
@@ -431,6 +431,7 @@ extension TransactionSummary {
       userAssets: [.previewToken, .previewDaiToken],
       allTokens: [],
       assetRatios: [BraveWallet.BlockchainToken.previewToken.assetRatioId.lowercased(): 1],
+      nftMetadata: [:],
       solEstimatedTxFee: nil,
       currencyFormatter: .usdCurrencyFormatter
     )
@@ -451,6 +452,7 @@ extension ParsedTransaction {
       userAssets: [.previewToken, .previewDaiToken],
       allTokens: [],
       assetRatios: [BraveWallet.BlockchainToken.previewToken.assetRatioId.lowercased(): 1],
+      nftMetadata: [:],
       solEstimatedTxFee: nil,
       currencyFormatter: .usdCurrencyFormatter
     )

--- a/Sources/BraveWallet/Preview Content/MockContent.swift
+++ b/Sources/BraveWallet/Preview Content/MockContent.swift
@@ -285,6 +285,47 @@ extension BraveWallet.TransactionInfo {
       effectiveRecipient: BraveWallet.BlockchainToken.previewDaiToken.contractAddress
     )
   }
+  /// Sent `mockERC721NFTToken` NFT
+  static var previewERC721Send: BraveWallet.TransactionInfo {
+    BraveWallet.TransactionInfo(
+      id: "81111c05-612a-47c5-84b0-e95045d15b37",
+      fromAddress: BraveWallet.AccountInfo.previewAccount.accountId.address,
+      from: BraveWallet.AccountInfo.previewAccount.accountId,
+      txHash: "0x46d0ecf2ec9829d451154767c98ae372413bac809c25b16d1946aba100663e4b",
+      txDataUnion: .init(
+        ethTxData1559: .init(
+          baseData: .init(
+            nonce: "0x5",
+            gasPrice: "0xa06907542",
+            gasLimit: "0x12e61",
+            to: BraveWallet.BlockchainToken.mockERC721NFTToken.contractAddress,
+            value: "0x0",
+            data: _transactionBase64ToData("CV6nswAAAAAAAAAAAAAAAOWSQnoK7Okt4+3uHxjgFXwFhhVk//////////////////////////////////////////8="),
+            signOnly: false,
+            signedTransaction: nil
+          ),
+          chainId: BraveWallet.MainnetChainId,
+          maxPriorityFeePerGas: "",
+          maxFeePerGas: "",
+          gasEstimation: nil
+        )
+      ),
+      txStatus: .confirmed,
+      txType: .erc721SafeTransferFrom,
+      txParams: ["address", "address", "uint256"],
+      txArgs: [
+        "0x35dcec532e809a3daa04ed3fd958586f7bac9191", // owner
+        "0x3f2116ef98fcab1a9c3c2d8988e0064ab59acfca", // to address
+        BraveWallet.BlockchainToken.mockERC721NFTToken.tokenId // token id
+      ],
+      createdTime: Date(timeIntervalSince1970: 1636399671), // Monday, November 8, 2021 7:27:51 PM
+      submittedTime: Date(timeIntervalSince1970: 1636399673), // Monday, November 8, 2021 7:27:53 PM
+      confirmedTime: Date(timeIntervalSince1970: 1636402508), // Monday, November 8, 2021 8:15:08 PM
+      originInfo: .init(),
+      chainId: BraveWallet.MainnetChainId,
+      effectiveRecipient: "0x3f2116ef98fcab1a9c3c2d8988e0064ab59acfca"
+    )
+  }
   /// Solana System Transfer
   static var previewConfirmedSolSystemTransfer: BraveWallet.TransactionInfo {
     BraveWallet.TransactionInfo(

--- a/Sources/BraveWallet/Preview Content/MockStores.swift
+++ b/Sources/BraveWallet/Preview Content/MockStores.swift
@@ -236,6 +236,7 @@ extension TransactionsActivityStore {
     blockchainRegistry: MockBlockchainRegistry(),
     txService: MockTxService(),
     solTxManagerProxy: BraveWallet.TestSolanaTxManagerProxy.previewProxy,
+    ipfsApi: TestIpfsAPI(),
     userAssetManager: TestableWalletUserAssetManager()
   )
 }

--- a/Tests/BraveWalletTests/TransactionParserTests.swift
+++ b/Tests/BraveWalletTests/TransactionParserTests.swift
@@ -131,6 +131,7 @@ class TransactionParserTests: XCTestCase {
           fromValue: "0x1b667a56d488000",
           fromAmount: "0.1234",
           fromFiat: "$0.12",
+          fromTokenMetadata: nil,
           gasFee: .init(
             fee: "0.000031",
             fiat: "$0.000031"
@@ -146,6 +147,7 @@ class TransactionParserTests: XCTestCase {
       userAssets: tokens,
       allTokens: tokens,
       assetRatios: assetRatios,
+      nftMetadata: [:],
       solEstimatedTxFee: nil,
       currencyFormatter: currencyFormatter
     ) else {
@@ -226,6 +228,7 @@ class TransactionParserTests: XCTestCase {
           fromValue: "0x5ff20a91f724000",
           fromAmount: "0.4321",
           fromFiat: "$0.86",
+          fromTokenMetadata: nil,
           gasFee: .init(
             fee: "0.000078",
             fiat: "$0.000078"
@@ -241,6 +244,7 @@ class TransactionParserTests: XCTestCase {
       userAssets: tokens,
       allTokens: tokens,
       assetRatios: assetRatios,
+      nftMetadata: [:],
       solEstimatedTxFee: nil,
       currencyFormatter: currencyFormatter
     ) else {
@@ -331,6 +335,7 @@ class TransactionParserTests: XCTestCase {
       userAssets: tokens,
       allTokens: tokens,
       assetRatios: assetRatios,
+      nftMetadata: [:],
       solEstimatedTxFee: nil,
       currencyFormatter: currencyFormatter
     ) else {
@@ -421,6 +426,7 @@ class TransactionParserTests: XCTestCase {
       userAssets: tokens,
       allTokens: tokens,
       assetRatios: assetRatios,
+      nftMetadata: [:],
       solEstimatedTxFee: nil,
       currencyFormatter: currencyFormatter
     ) else {
@@ -506,6 +512,7 @@ class TransactionParserTests: XCTestCase {
       userAssets: tokens,
       allTokens: tokens,
       assetRatios: assetRatios,
+      nftMetadata: [:],
       solEstimatedTxFee: nil,
       currencyFormatter: currencyFormatter
     ) else {
@@ -591,6 +598,7 @@ class TransactionParserTests: XCTestCase {
       userAssets: tokens,
       allTokens: tokens,
       assetRatios: assetRatios,
+      nftMetadata: [:],
       solEstimatedTxFee: nil,
       currencyFormatter: currencyFormatter
     ) else {
@@ -661,6 +669,7 @@ class TransactionParserTests: XCTestCase {
           fromToken: .previewDaiToken,
           fromValue: "1",
           fromAmount: "1",
+          nftMetadata: nil,
           owner: "0x1111111111aaaaaaaaaa2222222222bbbbbbbbbb",
           tokenId: "token.id",
           gasFee: .init(
@@ -678,6 +687,7 @@ class TransactionParserTests: XCTestCase {
       userAssets: tokens,
       allTokens: tokens,
       assetRatios: assetRatios,
+      nftMetadata: [:],
       solEstimatedTxFee: nil,
       currencyFormatter: currencyFormatter
     ) else {
@@ -746,6 +756,7 @@ class TransactionParserTests: XCTestCase {
           fromValue: "100000000",
           fromAmount: "0.1",
           fromFiat: "$2.00",
+          fromTokenMetadata: nil,
           gasFee: .init(
             fee: "0.00123",
             fiat: "$0.0246"
@@ -761,6 +772,7 @@ class TransactionParserTests: XCTestCase {
       userAssets: tokens,
       allTokens: tokens,
       assetRatios: assetRatios,
+      nftMetadata: [:],
       solEstimatedTxFee: 1230000,
       currencyFormatter: currencyFormatter
     ) else {
@@ -843,6 +855,7 @@ class TransactionParserTests: XCTestCase {
           fromValue: "43210000",
           fromAmount: "43.21",
           fromFiat: "$648.15",
+          fromTokenMetadata: nil,
           gasFee: .init(
             fee: "0.0123",
             fiat: "$0.246"
@@ -858,6 +871,7 @@ class TransactionParserTests: XCTestCase {
       userAssets: tokens,
       allTokens: tokens,
       assetRatios: assetRatios,
+      nftMetadata: [:],
       solEstimatedTxFee: 12300000,
       currencyFormatter: currencyFormatter
     ) else {
@@ -927,6 +941,7 @@ class TransactionParserTests: XCTestCase {
           fromValue: "1",
           fromAmount: "1",
           fromFiat: "",
+          fromTokenMetadata: nil,
           gasFee: .init(
             fee: "0.0123",
             fiat: "$0.246"
@@ -942,6 +957,7 @@ class TransactionParserTests: XCTestCase {
       userAssets: tokens,
       allTokens: tokens,
       assetRatios: assetRatios,
+      nftMetadata: [:],
       solEstimatedTxFee: 12300000,
       currencyFormatter: currencyFormatter
     ) else {
@@ -1156,6 +1172,7 @@ class TransactionParserTests: XCTestCase {
       userAssets: tokens,
       allTokens: tokens,
       assetRatios: assetRatios,
+      nftMetadata: [:],
       solEstimatedTxFee: nil,
       currencyFormatter: currencyFormatter
     ) else {


### PR DESCRIPTION
## Summary of Changes
- NFT metadata was not being fetched in Activity tab. The only NFTs with an image would be auto-discovered NFTs, which would display when the `NFTIconView` placeholder was using `AssetIconView`.

This pull request fixes #8435

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
  1. Add an NFT you own manually, not via auto-discovery. The NFT should have an image attached that is displayed in NFT tab/grid.
  2. Create a Send transaction for the NFT (you don't have to confirm the transaction).
  3. Visit activity tab and wait for NFT image to show / load in the send transaction row. 
  4. Verify the same image shown in Send row as in NFT tab/grid.


## Screenshots:

![nft image in send](https://github.com/brave/brave-ios/assets/5314553/920f8010-a33e-4d5e-b73d-d40eb4758adc)


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
