### PR TITLE
Fix #8361: Open Add separator between inactive tabs

### DIFF
--- a/Sources/Brave/Frontend/Browser/Tabs/TabBar/TabBarCell.swift
+++ b/Sources/Brave/Frontend/Browser/Tabs/TabBar/TabBarCell.swift
@@ -30,10 +30,17 @@ class TabBarCell: UICollectionViewCell {
     $0.layer.shadowOffset = CGSize(width: 0, height: 1)
     $0.layer.shadowRadius = 2
   }
+  
+  private let separatorLine = UIView()
+
+  let separatorLineRight = UIView().then {
+    $0.isHidden = true
+  }
 
   var currentIndex: Int = -1 {
     didSet {
       isSelected = currentIndex == tabManager?.currentDisplayedIndex
+      separatorLine.isHidden = currentIndex == 0
     }
   }
   weak var tab: Tab?
@@ -56,7 +63,7 @@ class TabBarCell: UICollectionViewCell {
   override init(frame: CGRect) {
     super.init(frame: frame)
     
-    [highlightView, closeButton, titleLabel].forEach { contentView.addSubview($0) }
+    [highlightView, closeButton, titleLabel, separatorLine, separatorLineRight].forEach { contentView.addSubview($0) }
     initConstraints()
     updateFont()
     
@@ -67,6 +74,10 @@ class TabBarCell: UICollectionViewCell {
   private func updateColors() {
     let browserColors: any BrowserColors = tabManager?.privateBrowsingManager.browserColors ?? .standard
     backgroundColor = browserColors.tabBarTabBackground
+    
+    separatorLine.backgroundColor = .red // browserColors.dividerSubtle
+    separatorLineRight.backgroundColor = .red // browserColors.dividerSubtle
+    
     highlightView.backgroundColor = isSelected ? browserColors.tabBarTabActiveBackground : .clear
     highlightView.layer.shadowOpacity = isSelected ? 0.05 : 0.0
     highlightView.layer.shadowColor = UIColor.black.cgColor
@@ -93,6 +104,20 @@ class TabBarCell: UICollectionViewCell {
       make.top.bottom.equalTo(self)
       make.right.equalTo(self).inset(2)
       make.width.equalTo(30)
+    }
+    
+    separatorLine.snp.makeConstraints { make in
+      make.left.equalToSuperview()
+      make.width.equalTo(1)
+      make.height.equalTo((frame.height * 0.65))
+      make.centerY.equalToSuperview()
+    }
+
+    separatorLineRight.snp.makeConstraints { make in
+      make.right.equalToSuperview()
+      make.width.equalTo(1)
+      make.height.equalTo((frame.height * 0.65))
+      make.centerY.equalToSuperview()
     }
   }
 
@@ -149,5 +174,19 @@ class TabBarCell: UICollectionViewCell {
     super.layoutSubviews()
     
     highlightView.layer.shadowPath = UIBezierPath(roundedRect: highlightView.bounds, cornerRadius: 4).cgPath
+    
+    separatorLine.snp.remakeConstraints { make in
+      make.left.equalToSuperview()
+      make.width.equalTo(1)
+      make.height.equalTo((frame.height * 0.65))
+      make.centerY.equalToSuperview()
+    }
+
+    separatorLineRight.snp.remakeConstraints { make in
+      make.right.equalToSuperview()
+      make.width.equalTo(1)
+      make.height.equalTo((frame.height * 0.65))
+      make.centerY.equalToSuperview()
+    }
   }
 }

--- a/Sources/Brave/Frontend/Browser/Tabs/TabBar/TabBarCell.swift
+++ b/Sources/Brave/Frontend/Browser/Tabs/TabBar/TabBarCell.swift
@@ -31,16 +31,16 @@ class TabBarCell: UICollectionViewCell {
     $0.layer.shadowRadius = 2
   }
   
-  private let separatorLine = UIView()
-
-  let separatorLineRight = UIView().then {
+  private let separatorLine = UIView().then {
     $0.isHidden = true
   }
 
   var currentIndex: Int = -1 {
     didSet {
       isSelected = currentIndex == tabManager?.currentDisplayedIndex
-      separatorLine.isHidden = currentIndex == 0
+      separatorLine.isHidden = isSelected || 
+        currentIndex == 0 ||
+        currentIndex == (tabManager?.currentDisplayedIndex ?? 0) + 1
     }
   }
   weak var tab: Tab?
@@ -63,7 +63,7 @@ class TabBarCell: UICollectionViewCell {
   override init(frame: CGRect) {
     super.init(frame: frame)
     
-    [highlightView, closeButton, titleLabel, separatorLine, separatorLineRight].forEach { contentView.addSubview($0) }
+    [highlightView, closeButton, titleLabel, separatorLine].forEach { contentView.addSubview($0) }
     initConstraints()
     updateFont()
     
@@ -74,10 +74,7 @@ class TabBarCell: UICollectionViewCell {
   private func updateColors() {
     let browserColors: any BrowserColors = tabManager?.privateBrowsingManager.browserColors ?? .standard
     backgroundColor = browserColors.tabBarTabBackground
-    
-    separatorLine.backgroundColor = .red // browserColors.dividerSubtle
-    separatorLineRight.backgroundColor = .red // browserColors.dividerSubtle
-    
+    separatorLine.backgroundColor = browserColors.dividerSubtle
     highlightView.backgroundColor = isSelected ? browserColors.tabBarTabActiveBackground : .clear
     highlightView.layer.shadowOpacity = isSelected ? 0.05 : 0.0
     highlightView.layer.shadowColor = UIColor.black.cgColor
@@ -109,15 +106,7 @@ class TabBarCell: UICollectionViewCell {
     separatorLine.snp.makeConstraints { make in
       make.left.equalToSuperview()
       make.width.equalTo(1)
-      make.height.equalTo((frame.height * 0.65))
-      make.centerY.equalToSuperview()
-    }
-
-    separatorLineRight.snp.makeConstraints { make in
-      make.right.equalToSuperview()
-      make.width.equalTo(1)
-      make.height.equalTo((frame.height * 0.65))
-      make.centerY.equalToSuperview()
+      make.top.bottom.equalToSuperview().inset(5)
     }
   }
 
@@ -174,19 +163,5 @@ class TabBarCell: UICollectionViewCell {
     super.layoutSubviews()
     
     highlightView.layer.shadowPath = UIBezierPath(roundedRect: highlightView.bounds, cornerRadius: 4).cgPath
-    
-    separatorLine.snp.remakeConstraints { make in
-      make.left.equalToSuperview()
-      make.width.equalTo(1)
-      make.height.equalTo((frame.height * 0.65))
-      make.centerY.equalToSuperview()
-    }
-
-    separatorLineRight.snp.remakeConstraints { make in
-      make.right.equalToSuperview()
-      make.width.equalTo(1)
-      make.height.equalTo((frame.height * 0.65))
-      make.centerY.equalToSuperview()
-    }
   }
 }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8361

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
 -Add multiple tabs check there are separators in between tabs except start of the tabs bar and end of the tabs bar.
 
 Also the active tab will not have separators

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

![separators](https://github.com/brave/brave-ios/assets/6643505/4395bbeb-9050-4aca-87d8-c892bb8e6344)


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
