### PR TITLE
Fix #8759: fixed Japanese title of rating brave card

### DIFF
--- a/Sources/BraveStrings/Resources/ja.lproj/BraveShared.strings
+++ b/Sources/BraveStrings/Resources/ja.lproj/BraveShared.strings
@@ -3482,7 +3482,7 @@
 "today.rateBraveCardSubtitle" = "ご意見をお聞かせください！";
 
 /* Title shown on the Rate Brave Card */
-"today.rateBraveCardTitle" = "Braveをリンクしますか？";
+"today.rateBraveCardTitle" = "Braveを気に入っていますか？";
 
 /* No comment provided by engineer. */
 "today.refresh" = "更新";


### PR DESCRIPTION
<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
- Fixed Japanese `today.rateBraveCardTitle` translation

This pull request fixes #8759 

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality (I think no tests have to be updated)
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
- Ensure that actual title is changed as the following screenshot shows


## Screenshots:
<img src="https://github.com/brave/brave-ios/assets/37182704/e3d706cb-2d11-447e-852c-65e0114d129d" width="70%">



## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
