### PR TITLE
Fix #8548: Refactor `PortfolioSegmentedControl` to be reusable

### DIFF
--- a/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
@@ -24,7 +24,7 @@ struct PortfolioView: View {
   @Environment(\.buySendSwapDestination)
   private var buySendSwapDestination: Binding<BuySendSwapDestination?>
   
-  @State private var selectedContent: PortfolioSegmentedControl.SelectedContent = .assets
+  @State private var selectedContent: PortfolioSegmentedControl.Item = .assets
   @ObservedObject private var isShowingNFTsTab = Preferences.Wallet.isShowingNFTsTab
   
   var body: some View {


### PR DESCRIPTION
## Summary of Changes
- Refactors the segmented control into `WalletSegmentedControl` for re-use by Asset Details & Account Details v2 (and allowing more than 2 tabs).
- Added dynamic range & dynamic text range capabilities. Bar now increases height slightly to 60pt at larger font sizes, with minimum / default height of 40pt.

This pull request fixes #8548

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Test segmented control still works as expected. 


## Screenshots:


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
