### PR TITLE
Ref #8664: Hide 'Not Secure' mixed content warning when url is collapsed

### DIFF
--- a/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/CollapsedURLBarView.swift
+++ b/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/CollapsedURLBarView.swift
@@ -65,7 +65,8 @@ class CollapsedURLBarView: UIView {
     var title = AttributedString(Strings.tabToolbarNotSecureTitle)
     title.font = .preferredFont(forTextStyle: .caption1, compatibleWith: clampedTraitCollection)
     
-    let isTitleVisible = !traitCollection.preferredContentSizeCategory.isAccessibilityCategory
+    let isTitleVisible = !traitCollection.preferredContentSizeCategory.isAccessibilityCategory &&
+        secureContentState != .mixedContent
     
     switch secureContentState {
     case .localhost, .secure:


### PR DESCRIPTION
## Summary of Changes

This pull request is a follow-up for #8664 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Screenshots:

![image](https://github.com/brave/brave-ios/assets/529104/2e693d1a-bda6-4a2f-8471-b1b968090045)


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
