### PR TITLE
Fix #8585 - Fix Javascript Disabling <NoScript>

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -380,7 +380,18 @@ extension BrowserViewController: WKNavigationDelegate {
       if let documentTargetURL = documentTargetURL {
         let domainForShields = Domain.getOrCreate(forUrl: documentTargetURL, persistent: !isPrivateBrowsing)
         let isScriptsEnabled = !domainForShields.isShieldExpected(.NoScript, considerAllShieldsOption: true)
+        
+        // Due to a bug in iOS WKWebpagePreferences.allowsContentJavaScript does NOT work!
+        // https://github.com/brave/brave-ios/issues/8585
+        //
+        // However, the deprecated API WKWebViewConfiguration.preferences.javaScriptEnabled DOES work!
+        // Even though `configuration` is @NSCopying, somehow this actually updates the preferences LIVE!!
+        // This follows the same behaviour as Safari
+        //
+        // - Brandon T.
+        //
         preferences.allowsContentJavaScript = isScriptsEnabled
+        webView.configuration.preferences.javaScriptEnabled = isScriptsEnabled
       }
 
       // Cookie Blocking code below


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Fix Disabling JS not working due to a bug in iOS
- Also, note that we do not need to refresh the page. 
- Changing it on the configuration directly works!

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8585

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
