### PR TITLE
Fix #8446: Use correct `select` method on BVC when opening URLs

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController.swift
@@ -2979,6 +2979,15 @@ extension BrowserViewController: ToolbarUrlActionsDelegate {
     self.tabManager.addTabsForURLs(urls, zombie: false, isPrivate: tabIsPrivate)
   }
 
+#if DEBUG
+  public override func select(_ sender: Any?) {
+    if sender is URL {
+      assertionFailure("Wrong method called, use `select(url:)` or `select(_:action:)`")
+    }
+    super.select(sender)
+  }
+#endif
+  
   func select(url: URL) {
     select(url, action: .openInCurrentTab)
   }

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+BraveTalk.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+BraveTalk.swift
@@ -26,7 +26,7 @@ extension BrowserViewController {
           var components = URLComponents()
           components.host = currentHost
           components.scheme = url.scheme
-          self.select(components.url!)
+          self.select(url: components.url!)
         }
       }
     )

--- a/Sources/Brave/Shortcuts/ActivityShortcutManager.swift
+++ b/Sources/Brave/Shortcuts/ActivityShortcutManager.swift
@@ -192,7 +192,7 @@ public class ActivityShortcutManager: NSObject {
       } else {
         let controller = NewsSettingsViewController(dataSource: bvc.feedDataSource, openURL: { url in
           bvc.dismiss(animated: true)
-          bvc.select(url)
+          bvc.select(url: url)
         })
         controller.viewDidDisappear = {
           if Preferences.Review.braveNewsCriteriaPassed.value {


### PR DESCRIPTION
A crash was introduced in https://github.com/brave/brave-ios/pull/8306 due to accidentally calling the Obj-C `select(_ sender:)` method on UIResponder instead of `select(url:)`.

We may want to reconsider the name of the API in general

## Summary of Changes

This pull request fixes #8446 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
