### PR TITLE
Fix #8374: Cursor is misplaced for a selected URL when that URL doesn't fit the screen 

### DIFF
--- a/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
+++ b/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
@@ -621,20 +621,27 @@ class TopToolbarView: UIView, ToolbarProtocol {
     // look squished at the start of the animation and expand to be correct. As a workaround,
     // we becomeFirstResponder as the next event on UI thread, so the animation starts before we
     // set a first responder.
+    guard let urlTextField = locationTextField else {
+      return
+    }
+    
     if pasted {
       // Clear any existing text, focus the field, then set the actual pasted text.
       // This avoids highlighting all of the text.
-      locationTextField?.text = ""
+      urlTextField.text = ""
+    }
+    
+    DispatchQueue.main.async {
+      urlTextField.becomeFirstResponder()
+      self.setLocation(locationText, search: search)
+    }
+    
+    if !pasted {
       DispatchQueue.main.async {
-        self.locationTextField?.becomeFirstResponder()
-        self.setLocation(locationText, search: search)
-      }
-    } else {
-      DispatchQueue.main.async {
-        self.locationTextField?.becomeFirstResponder()
-        // Need to set location again so text could be immediately selected.
-        self.setLocation(locationText, search: search)
-        self.locationTextField?.selectAll(nil)
+        // When Not-pasted selecting text shiuld be from beggining to end
+        let textRange = urlTextField.textRange(
+          from: urlTextField.beginningOfDocument, to: urlTextField.endOfDocument)
+        urlTextField.selectedTextRange = textRange
       }
     }
     


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
Selection with text range instead of select all handles tghe case when text is bigger than textfield problems

This pull request fixes #8374

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->

1. Launch Brave
2. Open any website with a long URL, for example, https://www.apple.com/shop/buy-iphone/carrier-offers or https://en.m.wikipedia.org/wiki/National_Organization_for_the_Reform_of_Marijuana_Laws
3. Tap on the URL search bar > Observe

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->



https://github.com/brave/brave-ios/assets/6643505/5b05f2c7-9bbb-4da4-8fc3-ab1e0fa92268



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
