### PR TITLE
Fix #8462: Custom Networks list not updated when opened via browser settings

### DIFF
--- a/Sources/BraveWallet/Crypto/Stores/NetworkStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/NetworkStore.swift
@@ -167,7 +167,7 @@ public class NetworkStore: ObservableObject, WalletObserverStore {
     self.isSwapSupported = await swapService.isSwapSupported(chain.chainId)
   }
 
-  @MainActor private func updateChainList() async {
+  @MainActor func updateChainList() async {
     // fetch all networks for all coin types
     self.allChains = await rpcService.allNetworksForSupportedCoins(respectTestnetPreference: false)
     

--- a/Sources/BraveWallet/Settings/CustomNetworkListView.swift
+++ b/Sources/BraveWallet/Settings/CustomNetworkListView.swift
@@ -138,6 +138,9 @@ struct CustomNetworkListView: View {
       }
       .navigationViewStyle(StackNavigationViewStyle())
     }
+    .task {
+      await networkStore.updateChainList()
+    }
   }
 }
 


### PR DESCRIPTION
## Summary of Changes
- `NetworkStore` does not fetch chains at initialization, but instead after `WalletStore` sets up `CryptoStore`.
- When wallet settings are opened via browser settings, `WalletStore` is not yet created so we're not fetching chain list. Instead we can just make sure the chain list is updated when Custom Networks is opened.

This pull request fixes #8462

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Add a custom network (via DApp request or manually).
2. If you're on iOS 17, quit and relaunch the app.
3. Open Wallet settings via Browser settings.
    - Tap `...` button, Tap Settings, tap Web3
4. Open Custom Networks list, verify added network is visible


## Screenshots:


https://github.com/brave/brave-ios/assets/5314553/eeed7a31-fa7b-47e4-a234-8f5761b4aec6




## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
