### PR TITLE
Fix #8604: Restore Add Custom Token Auto-complete

### DIFF
--- a/Sources/BraveWallet/Crypto/Portfolio/AddCustomAssetView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/AddCustomAssetView.swift
@@ -81,8 +81,28 @@ struct AddCustomAssetView: View {
           header: WalletListHeaderView(title: networkSelectionStore.networkSelectionInForm?.coin == .sol ? Text(Strings.Wallet.tokenMintAddress) : Text(Strings.Wallet.tokenAddress))
         ) {
           TextField(Strings.Wallet.enterAddress, text: $addressInput)
+            .onChange(of: addressInput) { newValue in
+              guard !newValue.isEmpty,
+                      let network = networkSelectionStore.networkSelectionInForm else { return }
+              userAssetStore.tokenInfo(address: newValue, chainId: network.chainId) { token in
+                guard let token else { return }
+                if nameInput.isEmpty {
+                  nameInput = token.name
+                }
+                if symbolInput.isEmpty {
+                  symbolInput = token.symbol
+                }
+                if !token.isErc721, !token.isNft, decimalsInput.isEmpty {
+                  decimalsInput = "\(token.decimals)"
+                }
+                if let network = networkStore.allChains.first(where: { $0.chainId == token.chainId }) {
+                  networkSelectionStore.networkSelectionInForm = network
+                }
+              }
+            }
             .autocapitalization(.none)
             .autocorrectionDisabled()
+            .disabled(userAssetStore.isSearchingToken)
             .listRowBackground(Color(.secondaryBraveGroupedBackground))
         }
         Section(
@@ -104,27 +124,45 @@ struct AddCustomAssetView: View {
         Section(
           header: WalletListHeaderView(title: Text(Strings.Wallet.tokenName))
         ) {
-          TextField(Strings.Wallet.enterTokenName, text: $nameInput)
-            .autocapitalization(.none)
-            .autocorrectionDisabled()
-            .listRowBackground(Color(.secondaryBraveGroupedBackground))
+          HStack {
+            TextField(Strings.Wallet.enterTokenName, text: $nameInput)
+              .autocapitalization(.none)
+              .autocorrectionDisabled()
+              .disabled(userAssetStore.isSearchingToken)
+            if userAssetStore.isSearchingToken && nameInput.isEmpty {
+              ProgressView()
+            }
+          }
+          .listRowBackground(Color(.secondaryBraveGroupedBackground))
         }
         Section(
           header: WalletListHeaderView(title: Text(Strings.Wallet.tokenSymbol))
         ) {
-          TextField(Strings.Wallet.enterTokenSymbol, text: $symbolInput)
-            .autocapitalization(.none)
-            .autocorrectionDisabled()
-            .listRowBackground(Color(.secondaryBraveGroupedBackground))
+          HStack {
+            TextField(Strings.Wallet.enterTokenSymbol, text: $symbolInput)
+              .autocapitalization(.none)
+              .autocorrectionDisabled()
+              .disabled(userAssetStore.isSearchingToken)
+            if userAssetStore.isSearchingToken && symbolInput.isEmpty {
+              ProgressView()
+            }
+          }
+          .listRowBackground(Color(.secondaryBraveGroupedBackground))
         }
         switch selectedTokenType {
         case .token:
           Section(
             header: WalletListHeaderView(title: Text(Strings.Wallet.decimalsPrecision))
           ) {
-            TextField(NumberFormatter().string(from: NSNumber(value: 0)) ?? "0", text: $decimalsInput)
-              .keyboardType(.numberPad)
-              .listRowBackground(Color(.secondaryBraveGroupedBackground))
+            HStack {
+              TextField(NumberFormatter().string(from: NSNumber(value: 0)) ?? "0", text: $decimalsInput)
+                .keyboardType(.numberPad)
+                .disabled(userAssetStore.isSearchingToken)
+              if userAssetStore.isSearchingToken && decimalsInput.isEmpty {
+                ProgressView()
+              }
+            }
+            .listRowBackground(Color(.secondaryBraveGroupedBackground))
           }
           Section {
             Button(

--- a/Sources/BraveWallet/Crypto/Portfolio/AddCustomAssetView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/AddCustomAssetView.swift
@@ -95,9 +95,6 @@ struct AddCustomAssetView: View {
                 if !token.isErc721, !token.isNft, decimalsInput.isEmpty {
                   decimalsInput = "\(token.decimals)"
                 }
-                if let network = networkStore.allChains.first(where: { $0.chainId == token.chainId }) {
-                  networkSelectionStore.networkSelectionInForm = network
-                }
               }
             }
             .autocapitalization(.none)

--- a/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
@@ -212,7 +212,7 @@ public class UserAssetsStore: ObservableObject, WalletObserverStore {
     else if let token = allTokens.first(where: { $0.contractAddress.caseInsensitiveCompare(address) == .orderedSame }) {
       completion(token)
     } // else use network request to get token info
-    else if address.isETHAddress { // only Eth Mainnet supported, require ethereum address
+    else if address.isETHAddress { // only Eth networks supported, require ethereum address
       timer?.invalidate()
       timer = Timer.scheduledTimer(
         withTimeInterval: 0.25, repeats: false,

--- a/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
@@ -54,6 +54,7 @@ public class AssetStore: ObservableObject, Equatable, WalletObserverStore {
 
 public class UserAssetsStore: ObservableObject, WalletObserverStore {
   @Published private(set) var assetStores: [AssetStore] = []
+  @Published var isSearchingToken: Bool = false
   @Published var networkFilters: [Selectable<BraveWallet.NetworkInfo>] = [] {
     didSet {
       guard !oldValue.isEmpty else { return } // initial assignment to `networkFilters`
@@ -196,6 +197,37 @@ public class UserAssetsStore: ObservableObject, WalletObserverStore {
     assetManager.removeUserAsset(token) { [weak self] in
       self?.update()
       completion(true)
+    }
+  }
+
+  func tokenInfo(
+    address: String,
+    chainId: String,
+    completion: @escaping (BraveWallet.BlockchainToken?) -> Void
+  ) {
+    // First check user's visible assets
+    if let assetStore = assetStores.first(where: { $0.token.contractAddress.caseInsensitiveCompare(address) == .orderedSame }) {
+      completion(assetStore.token)
+    } // else check full tokens list
+    else if let token = allTokens.first(where: { $0.contractAddress.caseInsensitiveCompare(address) == .orderedSame }) {
+      completion(token)
+    } // else use network request to get token info
+    else if address.isETHAddress { // only Eth Mainnet supported, require ethereum address
+      timer?.invalidate()
+      timer = Timer.scheduledTimer(
+        withTimeInterval: 0.25, repeats: false,
+        block: { [weak self] _ in
+          guard let self = self else { return }
+          self.isSearchingToken = true
+          self.rpcService.ethTokenInfo(
+            address,
+            chainId: chainId,
+            completion: { token, status, error in
+              self.isSearchingToken = false
+              completion(token)
+            }
+          )
+        })
     }
   }
   

--- a/Sources/BraveWallet/Extensions/RpcServiceExtensions.swift
+++ b/Sources/BraveWallet/Extensions/RpcServiceExtensions.swift
@@ -385,37 +385,6 @@ extension BraveWalletJsonRpcService {
       })
     }
   }
-
-  /// Helper to fetch `symbol` and `decimals` ONLY given a token contract address & chainId.
-  /// This function will be replaced by a BraveCore function that will also fetch `name` & `coingeckoId`.
-  func getEthTokenInfo(
-    contractAddress: String,
-    chainId: String
-  ) async -> BraveWallet.BlockchainToken? {
-    // Fetches token info by contract address and chain ID. The returned token
-    // has the following fields populated:
-    //   - contract_address
-    //   - chain_id
-    //   - coin
-    //   - name
-    //   - symbol
-    //   - decimals
-    //   - coingecko_id
-    //
-    // The following fields are always set to false, and callers must NOT rely
-    // on them:
-    //   - is_erc721
-    //   - is_erc1155
-    //   - is_erc20
-    //   - is_nft
-    let (token, status, _) = await ethTokenInfo(contractAddress, chainId: chainId)
-    guard status == .success else { return nil }
-    token?.logo = ""
-    token?.isSpam = false
-    token?.visible = false
-    token?.tokenId = ""
-    return token
-  }
   
   /// Fetches the BlockchainToken for the given contract addresses. The token for a given contract
   /// address is not guaranteed to be found, and will not be provided in the result if not found.
@@ -425,8 +394,8 @@ extension BraveWalletJsonRpcService {
     await withTaskGroup(of: [BraveWallet.BlockchainToken?].self) { @MainActor group in
       for contractAddressesChainIdPair in contractAddressesChainIdPairs {
         group.addTask {
-          let token = await self.getEthTokenInfo(
-            contractAddress: contractAddressesChainIdPair.contractAddress,
+          let (token, _, _) = await self.ethTokenInfo(
+            contractAddressesChainIdPair.contractAddress,
             chainId: contractAddressesChainIdPair.chainId
           )
           if let token {


### PR DESCRIPTION
## Summary of Changes
- Autocomplete / autofill inadvertantly removed in [BraveCore v1.63 bump](https://github.com/brave/brave-ios/pull/8584/files), restored back in this PR using new API supporting all EVM networks.

This pull request fixes #8604

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Open Add Custom Asset view and select the custom assets network (must belong to an EVM), and then paste the contract address of the token. Ex. (SpaceChain token](https://www.coingecko.com/en/coins/spacechain-erc-20).
2. Verify it loads name, symbol, decimals as expect


## Screenshots:


https://github.com/brave/brave-ios/assets/5314553/b7337ac1-40e8-4173-b955-912958fa7648




## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
