### PR TITLE
Ref #8417: Hide "Not Secure" label when tab location view is too small

### DIFF
--- a/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
+++ b/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
@@ -79,7 +79,7 @@ class TabLocationView: UIView {
     var title = AttributedString(Strings.tabToolbarNotSecureTitle)
     title.font = .preferredFont(forTextStyle: .subheadline, compatibleWith: clampedTraitCollection)
     
-    let isTitleVisible = !traitCollection.preferredContentSizeCategory.isAccessibilityCategory
+    let isTitleVisible = !traitCollection.preferredContentSizeCategory.isAccessibilityCategory && bounds.width > 200
     
     switch secureContentState {
     case .localhost, .secure:
@@ -226,6 +226,8 @@ class TabLocationView: UIView {
   private let placeholderLabel = UILabel().then {
     $0.text = Strings.tabToolbarSearchAddressPlaceholderText
     $0.isHidden = true
+    $0.adjustsFontSizeToFitWidth = true
+    $0.minimumScaleFactor = 0.5
   }
   
   // A layout guide defining the available space for the URL itself
@@ -364,6 +366,12 @@ class TabLocationView: UIView {
     set {
       super.accessibilityElements = newValue
     }
+  }
+  
+  override func layoutSubviews() {
+    super.layoutSubviews()
+    
+    secureContentStateButton?.setNeedsUpdateConfiguration()
   }
   
   private func updateForTraitCollection() {


### PR DESCRIPTION
Also shrinks the placeholder label to fit since it can sometimes get truncated in compact configurations

## Summary of Changes

This pull request refs #8417

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
