### PR TITLE
Fix #8668: Increase max retries for Solana Swap transactions to improve reliability

### DIFF
--- a/Sources/BraveWallet/Crypto/Stores/SwapTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SwapTokenStore.swift
@@ -774,7 +774,7 @@ public class SwapTokenStore: ObservableObject, WalletObserverStore {
       fromBase64EncodedTransaction: jupiterTransaction,
       txType: .solanaSwap,
       send: .init(
-        maxRetries: .init(maxRetries: 2),
+        maxRetries: .init(maxRetries: 3),
         preflightCommitment: "processed",
         skipPreflight: .init(skipPreflight: true)
       )


### PR DESCRIPTION
## Summary of Changes
- The recent blockhash in Solana transactions acts as a nonce and prevents unintended replays, so these retries are safe.
- Updating to 3 max retries to align with desktop: https://github.com/brave/brave-core/blob/0ecd8a5470d06ce96921cb7585ecbc0f9878f3cf/components/brave_wallet_ui/page/screens/swap/hooks/useJupiter.ts#L263
- We'll look to further improve reliability of these transactions in core-side with https://github.com/brave/brave-browser/issues/35196

This pull request fixes #8668

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Test Solana swaps, confirming the swap transaction shouldn't get stuck in `Submitted` as often


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
