### PR TITLE
Fix #8606: Fix background tab navigation

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -494,7 +494,7 @@ extension BrowserViewController: WKNavigationDelegate {
        mimeTypesThatRequireSFSafariViewControllerHandling.contains(mimeType) {
       
       let isAboutHome = InternalURL(url)?.isAboutHomeURL == true
-      let isNonActiveTab = isAboutHome ? false : url.host != topToolbar.currentURL?.host
+      let isNonActiveTab = isAboutHome ? false : url.host != tabManager.selectedTab?.url?.host
       
       // Check website is trying to open Safari Controller in non-active tab
       if !isNonActiveTab {

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -492,7 +492,15 @@ extension BrowserViewController: WKNavigationDelegate {
     if navigationResponse.isForMainFrame, let url = responseURL, url.isWebPage(includeDataURIs: false),
        let mimeType = response.mimeType.flatMap({ UTType(mimeType: $0) }),
        mimeTypesThatRequireSFSafariViewControllerHandling.contains(mimeType) {
-      handleLinkWithSafariViewController(url, tab: tab)
+      
+      let isAboutHome = InternalURL(url)?.isAboutHomeURL == true
+      let isNonActiveTab = isAboutHome ? false : url.host != topToolbar.currentURL?.host
+      
+      // Check website is trying to open Safari Controller in non-active tab
+      if !isNonActiveTab {
+        handleLinkWithSafariViewController(url, tab: tab)
+      }
+      
       return .cancel
     }
 


### PR DESCRIPTION
Added active Tab check for Safari View Controller presentation for mime type application/x-apple-aspen-config"

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8606

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->

1. Open following URL and press exploit 
hxxps://csrf.jp/2024/mobileconfig/
2. Check it opens a new tab with goggle but no trigger happens and opens SafariViewController


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


https://github.com/brave/brave-ios/assets/6643505/d492257b-8959-48fc-a8dd-249abb25736d


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
