### PR TITLE
Fix #8658: Tab bar interaction is broken after it becomes visible

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Onboarding.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Onboarding.swift
@@ -239,6 +239,7 @@ extension BrowserViewController {
     popover.popoverDidDismiss = { _ in
       maskShape.removeFromSuperlayer()
       borderView.removeFromSuperview()
+      placeholderView.removeFromSuperview()
 
       didDismiss()
     }
@@ -246,6 +247,7 @@ extension BrowserViewController {
     borderView.didClickBorderedArea = { [weak popover] in
       maskShape.removeFromSuperlayer()
       borderView.removeFromSuperview()
+      placeholderView.removeFromSuperview()
         
       popover?.dismissPopover() {
         didClickBorderedArea()
@@ -256,6 +258,8 @@ extension BrowserViewController {
       controller.buttonTapped = {
         maskShape.removeFromSuperlayer()
         borderView.removeFromSuperview()
+        placeholderView.removeFromSuperview()
+
         didButtonClick?()
       }
     }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes brave/brave-browser#36591

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

https://github.com/brave/brave-ios/assets/17319991/7f25ee28-f71e-452a-8905-40d6059eb440

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
