### PR TITLE
Fix #8057: Add Download Delegate to handle PassKit blobs

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController.swift
@@ -192,6 +192,8 @@ public class BrowserViewController: UIViewController {
   var downloadToast: DownloadToast?  // A toast that is showing the combined download progress
   var addToPlayListActivityItem: (enabled: Bool, item: PlaylistInfo?)?  // A boolean to determine If AddToListActivity should be added
   var openInPlaylistActivityItem: (enabled: Bool, item: PlaylistInfo?)?  // A boolean to determine if OpenInPlaylistActivity should be shown
+  var shouldDownloadNavigationResponse: Bool = false
+  var pendingDownloads = [WKDownload: PendingDownload]()
 
   var navigationToolbar: ToolbarProtocol {
     return toolbar ?? topToolbar

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKDownloadDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKDownloadDelegate.swift
@@ -1,0 +1,71 @@
+// Copyright 2021 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import WebKit
+import PassKit
+import Shared
+
+extension BrowserViewController: WKDownloadDelegate {
+  
+  struct PendingDownload: Hashable, Equatable {
+    let fileURL: URL
+    let response: URLResponse
+    let suggestedFileName: String
+  }
+  
+  public func download(_ download: WKDownload, decideDestinationUsing response: URLResponse, suggestedFilename: String) async -> URL? {
+    let temporaryDir = NSTemporaryDirectory()
+    let fileName = temporaryDir + "/" + suggestedFilename
+    let url = URL(fileURLWithPath: fileName)
+    pendingDownloads[download] = PendingDownload(fileURL: url, response: response, suggestedFileName: suggestedFilename)
+    return url
+  }
+  
+  public func download(_ download: WKDownload, decidedPolicyForHTTPRedirection response: HTTPURLResponse, newRequest request: URLRequest) async -> WKDownload.RedirectPolicy {
+    return .allow
+  }
+  
+  public func download(_ download: WKDownload, respondTo challenge: URLAuthenticationChallenge) async -> (URLSession.AuthChallengeDisposition, URLCredential?) {
+    return (.performDefaultHandling, nil)
+  }
+  
+  @MainActor
+  public func downloadDidFinish(_ download: WKDownload) {
+    guard let downloadInfo = pendingDownloads[download] else {
+      return
+    }
+    
+    pendingDownloads.removeValue(forKey: download)
+    
+    let response = URLResponse(url: downloadInfo.fileURL,
+                               mimeType: downloadInfo.response.mimeType,
+                               expectedContentLength: Int(downloadInfo.response.expectedContentLength),
+                               textEncodingName: downloadInfo.response.textEncodingName)
+    
+    if let passbookHelper = OpenPassBookHelper(request: nil, response: response, canShowInWebView: false, forceDownload: false, browserViewController: self) {
+      passbookHelper.open()
+    }
+    
+    Task {
+      try FileManager.default.removeItem(at: downloadInfo.fileURL)
+    }
+  }
+  
+  @MainActor
+  public func download(_ download: WKDownload, didFailWithError error: Error, resumeData: Data?) {
+    // display an error
+    let alertController = UIAlertController(
+      title: Strings.unableToAddPassErrorTitle,
+      message: Strings.unableToAddPassErrorMessage,
+      preferredStyle: .alert)
+    alertController.addAction(
+      UIAlertAction(title: Strings.unableToAddPassErrorDismiss, style: .cancel) { (action) in
+        // Do nothing.
+      }
+    )
+    present(alertController, animated: true, completion: nil)
+  }
+}

--- a/Sources/Brave/Frontend/Browser/TabManagerNavDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/TabManagerNavDelegate.swift
@@ -105,6 +105,10 @@ class TabManagerNavDelegate: NSObject, WKNavigationDelegate {
           res = policy
         }
         
+        if policy == .download {
+          res = policy
+        }
+        
         pref = preferences
       }
     }
@@ -127,6 +131,10 @@ class TabManagerNavDelegate: NSObject, WKNavigationDelegate {
         if policy == .cancel {
           res = policy
         }
+        
+        if policy == .download {
+          res = policy
+        }
       }
     }
 
@@ -136,5 +144,25 @@ class TabManagerNavDelegate: NSObject, WKNavigationDelegate {
     }
     
     return res
+  }
+  
+  @MainActor
+  public func webView(_ webView: WKWebView, navigationAction: WKNavigationAction, didBecome download: WKDownload) {
+    for delegate in delegates {
+      delegate.webView?(webView, navigationAction: navigationAction, didBecome: download)
+      if download.delegate != nil {
+        return
+      }
+    }
+  }
+  
+  @MainActor
+  public func webView(_ webView: WKWebView, navigationResponse: WKNavigationResponse, didBecome download: WKDownload) {
+    for delegate in delegates {
+      delegate.webView?(webView, navigationResponse: navigationResponse, didBecome: download)
+      if download.delegate != nil {
+        return
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary of Changes
- Add WKDownload support for PassKit blobs

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8057

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
