### PR TITLE
Fix #8518: NFT grid placeholder height is not the same with other grids height

### DIFF
--- a/Sources/BraveWallet/Crypto/NFT/NFTView.swift
+++ b/Sources/BraveWallet/Crypto/NFT/NFTView.swift
@@ -455,7 +455,7 @@ struct SkeletonLoadingNFTView: View {
   
   var body: some View {
     LazyVGrid(columns: nftGrids) {
-      ForEach(0..<6) { _ in
+      ForEach(0..<8) { _ in
         VStack(alignment: .leading, spacing: 6) {
           LoadingNFTView()
             .frame(height: 176)

--- a/Sources/BraveWallet/Crypto/NFTImageView.swift
+++ b/Sources/BraveWallet/Crypto/NFTImageView.swift
@@ -42,7 +42,6 @@ struct NFTImageView<Placeholder: View>: View {
             WebImage(url: url)
               .resizable()
               .placeholder { placeholder() }
-              .indicator(.activity)
               .aspectRatio(contentMode: .fit)
           } else {
             WebImageReader(url: url) { image in
@@ -77,6 +76,7 @@ struct LoadingNFTView: View {
         Image(braveSystemName: "leo.nft")
           .foregroundColor(Color(braveSystemName: .containerBackground))
           .font(.system(size: floor(viewSize.width / 3)))
+          .aspectRatio(contentMode: .fit)
       }
       .background(
         GeometryReader { geometryProxy in
@@ -84,7 +84,7 @@ struct LoadingNFTView: View {
             .preference(key: SizePreferenceKey.self, value: geometryProxy.size)
         }
       )
-      .frame(minHeight: viewSize.width, maxHeight: 172)
+      .frame(height: viewSize.width)
       .onPreferenceChange(SizePreferenceKey.self) { newSize in
         viewSize = newSize
       }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
1. Remove progress view for NFT gif resource 
2. increate skeleton nft loading grids from 6 to 8 so that iPad has loading nft grids filled
3. Make the nft placeholder image has the same height and width to match other NFT grids 

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8518

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Please refer to the issue. 


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

New | Old
--- | ---
![simulator_screenshot_A35CA205-087C-49E2-8B30-6EBA5978A5E3](https://github.com/brave/brave-ios/assets/1187676/312422da-11a1-4e63-9657-d44894e7ce29) | ![simulator_screenshot_F6D1D2C7-892B-4436-B490-1CC8B2766DC7](https://github.com/brave/brave-ios/assets/1187676/b8a01e2a-cd68-40ed-8ea3-8ff66e559838)

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
