### PR TITLE
Fix #8694: Fix potential tab loss when window not found

### DIFF
--- a/Sources/Data/models/SessionWindow.swift
+++ b/Sources/Data/models/SessionWindow.swift
@@ -65,7 +65,7 @@ extension SessionWindow {
   }
   
   public static func from(windowId: UUID, in context: NSManagedObjectContext) -> SessionWindow? {
-    let predicate = NSPredicate(format: "\(#keyPath(SessionWindow.windowId)) == %@", windowId.uuidString)
+    let predicate = NSPredicate(format: "\(#keyPath(SessionWindow.windowId)) == %@", windowId as NSUUID)
     return first(where: predicate, context: context)
   }
   


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Pass WindowID as a UUID directly to NSPredicate

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8694

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
