### PR TITLE
Allow native Jitsi SDK on dev and staging Brave Talk hosts

### DIFF
--- a/Sources/Brave/Frontend/Browser/DomainUserScript.swift
+++ b/Sources/Brave/Frontend/Browser/DomainUserScript.swift
@@ -43,10 +43,9 @@ enum DomainUserScript: CaseIterable {
                   "search-dev-local.brave.com"])
 #if canImport(BraveTalk)
     case .braveTalkHelper:
-      return Set(["talk.brave.com", "beta.talk.brave.com",
-                 "talk.bravesoftware.com", "beta.talk.bravesoftware.com",
-                 "dev.talk.brave.software", "beta.talk.brave.software",
-                 "talk.brave.software"])
+      return Set(["talk.brave.com",
+                  "talk.bravesoftware.com",
+                  "talk.brave.software"])
 #endif
     case .bravePlaylistFolderSharingHelper:
       return Set(["playlist.bravesoftware.com", "playlist.brave.com"])

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/DomainSpecific/Paged/BraveTalkScript.js
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/DomainSpecific/Paged/BraveTalkScript.js
@@ -29,14 +29,12 @@ window.__firefox__.includeOnce("BraveTalkScript", function($) {
     });
   });
   
-  if (document.location.host === "talk.brave.com") {
-    const postRoom = $((event) => {
-      if (event.target.tagName !== undefined && event.target.tagName.toLowerCase() == "iframe") {
-        launchNativeBraveTalk(event.target.src);
-        window.removeEventListener("DOMNodeInserted", postRoom)
-      }
-    });
-    window.addEventListener("DOMNodeInserted", postRoom);
-  }
+  const postRoom = $((event) => {
+    if (event.target.tagName !== undefined && event.target.tagName.toLowerCase() == "iframe") {
+      launchNativeBraveTalk(event.target.src);
+      window.removeEventListener("DOMNodeInserted", postRoom)
+    }
+  });
+  window.addEventListener("DOMNodeInserted", postRoom);
 });
 

--- a/Tests/ClientTests/DomainUserScriptTests.swift
+++ b/Tests/ClientTests/DomainUserScriptTests.swift
@@ -38,11 +38,7 @@ class DomainUserScriptTests: XCTestCase {
   func testBraveTalkAPIAvailability() throws {
     let goodURLs = [
       URL(string: "https://talk.brave.com"),
-      URL(string: "https://beta.talk.brave.com"),
       URL(string: "https://talk.bravesoftware.com"),
-      URL(string: "https://beta.talk.bravesoftware.com"),
-      URL(string: "https://dev.talk.brave.software"),
-      URL(string: "https://beta.talk.brave.software"),
       URL(string: "https://talk.brave.com/account"),
     ].compactMap { $0 }
 


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes https://github.com/brave/brave-ios/issues/8753
Removing `if` condition to allow dev and staging Brave Talk servers to launch native Jitsi SDK. We already limit where this script can be injected, so there is no need for an additional check. The current list of allowed hosts is https://github.com/brave/brave-ios/blob/0d7f871621554e81588e90767c9c881a70506e05/Sources/Brave/Frontend/Browser/DomainUserScript.swift#L46-L49


## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
