### PR TITLE
Fix #2336: Add option to disable Bookmarks/OpenTabs/History suggestions when typing in url 

### DIFF
--- a/Sources/Brave/Frontend/Browser/Search/SearchEngines.swift
+++ b/Sources/Brave/Frontend/Browser/Search/SearchEngines.swift
@@ -181,6 +181,11 @@ public class SearchEngines {
     get { return Preferences.Search.shouldShowRecentSearches.value }
     set { Preferences.Search.shouldShowRecentSearches.value = newValue }
   }
+  
+  var shouldShowBrowserSuggestions: Bool {
+    get { return Preferences.Search.showBrowserSuggestions.value }
+    set { Preferences.Search.showBrowserSuggestions.value = newValue }
+  }
 
   func isEngineEnabled(_ engine: OpenSearchEngine) -> Bool {
     return disabledEngineNames.index(forKey: engine.shortName) == nil

--- a/Sources/Brave/Frontend/Browser/Search/SearchLoader.swift
+++ b/Sources/Brave/Frontend/Browser/Search/SearchLoader.swift
@@ -21,6 +21,14 @@ class SearchLoader: Loader<[Site], SearchViewController> {
 
   var query: String = "" {
     didSet {
+      // Browser suggestions preference control frequencey query over browser items
+      // like Open Tabs, Bookmarks, History. Disabling this preference should prevent
+      // data fetch from the sources
+      guard Preferences.Search.showBrowserSuggestions.value else {
+        load([])
+        return
+      }
+      
       if query.isEmpty {
         load([])
         return

--- a/Sources/Brave/Frontend/Browser/Search/SearchSuggestionDataSource.swift
+++ b/Sources/Brave/Frontend/Browser/Search/SearchSuggestionDataSource.swift
@@ -76,7 +76,11 @@ class SearchSuggestionDataSource {
       sections.append(.searchSuggestions)
     }
     sections.append(.findInPage)
-    sections.append(.openTabsAndHistoryAndBookmarks)
+    
+    if searchEngines?.shouldShowBrowserSuggestions == true {
+      sections.append(.openTabsAndHistoryAndBookmarks)
+    }
+    
     return sections
   }
   

--- a/Sources/Brave/Frontend/Browser/Search/SearchViewController.swift
+++ b/Sources/Brave/Frontend/Browser/Search/SearchViewController.swift
@@ -474,6 +474,12 @@ public class SearchViewController: SiteTableViewController, LoaderListener {
     case .searchSuggestions:
       return dataSource.suggestions.isEmpty ? 0 : headerHeight * 2.0
     case .openTabsAndHistoryAndBookmarks:
+      // Check for History Bookmarks Open Tabs suggestions
+      // Show Browser Suggestions Preference effects all the modes
+      if !Preferences.Search.showBrowserSuggestions.value {
+        return 0
+      }
+      
       // Private Browsing Mode (PBM) should *not* show items from normal mode History etc
       // when search suggestions is not enabled
       if Preferences.Privacy.privateBrowsingOnly.value,
@@ -667,6 +673,12 @@ public class SearchViewController: SiteTableViewController, LoaderListener {
         !dataSource.searchQuery.looksLikeAURL() &&
         !dataSource.tabType.isPrivate ? searchSuggestionsCount : 0
     case .openTabsAndHistoryAndBookmarks:
+      // Check for History Bookmarks Open Tabs suggestions
+      // Show Browser Suggestions Preference effects all the modes
+      if !Preferences.Search.showBrowserSuggestions.value {
+          return 0
+      }
+      
       // Private Browsing Mode (PBM) should *not* show items from normal mode History etc
       // when search suggestions is not enabled
       if Preferences.Privacy.privateBrowsingOnly.value, dataSource.searchEngines?.shouldShowSearchSuggestions == false {

--- a/Sources/Brave/Frontend/ClientPreferences.swift
+++ b/Sources/Brave/Frontend/ClientPreferences.swift
@@ -103,6 +103,8 @@ extension Preferences {
     static let shouldShowRecentSearches = Option<Bool>(key: "search.should-show-recent-searches", default: false)
     /// Whether or not to show recent searches opt-in
     static let shouldShowRecentSearchesOptIn = Option<Bool>(key: "search.should-show-recent-searches.opt-in", default: true)
+    /// Whether or not to show suggestions from browser `Open Tabs & Bookmarks & History` while the user types
+    static let showBrowserSuggestions = Option<Bool>(key: "search.show-browser-suggestions", default: true)
     /// How many times Brave Search websites has asked the user to check whether Brave Search can be set as a default
     static let braveSearchDefaultBrowserPromptCount =
       Option<Int>(key: "search.brave-search-default-website-prompt", default: 0)

--- a/Sources/Brave/Frontend/Settings/General/SearchEngines/SearchSettingsTableViewController.swift
+++ b/Sources/Brave/Frontend/Settings/General/SearchEngines/SearchSettingsTableViewController.swift
@@ -35,6 +35,7 @@ class SearchSettingsTableViewController: UITableViewController {
     static let searchEngineRowIdentifier = "searchEngineRowIdentifier"
     static let showSearchSuggestionsRowIdentifier = "showSearchSuggestionsRowIdentifier"
     static let showRecentSearchesRowIdentifier = "showRecentSearchRowIdentifier"
+    static let showBrowserSuggestionsRowIdentifier = "showBrowserSuggestionsRowIdentifier"
     static let quickSearchEngineRowIdentifier = "quickSearchEngineRowIdentifier"
     static let customSearchEngineRowIdentifier = "customSearchEngineRowIdentifier"
   }
@@ -52,8 +53,9 @@ class SearchSettingsTableViewController: UITableViewController {
     case standard
     case `private`
     case quick
-    case suggestions
+    case searchSuggestions
     case recentSearches
+    case browserSuggestions
   }
 
   private var searchEngines: SearchEngines
@@ -106,6 +108,7 @@ class SearchSettingsTableViewController: UITableViewController {
       $0.register(UITableViewCell.self, forCellReuseIdentifier: Constants.searchEngineRowIdentifier)
       $0.register(UITableViewCell.self, forCellReuseIdentifier: Constants.showSearchSuggestionsRowIdentifier)
       $0.register(UITableViewCell.self, forCellReuseIdentifier: Constants.showRecentSearchesRowIdentifier)
+      $0.register(UITableViewCell.self, forCellReuseIdentifier: Constants.showBrowserSuggestionsRowIdentifier)
       $0.register(UITableViewCell.self, forCellReuseIdentifier: Constants.quickSearchEngineRowIdentifier)
       $0.register(UITableViewCell.self, forCellReuseIdentifier: Constants.customSearchEngineRowIdentifier)
       $0.sectionHeaderTopPadding = 5
@@ -211,7 +214,7 @@ class SearchSettingsTableViewController: UITableViewController {
           $0.accessoryType = .disclosureIndicator
           $0.editingAccessoryType = .disclosureIndicator
         }
-      case CurrentEngineType.suggestions.rawValue:
+      case CurrentEngineType.searchSuggestions.rawValue:
         let toggle = UISwitch().then {
           $0.addTarget(self, action: #selector(didToggleSearchSuggestions), for: .valueChanged)
           $0.isOn = searchEngines.shouldShowSearchSuggestions
@@ -230,6 +233,17 @@ class SearchSettingsTableViewController: UITableViewController {
 
         cell = tableView.dequeueReusableCell(withIdentifier: Constants.showRecentSearchesRowIdentifier, for: indexPath).then {
           $0.textLabel?.text = Strings.searchSettingRecentSearchesCellTitle
+          $0.accessoryView = toggle
+          $0.selectionStyle = .none
+        }
+      case CurrentEngineType.browserSuggestions.rawValue:
+        let toggle = UISwitch().then {
+          $0.addTarget(self, action: #selector(didToggleBrowserSuggestions), for: .valueChanged)
+          $0.isOn = searchEngines.shouldShowBrowserSuggestions
+        }
+
+        cell = tableView.dequeueReusableCell(withIdentifier: Constants.showBrowserSuggestionsRowIdentifier, for: indexPath).then {
+          $0.textLabel?.text = Strings.searchSettingBrowserSuggestionCellTitle
           $0.accessoryView = toggle
           $0.selectionStyle = .none
         }
@@ -366,6 +380,11 @@ extension SearchSettingsTableViewController {
     // Setting the value in settings dismisses any opt-in.
     searchEngines.shouldShowRecentSearches = toggle.isOn
     searchEngines.shouldShowRecentSearchesOptIn = false
+  }
+  
+  @objc func didToggleBrowserSuggestions(_ toggle: UISwitch) {
+    // Setting the value effects all the modes private normal pbo
+    searchEngines.shouldShowBrowserSuggestions = toggle.isOn
   }
 
   @objc func dismissAnimated() {

--- a/Sources/Brave/Frontend/Settings/General/SearchEngines/SearchSettingsTableViewController.swift
+++ b/Sources/Brave/Frontend/Settings/General/SearchEngines/SearchSettingsTableViewController.swift
@@ -242,8 +242,11 @@ class SearchSettingsTableViewController: UITableViewController {
           $0.isOn = searchEngines.shouldShowBrowserSuggestions
         }
 
-        cell = tableView.dequeueReusableCell(withIdentifier: Constants.showBrowserSuggestionsRowIdentifier, for: indexPath).then {
+        cell = UITableViewCell(style: .subtitle, reuseIdentifier: Constants.showBrowserSuggestionsRowIdentifier).then {
           $0.textLabel?.text = Strings.searchSettingBrowserSuggestionCellTitle
+          $0.detailTextLabel?.numberOfLines = 0
+          $0.detailTextLabel?.textColor = .secondaryBraveLabel
+          $0.detailTextLabel?.text = Strings.searchSettingBrowserSuggestionCellDescription
           $0.accessoryView = toggle
           $0.selectionStyle = .none
         }

--- a/Sources/BraveStrings/BraveStrings.swift
+++ b/Sources/BraveStrings/BraveStrings.swift
@@ -542,11 +542,16 @@ extension Strings {
       value: "Reader Mode", comment: "Title of a bar that show up when you enter reader mode.")
 }
 
-// MARK:-  SearchSettingsTableViewController.swift
+// MARK: -  SearchSettingsTableViewController
+
 extension Strings {
   public static let searchSettingNavTitle = NSLocalizedString("SearchSettingNavTitle", tableName: "BraveShared", bundle: .module, value: "Search", comment: "Navigation title for search settings.")
   public static let searchSettingSuggestionCellTitle = NSLocalizedString("SearchSettingSuggestionCellTitle", tableName: "BraveShared", bundle: .module, value: "Show Search Suggestions", comment: "Label for show search suggestions setting.")
   public static let searchSettingRecentSearchesCellTitle = NSLocalizedString("SearchSettingRecentSearchesCellTitle", tableName: "BraveShared", bundle: .module, value: "Show Recent Searches", comment: "Label for showing recent search setting.")
+  public static let searchSettingBrowserSuggestionCellTitle =
+    NSLocalizedString("SearchSettingBrowserSuggestionCellTitle", tableName: "BraveShared", bundle: .module,
+      value: "Show Browser Suggestions",
+      comment: "Label for showing browser suggestion setting")
   public static let searchSettingAddCustomEngineCellTitle =
     NSLocalizedString("searchSettingAddCustomEngineCellTitle", tableName: "BraveShared", bundle: .module,
       value: "Add Custom Search Engine",

--- a/Sources/BraveStrings/BraveStrings.swift
+++ b/Sources/BraveStrings/BraveStrings.swift
@@ -552,6 +552,10 @@ extension Strings {
     NSLocalizedString("SearchSettingBrowserSuggestionCellTitle", tableName: "BraveShared", bundle: .module,
       value: "Show Browser Suggestions",
       comment: "Label for showing browser suggestion setting")
+  public static let searchSettingBrowserSuggestionCellDescription =
+    NSLocalizedString("SearchSettingBrowserSuggestionCellDescription", tableName: "BraveShared", bundle: .module,
+      value: "Turn this on to include results from your History and Bookmarks when searching",
+      comment: "Label for showing browser suggestion setting description")
   public static let searchSettingAddCustomEngineCellTitle =
     NSLocalizedString("searchSettingAddCustomEngineCellTitle", tableName: "BraveShared", bundle: .module,
       value: "Add Custom Search Engine",


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

Giving users capability to change Bookmarks/OpenTabs/History suggestion policy 

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #2336

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Test this preference by turning it on off with all browser modes normal, private and pmo. And be sure the behaviour is working properly as expected. The settings in under Search Engines section same as Search Suggestions, Recent Searches.

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

https://github.com/brave/brave-ios/assets/6643505/a1216ed6-d8ec-4e4e-abbf-a45558c4453e

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
