### PR TITLE
Fix #8481: Race condition in NFT tab when user hide/unhide NFT before balance or metadata is fetched

### DIFF
--- a/Sources/BraveWallet/Extensions/RpcServiceExtensions.swift
+++ b/Sources/BraveWallet/Extensions/RpcServiceExtensions.swift
@@ -103,6 +103,8 @@ extension BraveWalletJsonRpcService {
       }
     case .btc:
       completion(nil)
+    case .zec:
+      completion(nil)
     @unknown default:
       completion(nil)
     }

--- a/Tests/BraveWalletTests/NFTStoreTests.swift
+++ b/Tests/BraveWalletTests/NFTStoreTests.swift
@@ -73,6 +73,8 @@ class NFTStoreTests: XCTestCase {
         completion([.mockFilecoinTestnet])
       case .btc:
         XCTFail("Should not fetch btc network")
+      case .zec:
+        XCTFail("Should not fetch zec network")
       @unknown default:
         XCTFail("Should not fetch unknown network")
       }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8481

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
1. set up a wallet with some NFTs
2. make sure you have a slow network connection 
3. go to NFT tab and enable auto-discovery 
4. while wallet is still fetching NFTs metadata (image has not yet loaded) hide/unhide NFT
5. observe NFT is moved to the correct group and the count on the dropdown button is correct. 
6. Repeat the steps few times. 

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
