### PR TITLE
Fix #8717: Don't handle Brave Talk keyboard shortcuts while in PiP

### DIFF
--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+KeyCommands.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+KeyCommands.swift
@@ -352,7 +352,7 @@ extension BrowserViewController {
     }
     
 #if canImport(BraveTalk)
-    if braveTalkJitsiCoordinator.isCallActive {
+    if braveTalkJitsiCoordinator.isCallActive && !braveTalkJitsiCoordinator.isBraveTalkInPiPMode {
       keyCommandList.append(contentsOf: braveTalkKeyCommands)
     }
 #endif


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #8717 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
