### PR TITLE
Fix #8616: Swap Improvements

### DIFF
--- a/Sources/BraveWallet/Crypto/Stores/SwapTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SwapTokenStore.swift
@@ -353,13 +353,13 @@ public class SwapTokenStore: ObservableObject, WalletObserverStore {
   }
   
   @MainActor private func createEthSwapTransaction() async -> Bool {
-    self.isMakingTx = true
-    defer { self.isMakingTx = false }
     guard let accountInfo = self.accountInfo else {
       self.state = .error(Strings.Wallet.unknownError)
       self.clearAllAmount()
       return false
     }
+    self.isMakingTx = true
+    defer { self.isMakingTx = false }
     let coin = accountInfo.coin
     let network = await rpcService.network(coin, origin: nil)
     guard let swapParams = self.swapParameters(for: .perSellAsset, in: network) else {
@@ -748,6 +748,8 @@ public class SwapTokenStore: ObservableObject, WalletObserverStore {
           let selectedFromToken else {
       return false
     }
+    self.isMakingTx = true
+    defer { self.isMakingTx = false }
     let network = await rpcService.network(.sol, origin: nil)
     let jupiterSwapParams: BraveWallet.JupiterSwapParams = .init(
       chainId: network.chainId,

--- a/Sources/BraveWallet/Crypto/Stores/SwapTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SwapTokenStore.swift
@@ -777,8 +777,8 @@ public class SwapTokenStore: ObservableObject, WalletObserverStore {
       fromBase64EncodedTransaction: swapTransactions.swapTransaction,
       txType: .solanaSwap,
       send: .init(
-        maxRetries: nil,
-        preflightCommitment: nil,
+        maxRetries: .init(maxRetries: 2),
+        preflightCommitment: "processed",
         skipPreflight: .init(skipPreflight: true)
       )
     )


### PR DESCRIPTION
## Summary of Changes
- Update `maxRetries` to 2 and `preflightCommitment` to `"processed"` for higher success rate creating Solana swap transactions
- Fix loading state when creating Solana swap transactions (loading state only shown when fetching price quote currently)
- Fix possible race condition when sell amount changes after request for prior value sent. Sell amount changes are debounced before sent, but now we ignore response to price quote if the user changes the swap amount.
 
This pull request fixes #8616

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Try updating sell amount a few times; should see correct expected value in buy amount (race condition).
2. Create Solana Swap transaction, verify loading state shown. Should see higher success rate creating Solana transactions with v4 API.
3. Create Ethereum Swap transaction, verify loading state is still shown and ethereum swaps working as expected


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
