### PR TITLE
[ads] Trigger search result ad viewed event

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -404,6 +404,7 @@ var braveTarget: PackageDescription.Target = .target(
     .copy("Frontend/Reader/Reader.html"),
     .copy("Frontend/Reader/ReaderViewLoading.html"),
     .copy("Frontend/Browser/New Tab Page/Backgrounds/Assets/NTP_Images/corwin-prescott-3.jpg"),
+    .copy("Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/DomainSpecific/Paged/BraveSearchResultAdScript.js"),
     .copy("Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/DomainSpecific/Paged/BraveSearchScript.js"),
     .copy("Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/DomainSpecific/Paged/BraveSkusScript.js"),
     .copy("Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/DomainSpecific/Paged/nacl.min.js"),

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+WKNavigationDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+WKNavigationDelegate.swift
@@ -299,7 +299,12 @@ extension BrowserViewController: WKNavigationDelegate {
           // The tracker protection script
           // This script will track what is blocked and increase stats
           .trackerProtectionStats: requestURL.isWebPage(includeDataURIs: false) &&
-                                   domainForMainFrame.isShieldExpected(.AdblockAndTp, considerAllShieldsOption: true)
+                                   domainForMainFrame.isShieldExpected(.AdblockAndTp, considerAllShieldsOption: true),
+
+          // Add Brave search result ads processing script.
+          .searchResultAd: BraveSearchManager.isValidURL(requestURL) && 
+                           !isPrivateBrowsing &&
+                           !rewards.isEnabled
         ])
       }
       
@@ -324,6 +329,8 @@ extension BrowserViewController: WKNavigationDelegate {
         return (.cancel, preferences)
       }
 
+      tab?.braveSearchResultAdManager = BraveSearchResultAdManager(url: requestURL, rewards: rewards, isPrivateBrowsing: isPrivateBrowsing)
+
       // We fetch cookies to determine if backup search was enabled on the website.
       let profile = self.profile
       let cookies = await webView.configuration.websiteDataStore.httpCookieStore.allCookies()
@@ -347,6 +354,7 @@ extension BrowserViewController: WKNavigationDelegate {
         }
       }
     } else {
+      tab?.braveSearchResultAdManager = nil
       tab?.braveSearchManager = nil
     }
 

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -2554,7 +2554,8 @@ extension BrowserViewController: TabDelegate {
       injectedScripts += [
         LoginsScriptHandler(tab: tab, profile: profile, passwordAPI: braveCore.passwordAPI),
         EthereumProviderScriptHandler(tab: tab),
-        SolanaProviderScriptHandler(tab: tab)
+        SolanaProviderScriptHandler(tab: tab),
+        BraveSearchResultAdScriptHandler(tab: tab)
       ]
     }
 

--- a/Sources/Brave/Frontend/Browser/Search/BraveSearchResultAdManager.swift
+++ b/Sources/Brave/Frontend/Browser/Search/BraveSearchResultAdManager.swift
@@ -1,0 +1,28 @@
+// Copyright 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import BraveCore
+
+// A helper class to handle Brave Search Result Ads.
+class BraveSearchResultAdManager: NSObject {
+  private let rewards: BraveRewards
+
+  init?(url: URL, rewards: BraveRewards, isPrivateBrowsing: Bool) {
+    if !BraveSearchManager.isValidURL(url) ||
+       isPrivateBrowsing ||
+       rewards.isEnabled {
+      return nil
+    }
+
+    self.rewards = rewards
+  }
+
+  func triggerSearchResultAdEvent(_ searchResultAdInfo: BraveAds.SearchResultAdInfo) {
+      rewards.ads.triggerSearchResultAdEvent(
+        searchResultAdInfo,
+        eventType: .viewed,
+        completion: { _ in })
+  }
+}

