### PR TITLE
No Bug: Fix for bad access crash causing flakey test

### DIFF
--- a/Sources/BraveWallet/Crypto/Stores/SelectAccountTokenStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/SelectAccountTokenStore.swift
@@ -324,7 +324,7 @@ class SelectAccountTokenStore: ObservableObject, WalletObserverStore {
               return nil
             }
             var price: String?
-            if let tokenPrice = pricesForTokensCache[token.assetRatioId.lowercased()],
+            if let tokenPrice = pricesCache[token.assetRatioId.lowercased()],
                balance > 0 {
               price = currencyFormatter.string(from: NSNumber(value: (Double(tokenPrice) ?? 0) * balance))
             }


### PR DESCRIPTION
## Summary of Changes
- Unsafe access to non-thread safe dictionary instead of dictionary copy. Could cause crash, and resolves flakey `SelectAccountTokenStore.testUpdate()` unit test.

This pull request fixes #<number>

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
- Run `SelectAccountTokenStoreTests` repeatedly 👍


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
