### PR TITLE
Fix #8674: Add default browser P3A

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -575,6 +575,7 @@ public class BrowserViewController: UIViewController {
     recordGeneralBottomBarLocationP3A()
     PlaylistP3A.recordHistogram()
     recordAdsUsageType()
+    recordDefaultBrowserLikelyhoodP3A()
     
     // Revised Review Handling
     AppReviewManager.shared.handleAppReview(for: .revisedCrossPlatform, using: self)
@@ -3156,6 +3157,9 @@ extension BrowserViewController {
     // in case an external url is triggered
     if case .url(let navigatedURL, _) = path {
       if navigatedURL?.isWebPage(includeDataURIs: false) == true {
+        Preferences.General.lastHTTPURLOpenedDate.value = .now
+        recordDefaultBrowserLikelyhoodP3A(openedHTTPLink: true)
+        
         Preferences.General.defaultBrowserCalloutDismissed.value = true
         Preferences.DefaultBrowserIntro.defaultBrowserNotificationScheduled.value = true
         

--- a/Sources/Brave/Frontend/ClientPreferences.swift
+++ b/Sources/Brave/Frontend/ClientPreferences.swift
@@ -84,6 +84,9 @@ extension Preferences {
     static var defaultPageZoomLevel = Option<Double>(key: "general.default-page-zoom-level", default: 1.0)
     
     static let isUsingBottomBar = Option<Bool>(key: "general.bottom-bar", default: false)
+    
+    /// The last time the app opened and handed a http or https url
+    static let lastHTTPURLOpenedDate = Option<Date?>(key: "general.last-url-opened-date", default: nil)
   }
 
   final public class Search {

--- a/Sources/Brave/Helpers/DefaultBrowserHelper.swift
+++ b/Sources/Brave/Helpers/DefaultBrowserHelper.swift
@@ -1,0 +1,15 @@
+// Copyright 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Foundation
+import Preferences
+
+enum DefaultBrowserHelper {
+  /// Whether or not its likely that Brave is the users default browser based on a 14 day usage period
+  static func isBraveLikelyDefaultBrowser() -> Bool {
+    guard let date = Preferences.General.lastHTTPURLOpenedDate.value else { return false }
+    return date >= Date.now.addingTimeInterval(-14.days)
+  }
+}

--- a/Tests/ClientTests/DefaultBrowserHelperTests.swift
+++ b/Tests/ClientTests/DefaultBrowserHelperTests.swift
@@ -1,0 +1,42 @@
+// Copyright 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Foundation
+@testable import Brave
+import XCTest
+import Preferences
+
+class DefaultBrowserHelperTests: XCTestCase {
+  override func setUp() async throws {
+    Preferences.General.lastHTTPURLOpenedDate.reset()
+  }
+  
+  func testUserRecentlyOpenedURL() {
+    let date = Date()
+    Preferences.General.lastHTTPURLOpenedDate.value = date
+    let isLikelyDefault = DefaultBrowserHelper.isBraveLikelyDefaultBrowser()
+    XCTAssertTrue(isLikelyDefault)
+  }
+  
+  func testUserNeverOpenedURL() {
+    // User never opened a link
+    let isLikelyDefault = DefaultBrowserHelper.isBraveLikelyDefaultBrowser()
+    XCTAssertFalse(isLikelyDefault)
+  }
+  
+  func testUserOpenedURL8DaysAgo() {
+    let date = Date()
+    Preferences.General.lastHTTPURLOpenedDate.value = date.addingTimeInterval(-8.days)
+    let isLikelyDefault = DefaultBrowserHelper.isBraveLikelyDefaultBrowser()
+    XCTAssertTrue(isLikelyDefault)
+  }
+  
+  func testUserOpenedURL30DaysAgo() {
+    let date = Date()
+    Preferences.General.lastHTTPURLOpenedDate.value = date.addingTimeInterval(-30.days)
+    let isLikelyDefault = DefaultBrowserHelper.isBraveLikelyDefaultBrowser()
+    XCTAssertFalse(isLikelyDefault)
+  }
+}


### PR DESCRIPTION
Core PR: https://github.com/brave/brave-core/pull/21888

## Summary of Changes

This pull request fixes #8674 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
