### PR TITLE
Fix #8603: Jupiter v4 to v6 migration & BraveCore bump to v1.63.107

### DIFF
--- a/Tests/BraveWalletTests/SwapTokenStoreTests.swift
+++ b/Tests/BraveWalletTests/SwapTokenStoreTests.swift
@@ -440,19 +440,22 @@ class SwapStoreTests: XCTestCase {
       network: .mockSolana,
       coin: .sol
     )
-    swapService._quote = { jupiterQuoteParams, completion in
+    swapService._quote = { swapQuoteParams, completion in
       // verify 0.005 is converted to 0.5
-      XCTAssertEqual(jupiterQuoteParams.slippagePercentage, "0.5")
-      let route: BraveWallet.JupiterRoute = .init(
-        inAmount: 10000000, // 0.01 SOL (9 decimals)
-        outAmount: 2500000, // 2.5 SPD (6 decimals)
-        amount: 2500000, // 2.5 SPD (6 decimals)
-        otherAmountThreshold: 2500000, // 2.5 SPD (6 decimals)
+      XCTAssertEqual(swapQuoteParams.slippagePercentage, "0.5")
+      let jupiterQuote: BraveWallet.JupiterQuote = .init(
+        inputMint: BraveWallet.BlockchainToken.mockSolToken.contractAddress,
+        inAmount: "10000000", // 0.01 SOL (9 decimals)
+        outputMint: BraveWallet.BlockchainToken.mockSpdToken.contractAddress,
+        outAmount: "2500000", // 2.5 SPD (6 decimals)
+        otherAmountThreshold: "2500000", // 2.5 SPD (6 decimals)
         swapMode: "",
-        priceImpactPct: 0,
-        slippageBps: 50, // 0.5%
-        marketInfos: [])
-      completion(.init(jupiterQuote: .init(routes: [route])), nil, "")
+        slippageBps: "50", // 0.5%
+        platformFee: nil,
+        priceImpactPct: "0",
+        routePlan: []
+      )
+      completion(.init(jupiterQuote: jupiterQuote), nil, "")
     }
     swapService._braveFee = { params, completion in
       let feeResponse = BraveWallet.BraveSwapFeeResponse(
@@ -697,15 +700,18 @@ class SwapStoreTests: XCTestCase {
 
   /// Test creating a sol swap transaction
   @MainActor func testSwapSolSwapTransaction() async {
-    let route: BraveWallet.JupiterRoute = .init(
-      inAmount: 3000000000,
-      outAmount: 2500000, // 2.5 SPD (6 decimals)
-      amount: 2500000, // 2.5 SPD (6 decimals)
-      otherAmountThreshold: 2500000, // 2.5 SPD (6 decimals)
+    let jupiterQuote: BraveWallet.JupiterQuote = .init(
+      inputMint: BraveWallet.BlockchainToken.mockSolToken.contractAddress,
+      inAmount: "3000000000",
+      outputMint: BraveWallet.BlockchainToken.mockSpdToken.contractAddress,
+      outAmount: "2500000", // 2.5 SPD (6 decimals)
+      otherAmountThreshold: "2500000", // 2.5 SPD (6 decimals)
       swapMode: "",
-      priceImpactPct: 0,
-      slippageBps: 50, // 0.5%
-      marketInfos: [])
+      slippageBps: "50", // 0.5%
+      platformFee: nil,
+      priceImpactPct: "0",
+      routePlan: []
+    )
     let (keyringService, blockchainRegistry, rpcService, swapService, txService, walletService, ethTxManagerProxy, solTxManagerProxy, mockAssetManager) = setupServices(
       network: .mockSolana,
       coin: .sol
@@ -738,7 +744,7 @@ class SwapStoreTests: XCTestCase {
       selectedFromToken: .mockSolToken,
       selectedToToken: .mockSpdToken,
       sellAmount: "0.01",
-      jupiterQuote: .init(routes: [route])
+      jupiterQuote: jupiterQuote
     )
     store.state = .swap
     

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@mozilla/readability": "^0.4.2",
-        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.63.90/brave-core-ios-1.63.90.tgz",
+        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.63.101/brave-core-ios-1.63.101.tgz",
         "leo": "github:brave/leo#792ab5c9f82784578e8f8fc14b9eaa24fa1956d2",
         "leo-sf-symbols": "github:brave/leo-sf-symbols#775bb8fca9df76679b9b272545e162418127c5de",
         "page-metadata-parser": "^1.1.3",
@@ -514,9 +514,9 @@
       }
     },
     "node_modules/brave-core-ios": {
-      "version": "1.63.90",
-      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.63.90/brave-core-ios-1.63.90.tgz",
-      "integrity": "sha512-ubHolAfELcJLXdBmFPnV1EAWUaQXlCGZln24MXFHIdVAKyq5FhsRR9zNVuvNaWqwefbxcra+QPVXT6TZcCDIpA==",
+      "version": "1.63.101",
+      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.63.101/brave-core-ios-1.63.101.tgz",
+      "integrity": "sha512-KcE3YqDpn/SCVy28TRxojflJOAz65rsdbOytZj4QvaAXgQXvXpk7y7AZiT4Qj0TqwtbWwV5PeeprI7EnibB0Ag==",
       "license": "ISC"
     },
     "node_modules/browserslist": {
@@ -3214,8 +3214,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-browser/releases/download/v1.63.90/brave-core-ios-1.63.90.tgz",
-      "integrity": "sha512-ubHolAfELcJLXdBmFPnV1EAWUaQXlCGZln24MXFHIdVAKyq5FhsRR9zNVuvNaWqwefbxcra+QPVXT6TZcCDIpA=="
+      "version": "https://github.com/brave/brave-browser/releases/download/v1.63.101/brave-core-ios-1.63.101.tgz",
+      "integrity": "sha512-KcE3YqDpn/SCVy28TRxojflJOAz65rsdbOytZj4QvaAXgQXvXpk7y7AZiT4Qj0TqwtbWwV5PeeprI7EnibB0Ag=="
     },
     "browserslist": {
       "version": "4.17.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@mozilla/readability": "^0.4.2",
-        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.63.101/brave-core-ios-1.63.101.tgz",
+        "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.63.107/brave-core-ios-1.63.107.tgz",
         "leo": "github:brave/leo#792ab5c9f82784578e8f8fc14b9eaa24fa1956d2",
         "leo-sf-symbols": "github:brave/leo-sf-symbols#775bb8fca9df76679b9b272545e162418127c5de",
         "page-metadata-parser": "^1.1.3",
@@ -514,9 +514,9 @@
       }
     },
     "node_modules/brave-core-ios": {
-      "version": "1.63.101",
-      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.63.101/brave-core-ios-1.63.101.tgz",
-      "integrity": "sha512-KcE3YqDpn/SCVy28TRxojflJOAz65rsdbOytZj4QvaAXgQXvXpk7y7AZiT4Qj0TqwtbWwV5PeeprI7EnibB0Ag==",
+      "version": "1.63.107",
+      "resolved": "https://github.com/brave/brave-browser/releases/download/v1.63.107/brave-core-ios-1.63.107.tgz",
+      "integrity": "sha512-PmAVQXWUoQh3flzt15eUWvdic2v70Gvh+hwT4bRSS2NnpoQr2H5qMRY1YhTHRv+fDwUuwUH8sJyMwxXrpdBjow==",
       "license": "ISC"
     },
     "node_modules/browserslist": {
@@ -3214,8 +3214,8 @@
       }
     },
     "brave-core-ios": {
-      "version": "https://github.com/brave/brave-browser/releases/download/v1.63.101/brave-core-ios-1.63.101.tgz",
-      "integrity": "sha512-KcE3YqDpn/SCVy28TRxojflJOAz65rsdbOytZj4QvaAXgQXvXpk7y7AZiT4Qj0TqwtbWwV5PeeprI7EnibB0Ag=="
+      "version": "https://github.com/brave/brave-browser/releases/download/v1.63.107/brave-core-ios-1.63.107.tgz",
+      "integrity": "sha512-PmAVQXWUoQh3flzt15eUWvdic2v70Gvh+hwT4bRSS2NnpoQr2H5qMRY1YhTHRv+fDwUuwUH8sJyMwxXrpdBjow=="
     },
     "browserslist": {
       "version": "4.17.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "license": "MPL-2.0",
   "dependencies": {
     "@mozilla/readability": "^0.4.2",
-    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.63.90/brave-core-ios-1.63.90.tgz",
+    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.63.101/brave-core-ios-1.63.101.tgz",
     "leo": "github:brave/leo#792ab5c9f82784578e8f8fc14b9eaa24fa1956d2",
     "leo-sf-symbols": "github:brave/leo-sf-symbols#775bb8fca9df76679b9b272545e162418127c5de",
     "page-metadata-parser": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "license": "MPL-2.0",
   "dependencies": {
     "@mozilla/readability": "^0.4.2",
-    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.63.101/brave-core-ios-1.63.101.tgz",
+    "brave-core-ios": "https://github.com/brave/brave-browser/releases/download/v1.63.107/brave-core-ios-1.63.107.tgz",
     "leo": "github:brave/leo#792ab5c9f82784578e8f8fc14b9eaa24fa1956d2",
     "leo-sf-symbols": "github:brave/leo-sf-symbols#775bb8fca9df76679b9b272545e162418127c5de",
     "page-metadata-parser": "^1.1.3",


### PR DESCRIPTION
## Summary of Changes
- Update `SwapTokenStore` for Jupiter v6 API migration

This pull request fixes #8603

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Verify Solana swaps are still working as expected

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
