### PR TITLE
Fix #8497: Scale VPN menu button icon correctly

### DIFF
--- a/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/VPNMenuButton.swift
+++ b/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/VPNMenuButton.swift
@@ -32,6 +32,8 @@ struct VPNMenuButton: View {
   @State private var isVPNStatusChanging: Bool = BraveVPN.reconnectPending
   @State private var isVPNEnabled = BraveVPN.isConnected
   @State private var isErrorShowing: Bool = false
+  
+  @ScaledMetric private var iconSize: CGFloat = 32.0
 
   private var isVPNEnabledBinding: Binding<Bool> {
     Binding(
@@ -126,7 +128,7 @@ struct VPNMenuButton: View {
     HStack(spacing: 14) {
       Image(braveSystemName: retryStateActive ? "leo.warning.triangle-filled" : "leo.product.vpn")
         .font(.body)
-        .frame(width: 32, height: 32)
+        .frame(width: iconSize, height: iconSize)
         .foregroundColor(retryStateActive ? Color(.braveErrorLabel) : Color(.braveLabel))
         .background(
           RoundedRectangle(cornerRadius: 8, style: .continuous)


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #8497 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Screenshots:

https://github.com/brave/brave-ios/assets/529104/7af7b8c6-9941-4dcc-bd2e-18fa22118fa4

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
