### PR TITLE
Fix #8345, #8425: Add 'Creating Wallet...' step to onboarding

### DIFF
--- a/Sources/BraveWallet/Crypto/CryptoView.swift
+++ b/Sources/BraveWallet/Crypto/CryptoView.swift
@@ -236,7 +236,7 @@ public struct CryptoView: View {
         }
       case .unlock:
         UIKitNavigationView {
-          UnlockWalletView(keyringStore: keyringStore)
+          UnlockWalletView(keyringStore: keyringStore, dismissAction: dismissAction)
             .toolbar {
               dismissButtonToolbarContents
             }
@@ -252,7 +252,7 @@ public struct CryptoView: View {
           .zIndex(2)  // Needed or the dismiss animation messes up
         } else {
           UIKitNavigationView {
-            SetupCryptoView(keyringStore: keyringStore)
+            SetupCryptoView(keyringStore: keyringStore, dismissAction: dismissAction)
               .toolbar {
                 ToolbarItemGroup(placement: .destructiveAction) {
                   Button(action: {

--- a/Sources/BraveWallet/Crypto/Onboarding/CreateWalletView.swift
+++ b/Sources/BraveWallet/Crypto/Onboarding/CreateWalletView.swift
@@ -10,40 +10,6 @@ import DesignSystem
 import Strings
 import struct Shared.AppConstants
 
-struct CreateWalletContainerView: View {
-  @ObservedObject var keyringStore: KeyringStore
-  let setupOption: OnboardingSetupOption
-  let onValidPasswordEntered: ((_ validPassword: String) -> Void)?
-  // Used to dismiss all of Wallet
-  let dismissAction: () -> Void
-  
-  init(
-    keyringStore: KeyringStore,
-    setupOption: OnboardingSetupOption,
-    onValidPasswordEntered: ((_ validPassword: String) -> Void)? = nil,
-    dismissAction: @escaping () -> Void
-  ) {
-    self.keyringStore = keyringStore
-    self.setupOption = setupOption
-    self.onValidPasswordEntered = onValidPasswordEntered
-    self.dismissAction = dismissAction
-  }
-  
-  var body: some View {
-    ScrollView(.vertical) {
-      CreateWalletView(
-        keyringStore: keyringStore,
-        setupOption: setupOption,
-        onValidPasswordEntered: onValidPasswordEntered,
-        dismissAction: dismissAction
-      )
-      .background(Color(.braveBackground))
-    }
-    .background(Color(.braveBackground).edgesIgnoringSafeArea(.all))
-    .transparentNavigationBar(backButtonTitle: Strings.Wallet.createWalletBackButtonTitle, backButtonDisplayMode: .generic)
-  }
-}
-
 private enum ValidationError: LocalizedError, Equatable {
   case requirementsNotMet
   case inputsDontMatch
@@ -58,7 +24,7 @@ private enum ValidationError: LocalizedError, Equatable {
   }
 }
 
-private struct CreateWalletView: View {
+struct CreateWalletView: View {
   @ObservedObject var keyringStore: KeyringStore
   let setupOption: OnboardingSetupOption
   let onValidPasswordEntered: ((_ validPassword: String) -> Void)?
@@ -77,6 +43,18 @@ private struct CreateWalletView: View {
   @State private var isShowingCreatingWallet: Bool = false
   
   @FocusState private var isFieldFocused: Bool
+  
+  init(
+    keyringStore: KeyringStore,
+    setupOption: OnboardingSetupOption,
+    onValidPasswordEntered: ((_ validPassword: String) -> Void)? = nil,
+    dismissAction: @escaping () -> Void
+  ) {
+    self.keyringStore = keyringStore
+    self.setupOption = setupOption
+    self.onValidPasswordEntered = onValidPasswordEntered
+    self.dismissAction = dismissAction
+  }
 
   private func createWallet() {
     switch setupOption {
@@ -137,7 +115,7 @@ private struct CreateWalletView: View {
     }
   }
   
-  func errorLabel(_ error: ValidationError?) -> some View {
+  private func errorLabel(_ error: ValidationError?) -> some View {
     HStack(spacing: 12) {
       Image(braveSystemName: "leo.warning.circle-filled")
         .renderingMode(.template)
@@ -161,65 +139,67 @@ private struct CreateWalletView: View {
   }
 
   var body: some View {
-    VStack(spacing: 16) {
-      VStack {
-        Text(Strings.Wallet.createWalletTitle)
-          .font(.title)
-          .padding(.bottom)
-          .multilineTextAlignment(.center)
-          .foregroundColor(Color(uiColor: WalletV2Design.textPrimary))
-        Text(Strings.Wallet.createWalletSubTitle)
-          .font(.subheadline)
-          .padding(.bottom)
-          .multilineTextAlignment(.center)
-          .foregroundColor(Color(uiColor: WalletV2Design.textSecondary))
-      }
-      VStack(alignment: .leading, spacing: 20) {
-        VStack(spacing: 30) {
-          VStack(alignment: .leading, spacing: 10) {
-            Text(Strings.Wallet.newPasswordPlaceholder)
-              .foregroundColor(Color(uiColor: WalletV2Design.textPrimary))
-            HStack(spacing: 8) {
-              SecureField(Strings.Wallet.newPasswordPlaceholder, text: $password)
-                .textContentType(.newPassword)
-                .focused($isFieldFocused)
-              Spacer()
-              if passwordStatus != .none {
-                passwordStatusView(passwordStatus)
-              }
-            }
-            Divider()
-          }
-          VStack(alignment: .leading, spacing: 12) {
-            Text(Strings.Wallet.repeatedPasswordPlaceholder)
-              .foregroundColor(.primary)
-            HStack(spacing: 8) {
-              SecureField(Strings.Wallet.repeatedPasswordPlaceholder, text: $repeatedPassword, onCommit: createWallet)
-                .textContentType(.newPassword)
-              Spacer()
-              if isInputsMatch {
-                Text("\(Image(braveSystemName: "leo.check.normal")) \(Strings.Wallet.repeatedPasswordMatch)")
-                  .multilineTextAlignment(.trailing)
-                  .font(.footnote)
-                  .foregroundColor(.secondary)
-              }
-            }
-            Divider()
-          }
+    ScrollView(.vertical) {
+      VStack(spacing: 16) {
+        VStack {
+          Text(Strings.Wallet.createWalletTitle)
+            .font(.title)
+            .padding(.bottom)
+            .multilineTextAlignment(.center)
+            .foregroundColor(Color(uiColor: WalletV2Design.textPrimary))
+          Text(Strings.Wallet.createWalletSubTitle)
+            .font(.subheadline)
+            .padding(.bottom)
+            .multilineTextAlignment(.center)
+            .foregroundColor(Color(uiColor: WalletV2Design.textSecondary))
         }
-        .font(.subheadline)
-        errorLabel(validationError)
+        VStack(alignment: .leading, spacing: 20) {
+          VStack(spacing: 30) {
+            VStack(alignment: .leading, spacing: 10) {
+              Text(Strings.Wallet.newPasswordPlaceholder)
+                .foregroundColor(Color(uiColor: WalletV2Design.textPrimary))
+              HStack(spacing: 8) {
+                SecureField(Strings.Wallet.newPasswordPlaceholder, text: $password)
+                  .textContentType(.newPassword)
+                  .focused($isFieldFocused)
+                Spacer()
+                if passwordStatus != .none {
+                  passwordStatusView(passwordStatus)
+                }
+              }
+              Divider()
+            }
+            VStack(alignment: .leading, spacing: 12) {
+              Text(Strings.Wallet.repeatedPasswordPlaceholder)
+                .foregroundColor(.primary)
+              HStack(spacing: 8) {
+                SecureField(Strings.Wallet.repeatedPasswordPlaceholder, text: $repeatedPassword, onCommit: createWallet)
+                  .textContentType(.newPassword)
+                Spacer()
+                if isInputsMatch {
+                  Text("\(Image(braveSystemName: "leo.check.normal")) \(Strings.Wallet.repeatedPasswordMatch)")
+                    .multilineTextAlignment(.trailing)
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
+                }
+              }
+              Divider()
+            }
+          }
+          .font(.subheadline)
+          errorLabel(validationError)
+        }
+        Button(action: createWallet) {
+          Text(Strings.Wallet.continueButtonTitle)
+            .frame(maxWidth: .infinity)
+        }
+        .buttonStyle(BraveFilledButtonStyle(size: .large))
+        .disabled(isContinueDisabled)
+        .padding(.top, 60)
       }
-      Button(action: createWallet) {
-        Text(Strings.Wallet.continueButtonTitle)
-          .frame(maxWidth: .infinity)
-      }
-      .buttonStyle(BraveFilledButtonStyle(size: .large))
-      .disabled(isContinueDisabled)
-      .padding(.top, 60)
+      .padding(.horizontal, 20)
+      .padding(.bottom, 20)
     }
-    .padding(.horizontal, 20)
-    .padding(.bottom, 20)
     .background(Color(.braveBackground).edgesIgnoringSafeArea(.all))
     .background(
       NavigationLink(
@@ -235,9 +215,12 @@ private struct CreateWalletView: View {
     .onChange(of: password, perform: handleInputChange)
     .onChange(of: repeatedPassword, perform: handleInputChange)
     .navigationBarBackButtonHidden(isShowingCreatingWallet)
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
     .overlay {
       if isShowingCreatingWallet {
         CreatingWalletView()
+          .ignoresSafeArea()
+          .frame(maxWidth: .infinity, maxHeight: .infinity)
       }
     }
     .toolbar(content: {
@@ -254,6 +237,10 @@ private struct CreateWalletView: View {
     .onAppear {
       isFieldFocused = true
     }
+    .transparentNavigationBar(
+      backButtonTitle: Strings.Wallet.createWalletBackButtonTitle,
+      backButtonDisplayMode: .generic
+    )
   }
 }
 
@@ -261,7 +248,7 @@ private struct CreateWalletView: View {
 struct CreateWalletView_Previews: PreviewProvider {
   static var previews: some View {
     NavigationView {
-      CreateWalletContainerView(
+      CreateWalletView(
         keyringStore: .previewStore,
         setupOption: .new,
         dismissAction: {}

--- a/Sources/BraveWallet/Crypto/Onboarding/CreateWalletView.swift
+++ b/Sources/BraveWallet/Crypto/Onboarding/CreateWalletView.swift
@@ -241,7 +241,7 @@ private struct CreateWalletView: View {
       }
     }
     .toolbar(content: {
-      ToolbarItem(placement: .topBarLeading) {
+      ToolbarItem(placement: .navigationBarLeading) {
         if isShowingCreatingWallet {
           Button(action: dismissAction) { // dismiss all of wallet
             Image("wallet-dismiss", bundle: .module)

--- a/Sources/BraveWallet/Crypto/Onboarding/LegalView.swift
+++ b/Sources/BraveWallet/Crypto/Onboarding/LegalView.swift
@@ -76,7 +76,7 @@ struct LegalView: View {
     .padding()
     .background(
       NavigationLink(
-        destination: CreateWalletContainerView(
+        destination: CreateWalletView(
           keyringStore: keyringStore,
           setupOption: setupOption,
           dismissAction: dismissAction
@@ -89,7 +89,7 @@ struct LegalView: View {
     )
     .background(
       NavigationLink(
-        destination: RestoreWalletContainerView(
+        destination: RestoreWalletView(
           keyringStore: keyringStore,
           dismissAction: dismissAction
         ),

--- a/Sources/BraveWallet/Crypto/Onboarding/LegalView.swift
+++ b/Sources/BraveWallet/Crypto/Onboarding/LegalView.swift
@@ -8,17 +8,14 @@ import DesignSystem
 
 struct LegalView: View {
   @ObservedObject var keyringStore: KeyringStore
-  var setupOption: SetupOption
+  let setupOption: OnboardingSetupOption
+  // Used to dismiss all of Wallet
+  let dismissAction: () -> Void
   
   @State private var isResponsibilityCheckboxChecked: Bool = false
   @State private var isTermsCheckboxChecked: Bool = false
   @State private var isShowingCreateNewWallet: Bool = false
   @State private var isShowingRestoreExistedWallet: Bool = false
-  
-  enum SetupOption {
-    case new
-    case restore
-  }
   
   private var isContinueDisabled: Bool {
     !isResponsibilityCheckboxChecked || !isTermsCheckboxChecked
@@ -79,7 +76,11 @@ struct LegalView: View {
     .padding()
     .background(
       NavigationLink(
-        destination: CreateWalletContainerView(keyringStore: keyringStore),
+        destination: CreateWalletContainerView(
+          keyringStore: keyringStore,
+          setupOption: setupOption,
+          dismissAction: dismissAction
+        ),
         isActive: $isShowingCreateNewWallet,
         label: {
           EmptyView()
@@ -88,7 +89,10 @@ struct LegalView: View {
     )
     .background(
       NavigationLink(
-        destination: RestoreWalletContainerView(keyringStore: keyringStore),
+        destination: RestoreWalletContainerView(
+          keyringStore: keyringStore,
+          dismissAction: dismissAction
+        ),
         isActive: $isShowingRestoreExistedWallet,
         label: {
           EmptyView()
@@ -118,7 +122,11 @@ struct LegalCheckbox: View {
 #if DEBUG
 struct LegalView_Previews: PreviewProvider {
   static var previews: some View {
-    LegalView(keyringStore: .previewStore, setupOption: .new)
+    LegalView(
+      keyringStore: .previewStore,
+      setupOption: .new,
+      dismissAction: {}
+    )
   }
 }
 #endif

--- a/Sources/BraveWallet/Crypto/Onboarding/RestoreWalletView.swift
+++ b/Sources/BraveWallet/Crypto/Onboarding/RestoreWalletView.swift
@@ -201,7 +201,7 @@ private struct RestoreWalletView: View {
       }
     }
     .toolbar(content: {
-      ToolbarItem(placement: .topBarLeading) {
+      ToolbarItem(placement: .navigationBarLeading) {
         if isShowingCreatingWallet {
           Button(action: dismissAction) { // dismiss all of wallet
             Image("wallet-dismiss", bundle: .module)

--- a/Sources/BraveWallet/Crypto/Onboarding/RestoreWalletView.swift
+++ b/Sources/BraveWallet/Crypto/Onboarding/RestoreWalletView.swift
@@ -10,22 +10,7 @@ import Strings
 import struct Shared.AppConstants
 import Preferences
 
-struct RestoreWalletContainerView: View {
-  @ObservedObject var keyringStore: KeyringStore
-  // Used to dismiss all of Wallet
-  let dismissAction: () -> Void
-
-  var body: some View {
-    ScrollView(.vertical) {
-      RestoreWalletView(keyringStore: keyringStore, dismissAction: dismissAction)
-        .background(Color(.braveBackground))
-    }
-    .background(Color(.braveBackground).edgesIgnoringSafeArea(.all))
-    .transparentUnlessScrolledNavigationAppearance()
-  }
-}
-
-private struct RestoreWalletView: View {
+struct RestoreWalletView: View {
   @ObservedObject var keyringStore: KeyringStore
   // Used to dismiss all of Wallet
   let dismissAction: () -> Void
@@ -195,9 +180,13 @@ private struct RestoreWalletView: View {
       handleRecoveryWordsChanged(oldValue: recoveryWords, newValue: newValue)
     }
     .navigationBarBackButtonHidden(isShowingCreatingWallet)
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .background(Color(.braveBackground).edgesIgnoringSafeArea(.all))
     .overlay {
       if isShowingCreatingWallet {
         CreatingWalletView()
+          .ignoresSafeArea()
+          .frame(maxWidth: .infinity, maxHeight: .infinity)
       }
     }
     .toolbar(content: {
@@ -213,7 +202,7 @@ private struct RestoreWalletView: View {
     })
     .sheet(isPresented: $isShowingCreateNewPassword) {
       NavigationView {
-        CreateWalletContainerView(
+        CreateWalletView(
           keyringStore: keyringStore,
           setupOption: .restore,
           onValidPasswordEntered: restoreWallet,
@@ -228,6 +217,7 @@ private struct RestoreWalletView: View {
         }
       }
     }
+    .transparentUnlessScrolledNavigationAppearance()
   }
   
   private func resignFirstResponder() {
@@ -260,7 +250,7 @@ private struct RestoreWalletView: View {
 struct RestoreWalletView_Previews: PreviewProvider {
   static var previews: some View {
     NavigationView {
-      RestoreWalletContainerView(
+      RestoreWalletView(
         keyringStore: .previewStore,
         dismissAction: {}
       )

--- a/Sources/BraveWallet/Crypto/Onboarding/SetupCryptoView.swift
+++ b/Sources/BraveWallet/Crypto/Onboarding/SetupCryptoView.swift
@@ -9,10 +9,17 @@ import Introspect
 import DesignSystem
 import Strings
 
+enum OnboardingSetupOption {
+  case new
+  case restore
+}
+
 struct SetupCryptoView: View {
   @ObservedObject var keyringStore: KeyringStore
+  // Used to dismiss all of Wallet
+  let dismissAction: () -> Void
   
-  @State private var setupOption: LegalView.SetupOption?
+  @State private var setupOption: OnboardingSetupOption?
   
   var body: some View {
     ScrollView {
@@ -117,7 +124,11 @@ struct SetupCryptoView: View {
         ),
         destination: {
           if let option = setupOption {
-            LegalView(keyringStore: keyringStore, setupOption: option)
+            LegalView(
+              keyringStore: keyringStore,
+              setupOption: option,
+              dismissAction: dismissAction
+            )
           }
         },
         label: {
@@ -134,7 +145,10 @@ struct SetupCryptoView: View {
 struct SetupCryptoView_Previews: PreviewProvider {
   static var previews: some View {
     NavigationView {
-      SetupCryptoView(keyringStore: .previewStore)
+      SetupCryptoView(
+        keyringStore: .previewStore,
+        dismissAction: {}
+      )
     }
     .previewLayout(.sizeThatFits)
     .previewColorSchemes()

--- a/Sources/BraveWallet/Crypto/Stores/KeyringStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/KeyringStore.swift
@@ -285,6 +285,11 @@ public class KeyringStore: ObservableObject, WalletObserverStore {
       // strong ref which keeps `KeyringStore` alive.
       let isWalletCreated = await keyringService.isWalletCreated()
       self.isOnboardingVisible = !isWalletCreated
+      if isRestoringWallet && isWalletCreated {
+        // user dismissed wallet while restoring, but after wallet was created in core.
+        keyringService.notifyWalletBackupComplete()
+        self.isWalletBackedUp = await keyringService.isWalletBackedUp()
+      }
     }
     keyringServiceObserver = nil
     rpcServiceObserver = nil

--- a/Sources/BraveWallet/Crypto/Stores/KeyringStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/KeyringStore.swift
@@ -213,6 +213,14 @@ public class KeyringStore: ObservableObject, WalletObserverStore {
   
   public func setupObservers() {
     guard !isObserving else { return }
+    Task { @MainActor in
+      // For case where Wallet is dismissed while wallet is being created.
+      // Ex. User creates wallet, dismisses & re-opens Wallet before
+      // create wallet completion callback. Callback is held with
+      // strong ref which keeps `KeyringStore` alive.
+      let isWalletCreated = await keyringService.isWalletCreated()
+      self.isOnboardingVisible = !isWalletCreated
+    }
     self.keyringServiceObserver = KeyringServiceObserver(
       keyringService: keyringService,
       _walletReset: { [weak self] in
@@ -270,6 +278,14 @@ public class KeyringStore: ObservableObject, WalletObserverStore {
   }
   
   public func tearDown() {
+    Task { @MainActor in
+      // For case where Wallet is dismissed while wallet is being created.
+      // Ex. User creates wallet, dismisses & re-opens Wallet before
+      // create wallet completion callback. Callback is held with
+      // strong ref which keeps `KeyringStore` alive.
+      let isWalletCreated = await keyringService.isWalletCreated()
+      self.isOnboardingVisible = !isWalletCreated
+    }
     keyringServiceObserver = nil
     rpcServiceObserver = nil
   }

--- a/Sources/BraveWallet/Crypto/UnlockWalletView.swift
+++ b/Sources/BraveWallet/Crypto/UnlockWalletView.swift
@@ -82,7 +82,7 @@ struct UnlockWalletView: View {
             .disabled(!isPasswordValid)
             
             NavigationLink(
-              destination: RestoreWalletContainerView(
+              destination: RestoreWalletView(
                 keyringStore: keyringStore,
                 dismissAction: dismissAction
               )

--- a/Sources/BraveWallet/Crypto/UnlockWalletView.swift
+++ b/Sources/BraveWallet/Crypto/UnlockWalletView.swift
@@ -10,6 +10,8 @@ import LocalAuthentication
 
 struct UnlockWalletView: View {
   @ObservedObject var keyringStore: KeyringStore
+  // Used to dismiss all of Wallet
+  let dismissAction: () -> Void
 
   @State private var password: String = ""
   @FocusState private var isPasswordFieldFocused: Bool
@@ -81,7 +83,8 @@ struct UnlockWalletView: View {
             
             NavigationLink(
               destination: RestoreWalletContainerView(
-                keyringStore: keyringStore
+                keyringStore: keyringStore,
+                dismissAction: dismissAction
               )
             ) {
               Text(Strings.Wallet.restoreWalletButtonTitle)
@@ -161,7 +164,8 @@ struct UnlockWalletView_Previews: PreviewProvider {
   static var previews: some View {
     NavigationView {
       UnlockWalletView(
-        keyringStore: .previewStoreWithWalletCreated
+        keyringStore: .previewStoreWithWalletCreated,
+        dismissAction: {}
       )
     }
     .previewColorSchemes()

--- a/Sources/BraveWallet/WalletHostingViewController.swift
+++ b/Sources/BraveWallet/WalletHostingViewController.swift
@@ -95,7 +95,7 @@ public class WalletHostingViewController: UIHostingController<CryptoView> {
         // As a workaround to this issue, we can just watch keyring's `isLocked` value from here
         // and dismiss the first sheet ourselves to ensure we dont get stuck with a child view visible
         // while the wallet is locked.
-        if /*#unavailable(iOS 16.4),*/
+        if #unavailable(iOS 16.4),
            let self = self,
            isLocked,
            let presentedViewController = self.presentedViewController,

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -856,6 +856,13 @@ extension Strings {
       value: "Strong",
       comment: "A label will be displayed beside input password when it is considered as a strong password"
     )
+    public static let creatingWallet = NSLocalizedString(
+      "wallet.creatingWallet",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Creating Wallet...",
+      comment: "The title of the creating wallet screen, shown after user enters their password while the wallet is being set up."
+    )
     public static let biometricsSetupErrorTitle = NSLocalizedString(
       "wallet.biometricsSetupErrorTitle",
       tableName: "BraveWallet",


### PR DESCRIPTION
## Summary of Changes
- Wallet data files are now registered & downloaded when a wallet is created or restored for the first time (existing Wallet users are already registered). This means we'll have a longer asynchronous time between user tapping `Continue` on password step before the wallet is setup. To handle this case, a `Creating Wallet...` view is used.
Adds a down carat button to the Onboarding flow when `Creating Wallet...` is shown so user knows they can dismiss. Dismissal will not cancel wallet creation, it will continue in background (wallet data files fetched in background).

This pull request fixes #8345,
fixes #8425

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
### Create Wallet flows
1. Start from fresh install (so wallet data files need to download)
2. Open Wallet onboarding and use create new wallet flow.
    - The `Creating Wallet...` step is after pressing `Continue` on Create a Password view. Onboarding should progress as normal.
3. Verify it continues with onboarding flow works as expected (`Creating Wallet` view could be missed on faster internet connection).
4. Delete Brave app & re-install.
5. Test create wallet flow from fresh install, but disable or use network link conditioner to severely slow network connection before tapping `Continue` on Create a Password view. 
6. Dismiss wallet via down-arrow button on `Creating Wallet...` view.
7. Re-open Wallet; Portfolio should be shown. You can re-enable regular network conditions and the wallet data files will download in the background. Some asset icons won't be visible until download completes (and icons moved off screen & back on). Should be an uncommon case.

### Restore Wallet flows
1. Start from fresh install (so wallet data files need to download)
2. Open Wallet onboarding and use restore wallet flow.
3. When entering seed phrase, type it invalid phrase like `1` for each word (each field must be populated).
4. Tap `Continue` and `Create a Password` modal is opened.
5. Verify passwords must match for continue button to be enabled.
6. Tap `Continue`. Verify `Create a Password` modal dismisses to show invalid seed phrase error.
7. Enter correct seed phrase and tap `Continue`.
8. Verify it continues with onboarding flow works as expected (`Creating Wallet` view could be missed on faster internet connection).
9. Delete Brave app & re-install.
10. Test restore wallet flow from fresh install again, but disable or use network link conditioner to severely slow network connection before tapping `Continue` on Create a Password view. 
11. Dismiss wallet via down-arrow button on `Creating Wallet...` view.
12. Re-open Wallet; Portfolio should be shown. You can re-enable regular network conditions and the wallet data files will download in the background. Some asset icons won't be visible until download completes (and icons moved off screen & back on). Should be an uncommon case.


### iPad Split Screen bug #8425
I was unable to reproduce this bug, but @srirambv got it a couple times. I've added additional protections for the case where a user has 2 Brave windows open both showing Wallet onboarding (and forced non-dismissal scenario in code to test). In the case where the 2nd window does _not_ automatically dismiss onboarding after the 1st window creates the wallet, tapping `Continue` will dismiss the onboarding flow instead of creating a second wallet / duplicate Ethereum & Solana accounts.

## Screenshots:

<video src="https://github.com/brave/brave-ios/assets/5314553/8acb7a5f-667e-45b2-8832-cf57f02ee954"> | <video src="https://github.com/brave/brave-ios/assets/5314553/27487502-9b5c-4082-861c-018e6e38ab5c">
--|--
<video src="https://github.com/brave/brave-ios/assets/5314553/2cee5fb9-ab90-4998-a3ce-b3d77949d153"> | <video src="https://github.com/brave/brave-ios/assets/5314553/754ce0d5-de30-45c6-98d2-f62ce57b2d5b">



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
