### PR TITLE
Fix #8502: Use correct Brave icons for top news widgets

### DIFF
--- a/App/BraveWidgets/TopNewsListWidget.swift
+++ b/App/BraveWidgets/TopNewsListWidget.swift
@@ -73,10 +73,10 @@ private struct TopNewsListView: View {
   private var headerView: some View {
     HStack {
       HStack(spacing: 4) {
-        Image(braveSystemName: "leo.brave.icon-monochrome")
-          .font(.system(size: 12))
-          .imageScale(.large)
-          .foregroundColor(Color(.braveOrange))
+        Image("brave-icon-no-bg")
+          .resizable()
+          .aspectRatio(contentMode: .fit)
+          .frame(width: 16, height: 16)
         Text(Strings.Widgets.braveNews)
           .foregroundColor(Color(.braveLabel))
           .font(.system(size: 14, weight: .bold, design: .rounded))

--- a/App/BraveWidgets/TopNewsWidget.swift
+++ b/App/BraveWidgets/TopNewsWidget.swift
@@ -130,7 +130,7 @@ private struct LockScreenTopNewsView: View {
           .layoutPriority(2)
           .multilineTextAlignment(.leading)
         HStack(spacing: 3) {
-          Image(braveSystemName: "leo.brave.icon-monochrome")
+          Image(braveSystemName: "leo.brave.icon-outline")
             .foregroundColor(.orange)
             .font(.system(size: 12))
             .padding(.trailing, -1)

--- a/Sources/DesignSystem/Icons/Symbols.xcassets/leo.brave.icon-outline.symbolset/Contents.json
+++ b/Sources/DesignSystem/Icons/Symbols.xcassets/leo.brave.icon-outline.symbolset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "symbols" : [
+    {
+      "idiom" : "universal"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #8502

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Screenshots:

<img width="363" alt="image" src="https://github.com/brave/brave-ios/assets/529104/b6aaafc2-e58f-4bd1-a944-2d7b9677e497">


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
