### PR TITLE
Always run brave ads if ShouldAlwaysRunBraveAdsService feature is true

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -345,7 +345,7 @@ public class BrowserViewController: UIViewController {
     }
 
     rewards.ads.captchaHandler = self
-    let shouldStartAds = rewards.ads.isEnabled || Preferences.BraveNews.isEnabled.value
+    let shouldStartAds = rewards.ads.isEnabled || Preferences.BraveNews.isEnabled.value || BraveAds.shouldAlwaysRunService()
     if shouldStartAds {
       // Only start rewards service automatically if ads is enabled
       if rewards.isEnabled {

--- a/Sources/Brave/Frontend/Rewards/BraveRewards.swift
+++ b/Sources/Brave/Frontend/Rewards/BraveRewards.swift
@@ -100,7 +100,7 @@ public class BraveRewards: NSObject {
   private var braveNewsObservation: AnyCancellable?
 
   private var shouldShutdownAds: Bool {
-    ads.isServiceRunning() && !ads.isEnabled && !Preferences.BraveNews.isEnabled.value
+    ads.isServiceRunning() && !ads.isEnabled && !Preferences.BraveNews.isEnabled.value && !BraveAds.shouldAlwaysRunService()
   }
 
   /// Propose that the ads service should be shutdown based on whether or not that all features


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

PR has been moved to brave-core repo https://github.com/brave/brave-core/pull/22008


Added ability to always run brave ads if ShouldAlwaysRunBraveAdsService feature is true.
Corresponding brave-core change: https://github.com/brave/brave-core/pull/21736

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8696

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->

### `ShouldAlwaysRunBraveAdsService` feature DISABLED

### Test case 1:
- Fresh install
- Launch browser
    - EXPECTED RESULT: Ads service is not started

### Test case 2:
- Fresh install
- Launch browser
- Join Brave Rewards
    - EXPECTED RESULT: Ads service is started
- Quit browser
- Launch browser
    - EXPECTED RESULT: Ads service is started
- Disable Brave Rewards
    - EXPECTED RESULT: Ads service is stopped
- Quit browser
- Launch browser
    - EXPECTED RESULT: Ads service is not started

### Test case 3:
- Fresh install
- Launch browser
- Join Brave News
    - EXPECTED RESULT: Ads service is started
- Quit browser
- Launch browser
    - EXPECTED RESULT: Ads service is started
- Disable Brave News
    - EXPECTED RESULT: Ads service is stopped
- Quit browser
- Launch browser
    - EXPECTED RESULT: Ads service is not started

—

### `ShouldAlwaysRunBraveAdsService` feature ENABLED

### Test case 1:
- Fresh install
    - EXPECTED RESULT: Ads service is started
- Launch browser
- Quit browser
- Launch browser
    - EXPECTED RESULT: Ads service is started

### Test case 2:
- Fresh install
- Launch browser
    - EXPECTED RESULT: Ads service is started
- Join Brave Rewards
    - EXPECTED RESULT: Ads service should not be restarted
- Quit browser
- Launch browser
    - EXPECTED RESULT: Ads service is started
- Disable Brave Rewards
    - EXPECTED RESULT: Ads service should not stop
- Quit browser
- Launch browser
    - EXPECTED RESULT: Ads service is started

### Test case 3:
- Fresh install
- Launch browser
    - EXPECTED RESULT: Ads service is started
- Join Brave News
    - EXPECTED RESULT: Ads service should not be restarted
- Quit browser
- Launch browser
    - EXPECTED RESULT: Ads service is started
- Disable Brave News
    - EXPECTED RESULT: Ads service should not stop
- Quit browser
- Launch browser
    - EXPECTED RESULT: Ads service is started

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
