### PR TITLE
Fix #8703: Match Desktop Cert Display

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+WKNavigationDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+WKNavigationDelegate.swift
@@ -802,10 +802,9 @@ extension BrowserViewController: WKNavigationDelegate {
     // Also, when Chromium cert validation passes, BUT Apple cert validation fails, the request is cancelled automatically by WebKit
     // In such a case, the webView.serverTrust is `nil`. The only time we have a valid trust is when we received the challenge
     // so we need to update the URL-Bar to show that serverTrust when WebKit's is nil.
-    let serverTrust = webView.serverTrust ?? tab.sslPinningTrust
     observeValue(forKeyPath: KVOConstants.serverTrust.keyPath,
                  of: webView,
-                 change: [.newKey: serverTrust as Any, .kindKey: 1],
+                 change: [.newKey: webView.serverTrust ?? tab.sslPinningTrust as Any, .kindKey: 1],
                  context: nil)
     
     // Ignore the "Frame load interrupted" error that is triggered when we cancel a request
@@ -840,7 +839,7 @@ extension BrowserViewController: WKNavigationDelegate {
     if let url = error.userInfo[NSURLErrorFailingURLErrorKey] as? URL {
       
       // The certificate came from the WebKit SSL Handshake validation and the cert is untrusted
-      if let serverTrust = serverTrust, error.userInfo["NSErrorPeerCertificateChainKey"] == nil {
+      if webView.serverTrust == nil, let serverTrust = tab.sslPinningTrust, error.userInfo["NSErrorPeerCertificateChainKey"] == nil {
         // Build a cert chain error to display in the cert viewer in such cases, as we aren't given one by WebKit
         var userInfo = error.userInfo
         userInfo["NSErrorPeerCertificateChainKey"] = SecTrustCopyCertificateChain(serverTrust) as? [SecCertificate] ?? []


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Match the Desktop Cert Display when WebKit gives no trust, but has a handshake (extremely rare and not a bug in WebKit).
- Match the Desktop Cert Display when WebKit gives a trust, but no handshake at all (extremely rare and a bug in WebKit afaict).

TLDR: 
Sometimes webkit gives a trust in the handshake, but none in didFailProvisionalNavigation. 
Other times it gives a trust in didFailProvisionalNavigation, but none in the didReceiveChallenge handshake.
Both times, there is no trust at the END of the function call. Once the functions are called and returned from, `webView.serverTrust` becomes nil. 
This is yet another edge case where the URL Bar can again show incorrectly. I'm not sure the reason why WebKit does this, but Chromium states that events come out of order and handles these edge cases the same way.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8703

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
