### PR TITLE
Fix #8688: Fix URL-Bar not updating sometimes to show the latest cert status

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -3286,7 +3286,7 @@ extension BrowserViewController: IAPObserverDelegate {
 extension BrowserViewController {
   
   func displayPageCertificateInfo() {
-    guard let webView = tabManager.selectedTab?.webView else {
+    guard let tab = tabManager.selectedTab, let webView = tab.webView else {
       Logger.module.error("Invalid WebView")
       return
     }

--- a/Sources/Brave/Frontend/Browser/Helpers/ErrorPageHelper.swift
+++ b/Sources/Brave/Frontend/Browser/Helpers/ErrorPageHelper.swift
@@ -105,15 +105,20 @@ class ErrorPageHelper {
       // 'timestamp' is used for the js reload logic
       URLQueryItem(name: "timestamp", value: "\(Int(Date().timeIntervalSince1970 * 1000))"),
     ]
+    
+    // The error came from WebKit's internal validation and the cert is untrusted
+    if error.userInfo["NSErrorPeerUntrustedByApple"] as? Bool == true {
+      queryItems.append(URLQueryItem(name: "peeruntrusted", value: "true"))
+    }
 
     // If this is an invalid certificate, show a certificate error allowing the
     // user to go back or continue. The certificate itself is encoded and added as
     // a query parameter to the error page URL; we then read the certificate from
     // the URL if the user wants to continue.
     if CertificateErrorPageHandler.isValidCertificateError(error: error),
-      let certChain = error.userInfo["NSErrorPeerCertificateChainKey"] as? [SecCertificate],
-      let underlyingError = error.userInfo[NSUnderlyingErrorKey] as? NSError,
-      let certErrorCode = underlyingError.userInfo["_kCFStreamErrorCodeKey"] as? Int {
+       let certChain = error.userInfo["NSErrorPeerCertificateChainKey"] as? [SecCertificate],
+       let underlyingError = error.userInfo[NSUnderlyingErrorKey] as? NSError,
+       let certErrorCode = underlyingError.userInfo["_kCFStreamErrorCodeKey"] as? Int {
       let encodedCerts = ErrorPageHelper.encodeCertChain(certChain)
       queryItems.append(URLQueryItem(name: "badcerts", value: encodedCerts))
 

--- a/Sources/Brave/Frontend/Browser/Interstitial Pages/CertificateErrorPageHandler.swift
+++ b/Sources/Brave/Frontend/Browser/Interstitial Pages/CertificateErrorPageHandler.swift
@@ -17,7 +17,7 @@ class CertificateErrorPageHandler: InterstitialPageHandler {
   }
 
   func response(for model: ErrorPageModel) -> (URLResponse, Data)? {
-    let hasCertificate = model.components.valueForQuery("certerror") != nil
+    let hasCertificate = model.components.valueForQuery("certerror") != nil && model.components.valueForQuery("peeruntrusted") == nil
 
     guard let asset = Bundle.module.path(forResource: "CertificateError", ofType: "html") else {
       assert(false)

--- a/Sources/Brave/Frontend/Browser/Tab.swift
+++ b/Sources/Brave/Frontend/Browser/Tab.swift
@@ -95,6 +95,7 @@ class Tab: NSObject {
 
   var secureContentState: TabSecureContentState = .unknown
   var sslPinningError: Error?
+  var sslPinningTrust: SecTrust?
 
   private let _syncTab: BraveSyncTab?
   private let _faviconDriver: FaviconDriver?


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Update cert validation on Request Failure
- Added a certificate trust error handling when WebKit throws an error internally and we receive no certs.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8688

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
