### PR TITLE
[ads] Unify iOS kBraveNTPBrandedWallpaper

### DIFF
--- a/Sources/Brave/Frontend/Browser/HomePanel/NTPDataSource.swift
+++ b/Sources/Brave/Frontend/Browser/HomePanel/NTPDataSource.swift
@@ -71,19 +71,6 @@ public class NTPDataSource {
   /// This is reset on each launch, so `3` can be shown again if app is removed from memory.
   /// This number _must_ be less than the number of backgrounds!
   private static let numberOfDuplicateAvoidance = 6
-  /// The number of images in a sponsorship rotation.
-  ///     i.e. This number will be repeated before a new sponsorship is shown.
-  ///          If sposnored image is shown as Nth image, this number of normal images will be shown before Nth is reached again.
-  private static let sponsorshipShowRate = 4
-  /// On this value, a sponsored image will be shown.
-  private static let sponsorshipShowValue = 2
-
-  /// The counter that indicates what background should be shown, this is used to determine when a new
-  ///     sponsored image should be shown. (`1` means, first image in cycle N, should be shown).
-  /// One example, if rotation is every 4 images, but sponsored image should be shown as 2nd image, then this will
-  ///     be reset back to `1` after reaching `4`, and when the value is `2`, a sponsored image will be shown.
-  /// This can be easily converted to a preference to persist
-  private var backgroundRotationCounter = 1
 
   let service: NTPBackgroundImagesService
 
@@ -133,7 +120,7 @@ public class NTPDataSource {
       if let sponsor = service.sponsoredImageData {
         let attemptSponsored =
           Preferences.NewTabPage.backgroundSponsoredImages.value
-          && backgroundRotationCounter == NTPDataSource.sponsorshipShowValue
+          &&  Preferences.NewTabPage.backgroundRotationCounter.value == service.initialCountToBrandedWallpaper
           && !privateBrowsingManager.isPrivateBrowsing
 
         if attemptSponsored {
@@ -186,9 +173,9 @@ public class NTPDataSource {
     }()
 
     // Force back to `0` if at end
-    backgroundRotationCounter %= NTPDataSource.sponsorshipShowRate
+    Preferences.NewTabPage.backgroundRotationCounter.value %= service.countToBrandedWallpaper
     // Increment regardless, this is a counter, not an index, so smallest should be `1`
-    backgroundRotationCounter += 1
+    Preferences.NewTabPage.backgroundRotationCounter.value += 1
 
     guard let bgWithIndex = backgroundSet[safe: backgroundIndex] else { return nil }
     return bgWithIndex

--- a/Sources/Brave/Frontend/ClientPreferences.swift
+++ b/Sources/Brave/Frontend/ClientPreferences.swift
@@ -145,6 +145,12 @@ extension Preferences {
     /// Whether sponsored images are included into the background image rotation
     static let backgroundSponsoredImages = Option<Bool>(key: "newtabpage.background-sponsored-images", default: true)
 
+    /// The counter that indicates what background should be shown, this is used to determine when a new
+    ///     sponsored image should be shown. (`1` means, first image in cycle N, should be shown).
+    /// One example, if rotation is every 4 images, but sponsored image should be shown as 2nd image, then this will
+    ///     be reset back to `1` after reaching `4`, and when the value is `2`, a sponsored image will be shown.
+    static let backgroundRotationCounter = Option<Int>(key: "newtabpage.background-rotation-count", default: 0)
+
     /// At least one notification must show before we lock showing subsequent notifications.
     static let atleastOneNTPNotificationWasShowed = Option<Bool>(
       key: "newtabpage.one-notificaiton-showed",


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8701

Requires https://github.com/brave/brave-core/pull/21751

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->

- Fresh install
- Launch browser
- Wait a few minutes for the seed to be fetched (or you can background/foreground the browser)
- Open *Settings > Version #.# (#.#.#.#) > View all version info > Active Variations** 
- Check if `Active Variations:` list contains the enabled studies for iOS. 
- If enabled studies for iOS are not listed in `Active Variations:` then terminate and start browser. Make sure that `Active Variations:` list contains the enabled studies for iOS.
- Open new tabs until an New Tab Takeover ad is shown
    - EXPECTED RESULT: New Tab Takeover ad should be shown on the nth `BraveNTPBrandedWallpaper`/`initial_count_to_branded_wallpaper` Griffin feature param
- Open new tabs until an New Tab Takeover ad is shown
    - EXPECTED RESULT: New Tab Takeover ad should be shown on the nth `BraveNTPBrandedWallpaper`/`count_to_branded_wallpaper` Griffin feature param

We should also test the default values if the Griffin feature does not exist. Default value is 2 for `BraveNTPBrandedWallpaper`/`initial_count_to_branded_wallpaper` and 3 for `BraveNTPBrandedWallpaper`/`count_to_branded_wallpaper`.

And that the position is persisted across browser restarts.

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
