### PR TITLE
Fix #8594: "Scan QR Code" from quick action to open a new tab

### DIFF
--- a/Sources/Brave/Frontend/Browser/QuickActions.swift
+++ b/Sources/Brave/Frontend/Browser/QuickActions.swift
@@ -89,6 +89,8 @@ public class QuickActions: NSObject {
   }
 
   fileprivate func handleScanQR(withBrowserViewController bvc: BrowserViewController) {
+    // Open a new tab when Scan QR code is executed from quick long press action 
+    bvc.openBlankNewTab(attemptLocationFieldFocus: false, isPrivate: false)
     bvc.scanQRCode()
   }
 }


### PR DESCRIPTION
Open New tab when Scan QR code is executed from quick long press action

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8594

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->

Long Press Icon
Scan a QR Code
Check new tab opened before scan screen is shown

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


https://github.com/brave/brave-ios/assets/6643505/e3d18e79-259e-4e67-9d17-f5d41213cc6b


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
