### PR TITLE
Fix #8517: Update logic for multi-window on iPhone

### DIFF
--- a/Sources/Brave/Migration/Migration.swift
+++ b/Sources/Brave/Migration/Migration.swift
@@ -55,10 +55,16 @@ public class Migration {
   
   public static func migrateLostTabsActiveWindow() {
     if UIApplication.shared.supportsMultipleScenes { return }
-    if Preferences.Migration.lostTabsWindowIDMigrationOne.value { return }
+    if Preferences.Migration.lostTabsWindowIDMigration.value { return }
     
-    let sessionWindows = SessionWindow.all()
-    guard let activeWindow = sessionWindows.first(where: { $0.isSelected }) else {
+    var sessionWindows = SessionWindow.all()
+    var activeWindow = sessionWindows.first(where: { $0.isSelected })
+    if activeWindow == nil {
+      activeWindow = sessionWindows.removeFirst()
+    }
+    
+    guard let activeWindow = activeWindow else {
+      Preferences.Migration.lostTabsWindowIDMigration.value = true
       return
     }
     
@@ -93,7 +99,7 @@ public class Migration {
       }
     }
     
-    Preferences.Migration.lostTabsWindowIDMigrationOne.value = true
+    Preferences.Migration.lostTabsWindowIDMigration.value = true
   }
 
   public static func postCoreDataInitMigrations() {
@@ -158,8 +164,8 @@ fileprivate extension Preferences {
       key: "migration.ad-block-and-tracking-protection-shield-level-completed", default: false
     )
     
-    static let lostTabsWindowIDMigrationOne = Option<Bool>(
-      key: "migration.lost-tabs-window-id-one",
+    static let lostTabsWindowIDMigration = Option<Bool>(
+      key: "migration.lost-tabs-window-id-two",
       default: !UIApplication.shared.supportsMultipleScenes
     )
   }


### PR DESCRIPTION
## Summary of Changes
- Always restore the first window or active window no matter what. Active window is priority, first window is the fallback.
- This ignores the Apple UserActivity that is given to us to "restore" because it can be nil when you kill the app to fast, or perhaps when some other condition happens.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8517

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes
  
## Test Plan:
- Test session restore on iPhone and iPad.

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
