### PR TITLE
Fix #8561: Fix issue with stats script sending empty image sources

### DIFF
--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Paged/TrackingProtectionStats.js
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Paged/TrackingProtectionStats.js
@@ -120,6 +120,9 @@ window.__firefox__.execute(function($) {
           // If this `Image` instance fails to load, we can assume
           // it has been blocked.
           this._tpErrorHandler = $(function() {
+            // We don't need to send it if the src is set to ""
+            // (which will give us `window.location.href`)
+            if (this.src === window.location.href) { return }
             sendMessage(this.src, "image");
           });
           this.addEventListener("error", this._tpErrorHandler);


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8561 

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->

- Enable shields
- Go to https://search.brave.com/news?q=test
- Scroll down
- Check there is no problem while scrolling

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->
Scrolling should be fast and responsive not like in this video


https://github.com/brave/brave-ios/assets/6643505/177decf2-f20d-4fdf-ac17-c1962fa680b7



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
