### PR TITLE
Fix #8721: Approve transaction does not show confirmation after editing allowance

### DIFF
--- a/Sources/BraveWallet/Panels/RequestContainerView.swift
+++ b/Sources/BraveWallet/Panels/RequestContainerView.swift
@@ -26,11 +26,11 @@ struct RequestContainerView<DismissContent: ToolbarContent>: View {
               confirmationStore: cryptoStore.openConfirmationStore(),
               networkStore: cryptoStore.networkStore,
               keyringStore: keyringStore,
-              onDismiss: onDismiss
+              onDismiss: {
+                cryptoStore.closeConfirmationStore()
+                onDismiss()
+              }
             )
-            .onDisappear {
-              cryptoStore.closeConfirmationStore()
-            }
           case .addSuggestedToken(let request):
             AddSuggestedTokenView(
               token: request.token,
@@ -60,11 +60,11 @@ struct RequestContainerView<DismissContent: ToolbarContent>: View {
               keyringStore: keyringStore,
               cryptoStore: cryptoStore,
               networkStore: cryptoStore.networkStore,
-              onDismiss: onDismiss
+              onDismiss: {
+                onDismiss()
+                cryptoStore.closeSignMessageRequestStore()
+              }
             )
-            .onDisappear {
-              cryptoStore.closeSignMessageRequestStore()
-            }
           case let .signMessageError(signMessageErrors):
             SignMessageErrorView(
               signMessageErrors: signMessageErrors,

--- a/Sources/BraveWallet/Panels/RequestContainerView.swift
+++ b/Sources/BraveWallet/Panels/RequestContainerView.swift
@@ -26,10 +26,7 @@ struct RequestContainerView<DismissContent: ToolbarContent>: View {
               confirmationStore: cryptoStore.openConfirmationStore(),
               networkStore: cryptoStore.networkStore,
               keyringStore: keyringStore,
-              onDismiss: {
-                cryptoStore.closeConfirmationStore()
-                onDismiss()
-              }
+              onDismiss: onDismiss
             )
           case .addSuggestedToken(let request):
             AddSuggestedTokenView(
@@ -60,10 +57,7 @@ struct RequestContainerView<DismissContent: ToolbarContent>: View {
               keyringStore: keyringStore,
               cryptoStore: cryptoStore,
               networkStore: cryptoStore.networkStore,
-              onDismiss: {
-                onDismiss()
-                cryptoStore.closeSignMessageRequestStore()
-              }
+              onDismiss: onDismiss
             )
           case let .signMessageError(signMessageErrors):
             SignMessageErrorView(
@@ -108,8 +102,11 @@ struct RequestContainerView<DismissContent: ToolbarContent>: View {
       }
     }
     .navigationViewStyle(.stack)
-    .onAppear {
-      // TODO: Fetch pending requests
+    .onDisappear {
+      // `onDisappear` on individual views will trigger for navigation pushes.
+      // Close stores when navigation covers manual dismiss & onDismiss() cases.
+      cryptoStore.closeConfirmationStore()
+      cryptoStore.closeSignMessageRequestStore()
     }
   }
 }


### PR DESCRIPTION
## Summary of Changes
- Fix case where `TransactionConfirmationStore` is torn down from observation when opening a detail view to edit approve tx permissions, which can cause spinner to show until transaction confirmation modal is dismissed because we miss the transaction updated observation method callback.
    - `onDisappear` is called when view pushes a detail view on the navigation stack, which closes the confirmation store early. Updated logic for `SignMessageRequestContainerView` to match.

This pull request fixes #8721

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Create an ERC20 approve transaction
2. Edit Permissions / allowance for the transaction
3. Confirm the transaction
4. Verify transaction confirmation shows after as expected


## Screenshots:

https://github.com/brave/brave-ios/assets/5314553/0e090882-03d9-42cf-9c62-fd642fe08621



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
