### PR TITLE
No Bug: Fix for console warning about `leo.nft` symbol size

### DIFF
--- a/Sources/BraveWallet/Crypto/NFTImageView.swift
+++ b/Sources/BraveWallet/Crypto/NFTImageView.swift
@@ -67,6 +67,12 @@ struct NFTImageView<Placeholder: View>: View {
 struct LoadingNFTView: View {
   var shimmer: Bool = true
   @State var viewSize: CGSize = .zero
+  
+  private var fontSizeForNFTImage: CGFloat {
+    guard viewSize.width > 0 else { return 12 }
+    return floor(viewSize.width / 3)
+  }
+  
   var body: some View {
     Color(braveSystemName: .containerHighlight)
       .cornerRadius(4)
@@ -75,7 +81,7 @@ struct LoadingNFTView: View {
       .overlay {
         Image(braveSystemName: "leo.nft")
           .foregroundColor(Color(braveSystemName: .containerBackground))
-          .font(.system(size: floor(viewSize.width / 3)))
+          .font(.system(size: fontSizeForNFTImage))
           .aspectRatio(contentMode: .fit)
       }
       .background(


### PR DESCRIPTION
## Summary of Changes
Opening NFT tab can log a few console warnings about `leo.nft` symbol, for example:
```
[SwiftUI] No image named 'leo.nft' found in asset catalog for /Users/stephenheaps/Library/Developer/CoreSimulator/Devices/B85864FA-AD05-49A0-A247-146C5D39394F/data/Containers/Bundle/Application/DC7A00C9-BB00-40BB-BB16-7FD7459F9A25/Client.app/Brave_DesignSystem.bundle
[framework] CoreUI: -[CUICatalog namedVectorGlyphWithName:scaleFactor:deviceIdiom:layoutDirection:glyphSize:glyphWeight:glyphPointSize:appearanceName:] 'leo.nft' called with scaleFactor == 2.000000 glyphPointSize == 0.000000 at '/Users/stephenheaps/Library/Developer/CoreSimulator/Devices/B85864FA-AD05-49A
```

This pull request fixes #<number>

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Open NFT tab on any device with debugger attached, filter by `leo.nft`.
2. Verify no more logs/warnings about `leo.nft` symbol


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
