### PR TITLE
Fix #8619: Send correct ad notification clicked event

### DIFF
--- a/Sources/Brave/Frontend/Brave Rewards/Ads/AdsNotificationHandler.swift
+++ b/Sources/Brave/Frontend/Brave Rewards/Ads/AdsNotificationHandler.swift
@@ -43,7 +43,7 @@ class AdsNotificationHandler: BraveAdsNotificationHandler {
       guard let self = self else { return }
       switch action {
       case .opened:
-        self.ads.triggerNotificationAdEvent(notification.placementID, eventType: .viewed, completion: { _ in })
+        self.ads.triggerNotificationAdEvent(notification.placementID, eventType: .clicked, completion: { _ in })
       case .dismissed:
         self.ads.triggerNotificationAdEvent(notification.placementID, eventType: .dismissed, completion: { _ in })
       case .timedOut:


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes https://github.com/brave/brave-ios/issues/8619. The bug was introduced here: https://github.com/brave/brave-ios/pull/8386/commits/4184ad9a1e6df8bc04c4fabb66bfb43bfcfb5edb#diff-67a521f6442870976583e55f3c26ea1f2b4fb04e5dc09a237c02c96da86a1a0cR46

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->

1. Trigger notification ad
2. Tap notification ad
3. Make sure that the `clicked` event was fired

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
