### PR TITLE
Fix #8576: Address bar blank before website starts loading

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController.swift
@@ -1759,7 +1759,7 @@ public class BrowserViewController: UIViewController {
         // didCommit is called and it will cause url bar be empty in that period
         // To fix this when tab display url is empty, webview url is used
         if tab.url?.displayURL == nil {
-          if let url = webView.url, !InternalURL.isValid(url: url) {
+          if let url = webView.url, !url.isLocal, !InternalURL.isValid(url: url) {
             updateToolbarCurrentURL(url.displayURL)
           }
         }

--- a/Sources/Brave/Frontend/Browser/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController.swift
@@ -1755,6 +1755,14 @@ public class BrowserViewController: UIViewController {
         navigateInTab(tab: tab)
       } else {
         updateURLBar()
+        // If navigation will start from NTP, tab display url will be nil until
+        // didCommit is called and it will cause url bar be empty in that period
+        // To fix this when tab display url is empty, webview url is used
+        if tab.url?.displayURL == nil {
+          if let url = webView.url, !InternalURL.isValid(url: url) {
+            updateToolbarCurrentURL(url.displayURL)
+          }
+        }
       }
 
       // Rewards reporting


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8576

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->

1.  Open new tab
2. Search for website or keyword
3. Observe

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


https://github.com/brave/brave-ios/assets/6643505/3219bf48-0d38-473c-bd2d-a449118a1f26


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
