### PR TITLE
Fix #8517: Fix crash on launch due to active window changes

### DIFF
--- a/App/iOS/Delegates/SceneDelegate.swift
+++ b/App/iOS/Delegates/SceneDelegate.swift
@@ -533,12 +533,15 @@ extension SceneDelegate {
     let activeWindow = SessionWindow.getActiveWindow(context: DataController.swiftUIContext)
     let activeSession = UIApplication.shared.openSessions
       .compactMap({ BrowserState.getWindowInfo(from: $0) })
-      .first(where: { $0.windowId == activeWindow?.windowId.uuidString })
+      .first(where: { $0.windowId != nil && $0.windowId == activeWindow?.windowId.uuidString })
       
     if activeSession != nil {
       if !UIApplication.shared.supportsMultipleScenes {
         // iPhones should not create new windows
-        return (activeWindow!.windowId, false, nil)
+        if let activeWindow = activeWindow {
+          // If there's no active window, fall through and create one
+          return (activeWindow.windowId, false, nil)
+        }
       }
       
       // An existing window is already active on screen


### PR DESCRIPTION
## Summary of Changes
- Amendment to the previous fix for active window to prevent crashes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8517

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
