### PR TITLE
Fix #8445: View recovery phrases button is not tappable

### DIFF
--- a/Sources/BraveWallet/Crypto/Onboarding/BackupWalletView.swift
+++ b/Sources/BraveWallet/Crypto/Onboarding/BackupWalletView.swift
@@ -35,8 +35,11 @@ struct BackupWalletView: View {
       return
     }
     
-    // password filed resign first responder in case ScrollView gets changed
-    // which could effect the next step. Details see #8445
+    // Dismiss keyboard for password field before leaving this view #8445.
+    // Without dismissal, it's possible the scroll view in the detail view
+    // has incorrect frame (sitting above the area the keyboard used to be)
+    // which can show the scroll view contents out of the scroll bounds
+    // but will block tap interactions.
     resignFirstResponder()
     
     keyringStore.recoveryPhrase(password: password) { words in

--- a/Sources/BraveWallet/Crypto/Onboarding/BackupWalletView.swift
+++ b/Sources/BraveWallet/Crypto/Onboarding/BackupWalletView.swift
@@ -34,6 +34,11 @@ struct BackupWalletView: View {
       // user can press return in field to execute when continue button is disabled
       return
     }
+    
+    // password filed resign first responder in case ScrollView gets changed
+    // which could effect the next step. Details see #8445
+    resignFirstResponder()
+    
     keyringStore.recoveryPhrase(password: password) { words in
       if words.isEmpty {
         passwordError = .incorrectPassword
@@ -41,6 +46,10 @@ struct BackupWalletView: View {
         recoveryWords = words
       }
     }
+  }
+  
+  private func resignFirstResponder() {
+    UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
   }
 
   var body: some View {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
This issue is caused by the `ScrollView` has the wrong frame even though screen size is big enough for it to expand.
With further investigation, wrong frame caused by keyboard not being dismissed in the previous step which cause SwiftUI thinks the screen height is the actual height minus keyboard height. 
Attached screenshots below to see the height differences. 

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8445

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Apparently, only @kdenhartog and I can repro this. I'm adding him as reviewer to see if he can verify.

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

When button is not tappable | When button is tappable
--- | ---
![IMG_3281](https://github.com/brave/brave-ios/assets/1187676/0ff306ae-140b-4f34-be50-43a1643b1be4) | ![IMG_3282](https://github.com/brave/brave-ios/assets/1187676/159d6b84-2f22-4ad0-aca0-a79fb8d1079f)

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
