### PR TITLE
Fix #8614: Playlist auto download not working

### DIFF
--- a/Sources/Data/models/PlaylistItem.swift
+++ b/Sources/Data/models/PlaylistItem.swift
@@ -336,16 +336,15 @@ final public class PlaylistItem: NSManagedObject, CRUD, Identifiable {
       }
     }
   }
-
-  public static func updateCache(uuid: String, cachedData: Data?) {
+    public static func updateCache(uuid: String, pageSrc: String, cachedData: Data?) {
     DataController.perform(context: .new(inMemory: false), save: true) { context in
-      let item = PlaylistItem.first(where: NSPredicate(format: "uuid == %@", uuid), context: context)
-
-      if let cachedData = cachedData, !cachedData.isEmpty {
-        item?.cachedData = cachedData
-      } else {
-        item?.cachedData = nil
-      }
+        if let item = PlaylistItem.first(where: NSPredicate(format: "uuid == %@ OR pageSrc == %@", uuid, pageSrc), context: context) {
+            if let cachedData = cachedData, !cachedData.isEmpty {
+              item.cachedData = cachedData
+            } else {
+              item.cachedData = nil
+            }
+        }
     }
   }
 

--- a/Sources/Playlist/PlaylistDownloadManager.swift
+++ b/Sources/Playlist/PlaylistDownloadManager.swift
@@ -26,6 +26,7 @@ struct MediaDownloadTask {
   let id: String
   let name: String
   let asset: AVURLAsset
+  let pageSrc: String
 }
 
 public enum PlaylistDownloadError: Error {
@@ -277,7 +278,7 @@ private class PlaylistHLSDownloadManager: NSObject, AVAssetDownloadDelegate {
         if downloadTask.state != .completed,
           let item = PlaylistItem.getItem(uuid: itemId) {
           let info = PlaylistInfo(item: item)
-          let asset = MediaDownloadTask(id: info.tagId, name: info.name, asset: downloadTask.urlAsset)
+          let asset = MediaDownloadTask(id: info.tagId, name: info.name, asset: downloadTask.urlAsset, pageSrc: info.pageSrc)
           self.activeDownloadTasks[downloadTask] = asset
         }
       }
@@ -305,7 +306,7 @@ private class PlaylistHLSDownloadManager: NSObject, AVAssetDownloadDelegate {
     else { return }
 
     task.taskDescription = item.tagId
-    activeDownloadTasks[task] = MediaDownloadTask(id: item.tagId, name: item.name, asset: asset)
+    activeDownloadTasks[task] = MediaDownloadTask(id: item.tagId, name: item.name, asset: asset, pageSrc: item.pageSrc)
     task.resume()
 
     DispatchQueue.main.async {
@@ -400,7 +401,7 @@ private class PlaylistHLSDownloadManager: NSObject, AVAssetDownloadDelegate {
       }
 
       DispatchQueue.main.async {
-        PlaylistItem.updateCache(uuid: asset.id, cachedData: nil)
+        PlaylistItem.updateCache(uuid: asset.id, pageSrc: asset.pageSrc, cachedData: nil)
         self.delegate?.onDownloadStateChanged(streamDownloader: self, id: asset.id, state: .invalid, displayName: nil, error: error)
       }
     }
@@ -431,7 +432,7 @@ private class PlaylistHLSDownloadManager: NSObject, AVAssetDownloadDelegate {
           pendingCancellationTasks.removeAll(where: { $0 == task })
 
           DispatchQueue.main.async {
-            PlaylistItem.updateCache(uuid: asset.id, cachedData: nil)
+            PlaylistItem.updateCache(uuid: asset.id, pageSrc: asset.pageSrc, cachedData: nil)
             self.delegate?.onDownloadStateChanged(streamDownloader: self, id: asset.id, state: .invalid, displayName: nil, error: nil)
           }
           return
@@ -446,7 +447,7 @@ private class PlaylistHLSDownloadManager: NSObject, AVAssetDownloadDelegate {
 
       DispatchQueue.main.async {
         Logger.module.debug("\(PlaylistItem.getItem(uuid: asset.id).debugDescription)")
-        PlaylistItem.updateCache(uuid: asset.id, cachedData: nil)
+        PlaylistItem.updateCache(uuid: asset.id, pageSrc: asset.pageSrc, cachedData: nil)
         self.delegate?.onDownloadStateChanged(streamDownloader: self, id: asset.id, state: .invalid, displayName: nil, error: error)
       }
     } else {
@@ -461,7 +462,7 @@ private class PlaylistHLSDownloadManager: NSObject, AVAssetDownloadDelegate {
           let cachedData = try path.bookmarkData()
 
           DispatchQueue.main.async {
-            PlaylistItem.updateCache(uuid: asset.id, cachedData: cachedData)
+            PlaylistItem.updateCache(uuid: asset.id, pageSrc: asset.pageSrc, cachedData: cachedData)
             self.delegate?.onDownloadStateChanged(streamDownloader: self, id: asset.id, state: .downloaded, displayName: nil, error: nil)
           }
         } catch {
@@ -502,7 +503,7 @@ private class PlaylistFileDownloadManager: NSObject, URLSessionDownloadDelegate 
             let item = PlaylistItem.getItem(uuid: itemId),
             let assetUrl = URL(string: item.mediaSrc) {
             let info = PlaylistInfo(item: item)
-            let asset = MediaDownloadTask(id: info.tagId, name: info.name, asset: AVURLAsset(url: assetUrl, options: AVAsset.defaultOptions))
+            let asset = MediaDownloadTask(id: info.tagId, name: info.name, asset: AVURLAsset(url: assetUrl, options: AVAsset.defaultOptions), pageSrc: info.pageSrc)
             self.activeDownloadTasks[task] = asset
           }
         }
@@ -526,7 +527,7 @@ private class PlaylistFileDownloadManager: NSObject, URLSessionDownloadDelegate 
     let task = session.downloadTask(with: request)
 
     task.taskDescription = item.tagId
-    activeDownloadTasks[task] = MediaDownloadTask(id: item.tagId, name: item.name, asset: asset)
+    activeDownloadTasks[task] = MediaDownloadTask(id: item.tagId, name: item.name, asset: asset, pageSrc: item.pageSrc)
     task.resume()
 
     DispatchQueue.main.async {
@@ -556,7 +557,7 @@ private class PlaylistFileDownloadManager: NSObject, URLSessionDownloadDelegate 
         if let cacheLocation = delegate?.localAsset(for: asset.id)?.url {
           do {
             try FileManager.default.removeItem(at: cacheLocation)
-            PlaylistItem.updateCache(uuid: asset.id, cachedData: nil)
+            PlaylistItem.updateCache(uuid: asset.id, pageSrc: asset.pageSrc, cachedData: nil)
           } catch {
             Logger.module.error("Could not delete asset cache \(asset.name): \(error.localizedDescription)")
           }
@@ -615,7 +616,7 @@ private class PlaylistFileDownloadManager: NSObject, URLSessionDownloadDelegate 
       }
 
       DispatchQueue.main.async {
-        PlaylistItem.updateCache(uuid: asset.id, cachedData: nil)
+        PlaylistItem.updateCache(uuid: asset.id, pageSrc: asset.pageSrc, cachedData: nil)
         self.delegate?.onDownloadStateChanged(streamDownloader: self, id: asset.id, state: .invalid, displayName: nil, error: error)
       }
     }
@@ -668,7 +669,7 @@ private class PlaylistFileDownloadManager: NSObject, URLSessionDownloadDelegate 
           let cachedData = try path.bookmarkData()
 
           DispatchQueue.main.async {
-            PlaylistItem.updateCache(uuid: asset.id, cachedData: cachedData)
+            PlaylistItem.updateCache(uuid: asset.id, pageSrc: asset.pageSrc, cachedData: cachedData)
             self.delegate?.onDownloadStateChanged(streamDownloader: self, id: asset.id, state: .downloaded, displayName: nil, error: nil)
           }
         } catch {
@@ -711,7 +712,7 @@ private class PlaylistDataDownloadManager: NSObject, URLSessionDataDelegate {
             let item = PlaylistItem.getItem(uuid: itemId),
             let assetUrl = URL(string: item.mediaSrc) {
             let info = PlaylistInfo(item: item)
-            let asset = MediaDownloadTask(id: info.tagId, name: info.name, asset: AVURLAsset(url: assetUrl, options: AVAsset.defaultOptions))
+            let asset = MediaDownloadTask(id: info.tagId, name: info.name, asset: AVURLAsset(url: assetUrl, options: AVAsset.defaultOptions), pageSrc: info.pageSrc )
             self.activeDownloadTasks[task] = asset
           }
         }
@@ -735,7 +736,7 @@ private class PlaylistDataDownloadManager: NSObject, URLSessionDataDelegate {
     let task = session.dataTask(with: request)
 
     task.taskDescription = item.tagId
-    activeDownloadTasks[task] = MediaDownloadTask(id: item.tagId, name: item.name, asset: asset)
+    activeDownloadTasks[task] = MediaDownloadTask(id: item.tagId, name: item.name, asset: asset, pageSrc: item.pageSrc)
     task.resume()
 
     DispatchQueue.main.async {
@@ -765,7 +766,7 @@ private class PlaylistDataDownloadManager: NSObject, URLSessionDataDelegate {
         if let cacheLocation = delegate?.localAsset(for: asset.id)?.url {
           do {
             try FileManager.default.removeItem(at: cacheLocation)
-            PlaylistItem.updateCache(uuid: asset.id, cachedData: nil)
+            PlaylistItem.updateCache(uuid: asset.id, pageSrc: asset.pageSrc, cachedData: nil)
           } catch {
             Logger.module.error("Could not delete asset cache \(asset.name): \(error.localizedDescription)")
           }
@@ -811,7 +812,7 @@ private class PlaylistDataDownloadManager: NSObject, URLSessionDataDelegate {
       }
       
       DispatchQueue.main.async {
-        PlaylistItem.updateCache(uuid: asset.id, cachedData: nil)
+        PlaylistItem.updateCache(uuid: asset.id, pageSrc: asset.pageSrc, cachedData: nil)
         self.delegate?.onDownloadStateChanged(streamDownloader: self, id: asset.id, state: .invalid, displayName: nil, error: error)
       }
     }
@@ -841,7 +842,7 @@ private class PlaylistDataDownloadManager: NSObject, URLSessionDataDelegate {
         let cachedData = try path.bookmarkData()
 
         DispatchQueue.main.async {
-          PlaylistItem.updateCache(uuid: asset.id, cachedData: cachedData)
+          PlaylistItem.updateCache(uuid: asset.id, pageSrc: asset.pageSrc, cachedData: cachedData)
           self.delegate?.onDownloadStateChanged(streamDownloader: self, id: asset.id, state: .downloaded, displayName: nil, error: nil)
         }
       } catch {

--- a/Sources/Playlist/PlaylistManager.swift
+++ b/Sources/Playlist/PlaylistManager.swift
@@ -398,7 +398,7 @@ public class PlaylistManager: NSObject {
         let url = try URL(resolvingBookmarkData: cachedData, bookmarkDataIsStale: &isStale)
         if FileManager.default.fileExists(atPath: url.path) {
           try FileManager.default.removeItem(atPath: url.path)
-          PlaylistItem.updateCache(uuid: item.tagId, cachedData: nil)
+          PlaylistItem.updateCache(uuid: item.tagId, pageSrc: item.pageSrc, cachedData: nil)
           onDownloadStateChanged(id: item.tagId, state: .invalid, displayName: nil, error: nil)
         }
         return true
@@ -463,7 +463,7 @@ public class PlaylistManager: NSObject {
             assets.forEach({
               if let item = PlaylistItem.cachedItem(cacheURL: $0), let itemId = item.uuid {
                 self.cancelDownload(itemId: itemId)
-                PlaylistItem.updateCache(uuid: itemId, cachedData: nil)
+                PlaylistItem.updateCache(uuid: itemId, pageSrc: item.pageSrc, cachedData: nil)
               }
             })
           } catch {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

This pull request fixes #8614


### Current state

It seems that `PlaylistItem.updateCache` fails to find the playlist item stored in CoreData by uuid, this is due to the uuid getting changed after initially being added to the playlist.

1.  `PlaylistItem.addItem` gets called with correct initial uuid (`item.tagId`)
2. `PlaylistItem.updateItem` is triggered (possibly by a script?), overrides the stored `item.uuid` in CoreData
3. Video file gets downloaded
4. `PlaylistItem.updateCache` gets called, trying to link the `cachedData` using the original `uuid`, doesn't find, silently fails.
5. Video file still exists, however not linked to any `PlaylistItem` (dangling disk space)
6. User attempts to download manually by clicking download in the playlist table view
7. Another Video file gets downloaded (duplicate, old one stays), this time the 2nd (updated) `uuid` is used, so the video file and playlist get linked successfully.

### This PR
I've added another check using `pageSrc` to attempt to find the `PlaylistItem` in case the `uuid` check fails. This allows the video file to be linked successfully to the `PlaylistItem` 

 
## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

1. Open Youtube.com
4. Open a video
9. Click on add to playlist
10. Video will now download properly



## Screenshots:

https://github.com/brave/brave-ios/assets/4982099/8d9d843a-9767-44f6-9e07-f54023844a28



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
