### PR TITLE
Fix #8647: Fix crash when loading invalid URLs

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Wallet.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Wallet.swift
@@ -180,7 +180,7 @@ extension Tab: BraveWalletProviderDelegate {
       // assigned for a specific origin, the provider(s) will check origin
       // of all open Tab's to see if that provider needs(s) updated too.
       // We can get the url from the SessionTab, and return it's origin.
-      if let sessionTabOrigin = SessionTab.from(tabId: id)?.url.origin {
+      if let sessionTabOrigin = SessionTab.from(tabId: id)?.url?.origin {
         return sessionTabOrigin
       }
       assert(false, "We should have a valid origin to get to this point")

--- a/Sources/Brave/Frontend/Browser/Tab.swift
+++ b/Sources/Brave/Frontend/Browser/Tab.swift
@@ -613,7 +613,7 @@ class Tab: NSObject {
     } else {
       if let tabUrl = url, tabUrl.isWebPage() {
         return tabUrl
-      } else if let fetchedTab = SessionTab.from(tabId: id), fetchedTab.url.isWebPage() {
+      } else if let fetchedTab = SessionTab.from(tabId: id), fetchedTab.url?.isWebPage() == true {
         return url
       }
     }

--- a/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/AddEditBookmarkTableViewController.swift
+++ b/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/AddEditBookmarkTableViewController.swift
@@ -377,10 +377,10 @@ class AddEditBookmarkTableViewController: UITableViewController {
         if let url = tab.url, url.isWebPage(), !(InternalURL(url)?.isAboutHomeURL ?? false) {
           bookmarkManager.add(url: url, title: tab.title, parentFolder: parentFolder)
         }
-      } else if let fetchedTab = SessionTab.from(tabId: tab.id) {
-        if fetchedTab.url.isWebPage(), !(InternalURL(fetchedTab.url)?.isAboutHomeURL ?? false) {
+      } else if let fetchedTab = SessionTab.from(tabId: tab.id), let tabURL = fetchedTab.url {
+        if tabURL.isWebPage(), !(InternalURL(tabURL)?.isAboutHomeURL ?? false) {
           bookmarkManager.add(
-            url: fetchedTab.url,
+            url: tabURL,
             title: fetchedTab.title,
             parentFolder: parentFolder)
         }

--- a/Sources/Brave/Migration/Migration.swift
+++ b/Sources/Brave/Migration/Migration.swift
@@ -85,7 +85,7 @@ public class Migration {
       // Restore private tabs if persistency is enabled
       if Preferences.Privacy.persistentPrivateBrowsing.value {
         zombieTabs.filter({ $0.isPrivate }).forEach {
-          if !activeURLs.contains($0.url) {
+          if let url = $0.url, !activeURLs.contains(url) {
             SessionTab.move(tab: $0.tabId, toWindow: activeWindow.windowId)
           }
         }
@@ -93,7 +93,7 @@ public class Migration {
       
       // Restore regular tabs
       zombieTabs.filter({ !$0.isPrivate }).forEach {
-        if !activeURLs.contains($0.url) {
+        if let url = $0.url, !activeURLs.contains(url) {
           SessionTab.move(tab: $0.tabId, toWindow: activeWindow.windowId)
         }
       }

--- a/Sources/Data/models/Model.xcdatamodeld/Model27.xcdatamodel/contents
+++ b/Sources/Data/models/Model.xcdatamodeld/Model27.xcdatamodel/contents
@@ -1,0 +1,221 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22522" systemVersion="22G120" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="BlockedResource" representedClassName="Data.BlockedResource" syncable="YES">
+        <attribute name="domain" optional="YES" attributeType="String"/>
+        <attribute name="faviconUrl" optional="YES" attributeType="String"/>
+        <attribute name="host" optional="YES" attributeType="String"/>
+        <attribute name="timestamp" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <fetchIndex name="byHost">
+            <fetchIndexElement property="host" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <fetchIndex name="byDomain">
+            <fetchIndexElement property="domain" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="Bookmark" representedClassName="Data.Favorite" syncable="YES">
+        <attribute name="created" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="customTitle" optional="YES" attributeType="String"/>
+        <attribute name="isFavorite" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="isFolder" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="lastVisited" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="order" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="syncDisplayUUID" optional="YES" attributeType="String"/>
+        <attribute name="syncOrder" optional="YES" attributeType="String"/>
+        <attribute name="syncParentDisplayUUID" optional="YES" attributeType="String"/>
+        <attribute name="tags" optional="YES" attributeType="Transformable"/>
+        <attribute name="title" optional="YES" attributeType="String"/>
+        <attribute name="url" optional="YES" attributeType="String"/>
+        <attribute name="visits" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="domain" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Domain" inverseName="bookmarks" inverseEntity="Domain"/>
+        <fetchIndex name="byLastVisitedIndex">
+            <fetchIndexElement property="lastVisited" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <fetchIndex name="byUrlIndex">
+            <fetchIndexElement property="url" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <fetchIndex name="byVisitsIndex">
+            <fetchIndexElement property="visits" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="BraveVPNAlert" representedClassName="Data.BraveVPNAlert" syncable="YES">
+        <attribute name="action" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="category" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="host" optional="YES" attributeType="String"/>
+        <attribute name="message" optional="YES" attributeType="String"/>
+        <attribute name="timestamp" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="title" optional="YES" attributeType="String"/>
+        <attribute name="uuid" optional="YES" attributeType="String"/>
+        <fetchIndex name="byUUID">
+            <fetchIndexElement property="uuid" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="uuid"/>
+            </uniquenessConstraint>
+            <uniquenessConstraint>
+                <constraint value="timestamp"/>
+                <constraint value="host"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="CustomFilterListSetting" representedClassName="Data.CustomFilterListSetting" syncable="YES">
+        <attribute name="externalURL" optional="YES" attributeType="URI"/>
+        <attribute name="isEnabled" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="uuid" optional="YES" attributeType="String"/>
+    </entity>
+    <entity name="DataSaved" representedClassName="Data.DataSaved" syncable="YES">
+        <attribute name="amount" optional="YES" attributeType="String"/>
+        <attribute name="savedUrl" optional="YES" attributeType="String"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="savedUrl"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="Domain" representedClassName="Data.Domain" syncable="YES">
+        <attribute name="blockedFromTopSites" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="shield_adblockAndTp" optional="YES" attributeType="Boolean" usesScalarValueType="NO"/>
+        <attribute name="shield_allOff" optional="YES" attributeType="Boolean" usesScalarValueType="NO"/>
+        <attribute name="shield_fpProtection" optional="YES" attributeType="Boolean" usesScalarValueType="NO"/>
+        <attribute name="shield_httpse" optional="YES" attributeType="Boolean" usesScalarValueType="NO"/>
+        <attribute name="shield_noScript" optional="YES" attributeType="Boolean" usesScalarValueType="NO"/>
+        <attribute name="shield_safeBrowsing" optional="YES" attributeType="Boolean" usesScalarValueType="NO"/>
+        <attribute name="topsite" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="url" optional="YES" attributeType="String"/>
+        <attribute name="visits" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="wallet_permittedAccounts" optional="YES" attributeType="String"/>
+        <attribute name="wallet_solanaPermittedAcccounts" optional="YES" attributeType="String"/>
+        <attribute name="zoom_level" optional="YES" attributeType="Double" usesScalarValueType="NO"/>
+        <relationship name="bookmarks" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Bookmark" inverseName="domain" inverseEntity="Bookmark"/>
+        <fetchIndex name="byBlockedFromTopSitesIndex">
+            <fetchIndexElement property="blockedFromTopSites" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <fetchIndex name="byUrlIndex">
+            <fetchIndexElement property="url" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <fetchIndex name="byVisitsIndex">
+            <fetchIndexElement property="visits" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="FeedSourceOverride" representedClassName="Data.FeedSourceOverride" syncable="YES">
+        <attribute name="enabled" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="publisherID" attributeType="String"/>
+        <fetchIndex name="byPublisherID">
+            <fetchIndexElement property="publisherID" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="publisherID"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="FilterListSetting" representedClassName="Data.FilterListSetting" syncable="YES">
+        <attribute name="componentId" optional="YES" attributeType="String"/>
+        <attribute name="folderPath" optional="YES" attributeType="String"/>
+        <attribute name="isAlwaysAggressive" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="isEnabled" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="isHidden" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="order" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="uuid" attributeType="String"/>
+    </entity>
+    <entity name="PlaylistFolder" representedClassName="Data.PlaylistFolder" syncable="YES">
+        <attribute name="creatorLink" optional="YES" attributeType="String"/>
+        <attribute name="creatorName" optional="YES" attributeType="String"/>
+        <attribute name="dateAdded" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="order" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="sharedFolderETag" optional="YES" attributeType="String"/>
+        <attribute name="sharedFolderId" optional="YES" attributeType="String"/>
+        <attribute name="sharedFolderUrl" optional="YES" attributeType="String"/>
+        <attribute name="title" attributeType="String"/>
+        <attribute name="uuid" attributeType="String"/>
+        <relationship name="playlistItems" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="PlaylistItem" inverseName="playlistFolder" inverseEntity="PlaylistItem"/>
+    </entity>
+    <entity name="PlaylistItem" representedClassName="Data.PlaylistItem" syncable="YES">
+        <attribute name="cachedData" optional="YES" attributeType="Binary"/>
+        <attribute name="dateAdded" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="duration" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="lastPlayedOffset" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="mediaSrc" attributeType="String"/>
+        <attribute name="mimeType" attributeType="String"/>
+        <attribute name="name" attributeType="String"/>
+        <attribute name="order" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="pageSrc" attributeType="String"/>
+        <attribute name="pageTitle" optional="YES" attributeType="String"/>
+        <attribute name="uuid" optional="YES" attributeType="String"/>
+        <relationship name="playlistFolder" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="PlaylistFolder" inverseName="playlistItems" inverseEntity="PlaylistFolder"/>
+    </entity>
+    <entity name="RecentlyClosed" representedClassName="Data.RecentlyClosed" syncable="YES">
+        <attribute name="dateAdded" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="historyIndex" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="historyList" optional="YES" attributeType="Transformable"/>
+        <attribute name="interactionState" optional="YES" attributeType="Binary"/>
+        <attribute name="title" optional="YES" attributeType="String"/>
+        <attribute name="url" attributeType="String"/>
+    </entity>
+    <entity name="RecentSearch" representedClassName="Data.RecentSearch" syncable="YES">
+        <attribute name="dateAdded" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="searchType" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="text" optional="YES" attributeType="String"/>
+        <attribute name="websiteUrl" optional="YES" attributeType="String"/>
+    </entity>
+    <entity name="RSSFeedSource" representedClassName="Data.RSSFeedSource" syncable="YES">
+        <attribute name="feedUrl" attributeType="String"/>
+        <attribute name="title" optional="YES" attributeType="String"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="feedUrl"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="SessionTab" representedClassName="Data.SessionTab" syncable="YES">
+        <attribute name="index" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="interactionState" attributeType="Binary"/>
+        <attribute name="isPrivate" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="isSelected" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="lastUpdated" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="screenshotData" attributeType="Binary"/>
+        <attribute name="tabId" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="title" attributeType="String"/>
+        <attribute name="url" optional="YES" attributeType="URI"/>
+        <relationship name="sessionTabGroup" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SessionTabGroup" inverseName="sessionTabs" inverseEntity="SessionTabGroup"/>
+        <relationship name="sessionWindow" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SessionWindow" inverseName="sessionTabs" inverseEntity="SessionWindow"/>
+    </entity>
+    <entity name="SessionTabGroup" representedClassName="Data.SessionTabGroup" syncable="YES">
+        <attribute name="groupId" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="index" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="title" attributeType="String"/>
+        <relationship name="sessionTabs" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="SessionTab" inverseName="sessionTabGroup" inverseEntity="SessionTab"/>
+        <relationship name="sessionWindow" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SessionWindow" inverseName="sessionTabGroups" inverseEntity="SessionWindow"/>
+    </entity>
+    <entity name="SessionWindow" representedClassName="Data.SessionWindow" syncable="YES">
+        <attribute name="index" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="isPrivate" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="isSelected" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="windowId" attributeType="UUID" usesScalarValueType="NO"/>
+        <relationship name="sessionTabGroups" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="SessionTabGroup" inverseName="sessionWindow" inverseEntity="SessionTabGroup"/>
+        <relationship name="sessionTabs" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="SessionTab" inverseName="sessionWindow" inverseEntity="SessionTab"/>
+    </entity>
+    <entity name="WalletUserAsset" representedClassName="Data.WalletUserAsset" syncable="YES">
+        <attribute name="chainId" optional="YES" attributeType="String"/>
+        <attribute name="coin" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="coingeckoId" optional="YES" attributeType="String"/>
+        <attribute name="contractAddress" optional="YES" attributeType="String"/>
+        <attribute name="decimals" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="isDeletedByUser" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="isERC20" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="isERC721" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="isERC1155" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="isNFT" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="isSpam" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="logo" optional="YES" attributeType="String"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="symbol" optional="YES" attributeType="String"/>
+        <attribute name="tokenId" optional="YES" attributeType="String"/>
+        <attribute name="visible" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <relationship name="walletUserAssetGroup" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="WalletUserAssetGroup" inverseName="walletUserAssets" inverseEntity="WalletUserAssetGroup"/>
+    </entity>
+    <entity name="WalletUserAssetGroup" representedClassName="Data.WalletUserAssetGroup" syncable="YES">
+        <attribute name="groupId" optional="YES" attributeType="String"/>
+        <relationship name="walletUserAssets" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="WalletUserAsset" inverseName="walletUserAssetGroup" inverseEntity="WalletUserAsset"/>
+    </entity>
+</model>

--- a/Sources/Data/models/SessionTab.swift
+++ b/Sources/Data/models/SessionTab.swift
@@ -16,7 +16,7 @@ public final class SessionTab: NSManagedObject, CRUD {
   @NSManaged public var lastUpdated: Date
   @NSManaged public var screenshotData: Data
   @NSManaged public var title: String
-  @NSManaged public var url: URL
+  @NSManaged public var url: URL?
   @NSManaged private(set) public var tabId: UUID
   
   @NSManaged private(set) public var sessionTabGroup: SessionTabGroup?
@@ -47,7 +47,7 @@ public final class SessionTab: NSManagedObject, CRUD {
               lastUpdated: Date,
               screenshotData: Data,
               title: String,
-              url: URL,
+              url: URL?,
               tabId: UUID = UUID()) {
     guard let entity = Self.entity(context) else {
       fatalError("No such Entity: SessionTab")


### PR DESCRIPTION
## Summary of Changes
- Make all Tab URLs optional. If a URL is invalid, load `about:blank` like Desktop does.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8647

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
