### PR TITLE
Fix #8661: Always allow WebKit to load popup URLs before switching tabs

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+WKNavigationDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+WKNavigationDelegate.swift
@@ -1016,6 +1016,16 @@ extension BrowserViewController: WKUIDelegate {
     newTab.url = URL(string: "about:blank")
     
     toolbarVisibilityViewModel.toolbarState = .expanded
+    
+    // Wait until WebKit starts the request before selecting the new tab, otherwise the tab manager may
+    // restore it as if it was a dead tab.
+    var observation: NSKeyValueObservation?
+    observation = newTab.webView?.observe(\.url, changeHandler: { [weak self] webView, _ in
+      _ = observation // Silence write but not read warning
+      observation = nil
+      guard let self = self, let tab = self.tabManager[webView] else { return }
+      self.tabManager.selectTab(tab)
+    })
 
     return newTab.webView
   }

--- a/Sources/Brave/Frontend/Browser/TabManager.swift
+++ b/Sources/Brave/Frontend/Browser/TabManager.swift
@@ -411,14 +411,6 @@ class TabManager: NSObject {
   @MainActor func addPopupForParentTab(_ parentTab: Tab, configuration: WKWebViewConfiguration) -> Tab {
     let popup = Tab(configuration: configuration, id: UUID(), type: parentTab.type, tabGeneratorAPI: tabGeneratorAPI)
     configureTab(popup, request: nil, afterTab: parentTab, flushToDisk: true, zombie: false, isPopup: true)
-
-    // Wait momentarily before selecting the new tab, otherwise the parent tab
-    // may be unable to set `window.location` on the popup immediately after
-    // calling `window.open("")`.
-    DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(100)) {
-      self.selectTab(popup)
-    }
-
     return popup
   }
 


### PR DESCRIPTION
There was a race condition on older devices that where WebKit would not load the popup URL before Brave attempted to select the tab. Selecting the tab would then attempt to restore it using the tab's current URL which would be `about:blank` since the web view had not made any requests yet.

## Summary of Changes

This pull request fixes #8661 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
