### PR TITLE
Fix #8489: Follow Safari's behaviour for Desktop-UA

### DIFF
--- a/Sources/Brave/Frontend/Browser/Tab.swift
+++ b/Sources/Brave/Frontend/Browser/Tab.swift
@@ -715,6 +715,13 @@ class Tab: NSObject {
 
   func updateUserAgent(_ webView: WKWebView, newURL: URL) {
     guard let baseDomain = newURL.baseDomain else { return }
+    
+    let screenWidth = webView.currentScene?.screen.bounds.width ?? webView.bounds.size.width
+    if webView.traitCollection.horizontalSizeClass == .compact && (webView.bounds.size.width < screenWidth / 2.0) {
+      let desktopMode = userAgentOverrides[baseDomain] == true
+      webView.customUserAgent = desktopMode ? UserAgent.desktop : UserAgent.mobile
+      return
+    }
 
     let desktopMode = userAgentOverrides[baseDomain] ?? UserAgent.shouldUseDesktopMode
     webView.customUserAgent = desktopMode ? UserAgent.desktop : UserAgent.mobile


### PR DESCRIPTION
## Summary of Changes
- Follow Safari's behaviour and choose the User-Agent when in compact mode based on the size of the WebView.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8489

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->
<img width="461" alt="image" src="https://github.com/brave/brave-ios/assets/1530031/c0356333-27fe-4620-9ce0-fe8e42b2ebf3">
<img width="462" alt="image" src="https://github.com/brave/brave-ios/assets/1530031/e5907dcf-f6fe-47ed-8899-f08b8a670a51">
<img width="459" alt="image" src="https://github.com/brave/brave-ios/assets/1530031/3e0c0792-bb55-440b-a469-cc13ec6fc39e">


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
