### PR TITLE
Fix #8371: Update Rewards icon properly when first enabling it

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController.swift
@@ -473,7 +473,7 @@ public class BrowserViewController: UIViewController {
       })
     }
     
-    rewardsEnabledObserveration = rewards.observe(\.isEnabled, options: [.new]) { [weak self] _, _ in
+    rewardsEnabledObserveration = rewards.ads.observe(\.isEnabled, options: [.new]) { [weak self] _, _ in
       guard let self = self else { return }
       self.updateRewardsButtonState()
       self.setupAdsNotificationHandler()

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
@@ -26,7 +26,7 @@ extension BrowserViewController {
       return
     }
     self.topToolbar.rewardsButton.isHidden = Preferences.Rewards.hideRewardsIcon.value || privateBrowsingManager.isPrivateBrowsing
-    self.topToolbar.rewardsButton.iconState = Preferences.Rewards.rewardsToggledOnce.value ? (rewards.isEnabled || rewards.isCreatingWallet ? .enabled : .disabled) : .initial
+    self.topToolbar.rewardsButton.iconState = rewards.isEnabled || rewards.isTurningOnRewards ? .enabled : (Preferences.Rewards.rewardsToggledOnce.value ? .disabled : .initial)
   }
 
   func showBraveRewardsPanel() {
@@ -44,7 +44,7 @@ extension BrowserViewController {
 
       Preferences.FullScreenCallout.rewardsCalloutCompleted.value = true
       present(controller, animated: true)
-      topToolbar.rewardsButton.iconState = Preferences.Rewards.rewardsToggledOnce.value ? (rewards.isEnabled || rewards.isCreatingWallet ? .enabled : .disabled) : .initial
+      topToolbar.rewardsButton.iconState = Preferences.Rewards.rewardsToggledOnce.value ? (rewards.isEnabled || rewards.isTurningOnRewards ? .enabled : .disabled) : .initial
       return
     }
 


### PR DESCRIPTION
Also fixes a race condition for first time rewards users where the rewards service hasn't started before they tap the switch to turn it on would cause a UI bug

## Summary of Changes

This pull request fixes #8371 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
