### PR TITLE
Fix #8515: Update SNS interstitial page copy and help page link

### DIFF
--- a/Sources/Brave/Frontend/Browser/Handlers/Web3DomainHandler.swift
+++ b/Sources/Brave/Frontend/Browser/Handlers/Web3DomainHandler.swift
@@ -26,14 +26,10 @@ extension Web3Service {
   var errorDescription: String {
     switch self {
     case .solana:
-      let termsOfUseUrl = WalletConstants.snsTermsOfUseURL.absoluteString
-      let privacyPolicyUrl = WalletConstants.snsPrivacyPolicyURL.absoluteString
+      let braveWikiUrl = WalletConstants.snsBraveWikiURL.absoluteString
       return String.localizedStringWithFormat(
         Strings.Wallet.snsDomainInterstitialPageDescription,
-        termsOfUseUrl,
-        Strings.Wallet.web3DomainInterstitialPageTAndU,
-        privacyPolicyUrl,
-        Strings.Wallet.web3DomainInterstitialPagePrivacyPolicy)
+        braveWikiUrl)
     case .ethereum:
       let termsOfUseUrl = WalletConstants.ensTermsOfUseURL.absoluteString
       let privacyPolicyUrl = WalletConstants.ensPrivacyPolicyURL.absoluteString

--- a/Sources/BraveWallet/WalletConstants.swift
+++ b/Sources/BraveWallet/WalletConstants.swift
@@ -29,11 +29,9 @@ public struct WalletConstants {
   /// The url to Brave Help Center for Wallet.
   static let braveWalletSupportURL = URL(string: "https://support.brave.com/hc/en-us/categories/360001059151-Brave-Wallet")!
   
-  /// Terms of Use for Solana Name Service (SNS)
-  public static let snsTermsOfUseURL: URL = URL(string: "https://syndica.io/terms-and-conditions/")!
-  
-  /// Privacy Policy for Solana Name Service (SNS)
-  public static let snsPrivacyPolicyURL: URL = URL(string: "https://syndica.io/privacy-policy/")!
+  // TODO: update wiki link
+  /// Brave Wiki page for Solana Name Service (SNS)
+  public static let snsBraveWikiURL: URL = URL(string: "https://brave.com")!
   
   /// Terms of Use for Ethereum Name Service (ENS)
   public static let ensTermsOfUseURL: URL = URL(string: "https://consensys.net/terms-of-use/")!

--- a/Sources/BraveWallet/WalletConstants.swift
+++ b/Sources/BraveWallet/WalletConstants.swift
@@ -31,7 +31,7 @@ public struct WalletConstants {
   
   // TODO: update wiki link
   /// Brave Wiki page for Solana Name Service (SNS)
-  public static let snsBraveWikiURL: URL = URL(string: "https://brave.com")!
+  public static let snsBraveWikiURL: URL = URL(string: "https://github.com/brave/brave-browser/wiki/Resolve-Methods-for-Solana-Name-Service")!
   
   /// Terms of Use for Ethereum Name Service (ENS)
   public static let ensTermsOfUseURL: URL = URL(string: "https://consensys.net/terms-of-use/")!

--- a/Sources/BraveWallet/WalletStrings.swift
+++ b/Sources/BraveWallet/WalletStrings.swift
@@ -4137,21 +4137,21 @@ extension Strings {
       "wallet.snsDomainInterstitialPageTitle",
       tableName: "BraveWallet",
       bundle: .module,
-      value: "Enable support of Solana Name Service (SNS) in Brave?",
+      value: "Enable Support of Solana Name Service (SNS) in Brave?",
       comment: "Title displayed when users chose Brave to ask them if they want the SNS to be resolved every time they enter one."
     )
     public static let snsDomainInterstitialPageDescription = NSLocalizedString(
       "wallet.snsDomainInterstitialPageDescription",
       tableName: "BraveWallet",
       bundle: .module,
-      value: "Brave will be using Syndica to resolve .sol domain names. Brave hides your IP address. If you enable this, Syndica will see that someone is trying to visit these .sol domains but nothing else. See Syndica's <a href=%@>%@</a> and <a href=%@>%@</a>.",
-      comment: "Description displayed when users chose Brave to ask them if they want the SNS to be resolved every time they enter one. The first '%@' will be replaced with a link to Syndica's terms of use page. The second '%@' will be replaced with the value of 'snsDomainInterstitialPageTAndU'. The third '%@' will be replaced with a link to Syndica's privacy policy page. The last '%@' will be replaced with the value of 'snsDomainInterstitialPagePrivacyPolicy'."
+      value: "Brave will use a third-party to resolve .sol domain names. Brave hides your IP address. If you enable this, the third-party will see that someone is trying to visit these .sol domains, but nothing else. For more information about which third-parties we use and their privacy policies, please see our <a href=%@>help page</a>.",
+      comment: "Description displayed when users chose Brave to ask them if they want the SNS to be resolved every time they enter one. The first '%@' will be replaced with a link to Brave's wiki page which will link to the providersterms of use page and privacy policy page. The last '%@' will be replaced with the value of 'snsDomainInterstitialPagePrivacyPolicy'."
     )
     public static let snsDomainInterstitialPageButtonProceed = NSLocalizedString(
       "wallet.snsDomainInterstitialPageButtonProceed",
       tableName: "BraveWallet",
       bundle: .module,
-      value: "Proceed using Syndica server",
+      value: "Proceed using an SNS server",
       comment: "Title on the button that users can click to enable Brave to resolve the SNS domain they entered."
     )
     // ENS
@@ -4159,7 +4159,7 @@ extension Strings {
       "wallet.ensDomainInterstitialPageTitle",
       tableName: "BraveWallet",
       bundle: .module,
-      value: "Enable support of Ethereum Name Service (ENS) in Brave?",
+      value: "Enable Support of Ethereum Name Service (ENS) in Brave?",
       comment: "Title displayed when users chose Brave to ask them if they want the ENS domain to be resolved every time they enter one."
     )
     public static let ensDomainInterstitialPageDescription = NSLocalizedString(


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
Copy update and link update

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8515

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
1. Make sure `Resolve Solana Name Service(SNS) Domain Names` is set as `Ask`
2. Visit a SNS domain (onybose.sol) in browser
3. You should see a interstitial page will show up. verify the copy should be the same in the screenshot
4. Click the `help page` will redirect you to page https://github.com/brave/brave-browser/wiki/Resolve-Methods-for-Solana-Name-Service
5. Check `Disable` and `Proceed using an SNS server` are still working as expected

**A follow up test (need to wait for a core bump that the preference of enabling SNS is set to be `Ask`)** (This can only be verified in 1.62)
1. Download a older version of Brave Browser with SNS preference feature included 
2. Change that preference to be either `Enabled` or `Disabled` **NOT** `Ask`
3. Upgrade the browser to version 1.61
4. Open wallet/settings to check if SNS preference value is now `Ask`
6. repeat the previous test steps. 

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->
![Simulator Screenshot - iPhone 15 Pro - 2023-12-12 at 22 12 35](https://github.com/brave/brave-ios/assets/1187676/863109f3-74bc-4e58-afad-32cf173ffded)


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
