### PR TITLE
Fix #8731: Fix issue with standard mode content blockers with large list

### DIFF
--- a/Sources/Brave/WebFilters/FilterListCustomURLDownloader.swift
+++ b/Sources/Brave/WebFilters/FilterListCustomURLDownloader.swift
@@ -123,7 +123,7 @@ actor FilterListCustomURLDownloader: ObservableObject {
     
     await AdBlockStats.shared.compile(
       lazyInfo: lazyInfo, resourcesInfo: resourcesInfo,
-      compileContentBlockers: downloadResult.isModified
+      compileContentBlockers: true
     )
   }
   


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8731 
Also removing a bunch of dead code that just complicates things in fixing this and creates more memory usage during compile.

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
There is no way to reproduce this issue with the current list of rule lists available. Instead we want to test that large lists work as intended:

1. Add the following custom rule list: https://gist.githubusercontent.com/cuba/f13fce20b8fbd043ac8174e39ba16788/raw/66efa96fd188e2d155e17f5b663b9a2f6e918e7e/TestAdBlockRules.txt
2. Wait a little bit for it to download and compile (1 minute) as it is quite a large list
3. Go to brave.com
4. Brave Logo should be blocked

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->
![Simulator Screenshot - iPhone 14 - 2024-02-02 at 15 42 21](https://github.com/brave/brave-ios/assets/909331/f102c5eb-87db-4dce-9185-786b804812f9)


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