--- a/Sources/Brave/Frontend/Browser/Tab.swift
+++ b/Sources/Brave/Frontend/Browser/Tab.swift
@@ -367,6 +367,9 @@ class Tab: NSObject {
   /// A helper property that handles native to Brave Search communication.
   var braveSearchManager: BraveSearchManager?
 
+  /// A helper property that handles Brave Search Result Ads.
+  var braveSearchResultAdManager: BraveSearchResultAdManager?
+
   private lazy var refreshControl = UIRefreshControl().then {
     $0.addTarget(self, action: #selector(reload), for: .valueChanged)
   }

--- a/Sources/Brave/Frontend/Browser/UserScriptManager.swift
+++ b/Sources/Brave/Frontend/Browser/UserScriptManager.swift
@@ -104,6 +104,7 @@ class UserScriptManager {
     case readyStateHelper
     case ethereumProvider
     case solanaProvider
+    case searchResultAd
     case youtubeQuality
     
     fileprivate var script: WKUserScript? {
@@ -118,7 +119,8 @@ class UserScriptManager {
       case .trackerProtectionStats: return ContentBlockerHelper.userScript
       case .ethereumProvider: return EthereumProviderScriptHandler.userScript
       case .solanaProvider: return SolanaProviderScriptHandler.userScript
-        
+      case .searchResultAd: return BraveSearchResultAdScriptHandler.userScript
+    
       // Always enabled scripts
       case .faviconFetcher: return FaviconScriptHandler.userScript
       case .rewardsReporting: return RewardsReportingScriptHandler.userScript

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/BraveSearchResultAdScriptHandler.swift
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/BraveSearchResultAdScriptHandler.swift
@@ -1,0 +1,121 @@
+// Copyright 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import WebKit
+import BraveCore
+import os.log
+
+class BraveSearchResultAdScriptHandler: TabContentScript {
+  private struct SearchResultAdResponse: Decodable {  
+    struct SearchResultAd: Decodable {
+      let creativeInstanceId: String
+      let placementId: String
+      let creativeSetId: String
+      let campaignId: String
+      let advertiserId: String
+      let landingPage: URL
+      let headlineText: String
+      let description: String
+      let rewardsValue: String
+      let conversionUrlPatternValue: String?
+      let conversionAdvertiserPublicKeyValue: String?
+      let conversionObservationWindowValue: Int?
+    }
+
+    let creatives: [SearchResultAd]
+  }
+
+  fileprivate weak var tab: Tab?
+
+  init(tab: Tab) {
+    self.tab = tab
+  }
+
+  static let scriptName = "BraveSearchResultAdScript"
+  static let scriptId = UUID().uuidString
+  static let messageHandlerName = "\(scriptName)_\(messageUUID)"
+  static let scriptSandbox: WKContentWorld = .page
+  static let userScript: WKUserScript? = {
+    guard var script = loadUserScript(named: scriptName) else {
+      return nil
+    }
+    return WKUserScript(source: secureScript(handlerName: messageHandlerName,
+                                             securityToken: scriptId,
+                                             script: script),
+                        injectionTime: .atDocumentEnd,
+                        forMainFrameOnly: true,
+                        in: scriptSandbox)
+  }()
+
+  func userContentController(
+    _ userContentController: WKUserContentController,
+    didReceiveScriptMessage message: WKScriptMessage, 
+    replyHandler: (Any?, String?) -> Void
+  ) {
+    defer { replyHandler(nil, nil) }
+
+    if !verifyMessage(message: message) {
+      assertionFailure("Missing required security token.")
+      return
+    }
+
+    guard let tab = tab,
+          let braveSearchResultAdManager = tab.braveSearchResultAdManager
+    else {
+      Logger.module.error("Failed to get Brave search result ad handler")
+      return
+    }
+
+    guard JSONSerialization.isValidJSONObject(message.body),
+          let messageData = try? JSONSerialization.data(withJSONObject: message.body, options: []),
+          let searchResultAds = try? JSONDecoder().decode(SearchResultAdResponse.self, from: messageData)
+    else {
+        Logger.module.error("Failed to process Brave search result ads")
+        return
+    }
+
+    processSearchResultAds(searchResultAds, braveSearchResultAdManager: braveSearchResultAdManager)
+  }
+
+  private func processSearchResultAds(
+    _ searchResultAds: SearchResultAdResponse,
+    braveSearchResultAdManager: BraveSearchResultAdManager
+  ) {
+    for ad in searchResultAds.creatives {
+      guard let rewardsValue = Double(ad.rewardsValue)
+        else {
+          Logger.module.error("Failed to process Brave search result ads")
+          return
+      }
+
+      var conversionInfo: BraveAds.ConversionInfo?
+      if let conversionUrlPatternValue = ad.conversionUrlPatternValue,
+         let conversionObservationWindowValue = ad.conversionObservationWindowValue {
+        let timeInterval = TimeInterval(conversionObservationWindowValue * 24 * 60 * 60)
+        conversionInfo = .init(
+            urlPattern: conversionUrlPatternValue,
+            verifiableAdvertiserPublicKeyBase64: ad.conversionAdvertiserPublicKeyValue,
+            observationWindow: Date(timeIntervalSince1970: timeInterval)
+        )
+      }
+
+      let searchResultAdInfo: BraveAds.SearchResultAdInfo = .init(
+        type: .searchResultAd,
+        placementId: ad.placementId,
+        creativeInstanceId: ad.creativeInstanceId,
+        creativeSetId: ad.creativeSetId,
+        campaignId: ad.campaignId,
+        advertiserId: ad.advertiserId,
+        targetUrl: ad.landingPage,
+        headlineText: ad.headlineText,
+        description: ad.description,
+        value: rewardsValue,
+        conversion: conversionInfo
+      )
+
+      braveSearchResultAdManager.triggerSearchResultAdEvent(searchResultAdInfo)
+    }
+  }
+}

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/DomainSpecific/Paged/BraveSearchResultAdScript.js
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/DomainSpecific/Paged/BraveSearchResultAdScript.js
@@ -1,0 +1,60 @@
+// Copyright 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+'use strict';
+
+window.__firefox__.includeOnce('BraveSearchResultAdScript', function($) {
+  let sendMessage = $(function(creatives) {
+    $.postNativeMessage('$<message_handler>', {
+      "securityToken": SECURITY_TOKEN,
+      "creatives": creatives
+    });
+  });
+
+  let getJsonLdCreatives = () => {
+    const scripts = document.querySelectorAll('script[type="application/ld+json"]');
+    const jsonLdList = Array.from(scripts).map(script => JSON.parse(script.textContent));
+    
+    if (!jsonLdList) {
+      return [];
+    }
+
+    const creativeFieldNamesMapping = {
+      'data-creative-instance-id': 'creativeInstanceId',
+      'data-placement-id': 'placementId',
+      'data-creative-set-id': 'creativeSetId',
+      'data-campaign-id': 'campaignId',
+      'data-advertiser-id': 'advertiserId',
+      'data-landing-page': 'landingPage',
+      'data-headline-text': 'headlineText',
+      'data-description': 'description',
+      'data-rewards-value': 'rewardsValue',
+      'data-conversion-url-pattern-value': 'conversionUrlPatternValue',
+      'data-conversion-advertiser-public-key-value': 'conversionAdvertiserPublicKeyValue',
+      'data-conversion-observation-window-value': 'conversionObservationWindowValue'
+    };
+
+    let jsonLdCreatives = [];
+    jsonLdList.forEach(jsonLd => {
+      if (jsonLd['@type'] === 'Product' && jsonLd.creatives) {
+        jsonLd.creatives.forEach(creative => {
+          if (creative['@type'] === 'SearchResultAd') {
+            let jsonLdCreative = {};
+            for (let key in creative) {
+              if (creativeFieldNamesMapping[key]) {
+                jsonLdCreative[creativeFieldNamesMapping[key]] = creative[key];
+              }
+            }
+            jsonLdCreatives.push(jsonLdCreative);
+          }
+        });
+      }
+    });
+
+    return jsonLdCreatives;
+  };
+
+  sendMessage(getJsonLdCreatives());
+});


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes

Corresponding brave-core change: https://github.com/brave/brave-core/pull/21974

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes https://github.com/brave/brave-browser/issues/33469

## Submitter Checklist:

- [ ] *Unit Tests* are updated to cover new or changed functionality
- [ ] User-facing strings use `NSLocalizableString()`
- [ ] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->

* Enable ShouldAlwaysRunBraveAdsService feature
* Make sure that Brave Ads service is started
* Trigger search result ad on search.brave.com
* Check that search result ad served event was triggered in ads service. There should be `[ads] Served search result ad with placement id` log message
* Check that search result ad viewed event was triggered in ads service. There should be `[ads] Viewed search result ad with placement id` log message

## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
