### PR TITLE
Ref #8417: Disable tint adjustment on secure state buttons

### DIFF
--- a/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/CollapsedURLBarView.swift
+++ b/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/CollapsedURLBarView.swift
@@ -17,7 +17,10 @@ class CollapsedURLBarView: UIView {
     $0.alignment = .firstBaseline
   }
   
-  private let secureContentStateView = UIButton()
+  private let secureContentStateView = UIButton().then {
+    $0.tintAdjustmentMode = .normal
+  }
+  
   private let separatorLine = UILabel().then {
     $0.isUserInteractionEnabled = false
     $0.isAccessibilityElement = false

--- a/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
+++ b/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
@@ -119,6 +119,7 @@ class TabLocationView: UIView {
     button.configurationUpdateHandler = { [unowned self] btn in
       btn.configuration = secureContentStateButtonConfiguration
     }
+    button.tintAdjustmentMode = .normal
     secureContentStateButton = button
     leadingView = button
   }


### PR DESCRIPTION
This turns off the grayscale effect that is given to the button while controllers are presented on top of the browser

## Summary of Changes

This pull request refs #8417 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
