### PR TITLE
Fix #7757: Resolve flakey Tx Confirmation Test

### DIFF
--- a/Sources/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
@@ -16,8 +16,6 @@ public class TransactionConfirmationStore: ObservableObject, WalletObserverStore
   @Published var symbol: String = ""
   /// The fiat value of `value`
   @Published var fiat: String = ""
-  /// The network name that this transaction is made on
-  @Published var network: BraveWallet.NetworkInfo?
   /// The gas value for this transaction
   @Published var gasValue: String = ""
   /// The symbol of the gas token for this transaction
@@ -479,7 +477,6 @@ public class TransactionConfirmationStore: ObservableObject, WalletObserverStore
   ) async {
     originInfo = activeParsedTransaction.transaction.originInfo
     transactionDetails = activeTransactionDetails
-    self.network = network
     
     switch activeParsedTransaction.details {
     case let .ethSend(details),

--- a/Sources/BraveWallet/Crypto/Transaction Confirmations/PendingTransactionView.swift
+++ b/Sources/BraveWallet/Crypto/Transaction Confirmations/PendingTransactionView.swift
@@ -440,7 +440,7 @@ struct PendingTransactionView: View {
         // Current network, transaction buttons
         HStack(alignment: .top) {
           if confirmationStore.activeParsedTransaction.transaction.txType != .ethSwap {
-            Text(confirmationStore.network?.chainName ?? "") // network shown below each token for swap
+            Text(confirmationStore.activeParsedTransaction.network.chainName) // network shown below each token for swap
           }
           Spacer()
           VStack(alignment: .trailing) {


### PR DESCRIPTION
## Summary of Changes
- Unit test verifying `network: NetworkInfo` property on `TransactionConfirmationStore` was flakey due to reactive-ness of the model when `nextTransaction()` is called. Since this test was written we now store the `NetworkInfo` for the transaction on the `ParsedTransaction` model itself. We can use this property to be more accurate (network tied directly to the parsed transaction model on display)

This pull request fixes 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Create a transaction on 3 different networks (different coin types a bonus). Transactions do not need confirmed.
2. Tap `next` to move between transactions, verify network is displayed as expected. 
3. Run `TransactionConfirmationStoreTests` at least a few times to verify flakey test is no longer flakey.


## Screenshots:




## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
