### PR TITLE
Ref #7835, #8494: Fix handling of External URL when in third-party frames but active tab #8495

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -892,12 +892,8 @@ extension BrowserViewController {
           }
         }
         popup.addButton(title: Strings.openExternalAppURLAllow, type: .primary) { [weak tab] () -> PopupViewDismissType in
-          if UIApplication.shared.canOpenURL(url) {
-            UIApplication.shared.open(url, options: [:]) { didOpen in
-              openedURLCompletionHandler(!didOpen)
-            }
-          } else {
-            openedURLCompletionHandler(true)
+          UIApplication.shared.open(url, options: [:]) { didOpen in
+            openedURLCompletionHandler(!didOpen)
           }
           removeTabIfEmpty()
           tab?.isExternalAppAlertPresented = false


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

To use [canOpenURL(_:)](https://developer.apple.com/documentation/uikit/uiapplication/1622952-canopenurl) an Application must declare the URL schemes you pass to this method by adding the LSApplicationQueriesSchemes key to your app's Info.plist file. This method always returns false for undeclared schemes, whether or not an appropriate app is installed.

We are a browser and we have to handle all schemes. Can Open URL is removed from handle external urls. It was added with https://github.com/brave/brave-ios/pull/8495

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7835 
This pull request fixes #8494

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->

Check Test Plan and details for https://developer.apple.com/documentation/uikit/uiapplication/1622952-canopenurl

Additionally open a slack link outside the browser and see it works.


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
