### PR TITLE
Fix #7877: Fix NightMode applying to elements with a background-image

### DIFF
--- a/Sources/Brave/Frontend/UserContent/UserScripts/Sandboxed/MainFrame/AtDocumentStart/NightModeScript.js
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Sandboxed/MainFrame/AtDocumentStart/NightModeScript.js
@@ -50,8 +50,8 @@ function getStyleElement() {
 }
 
 function applyInvertFilterToChildBackgroundImageElements(parentNode) {
-  parentNode.querySelectorAll("[style*=\"background\"]").forEach(function(el) {
-    if ((el.style.backgroundImage || "").startsWith("url")) {
+  [...parentNode.children].forEach(function(el) {
+    if ((getComputedStyle(el)["background-image"] || "").startsWith("url")) {
       applyInvertFilterToElement(el);
     }
   });


### PR DESCRIPTION
## Summary of Changes
- Use the computed style instead of a query selector, to determine which elements have a background-image and to invert them.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7877

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->
Before: 
<img width="337" alt="image" src="https://github.com/brave/brave-ios/assets/1530031/19036da2-01f5-437e-9995-57138e311c87">

After:
<img width="352" alt="image" src="https://github.com/brave/brave-ios/assets/1530031/1799f198-23b5-401e-8ee8-5ef622b9d9f8">

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
