### PR TITLE
Fix #8650: Fix SSL Status on Offline pages and Http pages

### DIFF
--- a/Sources/Brave/Frontend/Browser/Helpers/ErrorPageHelper.swift
+++ b/Sources/Brave/Frontend/Browser/Helpers/ErrorPageHelper.swift
@@ -135,18 +135,32 @@ class ErrorPageHelper {
 }
 
 extension ErrorPageHelper {
-  static func certificateError(for url: URL) -> Int {
+  static func errorCode(for url: URL) -> Int {
+    // ErrorCode is zero if there's no error.
+    // Non-Zero (negative or positive) when there is an error
+    
     if InternalURL.isValid(url: url),
       let internalUrl = InternalURL(url),
-      internalUrl.isErrorPage {
-
+       internalUrl.isErrorPage {
+      
       let query = url.getQuery()
       guard let code = query["code"],
-        let errCode = Int(code)
+            let errCode = Int(code)
       else {
         return 0
       }
-
+      
+      return errCode
+    }
+    return 0
+  }
+  
+  static func certificateError(for url: URL) -> Int {
+    let errCode = errorCode(for: url)
+    
+    // ErrorCode is zero if there's no error.
+    // Non-Zero (negative or positive) when there is an error
+    if errCode != 0 {
       if let code = CFNetworkErrors(rawValue: Int32(errCode)),
         CertificateErrorPageHandler.CFNetworkErrorsCertErrors.contains(code) {
         return errCode

--- a/Sources/Brave/Frontend/Browser/Interstitial Pages/NetworkErrorPageHandler.swift
+++ b/Sources/Brave/Frontend/Browser/Interstitial Pages/NetworkErrorPageHandler.swift
@@ -8,6 +8,14 @@ import Shared
 import BraveShared
 
 class NetworkErrorPageHandler: InterstitialPageHandler {
+  static func isNetworkError(errorCode: Int) -> Bool {
+    if let code = CFNetworkErrors(rawValue: Int32(errorCode)) {
+      return code == .cfurlErrorNotConnectedToInternet
+    }
+
+    return errorCode == NSURLErrorNotConnectedToInternet
+  }
+  
   func canHandle(error: NSError) -> Bool {
     // Handle CFNetwork Error
     if error.domain == kCFErrorDomainCFNetwork as String,


### PR DESCRIPTION
## Summary of Changes
- When there is no internet or we're on an internal page, we need to show our internal page as secure ONLY IF the page is not an invalid cert page.

- When on an internal page, no serverTrust exists, and hasSecureContent is triggered, causing the page to show as insecure since SSL is missing. We now double check that it is actually insecure. SSL security takes priority over mixed-content.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8650

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
