### PR TITLE
Fix #8565-8579: Re-enable Screen-Time.

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController.swift
@@ -380,8 +380,7 @@ public class BrowserViewController: UIViewController {
     }
     
     if Preferences.Privacy.screenTimeEnabled.value {
-      // Enable once fixed, ref #8566
-      //screenTimeViewController = STWebpageController()
+      screenTimeViewController = STWebpageController()
     }
   }
 
@@ -1251,11 +1250,7 @@ public class BrowserViewController: UIViewController {
       make.leading.trailing.equalTo(self.view)
     }
     
-    if let screenTimeViewController = screenTimeViewController {
-      webViewContainer.addSubview(screenTimeViewController.view)
-      addChild(screenTimeViewController)
-      screenTimeViewController.didMove(toParent: self)
-      
+    if let screenTimeViewController = screenTimeViewController, screenTimeViewController.parent != nil {
       screenTimeViewController.view.snp.remakeConstraints {
         $0.edges.equalTo(webViewContainer)
       }
@@ -1945,6 +1940,7 @@ public class BrowserViewController: UIViewController {
       }
 
       updateInContentHomePanel(url as URL)
+      updateScreenTimeUrl(url)
       updatePlaylistURLBar(tab: tab, state: tab.playlistItemState, item: tab.playlistItem)
     }
   }
@@ -3321,13 +3317,13 @@ extension BrowserViewController: PreferencesObserver {
       recordAdsUsageType()
     case Preferences.Privacy.screenTimeEnabled.key:
       if Preferences.Privacy.screenTimeEnabled.value {
-        // Enable once fixed, ref #8566
-        //screenTimeViewController = STWebpageController()
+        screenTimeViewController = STWebpageController()
         if let tab = tabManager.selectedTab {
           recordScreenTimeUsage(for: tab)
         }
       } else {
         screenTimeViewController?.view.removeFromSuperview()
+        screenTimeViewController?.willMove(toParent: nil)
         screenTimeViewController?.removeFromParent()
         screenTimeViewController?.suppressUsageRecording = true
         screenTimeViewController = nil

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+TabManagerDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+TabManagerDelegate.swift
@@ -64,6 +64,20 @@ extension BrowserViewController: TabManagerDelegate {
       webView.snp.remakeConstraints { make in
         make.left.right.top.bottom.equalTo(self.webViewContainer)
       }
+      
+      // Add ScreenTime above the WebView
+      if let screenTimeViewController = screenTimeViewController {
+        if screenTimeViewController.parent == nil {
+          addChild(screenTimeViewController)
+          screenTimeViewController.didMove(toParent: self)
+        }
+        
+        webViewContainer.addSubview(screenTimeViewController.view)
+        
+        screenTimeViewController.view.snp.remakeConstraints {
+          $0.edges.equalTo(webViewContainer)
+        }
+      }
 
       // This is a terrible workaround for a bad iOS 12 bug where PDF
       // content disappears any time the view controller changes (i.e.
@@ -137,6 +151,7 @@ extension BrowserViewController: TabManagerDelegate {
       topToolbar.updateReaderModeState(ReaderModeState.unavailable)
     }
 
+    updateScreenTimeUrl(tabManager.selectedTab?.url)
     updateInContentHomePanel(selected?.url as URL?)
 
     notificationsPresenter.removeNotification(with: WalletNotification.Constant.id)

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+ToolbarDelegate.swift
@@ -335,6 +335,7 @@ extension BrowserViewController: TopToolbarDelegate {
   func topToolbarDidLeaveOverlayMode(_ topToolbar: TopToolbarView) {
     hideSearchController()
     hideFavoritesController()
+    updateScreenTimeUrl(tabManager.selectedTab?.url)
     updateInContentHomePanel(tabManager.selectedTab?.url as URL?)
     updateTabsBarVisibility()
     if isUsingBottomBar {

--- a/Sources/Brave/Frontend/ClientPreferences.swift
+++ b/Sources/Brave/Frontend/ClientPreferences.swift
@@ -133,7 +133,7 @@ extension Preferences {
     /// The toggles states for clear private data screen
     static let clearPrivateDataToggles = Option<[Bool]>(key: "privacy.clear-data-toggles", default: [])
     /// Enables the Apple's Screen Time feature.
-    public static let screenTimeEnabled = Option<Bool>(key: "privacy.screentime", default: true)
+    public static let screenTimeEnabled = Option<Bool>(key: "privacy.screentime-toggle", default: AppConstants.buildChannel != .release)
     
   }
   final public class NewTabPage {

--- a/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/OtherPrivacySettingsSectionView.swift
+++ b/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/OtherPrivacySettingsSectionView.swift
@@ -69,14 +69,11 @@ struct OtherPrivacySettingsSectionView: View {
         subtitle: String.localizedStringWithFormat(Strings.googleSafeBrowsingUsingWebKitDescription, URL.brave.safeBrowsingHelp.absoluteString),
         option: Preferences.Shields.googleSafeBrowsing
       )
-      // Enable once fixed, ref #8566
-      /*
       OptionToggleView(
         title: Strings.screenTimeSetting,
         subtitle: String.localizedStringWithFormat(Strings.screenTimeSettingDescription, URL.brave.screenTimeHelp.absoluteString),
         option: Preferences.Privacy.screenTimeEnabled
       )
-       */
       ShieldToggleView(
         title: Strings.P3A.settingTitle,
         subtitle: Strings.P3A.settingSubtitle,


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Enable Screen-Time again.
- Instead of setting the URL to about blank, remove the controller from the view.
- Fix the order of functions and call the correct functions when doing child controller logic.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8565
This pull request fixes #8579

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
