### PR TITLE
Fix #8267: rpc url in custom network cannot be updated

### DIFF
--- a/Sources/BraveWallet/Crypto/Stores/NetworkStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/NetworkStore.swift
@@ -267,6 +267,7 @@ public class NetworkStore: ObservableObject, WalletObserverStore {
         if let oldNetwork = allChains.filter({ $0.coin == .eth }).first(where: { $0.id.lowercased() == network.id.lowercased() }) {
           let (_, addOldStatus, _) = await rpcService.addChain(oldNetwork)
           guard addOldStatus == .success else {
+            isAddingNewNetwork = false
             return (false, errMsg)
           }
           customNetworkNativeAssetMigration(network)
@@ -285,6 +286,7 @@ public class NetworkStore: ObservableObject, WalletObserverStore {
     } else {
       let (_, addStatus, errMsg) = await rpcService.addChain(network)
       guard addStatus == .success else {
+        isAddingNewNetwork = false
         return (false, errMsg)
       }
       customNetworkNativeAssetMigration(network)

--- a/Sources/BraveWallet/Crypto/Stores/NetworkStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/NetworkStore.swift
@@ -250,64 +250,48 @@ public class NetworkStore: ObservableObject, WalletObserverStore {
   // MARK: - Custom Networks
 
   @Published var isAddingNewNetwork: Bool = false
-
-  public func addCustomNetwork(
-    _ network: BraveWallet.NetworkInfo,
-    completion: @escaping (_ accepted: Bool, _ errMsg: String) -> Void
-  ) {
-    func add(network: BraveWallet.NetworkInfo, completion: @escaping (_ accepted: Bool, _ errMsg: String) -> Void) {
-      rpcService.addChain(network) { [self] chainId, status, message in
-        if status == .success {
-          // Update `ethereumChains` by api calling
-          Task {
-            await updateChainList()
+  
+  @MainActor func addCustomNetwork(_ network: BraveWallet.NetworkInfo) async -> (accepted: Bool, errMsg: String) {
+    isAddingNewNetwork = true
+    if allChains.filter({ $0.coin == .eth }).contains(where: { $0.id.lowercased() == network.id.lowercased() }) {
+      let removeStatus = await rpcService.removeChain(network.chainId, coin: network.coin)
+      guard removeStatus else {
+        return (false, "Not able to remove network chainId (\(network.chainId)")
+      }
+      // delete local stored user assets that in this custom network
+      assetManager.removeGroup(for: network.walletUserAssetGroupId, completion: nil)
+      
+      let (_, addStatus, errMsg) = await rpcService.addChain(network)
+      guard addStatus == .success else {
+        // if adding is not succeeded, we have to add back the old network info
+        if let oldNetwork = allChains.filter({ $0.coin == .eth }).first(where: { $0.id.lowercased() == network.id.lowercased() }) {
+          let (_, addOldStatus, _) = await rpcService.addChain(oldNetwork)
+          guard addOldStatus == .success else {
+            return (false, errMsg)
           }
           customNetworkNativeAssetMigration(network)
           isAddingNewNetwork = false
-          completion(true, "")
+          await updateChainList()
+          return (false, errMsg)
         } else {
-          // meaning add custom network failed for some reason.
-          // Also add the the old network back on rpc service
-          if let oldNetwork = allChains.filter({ $0.coin == .eth }).first(where: { $0.id.lowercased() == network.id.lowercased() }) {
-            rpcService.addChain(oldNetwork) { _, _, _ in
-              Task {
-                await self.updateChainList()
-              }
-              self.customNetworkNativeAssetMigration(network)
-              self.isAddingNewNetwork = false
-              completion(false, message)
-            }
-          } else {
-            isAddingNewNetwork = false
-            completion(false, message)
-          }
-        }
-      }
-    }
-
-    isAddingNewNetwork = true
-    if allChains.filter({ $0.coin == .eth }).contains(where: { $0.id.lowercased() == network.id.lowercased() }) {
-      removeNetworkForNewAddition(network) { [self] success in
-        guard success else {
           isAddingNewNetwork = false
-          completion(false, Strings.Wallet.failedToRemoveCustomNetworkErrorMessage)
-          return
+          return (false, errMsg)
         }
-        add(network: network, completion: completion)
       }
+      customNetworkNativeAssetMigration(network)
+      isAddingNewNetwork = false
+      await updateChainList()
+      return (true, "")
     } else {
-      add(network: network, completion: completion)
+      let (_, addStatus, errMsg) = await rpcService.addChain(network)
+      guard addStatus == .success else {
+        return (false, errMsg)
+      }
+      customNetworkNativeAssetMigration(network)
+      isAddingNewNetwork = false
+      await updateChainList()
+      return (true, "")
     }
-  }
-
-  /// This method will not update `ethereumChains`
-  private func removeNetworkForNewAddition(
-    _ network: BraveWallet.NetworkInfo,
-    completion: @escaping (_ success: Bool) -> Void
-  ) {
-    rpcService.removeChain(network.id, coin: network.coin, completion: completion)
-    // delete local stored user assets that in this custom network
-    assetManager.removeGroup(for: network.walletUserAssetGroupId, completion: nil)
   }
 
   public func removeCustomNetwork(

--- a/Sources/BraveWallet/Preview Content/MockStores.swift
+++ b/Sources/BraveWallet/Preview Content/MockStores.swift
@@ -56,8 +56,12 @@ extension NetworkStore {
   }
   
   static var previewStoreWithCustomNetworkAdded: NetworkStore {
-    let store = NetworkStore.previewStore
-    store.addCustomNetwork(
+    let keyringService = MockKeyringService()
+    let rpcService = MockJsonRpcService()
+    let walletService = MockBraveWalletService()
+    let swapService = MockSwapService()
+    let userAssetManager = TestableWalletUserAssetManager()
+    rpcService.addChain(
       .init(
         chainId: "0x100",
         chainName: "MockChain",
@@ -72,7 +76,15 @@ extension NetworkStore {
         supportedKeyrings: [BraveWallet.KeyringId.default.rawValue].map(NSNumber.init(value:)),
         isEip1559: false
       )
-    ) { _, _ in }
+    ) { _, _, _ in }
+      
+    let store = NetworkStore(
+      keyringService: keyringService,
+      rpcService: rpcService,
+      walletService: walletService,
+      swapService: swapService,
+      userAssetManager: userAssetManager
+    )
     return store
   }
 }

--- a/Sources/BraveWallet/Settings/CustomNetworkDetailsView.swift
+++ b/Sources/BraveWallet/Settings/CustomNetworkDetailsView.swift
@@ -529,7 +529,8 @@ struct CustomNetworkDetailsView: View {
       supportedKeyrings: [BraveWallet.KeyringId.default.rawValue].map(NSNumber.init(value:)),
       isEip1559: false
     )
-    networkStore.addCustomNetwork(network) { accepted, errMsg in
+    Task { @MainActor in
+      let (accepted, errMsg) = await networkStore.addCustomNetwork(network)
       guard accepted else {
         customNetworkError = .failed(errorMessage: errMsg)
         return


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8267

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
1. Test RPC urls can be changed to other valid rpc url for an existed custom network 
2. Test A new custom network can be still added with no problem. 

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
