### PR TITLE
Fix #8552:  Reopening closed tabs via Cmd + Shift + T is not working when these tabs are closed using Cmd + W

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+KeyCommands.swift
@@ -73,6 +73,8 @@ extension BrowserViewController {
       hideReaderModeBar(animated: false)
     }
     
+    // Initially add the tab to recently closed and remove it from Tab Data after
+    tabManager.addTabToRecentlyClosed(currentTab)
     tabManager.removeTab(currentTab)
   }
 


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

Adding Tab that is closed from key command to recently closed

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8552

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->

- Open Brave
- Open a few tabs
- Connect physical keyboard > Use shortcut Cmd + W to close a tab
- Now use Cmd + Shift + T to restore closed tab > Observe that tab is not restored

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

https://github.com/brave/brave-ios/assets/6643505/fdf572a0-aa0f-448d-b019-682238e9dacd

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
