### PR TITLE
Fix #8459: Accounts tab modals reset when returning from background

### DIFF
--- a/Sources/BraveWallet/Crypto/Accounts/AccountsHeaderView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/AccountsHeaderView.swift
@@ -13,8 +13,8 @@ struct AccountsHeaderView: View {
   var settingsStore: SettingsStore
   var networkStore: NetworkStore
 
-  @State private var isPresentingBackup: Bool = false
-  @State private var isPresentingAddAccount: Bool = false
+  @Binding var isPresentingBackup: Bool
+  @Binding var isPresentingAddAccount: Bool
 
   var body: some View {
     HStack {
@@ -27,20 +27,6 @@ struct AccountsHeaderView: View {
             .foregroundColor(Color(.braveBlurpleTint))
         }
       }
-      .background(
-        Color.clear
-          .sheet(isPresented: $isPresentingBackup) {
-            NavigationView {
-              BackupWalletView(
-                password: nil,
-                keyringStore: keyringStore
-              )
-            }
-            .navigationViewStyle(StackNavigationViewStyle())
-            .environment(\.modalPresentationMode, $isPresentingBackup)
-            .accentColor(Color(.braveBlurpleTint))
-          }
-      )
       Spacer()
       HStack(spacing: 16) {
         Button(action: {
@@ -49,18 +35,6 @@ struct AccountsHeaderView: View {
           Label(Strings.Wallet.addAccountTitle, systemImage: "plus")
             .labelStyle(.iconOnly)
         }
-        .background(
-          Color.clear
-            .sheet(isPresented: $isPresentingAddAccount) {
-              NavigationView {
-                AddAccountView(
-                  keyringStore: keyringStore,
-                  networkStore: networkStore
-                )
-              }
-              .navigationViewStyle(StackNavigationViewStyle())
-            }
-        )
         NavigationLink(
           destination: Web3SettingsView(
             settingsStore: settingsStore,
@@ -83,7 +57,9 @@ struct AccountsHeaderView_Previews: PreviewProvider {
     AccountsHeaderView(
       keyringStore: .previewStore,
       settingsStore: .previewStore,
-      networkStore: .previewStore
+      networkStore: .previewStore,
+      isPresentingBackup: .constant(false),
+      isPresentingAddAccount: .constant(false)
     )
     .previewLayout(.sizeThatFits)
     .previewColorSchemes()

--- a/Sources/BraveWallet/Crypto/Accounts/AccountsView.swift
+++ b/Sources/BraveWallet/Crypto/Accounts/AccountsView.swift
@@ -14,6 +14,8 @@ struct AccountsView: View {
   var cryptoStore: CryptoStore
   @ObservedObject var keyringStore: KeyringStore
   @State private var selectedAccount: BraveWallet.AccountInfo?
+  @State private var isPresentingBackup: Bool = false
+  @State private var isPresentingAddAccount: Bool = false
 
   private var primaryAccounts: [BraveWallet.AccountInfo] {
     keyringStore.allAccounts.filter(\.isPrimary)
@@ -29,7 +31,9 @@ struct AccountsView: View {
         header: AccountsHeaderView(
           keyringStore: keyringStore,
           settingsStore: cryptoStore.settingsStore,
-          networkStore: cryptoStore.networkStore
+          networkStore: cryptoStore.networkStore,
+          isPresentingBackup: $isPresentingBackup,
+          isPresentingAddAccount: $isPresentingAddAccount
         )
         .resetListHeaderStyle()
       ) {
@@ -106,6 +110,32 @@ struct AccountsView: View {
     )
     .listStyle(InsetGroupedListStyle())
     .listBackgroundColor(Color(UIColor.braveGroupedBackground))
+    .background(
+      Color.clear
+        .sheet(isPresented: $isPresentingBackup) {
+          NavigationView {
+            BackupWalletView(
+              password: nil,
+              keyringStore: keyringStore
+            )
+          }
+          .navigationViewStyle(StackNavigationViewStyle())
+          .environment(\.modalPresentationMode, $isPresentingBackup)
+          .accentColor(Color(.braveBlurpleTint))
+        }
+    )
+    .background(
+      Color.clear
+        .sheet(isPresented: $isPresentingAddAccount) {
+          NavigationView {
+            AddAccountView(
+              keyringStore: keyringStore,
+              networkStore: cryptoStore.networkStore
+            )
+          }
+          .navigationViewStyle(StackNavigationViewStyle())
+        }
+    )
   }
 }
 


### PR DESCRIPTION
## Summary of Changes
- Xcode 15 SDK bug on iOS 17+ only. 
- The state for the view in a `sheet` modifier on an item in the `List` in `AccountsView` is reset when the list is reset, which is occurring when we return from background: https://github.com/brave/brave-ios/blob/development/Sources/BraveWallet/Crypto/Stores/KeyringStore.swift#L207-L211
- Moving the `.sheet()` modifiers to the `List` instead of inside the list resolves the state reset issue.

This pull request fixes #8459

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
#### Backup modal reset
  1. Visit Accounts tab
  2. Tap `Backup` button.
  3. Enter password and toggle the switch then press `Continue`
      - Alternatively, you can simply use Face ID / Touch ID to reproduce the bug. Biometrics technically put the app into background state, then active state.
  4. Open application switcher to 'background' Brave app.
  5. Bring Brave app back into active state.
  6. Observe Backup flow has been reset to the start / password screen (password field empty, toggle disabled).
  7. Please re-test but use Face ID / Touch ID in step 3 🙂.
  
#### Add account modal reset
  1. Visit Accounts tab
  2. Tap `+` button.
  3. Tap on any of the coin types to enter a detail view
  4. Open application switcher.
  5. Bring Brave back into foreground
  6. Observe Add Account flow has been reset to the start / coin type selection. 


## Screenshots:


https://github.com/brave/brave-ios/assets/5314553/edafb00e-8929-4d25-85cf-7e9aea58a845



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
