### PR TITLE
Fix #8705: Add display for version info

### DIFF
--- a/Sources/Brave/Frontend/Settings/SettingsViewController.swift
+++ b/Sources/Brave/Frontend/Settings/SettingsViewController.swift
@@ -744,9 +744,20 @@ class SettingsViewController: TableViewController {
               UIPasteboard.general.setSecureString(AppStorageDebugComposer.compose(),
                                                    expirationDate: Date().addingTimeInterval(2.minutes))
             }
+            
+            let viewMoreDetails = UIAlertAction(title: Strings.viewAllVersionInfo, style: .default) { [unowned self, weak actionSheet] _ in
+              let versionController = ChromeWebViewController(privateBrowsing: false).then {
+                $0.loadURL("brave://version/?show-variations-cmd")
+              }
+              
+              actionSheet?.dismiss(animated: true, completion: {
+                self.present(versionController, animated: true)
+              })
+            }
 
             actionSheet.addAction(copyDebugInfoAction)
             actionSheet.addAction(copyAppInfoAction)
+            actionSheet.addAction(viewMoreDetails)
             actionSheet.addAction(UIAlertAction(title: Strings.cancelButtonTitle, style: .cancel, handler: nil))
             self.navigationController?.present(actionSheet, animated: true, completion: nil)
           }, cellClass: MultilineValue1Cell.self),

--- a/Sources/BraveStrings/BraveStrings.swift
+++ b/Sources/BraveStrings/BraveStrings.swift
@@ -1167,6 +1167,7 @@ extension Strings {
   NSLocalizedString("copyAppSizeInfoToClipboard", tableName: "BraveShared",
                     bundle: .module, value: "Copy app size info to clipboard.",
                     comment: "Copy app info to clipboard action sheet action.")
+  public static let viewAllVersionInfo = NSLocalizedString("copyAppSizeInfoToClipboard", tableName: "BraveShared", bundle: .module, value: "View all version info.", comment: "View all version info action sheet action.")
   public static let blockThirdPartyCookies = NSLocalizedString("Block3rdPartyCookies", tableName: "BraveShared", bundle: .module, value: "Block 3rd party cookies", comment: "cookie settings option")
   public static let blockAllCookies = NSLocalizedString("BlockAllCookies", tableName: "BraveShared", bundle: .module, value: "Block all Cookies", comment: "Title for setting to block all website cookies.")
   public static let blockAllCookiesAction = NSLocalizedString("BlockAllCookiesAction", tableName: "BraveShared", bundle: .module, value: "Block All", comment: "block all cookies settings action title")


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Add ability to view all version info just like on Desktop

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8705

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Screenshots:

![image](https://github.com/brave/brave-ios/assets/1530031/360b03fa-bf7e-4e5f-9a1a-29c0ee2d0685)
![image](https://github.com/brave/brave-ios/assets/1530031/331b862b-3d7d-493a-adb5-63eb6c5a5e58)
![image](https://github.com/brave/brave-ios/assets/1530031/335780c4-8b18-411c-9822-bb4429a66667)

## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
