### PR TITLE
Fix 8630: Disable Button Search Suggestion Opt-in not updating

### DIFF
--- a/Sources/Brave/Frontend/Browser/Search/SearchViewController.swift
+++ b/Sources/Brave/Frontend/Browser/Search/SearchViewController.swift
@@ -566,6 +566,7 @@ public class SearchViewController: SiteTableViewController, LoaderListener {
             }
             self.layoutSuggestionsOptInPrompt()
             self.reloadSearchEngines()
+            self.tableView.reloadData()
           }
         }
       }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

Adding reload so disable button will work properly. **_SIMPLE FIX_**

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8630

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->

1. Fresh Install Brave
2. Search for a keyword test
3. Check Search Suggestion Opt-In View and press disable

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

https://github.com/brave/brave-ios/assets/6643505/1b96dcc7-85df-4b84-b495-be60bcd36236

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
