### PR TITLE
Fix #7485, #8012, #8151: Fix Playlist PIP continuation in Background, Data URL playing, Onboarding Popup

### DIFF
--- a/Sources/Brave/Frontend/Browser/Playlist/Controllers/PlaylistListViewController+TableViewDataSource.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/Controllers/PlaylistListViewController+TableViewDataSource.swift
@@ -178,7 +178,7 @@ extension PlaylistListViewController: UITableViewDataSource {
       header.onAddPlaylist = { [unowned self] in
         guard let sharedFolderUrl = folder.sharedFolderUrl else { return }
         
-        if PlayListDownloadType(rawValue: Preferences.Playlist.autoDownloadVideo.value) != nil {
+        if PlayListDownloadType(rawValue: Preferences.Playlist.autoDownloadVideo.value) != .off {
           let controller = PopupViewController(rootView: PlaylistFolderSharingManagementView(onAddToPlaylistPressed: { [unowned self] in
             self.dismiss(animated: true)
             

--- a/Sources/Brave/Frontend/Browser/Playlist/Controllers/PlaylistListViewController.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/Controllers/PlaylistListViewController.swift
@@ -637,7 +637,7 @@ extension PlaylistListViewController {
       return
     }
 
-    playerView.stop()
+    playerView.pause()
     playerView.bringSubviewToFront(activityIndicator)
     activityIndicator.startAnimating()
     activityIndicator.isHidden = false

--- a/Sources/Brave/Frontend/Browser/Playlist/Controllers/PlaylistViewController.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/Controllers/PlaylistViewController.swift
@@ -581,6 +581,7 @@ extension PlaylistViewController: PlaylistViewControllerDelegate {
     stop(playerView)
 
     // Cancel all loading.
+    PlaylistManager.shared.playbackTask?.cancel()
     PlaylistManager.shared.playbackTask = nil
   }
 
@@ -864,7 +865,12 @@ extension PlaylistViewController: VideoViewDelegate {
   }
 
   func load(_ videoView: VideoView, asset: AVURLAsset, autoPlayEnabled: Bool) async throws /*`MediaPlaybackError`*/ {
-    self.clear()
+    // Task will be nil if the playback has stopped, but not paused
+    // If it is paused, and we're loading another track, don't bother clearing the player
+    // as this will break PIP
+    if PlaylistManager.shared.playbackTask == nil {
+      self.clear()
+    }
     
     let isNewItem = try await player.load(asset: asset)
     

--- a/Sources/Brave/Frontend/Browser/Playlist/Managers & Cache/PlaylistCarplayManager.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/Managers & Cache/PlaylistCarplayManager.swift
@@ -108,12 +108,11 @@ public class PlaylistCarplayManager: NSObject {
 
   func getPlaylistController(tab: Tab?, initialItem: PlaylistInfo?, initialItemPlaybackOffset: Double) -> PlaylistViewController {
 
-    // If background playback is enabled, tabs will continue to play media
+    // If background playback is enabled (on iPhone), tabs will continue to play media
     // Even if another controller is presented and even when PIP is enabled in playlist.
     // Therefore we need to stop the page/tab from playing when using playlist.
-    if Preferences.General.mediaAutoBackgrounding.value {
-      tab?.stopMediaPlayback()
-    }
+    // On iPad, media will continue to play with or without the background play setting.
+    tab?.stopMediaPlayback()
 
     // If there is no media player, create one,
     // pass it to the play-list controller

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/PlaylistScriptHandler.swift
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/PlaylistScriptHandler.swift
@@ -145,7 +145,7 @@ class PlaylistScriptHandler: NSObject, TabContentScript {
     Self.queue.async { [weak handler] in
       guard let handler = handler else { return }
 
-      if item.duration <= 0.0 && !item.detected || item.src.isEmpty || item.src.hasPrefix("data:") {
+      if item.duration <= 0.0 && !item.detected || item.src.isEmpty {
         DispatchQueue.main.async {
           handler.delegate?.updatePlaylistURLBar(tab: handler.tab, state: .none, item: nil)
         }

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Paged/PlaylistScript.js
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Paged/PlaylistScript.js
@@ -164,6 +164,14 @@ window.__firefox__.includeOnce("Playlist", function($) {
            style.visibility !== 'hidden';
   }
   
+  function getAllVideoElements() {
+    return [...document.querySelectorAll('video')].reverse();
+  }
+
+  function getAllAudioElements() {
+    return [...document.querySelectorAll('audio')].reverse();
+  }
+  
   function setupLongPress() {
     Object.defineProperty(window.__firefox__, '$<playlistLongPressed>', {
       enumerable: false,
@@ -220,14 +228,6 @@ window.__firefox__.includeOnce("Playlist", function($) {
   // MARK: ---------------------------------------
   
   function setupDetector() {
-    function getAllVideoElements() {
-      return [...document.querySelectorAll('video')].reverse();
-    }
-
-    function getAllAudioElements() {
-      return [...document.querySelectorAll('audio')].reverse();
-    }
-    
     function requestWhenIdleShim(fn) {
       var start = Date.now()
       return setTimeout(function () {

--- a/Sources/Playlist/PlaylistManager.swift
+++ b/Sources/Playlist/PlaylistManager.swift
@@ -275,6 +275,13 @@ public class PlaylistManager: NSObject {
   public func download(item: PlaylistInfo) {
     guard downloadManager.downloadTask(for: item.tagId) == nil, let assetUrl = URL(string: item.src) else { return }
     Task {
+      if assetUrl.scheme == "data" {
+        DispatchQueue.main.async {
+          self.downloadManager.downloadDataAsset(assetUrl, for: item)
+        }
+        return
+      }
+      
       let mimeType = await PlaylistMediaStreamer.getMimeType(assetUrl)
       guard let mimeType = mimeType?.lowercased() else { return }
 


### PR DESCRIPTION
## Summary of Changes
- Picture-In-Picture will now continue onto the next item when playing
- Tabs will now correctly pause audio/video when Playlist is displayed
- Brave-Playlist Onboarding popup will now only be displayed when saving for offline

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #7485, #8012, #8151

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
