### PR TITLE
Fix compiling only necessary files during launch

### DIFF
--- a/Sources/Brave/Frontend/Browser/User Scripts/UserScriptType.swift
+++ b/Sources/Brave/Frontend/Browser/User Scripts/UserScriptType.swift
@@ -92,7 +92,7 @@ extension UserScriptType: CustomDebugStringConvertible {
     case .nacl:
       return "nacl"
     case .gpc(let isEnabled):
-      return "gpc(\(isEnabled)"
+      return "gpc(\(isEnabled))"
     case .siteStateListener:
       return "siteStateListener"
     case .selectorsPoller:

--- a/Sources/Brave/WebFilters/ContentBlocker/ContentBlockerManager.swift
+++ b/Sources/Brave/WebFilters/ContentBlocker/ContentBlockerManager.swift
@@ -153,6 +153,8 @@ actor ContentBlockerManager {
   /// Should be used only as a cleanup once during launch to get rid of unecessary/old data.
   /// This is mostly for custom filter lists a user may have added.
   public func cleaupInvalidRuleLists(validTypes: Set<BlocklistType>) async {
+    let signpostID = Self.signpost.makeSignpostID()
+    let state = Self.signpost.beginInterval("cleaupInvalidRuleLists", id: signpostID)
     let availableIdentifiers = await ruleStore.availableIdentifiers() ?? []
     
     await availableIdentifiers.asyncConcurrentForEach { identifier in
@@ -170,6 +172,8 @@ actor ContentBlockerManager {
         assertionFailure()
       }
     }
+    
+    Self.signpost.endInterval("cleaupInvalidRuleLists", state)
   }
   
   /// Compile the rule list found in the given local URL using the specified modes

--- a/Sources/Brave/WebFilters/FilterList.swift
+++ b/Sources/Brave/WebFilters/FilterList.swift
@@ -46,6 +46,10 @@ struct FilterList: Identifiable {
   let entry: AdblockFilterListCatalogEntry
   var isEnabled: Bool = false
   
+  var isHidden: Bool {
+    // TODO: @JS get this from entry.hidden once it is available.
+    return false
+  }
   /// Tells us if this filter list is regional (i.e. if it contains language restrictions)
   var isRegional: Bool {
     return !entry.languages.isEmpty

--- a/Sources/Brave/WebFilters/FilterListStorage.swift
+++ b/Sources/Brave/WebFilters/FilterListStorage.swift
@@ -134,7 +134,7 @@ import Combine
     upsertSetting(
       uuid: filterList.entry.uuid,
       isEnabled: filterList.isEnabled,
-      isHidden: false,
+      isHidden: filterList.isHidden,
       componentId: filterList.entry.componentId,
       allowCreation: true,
       order: filterList.order,

--- a/Sources/Data/models/FilterListSetting.swift
+++ b/Sources/Data/models/FilterListSetting.swift
@@ -22,6 +22,17 @@ public final class FilterListSetting: NSManagedObject, CRUD {
   @MainActor @NSManaged public var isAlwaysAggressive: Bool
   @MainActor @NSManaged public var order: NSNumber?
   @MainActor @NSManaged private var folderPath: String?
+  
+  /// Tells us which filter lists should be compiled during launch.
+  ///
+  /// The filter lists that will be eagerly loaded are ones that are:
+  /// 1. Enabled
+  /// 2. Hidden (i.e. there is no UI to disable/enable them).
+  /// This includes the "default" and "first party" filter lists.
+  /// These are not available when using the regional catalog (i.e. `regional_catalog.json`).
+  @MainActor public var isEagerlyLoaded: Bool {
+    return isEnabled && isHidden
+  }
 
   @MainActor public var folderURL: URL? {
     get {


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This PR prepares for the list_catalog.json and fixes a number of issues during launch

1. Don't compile custom filter lists upon launch (this could have been causing load hangs for people with custom filter lists)
2. Explicitly don't compile shown filter lists upon launch. (it will compile hidden filter lists but those do not appear until we switch to list_catalog.json). There is no change in behaviour because there was a bug in the code which causes no filter lists to compile
3. Add signposts for some better launch profiling

Note except for part 2, none of this should affect launch performance. Later work will be done to improve launch performance (we will attempt to save and load dat files in the future which should give a performance boost)

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Test adblocking and launch performance.

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
