### PR TITLE
Fix #8755: Add variations as stable for Griffin until Channel is fixed in Brave-Core

### DIFF
--- a/App/iOS/Delegates/AppState.swift
+++ b/App/iOS/Delegates/AppState.swift
@@ -179,6 +179,17 @@ public class AppState {
     }
     switches.append(.init(key: .rewardsFlags, value: BraveRewards.Configuration.current().flags))
     
+    if AppConstants.buildChannel == .release {
+      // Chrome iOS sends "stable" and not "release" or anything else.
+      // Anything else will only work on staging builds.
+      switches.append(.init(key: .init(rawValue: "fake-variations-channel"), value: "stable"))
+    } else if AppConstants.buildChannel == .beta {
+      // Chrome iOS sends "stable" and not "release" or anything else.
+      // Anything else will only work on staging builds.
+      switches.append(.init(key: .init(rawValue: "fake-variations-channel"), value: "beta"))
+    }
+
+    
     // Initialize BraveCore
     return BraveCoreMain(userAgent: UserAgent.mobile, additionalSwitches: switches)
   }


### PR DESCRIPTION
## Summary of Changes
- Temporarily add a variations channel for Brave-Core from iOS switches until we start using 1.63.x

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8755

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
