### PR TITLE
Fix #8493: Privacy Hub hide action approval alert 

### DIFF
--- a/Sources/Brave/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
+++ b/Sources/Brave/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
@@ -799,7 +799,7 @@ class NewTabPageViewController: UIViewController {
         preferredStyle: .alert)
       
       alert.addAction(UIAlertAction(title: Strings.cancelButtonTitle, style: .cancel))
-      alert.addAction(UIAlertAction(title: Strings.OKString, style: .default) { [weak self] _ in
+      alert.addAction(UIAlertAction(title: Strings.PrivacyHub.hidePrivacyHubWidgetActionButtonTitle, style: .default) { [weak self] _ in
         Preferences.NewTabPage.showNewTabPrivacyHub.value = false
         Preferences.NewTabPage.hidePrivacyHubAlertShown.value = true
         self?.collectionView.reloadData()

--- a/Sources/Brave/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
+++ b/Sources/Brave/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
@@ -186,8 +186,7 @@ class NewTabPageViewController: UIViewController {
         
         self?.present(host, animated: true)
       }, hidePrivacyHubPressed: { [weak self] in
-        Preferences.NewTabPage.showNewTabPrivacyHub.value = false
-        self?.collectionView.reloadData()
+        self?.hidePrivacyHub()
       }),
       FavoritesSectionProvider(action: { [weak self] bookmark, action in
         self?.handleFavoriteAction(favorite: bookmark, action: action)
@@ -787,6 +786,23 @@ class NewTabPageViewController: UIViewController {
       return
     }
     feedDataSource.load(completion)
+  }
+  
+  private func hidePrivacyHub() {
+    let alert = UIAlertController(
+      title: "Hide Privacy Hub Widget",
+      message: "Do you want to hide Privacy Hub from New Tab Page?\n\nTo alter visiblity settings in future check out New Tab Page section under Settings.",
+      preferredStyle: .alert)
+    
+    alert.addAction(UIAlertAction(title: Strings.cancelButtonTitle, style: .cancel))
+
+    alert.addAction(UIAlertAction(title: Strings.OKString, style: .default) { [weak self] _ in
+      Preferences.NewTabPage.showNewTabPrivacyHub.value = false
+      self?.collectionView.reloadData()
+    })
+    
+    UIImpactFeedbackGenerator(style: .medium).bzzt()
+    present(alert, animated: true, completion: nil)
   }
 
   // MARK: - Actions

--- a/Sources/Brave/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
+++ b/Sources/Brave/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
@@ -789,20 +789,25 @@ class NewTabPageViewController: UIViewController {
   }
   
   private func hidePrivacyHub() {
-    let alert = UIAlertController(
-      title: "Hide Privacy Hub Widget",
-      message: "Do you want to hide Privacy Hub from New Tab Page?\n\nTo alter visiblity settings in future check out New Tab Page section under Settings.",
-      preferredStyle: .alert)
-    
-    alert.addAction(UIAlertAction(title: Strings.cancelButtonTitle, style: .cancel))
-
-    alert.addAction(UIAlertAction(title: Strings.OKString, style: .default) { [weak self] _ in
+    if Preferences.NewTabPage.hidePrivacyHubAlertShown.value {
       Preferences.NewTabPage.showNewTabPrivacyHub.value = false
-      self?.collectionView.reloadData()
-    })
-    
-    UIImpactFeedbackGenerator(style: .medium).bzzt()
-    present(alert, animated: true, completion: nil)
+      collectionView.reloadData()
+    } else {
+      let alert = UIAlertController(
+        title: Strings.PrivacyHub.hidePrivacyHubWidgetActionTitle,
+        message: Strings.PrivacyHub.hidePrivacyHubWidgetAlertDescription,
+        preferredStyle: .alert)
+      
+      alert.addAction(UIAlertAction(title: Strings.cancelButtonTitle, style: .cancel))
+      alert.addAction(UIAlertAction(title: Strings.OKString, style: .default) { [weak self] _ in
+        Preferences.NewTabPage.showNewTabPrivacyHub.value = false
+        Preferences.NewTabPage.hidePrivacyHubAlertShown.value = true
+        self?.collectionView.reloadData()
+      })
+      
+      UIImpactFeedbackGenerator(style: .medium).bzzt()
+      present(alert, animated: true, completion: nil)
+    }
   }
 
   // MARK: - Actions

--- a/Sources/Brave/Frontend/ClientPreferences.swift
+++ b/Sources/Brave/Frontend/ClientPreferences.swift
@@ -181,6 +181,11 @@ extension Preferences {
     public static let showNewTabPrivacyHub =
       Option<Bool>(key: "newtabpage.show-newtab-privacyhub", default: true)
     
+    /// First time when privacy hub hide action is tieggered user will be shown alert
+    static let hidePrivacyHubAlertShown = Option<Bool>(
+      key: "newtabpage.hide-privacyhub-alert",
+      default: false)
+    
     /// Tells the app whether we should show Favourites in new tab page view controller
     public static let showNewTabFavourites =
       Option<Bool>(key: "newtabpage.show-newtab-favourites", default: true)

--- a/Sources/BraveStrings/BraveStrings.swift
+++ b/Sources/BraveStrings/BraveStrings.swift
@@ -4709,6 +4709,11 @@ extension Strings {
       comment: "The title of the button action which hides the privacy hub"
     )
     
+    public static let hidePrivacyHubWidgetAlertDescription = NSLocalizedString("privacyHub.hidePrivacyHubWidgetAlertDescription", tableName: "BraveShared", bundle: .module,
+      value: "Do you want to hide Privacy Hub from New Tab Page?\n\nTo alter the visibility settings in future check out New Tab Page section under Settings.",
+      comment: "The description in alert of the hide action which hides the privacy hub"
+    )
+    
     public static let openPrivacyHubWidgetActionTitle = NSLocalizedString("privacyHub.openPrivacyHubWidgetActionTitle", tableName: "BraveShared", bundle: .module,
       value: "Open Privacy Hub",
       comment: "The title of the button action which open the privacy hub"

--- a/Sources/BraveStrings/BraveStrings.swift
+++ b/Sources/BraveStrings/BraveStrings.swift
@@ -4705,18 +4705,23 @@ extension Strings {
     )
     
     public static let hidePrivacyHubWidgetActionTitle = NSLocalizedString("privacyHub.hidePrivacyHubWidgetActionTitle", tableName: "BraveShared", bundle: .module,
-      value: "Hide Privacy Hub Widget",
+      value: "Hide Privacy Stats",
       comment: "The title of the button action which hides the privacy hub"
     )
     
     public static let hidePrivacyHubWidgetAlertDescription = NSLocalizedString("privacyHub.hidePrivacyHubWidgetAlertDescription", tableName: "BraveShared", bundle: .module,
-      value: "Do you want to hide Privacy Hub from New Tab Page?\n\nTo alter the visibility settings in future check out New Tab Page section under Settings.",
+      value: "Tap Hide to remove the Privacy Stats widget. You can always re-enable in Settings, under New Tab Page",
       comment: "The description in alert of the hide action which hides the privacy hub"
     )
     
     public static let openPrivacyHubWidgetActionTitle = NSLocalizedString("privacyHub.openPrivacyHubWidgetActionTitle", tableName: "BraveShared", bundle: .module,
       value: "Open Privacy Hub",
       comment: "The title of the button action which open the privacy hub"
+    )
+    
+    public static let hidePrivacyHubWidgetActionButtonTitle = NSLocalizedString("privacyHub.hidePrivacyHubWidgetActionButtonTitle", tableName: "BraveShared", bundle: .module, 
+       value: "Hide",
+       comment: "Hide Privacy Hub Alert Hide Button"
     )
   }
 }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

The Hide action is activated first time, it will show a dialog (an alert) asking user if they are sure about the action and the dialog should indicate where they can turn it back on or change settings for NTP.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8493

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->

- Press 3 dor icon on privacy hub inside new tab page control
- Choose  Hide Privacy Widget Action
- An alert should be shown to approve this action and a description should be in details about whre to switch it back on
- After making it visible again the alert should not present

## Screenshots:

====

https://github.com/brave/brave-ios/assets/6643505/4dc72e46-e283-46e7-b4e1-0121adeb602e


====

![1](https://github.com/brave/brave-ios/assets/6643505/3074a986-e04f-4ff2-92d0-2feb83deeb40)


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
