### PR TITLE
Fix #8227: When launching the QR code scanning UI while in the Landscape mode, the camera view is rotated 90 degrees

### DIFF
--- a/Sources/Brave/Frontend/Browser/Search/Recent Search/RecentSearchQRCodeScannerController.swift
+++ b/Sources/Brave/Frontend/Browser/Search/Recent Search/RecentSearchQRCodeScannerController.swift
@@ -66,6 +66,13 @@ class RecentSearchQRCodeScannerController: UIViewController {
   override func viewWillAppear(_ animated: Bool) {
     super.viewWillAppear(animated)
 
+    scannerView.cameraView.stopRunning()
+  }
+  
+  override func viewDidAppear(_ animated: Bool) {
+    if let orientation = view.window?.windowScene?.interfaceOrientation {
+        scannerView.cameraView.videoPreviewLayer?.connection?.videoOrientation = AVCaptureVideoOrientation(ui: orientation)
+    }
     scannerView.cameraView.startRunning()
   }
   

--- a/Sources/Brave/Frontend/Sync/SyncCameraView.swift
+++ b/Sources/Brave/Frontend/Sync/SyncCameraView.swift
@@ -124,7 +124,7 @@ class SyncCameraView: UIView, AVCaptureMetadataOutputObjectsDelegate {
     videoPreviewLayer?.frame = layer.bounds
     layer.addSublayer(videoPreviewLayer!)
 
-    captureSession.startRunning()
+    startRunning()
     bringSubviewToFront(cameraOverlayView)
 
     AVCaptureDevice.requestAccess(
@@ -143,11 +143,19 @@ class SyncCameraView: UIView, AVCaptureMetadataOutputObjectsDelegate {
   }
 
   func startRunning() {
-    captureSession?.startRunning()
+    DispatchQueue.global(qos: .default).async { [weak self] in
+      guard let self else { return }
+      
+      if self.captureSession?.isRunning == false {
+        self.captureSession?.startRunning()
+      }
+    }
   }
 
   func stopRunning() {
-    captureSession?.stopRunning()
+    if captureSession?.isRunning == true {
+      captureSession?.stopRunning()
+    }
   }
 
   func metadataOutput(_ output: AVCaptureMetadataOutput, didOutput metadataObjects: [AVMetadataObject], from connection: AVCaptureConnection) {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

Handling orientation changes properly qr code camera capture

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8227

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->

- Launch Brave
- Rotate the device to a Landscape Mode
- Tap in the URL search bar > Tap QR code thumbnail > Observe

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

https://github.com/brave/brave-ios/assets/6643505/b173f9c3-2944-4177-9aa6-deeaaaf0e429

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
