### PR TITLE
Fix #8709: Portfolio filters not opening intermittently

### DIFF
--- a/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
+++ b/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
@@ -29,6 +29,8 @@ struct PortfolioView: View {
   
   @State private var isPresentingEditUserAssets: Bool = false
   @State private var isPresentingAssetsFilters: Bool = false
+  @State private var isPresentingAddCustomNFT: Bool = false
+  @State private var isPresentingNFTsFilters: Bool = false
   
   var body: some View {
     ScrollView {
@@ -83,6 +85,40 @@ struct PortfolioView: View {
           }
         })
       })
+    .background(Color.clear
+      .sheet(isPresented: $isPresentingAddCustomNFT) {
+        AddCustomAssetView(
+          networkStore: networkStore,
+          networkSelectionStore: networkStore.openNetworkSelectionStore(mode: .formSelection),
+          keyringStore: keyringStore,
+          userAssetStore: cryptoStore.nftStore.userAssetsStore,
+          supportedTokenTypes: [.nft]
+        ) {
+          cryptoStore.updateAssets()
+        }
+      })
+    .background(Color.clear
+      .sheet(isPresented: $isPresentingNFTsFilters) {
+        FiltersDisplaySettingsView(
+          filters: cryptoStore.nftStore.filters,
+          isNFTFilters: true,
+          networkStore: networkStore,
+          save: { filters in
+            cryptoStore.nftStore.saveFilters(filters)
+          }
+        )
+        .osAvailabilityModifiers({ view in
+          if #available(iOS 16, *) {
+            view
+              .presentationDetents([
+                .fraction(0.6),
+                .large
+              ])
+          } else {
+            view
+          }
+        })
+      })
   }
   
   private var contentDrawer: some View {
@@ -108,7 +144,9 @@ struct PortfolioView: View {
             cryptoStore: cryptoStore,
             keyringStore: keyringStore,
             networkStore: cryptoStore.networkStore,
-            nftStore: cryptoStore.nftStore
+            nftStore: cryptoStore.nftStore,
+            isPresentingFilters: $isPresentingNFTsFilters,
+            isPresentingAddCustomNFT: $isPresentingAddCustomNFT
           )
           .padding(.horizontal, 8)
         }

--- a/Sources/BraveWallet/Crypto/WalletDisclosureGroup.swift
+++ b/Sources/BraveWallet/Crypto/WalletDisclosureGroup.swift
@@ -40,7 +40,7 @@ struct WalletDisclosureGroup<Label: View, Content: View>: View {
   }
   
   var body: some View {
-    LazyVStack {
+    VStack(spacing: 4) {
       header
       if isExpanded {
         Divider()


### PR DESCRIPTION
## Summary of Changes
- Moved Portfolio Assets & NFT filter sheet presentations outside of Portfolio `ScrollView`, previously in a `LazyVStack` which seems to have caused presentation issues after scrolling larger lists of assets.
- Updated some layout logic to remove `LazyVStack`s where not necessary; occasionally hitting mis-estimated row heights in the assets listscroll view.

This pull request fixes #8709

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Open Portfolio filters and group assets by account (easier to reproduce when grouped).
2. Collapse 1 or more of the groups, but not all (keep some larger groups expanded).
3. Scroll up and down the Portfolio assets list quickly.
4. Tap Filters button
5. Verify filters tray always opens.
6. Repeat a few times; this bug was not occurring consistently.


## Screenshots:

https://github.com/brave/brave-ios/assets/5314553/f49a8f88-ee07-4570-b028-5d90f7b0995d


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
