### PR TITLE
Fix #8136: Assets line chart V2

### DIFF
--- a/Sources/BraveWallet/Crypto/Asset Details/AssetDetailHeaderView.swift
+++ b/Sources/BraveWallet/Crypto/Asset Details/AssetDetailHeaderView.swift
@@ -27,6 +27,7 @@ struct AssetDetailHeaderView: View {
   @Environment(\.sizeCategory) private var sizeCategory
   @Environment(\.horizontalSizeClass) private var horizontalSizeClass
   @Environment(\.openURL) private var openWalletURL
+  @Environment(\.colorScheme) private var colourScheme
   @State private var selectedCandle: BraveWallet.AssetTimePrice?
 
   private var deltaText: some View {
@@ -229,7 +230,7 @@ struct AssetDetailHeaderView: View {
           let data = assetDetailStore.priceHistory.isEmpty ? emptyData : assetDetailStore.priceHistory
           LineChartView(data: data, numberOfColumns: data.count, selectedDataPoint: $selectedCandle) {
             LinearGradient(
-              gradient: Gradient(colors: [Color(.braveBlurpleTint).opacity(0.2), .clear]),
+              gradient: Gradient(colors: [Color(.braveBlurpleTint).opacity(colourScheme == .dark ? 0.5 : 0.2), .clear]),
               startPoint: .top,
               endPoint: .bottom
             )

--- a/Sources/BraveWallet/Crypto/Asset Details/AssetDetailHeaderView.swift
+++ b/Sources/BraveWallet/Crypto/Asset Details/AssetDetailHeaderView.swift
@@ -228,8 +228,12 @@ struct AssetDetailHeaderView: View {
           .shimmer(assetDetailStore.isLoadingPrice)
           let data = assetDetailStore.priceHistory.isEmpty ? emptyData : assetDetailStore.priceHistory
           LineChartView(data: data, numberOfColumns: data.count, selectedDataPoint: $selectedCandle) {
-            Color(.walletGreen)
-              .shimmer(assetDetailStore.isLoadingChart)
+            LinearGradient(
+              gradient: Gradient(colors: [Color(.braveBlurpleTint).opacity(0.2), .clear]),
+              startPoint: .top,
+              endPoint: .bottom
+            )
+            .shimmer(assetDetailStore.isLoadingChart)
           }
           .chartAccessibility(
             title: String.localizedStringWithFormat(

--- a/Sources/BraveWallet/Crypto/Portfolio/PortfolioHeaderView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/PortfolioHeaderView.swift
@@ -167,8 +167,12 @@ struct PortfolioHeaderView: View {
       timeframeSelector
       let chartData = historicalBalances.isEmpty ? emptyBalanceData : historicalBalances
       LineChartView(data: chartData, numberOfColumns: chartData.count, selectedDataPoint: $selectedBalance) {
-        LinearGradient(braveGradient: .lightGradient02)
-          .shimmer(isLoading)
+        LinearGradient(
+          gradient: Gradient(colors: [Color(.braveBlurpleTint).opacity(0.2), .clear]),
+          startPoint: .top,
+          endPoint: .bottom
+        )
+        .shimmer(isLoading)
       }
       .chartAccessibility(
         title: Strings.Wallet.portfolioPageTitle,

--- a/Sources/BraveWallet/Crypto/Portfolio/PortfolioHeaderView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/PortfolioHeaderView.swift
@@ -23,6 +23,8 @@ struct PortfolioHeaderView: View {
   @State private var selectedBalance: BalanceTimePrice?
   @ObservedObject private var isShowingGraph = Preferences.Wallet.isShowingGraph
   @ObservedObject private var isShowingBalances = Preferences.Wallet.isShowingBalances
+  
+  @Environment(\.colorScheme) private var colourScheme
 
   private var isShowingBackupBanner: Bool {
     !keyringStore.isWalletBackedUp && !dismissedBackupBannerThisSession
@@ -168,7 +170,7 @@ struct PortfolioHeaderView: View {
       let chartData = historicalBalances.isEmpty ? emptyBalanceData : historicalBalances
       LineChartView(data: chartData, numberOfColumns: chartData.count, selectedDataPoint: $selectedBalance) {
         LinearGradient(
-          gradient: Gradient(colors: [Color(.braveBlurpleTint).opacity(0.2), .clear]),
+          gradient: Gradient(colors: [Color(.braveBlurpleTint).opacity(colourScheme == .dark ? 0.5 : 0.2), .clear]),
           startPoint: .top,
           endPoint: .bottom
         )


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8136

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Check any screen that has line-chart (1. Portfolio 2. Asset Details)

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

![Simulator Screenshot - iPad (10th generation) - 2023-12-05 at 23 10 42](https://github.com/brave/brave-ios/assets/1187676/a3c9017d-32ee-473c-8702-865b750113a6) | ![Simulator Screenshot - iPad (10th generation) - 2023-12-05 at 23 10 19](https://github.com/brave/brave-ios/assets/1187676/bfaf0ec1-029e-4c13-9c40-bea308cff620) | ![Simulator Screenshot - iPad (10th generation) - 2023-12-05 at 23 10 54](https://github.com/brave/brave-ios/assets/1187676/0f76b0dc-e62c-479a-820f-d0649d479aac) | ![Simulator Screenshot - iPad (10th generation) - 2023-12-05 at 23 11 11](https://github.com/brave/brave-ios/assets/1187676/a43b7bc1-0f17-45fc-89ef-0c8aae23d443)
--- | --- | --- | ---

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
