### PR TITLE
Fix #8451: Defer toolbar state updates on `viewWillAppear` by 1 cycle

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController.swift
@@ -1117,10 +1117,14 @@ public class BrowserViewController: UIViewController {
   override public func viewWillAppear(_ animated: Bool) {
     super.viewWillAppear(animated)
     if #available(iOS 17, *) {
-      // On iOS 17 rotating the device with a full screen modal presented (e.g. Playlist, Tab Tray)
-      // to landscape then back to portrait does not trigger `traitCollectionDidChange`/`willTransition`/etc
-      // calls and so the toolbar remains in the wrong state.
-      updateToolbarStateForTraitCollection(traitCollection)
+      // Have to defer this to the next cycle to avoid an iOS bug which lays out the toolbars without any
+      // bottom safe area, resulting in a layout bug.
+      DispatchQueue.main.async {
+        // On iOS 17 rotating the device with a full screen modal presented (e.g. Playlist, Tab Tray)
+        // to landscape then back to portrait does not trigger `traitCollectionDidChange`/`willTransition`/etc
+        // calls and so the toolbar remains in the wrong state.
+        self.updateToolbarStateForTraitCollection(self.traitCollection)
+      }
     }
     updateToolbarUsingTabManager(tabManager)
 


### PR DESCRIPTION
For some reason without this there's a chance iOS lays out the toolbars without any safe area insets

## Summary of Changes

This pull request fixes #8451 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
