### PR TITLE
Fix #8665: Fix an issue where URL won't load if already loaded in a different mode

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
@@ -105,7 +105,7 @@ extension BrowserViewController {
   private func loadNewTabWithRewardsURL(_ url: URL) {
     self.presentedViewController?.dismiss(animated: true)
 
-    if let tab = tabManager.getTabForURL(url) {
+    if let tab = tabManager.getTabForURL(url, isPrivate: privateBrowsingManager.isPrivateBrowsing) {
       tabManager.selectTab(tab)
     } else {
       let request = URLRequest(url: url)

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -1768,6 +1768,17 @@ public class BrowserViewController: UIViewController {
         // Catch history pushState navigation, but ONLY for same origin navigation,
         // for reasons above about URL spoofing risk.
         navigateInTab(tab: tab)
+      } else {
+        updateURLBar()
+        
+        // If navigation will start from NTP, tab display url will be nil until
+        // didCommit is called and it will cause url bar be empty in that period
+        // To fix this when tab display url is empty, webview url is used
+        if tab.url?.displayURL == nil {
+          if let url = webView.url, !url.isLocal, !InternalURL.isValid(url: url) {
+            updateToolbarCurrentURL(url.displayURL)
+          }
+        }
       }
 
       // Rewards reporting
@@ -2027,7 +2038,7 @@ public class BrowserViewController: UIViewController {
       popToBVC()
     }
 
-    if let tab = tabManager.getTabForURL(url) {
+    if let tab = tabManager.getTabForURL(url, isPrivate: isPrivate) {
       tabManager.selectTab(tab)
     } else {
       openURLInNewTab(url, isPrivate: isPrivate, isPrivileged: isPrivileged)
@@ -2039,7 +2050,7 @@ public class BrowserViewController: UIViewController {
     
     if let tabID = id, let tab = tabManager.getTabForID(tabID) {
       tabManager.selectTab(tab)
-    } else if let tab = tabManager.getTabForURL(url) {
+    } else if let tab = tabManager.getTabForURL(url, isPrivate: privateBrowsingManager.isPrivateBrowsing) {
       tabManager.selectTab(tab)
     } else {
       openURLInNewTab(url, isPrivate: privateBrowsingManager.isPrivateBrowsing, isPrivileged: false)

--- a/Sources/Brave/Frontend/Browser/TabManager.swift
+++ b/Sources/Brave/Frontend/Browser/TabManager.swift
@@ -850,12 +850,12 @@ class TabManager: NSObject {
     return nil
   }
 
-  func getTabForURL(_ url: URL) -> Tab? {
+  func getTabForURL(_ url: URL, isPrivate: Bool) -> Tab? {
     assert(Thread.isMainThread)
     
     let tab = allTabs.filter {
-      guard let webViewURL = $0.webView?.url else {
-        return  false
+      guard let webViewURL = $0.webView?.url, $0.isPrivate else {
+        return false
       }
       
       return webViewURL.schemelessAbsoluteDisplayString == url.schemelessAbsoluteDisplayString


### PR DESCRIPTION
## Summary of Changes
- Check which mode the user is currently in, in order to load the URL.
- Update URLBar url for external URLs

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8665

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
