### PR TITLE
Fix #8529: Update logic to support unknown tokens from non-mainnet transactions

### DIFF
--- a/Sources/BraveWallet/Extensions/AssetRatioServiceExtensions.swift
+++ b/Sources/BraveWallet/Extensions/AssetRatioServiceExtensions.swift
@@ -108,20 +108,4 @@ extension BraveWalletAssetRatioService {
     let prices = Dictionary(uniqueKeysWithValues: priceResult.assetPrices.map { ($0.fromAsset, $0.price) })
     return prices
   }
-  
-  /// Fetches the BlockchainToken for the given contract addresses. The token for a given contract
-  /// address is not guaranteed to be found, and will not be provided in the result if not found.
-  @MainActor func fetchTokens(
-    for contractAddresses: [String]
-  ) async -> [BraveWallet.BlockchainToken] {
-    await withTaskGroup(of: [BraveWallet.BlockchainToken?].self) { @MainActor group in
-      for contractAddress in contractAddresses {
-        group.addTask { @MainActor in
-          let token = await self.tokenInfo(contractAddress)
-          return [token]
-        }
-      }
-      return await group.reduce([BraveWallet.BlockchainToken?](), { $0 + $1 })
-    }.compactMap { $0 }
-  }
 }

--- a/Sources/BraveWallet/Extensions/RpcServiceExtensions.swift
+++ b/Sources/BraveWallet/Extensions/RpcServiceExtensions.swift
@@ -385,4 +385,78 @@ extension BraveWalletJsonRpcService {
       })
     }
   }
+
+  /// Helper to fetch `symbol` and `decimals` ONLY given a token contract address & chainId.
+  /// This function will be replaced by a BraveCore function that will also fetch `name` & `coingeckoId`.
+  func getEthTokenInfo(
+    contractAddress: String,
+    chainId: String
+  ) async -> BraveWallet.BlockchainToken? {
+    let (symbol, symbolStatus, _) = await ethTokenSymbol(contractAddress, chainId: chainId)
+    let (decimals, decimalsStatus, _) = await ethTokenDecimals(contractAddress, chainId: chainId)
+    guard symbolStatus == .success || decimalsStatus == .success else { return nil }
+    return .init(
+      contractAddress: contractAddress,
+      name: "",
+      logo: "",
+      isErc20: false, // rpcService.getSupportsInterface() is private / internal.
+      isErc721: false, // rpcService.getSupportsInterface() is private / internal.
+      isErc1155: false, // rpcService.getSupportsInterface() is private / internal.
+      isNft: false,
+      isSpam: false,
+      symbol: symbol,
+      decimals: Int32(decimals.removingHexPrefix, radix: 16) ?? 0,
+      visible: false,
+      tokenId: "",
+      coingeckoId: "", // blockchainRegistry can fetch this for us, but not needed in Tx Confirmation.
+      chainId: chainId,
+      coin: .eth
+    )
+  }
+  
+  /// Fetches the BlockchainToken for the given contract addresses. The token for a given contract
+  /// address is not guaranteed to be found, and will not be provided in the result if not found.
+  @MainActor func fetchEthTokens(
+    for contractAddressesChainIdPairs: [ContractAddressChainIdPair]
+  ) async -> [BraveWallet.BlockchainToken] {
+    await withTaskGroup(of: [BraveWallet.BlockchainToken?].self) { @MainActor group in
+      for contractAddressesChainIdPair in contractAddressesChainIdPairs {
+        group.addTask {
+          let token = await self.getEthTokenInfo(
+            contractAddress: contractAddressesChainIdPair.contractAddress,
+            chainId: contractAddressesChainIdPair.chainId
+          )
+          if let token {
+            return [token]
+          }
+          return []
+        }
+      }
+      return await group.reduce([BraveWallet.BlockchainToken?](), { $0 + $1 })
+    }.compactMap { $0 }
+  }
+}
+
+struct ContractAddressChainIdPair: Equatable {
+  let contractAddress: String
+  let chainId: String
+}
+
+extension Array where Element == BraveWallet.TransactionInfo {
+  func unknownTokenContractAddressChainIdPairs(
+    knownTokens: [BraveWallet.BlockchainToken]
+  ) -> [ContractAddressChainIdPair] {
+    flatMap { transaction in
+      transaction.tokenContractAddresses
+        .filter { contractAddress in
+          !knownTokens.contains(where: { knownToken in
+            knownToken.contractAddress.caseInsensitiveCompare(contractAddress) == .orderedSame &&
+            knownToken.chainId.caseInsensitiveCompare(knownToken.chainId) == .orderedSame
+          })
+        }
+        .map { contractAddress in
+        ContractAddressChainIdPair(contractAddress: contractAddress, chainId: transaction.chainId)
+      }
+    }
+  }
 }

--- a/Tests/BraveWalletTests/TransactionConfirmationStoreTests.swift
+++ b/Tests/BraveWalletTests/TransactionConfirmationStoreTests.swift
@@ -344,11 +344,11 @@ import Preferences
     )
     let networkExpectation = expectation(description: "network-expectation")
     store.$network
-      .dropFirst(7) // `network` is assigned multiple times during setup
-      .collect(5) // collect all transactions
+      .dropFirst(8) // `network` is assigned multiple times during setup
+      .collect(6) // collect all updates (1 extra for final tx network)
       .sink { networks in
         defer { networkExpectation.fulfill() }
-        XCTAssertEqual(networks.count, 5)
+        XCTAssertEqual(networks.count, 6)
         XCTAssertEqual(networks[safe: 0], BraveWallet.NetworkInfo.mockFilecoinMainnet)
         XCTAssertEqual(networks[safe: 1], BraveWallet.NetworkInfo.mockSolanaTestnet)
         XCTAssertEqual(networks[safe: 2], BraveWallet.NetworkInfo.mockSolana)


### PR DESCRIPTION
## Summary of Changes
- Previously we relied on the `GetTokenInfo` api on Asset Ratio Service to fetch tokens, but this api was ethereum mainnet only. By using `GetEthTokenDecimals` and `GetEthTokenSymbol` we can use RPC to fetch tokens from non-mainnet ethereum networks, for example Goerli.
- Added a `GetEthTokenInfo` api extension to JsonRpcService. This API can/will be replaced in a future version of BraveCore: https://github.com/brave/brave-core/pull/21191

This pull request fixes #8529

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Create a non-mainnet Ethereum transaction for a token not in user assets or blockchain registry (asset search in wallet).
    - I used cow swap to swap ETH to CoW token on Goerli Test network for testing.
    - https://swap.cow.fi/#/5/swap/ETH/COW
2. Verify token symbol and transaction value shows up as expect in Swap Confirmation, Activity tab, Tx details, etc.


## Screenshots:

![Goerli Swap Confirmation](https://github.com/brave/brave-ios/assets/5314553/420a28ea-3ccf-48de-aab9-b920f3b7ed9d) | ![Goerli Swap Tx Details](https://github.com/brave/brave-ios/assets/5314553/a9f00898-e4ce-483a-b6c7-e6101f82e49e)
--|--
![Goerli Swap Tx Activity](https://github.com/brave/brave-ios/assets/5314553/cba5e1d0-2afc-4034-b0c6-88f7ea6a51c8) | ![Goerli Swap Tx Account Activity](https://github.com/brave/brave-ios/assets/5314553/ee44915a-d9ab-4d5b-bfe1-4ad4dd275fee)
![Goerli Swap Asset Detail](https://github.com/brave/brave-ios/assets/5314553/cd8df04b-f9d2-4189-800f-a8cb49165889)


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
