### PR TITLE
Fix #8673: Move NTP P3A helper creation outside of NTP

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -270,6 +270,8 @@ public class BrowserViewController: UIViewController {
   
   /// In app purchase obsever for VPN Subscription action
   let iapObserver: IAPObserver
+  
+  private let ntpP3AHelper: NewTabPageP3AHelper
 
   public init(
     windowId: UUID,
@@ -334,6 +336,7 @@ public class BrowserViewController: UIViewController {
     }
     
     iapObserver = BraveVPN.iapObserver
+    ntpP3AHelper = .init(p3aUtils: braveCore.p3aUtils)
 
     super.init(nibName: nil, bundle: nil)
     didInit()
@@ -1419,7 +1422,7 @@ public class BrowserViewController: UIViewController {
         feedDataSource: feedDataSource,
         rewards: rewards,
         privateBrowsingManager: privateBrowsingManager,
-        p3aUtils: braveCore.p3aUtils
+        p3aHelper: ntpP3AHelper
       )
       // Donate NewTabPage Activity For Custom Suggestions
       let newTabPageActivity =

--- a/Sources/Brave/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
+++ b/Sources/Brave/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
@@ -140,14 +140,14 @@ class NewTabPageViewController: UIViewController {
     feedDataSource: FeedDataSource,
     rewards: BraveRewards,
     privateBrowsingManager: PrivateBrowsingManager,
-    p3aUtils: BraveP3AUtils
+    p3aHelper: NewTabPageP3AHelper
   ) {
     self.tab = tab
     self.rewards = rewards
     self.feedDataSource = feedDataSource
     self.privateBrowsingManager = privateBrowsingManager
     self.backgroundButtonsView = NewTabPageBackgroundButtonsView(privateBrowsingManager: privateBrowsingManager)
-    self.p3aHelper = .init(p3aUtils: p3aUtils)
+    self.p3aHelper = p3aHelper
     background = NewTabPageBackground(dataSource: dataSource)
     notifications = NewTabPageNotifications(rewards: rewards)
     collectionView = NewTabCollectionView(frame: .zero, collectionViewLayout: layout)


### PR DESCRIPTION
There was a chance that a user would simply never load a NTP during their session which means that P3A rotations wouldn't trigger new NTP-SI reports each day. This report was supposed to occur each rotation, not specifically per NTP view.

## Summary of Changes

This pull request fixes #8673 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

1. Prefix: Visit debug settings > BraveCore Switches and set express rotation interval of some short amount (and optionally do not randomize)
2. Load app as usual, view a NTP-SI and verify it reports correctly
3. Load a website in the current tab and kill the app
4. Re-open the app and do not visit any NTP (including non-SI versions), verify NTP-SI data is still reported correctly

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
