### PR TITLE
Fix #8667: Fix webcompat url for internal links

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ToolbarDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ToolbarDelegate.swift
@@ -446,8 +446,11 @@ extension BrowserViewController: TopToolbarDelegate {
     
     shields.showSubmitReportView = { [weak self] shieldsViewController in
       shieldsViewController.dismiss(animated: true) {
-        guard let url = shieldsViewController.tab.url else { return }
-        self?.showSubmitReportView(for: url)
+        if let internalURL = InternalURL(url), let displayURL = internalURL.displayURL {
+          self?.showSubmitReportView(for: displayURL)
+        } else {
+          self?.showSubmitReportView(for: url)
+        }
       }
     }
     

--- a/Sources/Shared/Extensions/URLExtensions.swift
+++ b/Sources/Shared/Extensions/URLExtensions.swift
@@ -631,4 +631,13 @@ public struct InternalURL {
     }
     return nil
   }
+  
+  public var displayURL: URL? {
+    if isErrorPage {
+      return originalURLFromErrorPage
+    } else if isReaderModePage {
+      return extractedUrlParam
+    }
+    return nil
+  }
 }


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8667

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
 See issue for STR

## Screenshots:
https://github.com/brave/brave-ios/assets/909331/96be95bb-46a5-45cf-9453-a973867b8880

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
