### PR TITLE
Fix #8635: URLBar updates and CertValidation

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -1768,16 +1768,6 @@ public class BrowserViewController: UIViewController {
         // Catch history pushState navigation, but ONLY for same origin navigation,
         // for reasons above about URL spoofing risk.
         navigateInTab(tab: tab)
-      } else {
-        updateURLBar()
-        // If navigation will start from NTP, tab display url will be nil until
-        // didCommit is called and it will cause url bar be empty in that period
-        // To fix this when tab display url is empty, webview url is used
-        if tab.url?.displayURL == nil {
-          if let url = webView.url, !url.isLocal, !InternalURL.isValid(url: url) {
-            updateToolbarCurrentURL(url.displayURL)
-          }
-        }
       }
 
       // Rewards reporting
@@ -1905,11 +1895,10 @@ public class BrowserViewController: UIViewController {
         port = 80
       }
       
-      Task.detached {
+      Task { @MainActor in
         do {
-          let result = BraveCertificateUtility.verifyTrust(serverTrust,
-                                                           host: host,
-                                                           port: port)
+          let result = await BraveCertificateUtils.verifyTrust(serverTrust, host: host, port: port)
+          
           // Cert is valid!
           if result == 0 {
             tab.secureContentState = .secure
@@ -1925,9 +1914,7 @@ public class BrowserViewController: UIViewController {
           tab.secureContentState = .invalidCert
         }
         
-        Task { @MainActor in
-          self.updateURLBar()
-        }
+        self.updateURLBar()
       }
     case ._sampledPageTopColor:
       updateStatusBarOverlayColor()
@@ -2837,15 +2824,6 @@ extension BrowserViewController: ToolbarUrlActionsDelegate {
     let tabIsPrivate = TabType.of(tabManager.selectedTab).isPrivate
     self.tabManager.addTabsForURLs(urls, zombie: false, isPrivate: tabIsPrivate)
   }
-
-#if DEBUG
-  public override func select(_ sender: Any?) {
-    if sender is URL {
-      assertionFailure("Wrong method called, use `select(url:)` or `select(_:action:)`")
-    }
-    super.select(sender)
-  }
-#endif
   
   func select(url: URL, isUserDefinedURLNavigation: Bool) {
     select(url, action: .openInCurrentTab, isUserDefinedURLNavigation: isUserDefinedURLNavigation)

--- a/Sources/CertificateUtilities/BraveCertificateUtils.swift
+++ b/Sources/CertificateUtilities/BraveCertificateUtils.swift
@@ -5,6 +5,7 @@
 
 import Foundation
 import Shared
+import BraveCore
 
 public struct BraveCertificateUtils {
   /// Formats a hex string
@@ -231,5 +232,9 @@ public extension BraveCertificateUtils {
         }
       }
     }
+  }
+  
+  static func verifyTrust(_ trust: SecTrust, host: String, port: Int) async -> Int {
+    return Int(BraveCertificateUtility.verifyTrust(trust, host: host, port: port))
   }
 }


### PR DESCRIPTION
## Summary of Changes

- Update URL bar on cancellation instead of URL change, because URL change can update the certificate state and URL spoofing is possible.

- Remove `didCommit` serverTrust validation as it works fine with URLBar Revamp. 
- Make the validation function async-await
- Remove `select` as it crashes in debug builds

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8635
and
This pull request fixes #8393
This pull request fixes #7403 
This pull request fixes #8576

#8393 #7403  #8576 has to be re-tested.

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
- Re-test all the linked tickets


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
