### PR TITLE
Fix #8540: Bump Brave-Core to 1.61.102 to Fix Crash in Sync Cr120

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@mozilla/readability": "^0.4.2",
-        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.62.93/brave-core-ios-1.62.93.tgz",
+        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.61.102/brave-core-ios-1.61.102.tgz",
         "leo": "github:brave/leo#792ab5c9f82784578e8f8fc14b9eaa24fa1956d2",
         "leo-sf-symbols": "github:brave/leo-sf-symbols#775bb8fca9df76679b9b272545e162418127c5de",
         "page-metadata-parser": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "license": "MPL-2.0",
   "dependencies": {
     "@mozilla/readability": "^0.4.2",
-    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.62.93/brave-core-ios-1.62.93.tgz",
+    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.61.102/brave-core-ios-1.61.102.tgz",
     "leo": "github:brave/leo#792ab5c9f82784578e8f8fc14b9eaa24fa1956d2",
     "leo-sf-symbols": "github:brave/leo-sf-symbols#775bb8fca9df76679b9b272545e162418127c5de",
     "page-metadata-parser": "^1.1.3",


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Bump Brave Core to 1.61.102
- Fixes Crash in joining sync chain on Cr120.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8540

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
