### PR TITLE
Ref #8431: Copy mistake in confirmation message after resetting VPN config

### DIFF
--- a/Sources/BraveStrings/BraveStrings.swift
+++ b/Sources/BraveStrings/BraveStrings.swift
@@ -2821,7 +2821,7 @@ extension Strings {
         comment: "Button to manage your VPN subscription")
     
     public static let settingsRedeemOfferCode =
-      NSLocalizedString("vpn.settingsManageSubscription", tableName: "BraveShared", bundle: .module,
+      NSLocalizedString("vpn.settingsRedeemOfferCode", tableName: "BraveShared", bundle: .module,
         value: "Redeem Offer Code",
         comment: "Button to redeem offer code subscription")
     

--- a/Sources/BraveStrings/BraveStrings.swift
+++ b/Sources/BraveStrings/BraveStrings.swift
@@ -3067,22 +3067,27 @@ extension Strings {
 
     public static let resetVPNErrorTitle =
       NSLocalizedString("vpn.resetVPNErrorTitle", tableName: "BraveShared", bundle: .module,
-        value: "Error",
+        value: "Reset Failed",
         comment: "Title for error message when vpn configuration reset fails.")
 
     public static let resetVPNErrorBody =
       NSLocalizedString("vpn.resetVPNErrorBody", tableName: "BraveShared", bundle: .module,
-        value: "Failed to reset vpn configuration, please try again later.",
+        value: "Unable to reset VPN configuration. Please try again. If the issue persists, contact support for assistance.",
         comment: "Message to show when vpn configuration reset fails.")
+    
+    public static let resetVPNErrorButtonActionTitle =
+      NSLocalizedString("vpn.resetVPNErrorButtonActionTitle", tableName: "BraveShared", bundle: .module,
+        value: "Try Again",
+        comment: "Title of button to try again when vpn configuration reset fails.")
     
     public static let resetVPNSuccessTitle =
       NSLocalizedString("vpn.resetVPNSuccessTitle", tableName: "BraveShared", bundle: .module,
-        value: "Success",
+        value: "Reset Successful",
         comment: "Title for success message when vpn configuration reset succeeds.")
 
     public static let resetVPNSuccessBody =
       NSLocalizedString("vpn.resetVPNSuccessBody", tableName: "BraveShared", bundle: .module,
-        value: "VPN Configuration is reset successfully.",
+        value: "VPN configuration has been reset successfully.",
         comment: "Message to show when vpn configuration reset succeeds.")
 
     public static let contactFormDoNotEditText =

--- a/Sources/BraveVPN/BraveVPNSettingsViewController.swift
+++ b/Sources/BraveVPN/BraveVPNSettingsViewController.swift
@@ -323,8 +323,17 @@ public class BraveVPNSettingsViewController: TableViewController {
       message: success ? Strings.VPN.resetVPNSuccessBody : Strings.VPN.resetVPNErrorBody,
       preferredStyle: .alert)
 
-    let okAction = UIAlertAction(title: Strings.OKString, style: .default)
-    alert.addAction(okAction)
+    if success {
+      let okAction = UIAlertAction(title: Strings.OKString, style: .default)
+      alert.addAction(okAction)
+    } else {
+      alert.addAction(UIAlertAction(title: Strings.close, style: .cancel, handler: nil))
+      alert.addAction(UIAlertAction(
+        title: Strings.VPN.resetVPNErrorButtonActionTitle, style: .default,
+        handler: { [weak self] _ in
+          self?.resetConfigurationTapped()
+      }))
+    }
 
     present(alert, animated: true)
   }


### PR DESCRIPTION
Changed text for error with success case for reset configuration
Added retry action

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8431

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
Enable VPN
Open Brave Firewall + VPN settings menu
Select Reset Configuration, confirm reset
Observe


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
