### PR TITLE
Fix #8608: Authenticate when disabling browser lock

### DIFF
--- a/Sources/Brave/Frontend/Settings/SettingsViewController.swift
+++ b/Sources/Brave/Frontend/Settings/SettingsViewController.swift
@@ -485,7 +485,7 @@ class SettingsViewController: TableViewController {
       let privateTabsRow = Row(
         text: Strings.TabsSettings.privateTabsSettingsTitle,
         selection: { [unowned self] in
-          let vc = UIHostingController(rootView: PrivateTabsView(tabManager: tabManager))
+          let vc = UIHostingController(rootView: PrivateTabsView(tabManager: tabManager, askForAuthentication: self.askForLocalAuthentication))
           self.navigationController?.pushViewController(vc, animated: true)
         },
         image: UIImage(braveSystemNamed: "leo.product.private-window"),
@@ -656,11 +656,24 @@ class SettingsViewController: TableViewController {
     return Section(
       header: .title(Strings.security),
       rows: [
-        .boolRow(
-          title: Strings.Privacy.browserLock,
+        Row(
+          text: Strings.Privacy.browserLock,
           detailText: Strings.Privacy.browserLockDescription,
-          option: Preferences.Privacy.lockWithPasscode,
-          image: UIImage(braveSystemNamed: "leo.biometric.login")),
+          image: UIImage(braveSystemNamed: "leo.biometric.login"),
+          accessory: .view(SwitchAccessoryView(initialValue: Preferences.Privacy.lockWithPasscode.value, valueChange: { isOn in
+            if isOn {
+              Preferences.Privacy.lockWithPasscode.value = isOn
+            } else {
+              self.askForLocalAuthentication { [weak self] success, error in
+                if success {
+                  Preferences.Privacy.lockWithPasscode.value = isOn
+                }
+              }
+            }
+          })),
+          cellClass: MultilineSubtitleCell.self,
+          uuid: Preferences.Privacy.lockWithPasscode.key
+        ),
         Row(
           text: Strings.Login.loginListNavigationTitle,
           selection: { [unowned self] in

--- a/Sources/Brave/Frontend/Settings/Shields/OptionToggleView.swift
+++ b/Sources/Brave/Frontend/Settings/Shields/OptionToggleView.swift
@@ -9,7 +9,6 @@ import Preferences
 struct OptionToggleView: View {
   let title: String
   var subtitle: String?
-  var markdownSubtitle: LocalizedStringKey?
   @ObservedObject var option: Preferences.Option<Bool>
   let onChange: ShieldToggleView.OnChangeCallback?
   


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
Fixes: https://hackerone.com/reports/2302346

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8608

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Turn on Browser Lock (requires system passcode/faceid/touchid)
2. Turn it off.
3. It should require authentication to turn it off.

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
