### PR TITLE
Fix #8664: Add content blocker to upgrade passive mixed content

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -430,6 +430,7 @@ var braveTarget: PackageDescription.Target = .target(
     .copy("WebFilters/ContentBlocker/Lists/block-ads.json"),
     .copy("WebFilters/ContentBlocker/Lists/block-cookies.json"),
     .copy("WebFilters/ContentBlocker/Lists/block-trackers.json"),
+    .copy("WebFilters/ContentBlocker/Lists/mixed-content-upgrade.json"),
     .copy("WebFilters/ShieldStats/Adblock/Resources/ABPFilterParserData.dat"),
   ],
   plugins: ["LoggerPlugin"]

--- a/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
+++ b/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
@@ -79,7 +79,10 @@ class TabLocationView: UIView {
     var title = AttributedString(Strings.tabToolbarNotSecureTitle)
     title.font = .preferredFont(forTextStyle: .subheadline, compatibleWith: clampedTraitCollection)
     
-    let isTitleVisible = !traitCollection.preferredContentSizeCategory.isAccessibilityCategory && bounds.width > 200
+    // Hide the title with mixed content due to a WebKit bug (https://bugs.webkit.org/show_bug.cgi?id=258711)
+    // which fails to update `hasOnlySecureContent` even when promoting all http content.
+    let isTitleVisible = !traitCollection.preferredContentSizeCategory.isAccessibilityCategory &&
+        bounds.width > 200 && secureContentState != .mixedContent
     
     switch secureContentState {
     case .localhost, .secure:

--- a/Sources/Brave/WebFilters/ContentBlocker/ContentBlockerManager.swift
+++ b/Sources/Brave/WebFilters/ContentBlocker/ContentBlockerManager.swift
@@ -51,6 +51,7 @@ actor ContentBlockerManager {
     case blockAds
     case blockCookies
     case blockTrackers
+    case upgradeMixedContent
     
     func mode(isAggressiveMode: Bool) -> BlockingMode {
       switch self {
@@ -60,7 +61,7 @@ actor ContentBlockerManager {
         } else {
           return .standard
         }
-      case .blockCookies, .blockTrackers:
+      case .blockCookies, .blockTrackers, .upgradeMixedContent:
         return .general
       }
     }
@@ -70,6 +71,7 @@ actor ContentBlockerManager {
       case .blockAds: return "block-ads"
       case .blockCookies: return "block-cookies"
       case .blockTrackers: return "block-trackers"
+      case .upgradeMixedContent: return "mixed-content-upgrade"
       }
     }
   }
@@ -355,6 +357,9 @@ actor ContentBlockerManager {
     if Preferences.Privacy.blockAllCookies.value {
       results.insert(.blockCookies)
     }
+    
+    // Always upgrade mixed content
+    results.insert(.upgradeMixedContent)
     
     return results
   }

--- a/Sources/Brave/WebFilters/ContentBlocker/Lists/mixed-content-upgrade.json
+++ b/Sources/Brave/WebFilters/ContentBlocker/Lists/mixed-content-upgrade.json
@@ -1,0 +1,12 @@
+[
+  {
+    "trigger": {
+      "url-filter": "http://.*",
+      "if-top-url": ["https://.*"],
+      "resource-type": ["image", "media"]
+    },
+    "action": {
+      "type": "make-https"
+    }
+  }
+]


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #8664 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:

Note: Due to a WebKit bug (https://bugs.webkit.org/show_bug.cgi?id=258711) the app will still display the "Not Secure" triangle even if all http content is promoted to https.

- Verify that http content was promoted to HTTPS via [the web inspector in Settings.app > Safari > advanced](https://webkit.org/web-inspector/enabling-web-inspector/) and view via Safari on a mac. A console log should appear noting that it promoted the image to https and the Network tab should display a lock next to the upgraded content.
- Now that we hide the "Not Secure" title for mixed content: 
    - Verify that `very.badssl.com` (or any mixed content site) shows only the triangle icon but that the icon is still tappable.
    - Verify that `http.badssl.com`/`expired.badssl.com` still display the appropriate "Not Secure" title

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
