### PR TITLE
Fix #8253: Don't navigate to javascript:// URLs from the omnibox

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController.swift
@@ -1605,7 +1605,6 @@ public class BrowserViewController: UIViewController {
   ///   - url: The url submitted
   ///   - isUserDefinedURLNavigation: Boolean for  determining if url navigation is done from user defined spot
   ///     user defined spot like Favourites or Bookmarks
-  var isUserDefinedURLNavigation = false
   func finishEditingAndSubmit(_ url: URL, isUserDefinedURLNavigation: Bool = false) {
     if url.isBookmarklet {
       topToolbar.leaveOverlayMode()

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+BraveTalk.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+BraveTalk.swift
@@ -26,7 +26,7 @@ extension BrowserViewController {
           var components = URLComponents()
           components.host = currentHost
           components.scheme = url.scheme
-          self.select(url: components.url!)
+          self.select(url: components.url!, isUserDefinedURLNavigation: false)
         }
       }
     )

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+Wallet.swift
@@ -135,7 +135,7 @@ extension BrowserViewController: BraveWalletDelegate {
       self.dismiss(animated: true)
     }
     if let url = tabManager.selectedTab?.url, InternalURL.isValid(url: url) {
-      select(url: destinationURL)
+      select(url: destinationURL, isUserDefinedURLNavigation: false)
     } else {
       _ = tabManager.addTabAndSelect(
         URLRequest(url: destinationURL),

--- a/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarksViewController.swift
+++ b/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarksViewController.swift
@@ -481,12 +481,7 @@ class BookmarksViewController: SiteTableViewController, ToolbarUrlActionsProtoco
               ActivityShortcutManager.shared.donateCustomIntent(for: .openBookmarks, with: url.absoluteString)
             }
 
-            // Used to determine url navigation coming from a bookmark
-            // And handle it differently under finishEditingAndSubmit for bookmarklets
-            let bvc = self.currentScene?.browserViewController
-            bvc?.isUserDefinedURLNavigation = true
-            
-            self.toolbarUrlActionsDelegate?.select(url: url)
+            self.toolbarUrlActionsDelegate?.select(url: url, isUserDefinedURLNavigation: true)
           }
 
           if presentingViewController is MenuViewController {

--- a/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarksViewController.swift
+++ b/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarksViewController.swift
@@ -481,6 +481,11 @@ class BookmarksViewController: SiteTableViewController, ToolbarUrlActionsProtoco
               ActivityShortcutManager.shared.donateCustomIntent(for: .openBookmarks, with: url.absoluteString)
             }
 
+            // Used to determine url navigation coming from a bookmark
+            // And handle it differently under finishEditingAndSubmit for bookmarklets
+            let bvc = self.currentScene?.browserViewController
+            bvc?.isUserDefinedURLNavigation = true
+            
             self.toolbarUrlActionsDelegate?.select(url: url)
           }
 

--- a/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/HistoryViewController.swift
+++ b/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/HistoryViewController.swift
@@ -285,7 +285,7 @@ class HistoryViewController: SiteTableViewController, ToolbarUrlActionsProtocol 
       }
       
       dismiss(animated: true) {
-        self.toolbarUrlActionsDelegate?.select(url: url)
+        self.toolbarUrlActionsDelegate?.select(url: url, isUserDefinedURLNavigation: false)
       }
     }
 

--- a/Sources/Brave/Frontend/Browser/Toolbars/ToolbarUrlActionsDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/Toolbars/ToolbarUrlActionsDelegate.swift
@@ -10,5 +10,5 @@ protocol ToolbarUrlActionsDelegate: AnyObject {
   func copy(_ url: URL)
   func share(_ url: URL)
   func batchOpen(_ urls: [URL])
-  func select(url: URL)
+  func select(url: URL, isUserDefinedURLNavigation: Bool)
 }

--- a/Sources/Brave/Shortcuts/ActivityShortcutManager.swift
+++ b/Sources/Brave/Shortcuts/ActivityShortcutManager.swift
@@ -192,7 +192,7 @@ public class ActivityShortcutManager: NSObject {
       } else {
         let controller = NewsSettingsViewController(dataSource: bvc.feedDataSource, openURL: { url in
           bvc.dismiss(animated: true)
-          bvc.select(url: url)
+          bvc.select(url: url, isUserDefinedURLNavigation: false)
         })
         controller.viewDidDisappear = {
           if Preferences.Review.braveNewsCriteriaPassed.value {


### PR DESCRIPTION
Adding isUserDefinedURLNavigation checks to determine if url navigation is should be executed for bookmarklets.

This is caused by https://github.com/brave/brave-ios/pull/8306, in the process of removing visit type

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8453

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->

1. Go to any webpage
2. Type javascript:alert(123) in the url bar
3. Press enter

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


https://github.com/brave/brave-ios/assets/6643505/09ce56d8-03cf-4cf1-8fb5-23917b0e6e0c



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
