### PR TITLE
Fix #8736: Fix No Spam NFTs

### DIFF
--- a/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -276,9 +276,7 @@ public class CryptoStore: ObservableObject, WalletObserverStore {
             }
           }
           dispatchGroup.notify(queue: .main) {
-            if !discoveredAssets.isEmpty {
-              self.updateAutoDiscoveredAssets()
-            }
+            self.updateAutoDiscoveredAssets()
           }
         } else {
           self.autoDiscoveredAssets.append(contentsOf: discoveredAssets)


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
This is a blind fix for #8736. We are going to fetch spam NFTs after auto-discovery is finished. 

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8736
## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Please refer to the issue. 


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
