### PR TITLE
Fix #8738, #8708: Fix memory leak in `SettingsViewController`

### DIFF
--- a/Sources/Brave/Frontend/Settings/SettingsViewController.swift
+++ b/Sources/Brave/Frontend/Settings/SettingsViewController.swift
@@ -663,7 +663,7 @@ class SettingsViewController: TableViewController {
           text: Strings.Privacy.browserLock,
           detailText: Strings.Privacy.browserLockDescription,
           image: UIImage(braveSystemNamed: "leo.biometric.login"),
-          accessory: .view(SwitchAccessoryView(initialValue: Preferences.Privacy.lockWithPasscode.value, valueChange: { isOn in
+          accessory: .view(SwitchAccessoryView(initialValue: Preferences.Privacy.lockWithPasscode.value, valueChange: { [unowned self] isOn in
             if isOn {
               Preferences.Privacy.lockWithPasscode.value = isOn
             } else {


### PR DESCRIPTION
## Summary of Changes

This pull request fixes #8738,
fixes #8708


## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
1. Restore a wallet with NFTs
2. Once Portfolio is shown, dismiss wallet
3. Tap `...` -> `Settings` -> `Web3` (must be done through browser settings)
4. Reset wallet
    - Do not quit / relaunch the app
5. Re-open wallet and restore the same wallet from step 1
6. Open NFT tab, enable auto-discovery and wait
7. Observe no assets are duplicated, NFTs displayed in a grid as expected


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
