### PR TITLE
Fix #8762: Isolate Tab to MainActor and Update all Script Injection to be Async-Await

### DIFF
--- a/App/Client.xcodeproj/xcshareddata/xcschemes/ActionExtension.xcscheme
+++ b/App/Client.xcodeproj/xcshareddata/xcschemes/ActionExtension.xcscheme
@@ -73,7 +73,6 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES"
-      askForAppToLaunch = "Yes"
       launchAutomaticallySubstyle = "2">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/App/iOS/Delegates/SceneDelegate.swift
+++ b/App/iOS/Delegates/SceneDelegate.swift
@@ -243,7 +243,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
       AppState.shared.dau.sendPingToServer()
     }
     
-    BraveSkusManager.refreshSKUCredential(isPrivate: scene.browserViewController?.privateBrowsingManager.isPrivateBrowsing == true)
+    Task { @MainActor in
+      await BraveSkusManager.refreshSKUCredential(isPrivate: scene.browserViewController?.privateBrowsingManager.isPrivateBrowsing == true)
+    }
   }
 
   func sceneWillResignActive(_ scene: UIScene) {

--- a/Sources/Brave/Frontend/Browser/BraveGetUA.swift
+++ b/Sources/Brave/Frontend/Browser/BraveGetUA.swift
@@ -30,8 +30,9 @@ class BraveGetUA: TabContentScript {
                                in: scriptSandbox)
   }()
 
-  func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage, replyHandler: (Any?, String?) -> Void) {
+  func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) async -> (Any?, String?) {
     // 🙀 😭 🏃‍♀️💨
+    return (nil, nil)
   }
 
   static var isActivated: Bool {

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ReaderMode.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ReaderMode.swift
@@ -118,8 +118,8 @@ extension BrowserViewController {
   /// and be done with it. In the more complicated case, reader mode was already open for this page and we simply
   /// navigated away from it. So we look to the left and right in the BackForwardList to see if a readerized version
   /// of the current page is there. And if so, we go there.
-
-  func enableReaderMode() {
+  @MainActor
+  func enableReaderMode() async {
     guard let tab = tabManager.selectedTab, let webView = tab.webView else { return }
 
     let backList = webView.backForwardList.backList
@@ -132,11 +132,11 @@ extension BrowserViewController {
     if backList.count > 1 && backList.last?.url == readerModeURL {
       let playlistItem = tab.playlistItem
       webView.go(to: backList.last!)
-      PlaylistScriptHandler.updatePlaylistTab(tab: tab, item: playlistItem)
+      await PlaylistScriptHandler.updatePlaylistTab(tab: tab, item: playlistItem)
     } else if !forwardList.isEmpty && forwardList.first?.url == readerModeURL {
       let playlistItem = tab.playlistItem
       webView.go(to: forwardList.first!)
-      PlaylistScriptHandler.updatePlaylistTab(tab: tab, item: playlistItem)
+      await PlaylistScriptHandler.updatePlaylistTab(tab: tab, item: playlistItem)
     } else {
       // Store the readability result in the cache and load it. This will later move to the ReadabilityHelper.
       webView.evaluateSafeJavaScript(functionName: "\(ReaderModeNamespace).readerize", contentWorld: ReaderModeScriptHandler.scriptSandbox) { (object, error) -> Void in
@@ -144,7 +144,9 @@ extension BrowserViewController {
           let playlistItem = tab.playlistItem
           try? self.readerModeCache.put(currentURL, readabilityResult)
           if webView.load(PrivilegedRequest(url: readerModeURL) as URLRequest) != nil {
-            PlaylistScriptHandler.updatePlaylistTab(tab: tab, item: playlistItem)
+            Task { @MainActor in
+              await PlaylistScriptHandler.updatePlaylistTab(tab: tab, item: playlistItem)
+            }
           }
         }
       }
@@ -155,8 +157,8 @@ extension BrowserViewController {
   /// means that there is nothing in the BackForwardList except the internal url for the reader mode page. In that
   /// case we simply open a new page with the original url. In the more complicated page, the non-readerized version
   /// of the page is either to the left or right in the BackForwardList. If that is the case, we navigate there.
-
-  func disableReaderMode() {
+  @MainActor
+  func disableReaderMode() async {
     if let tab = tabManager.selectedTab,
       let webView = tab.webView {
       let backList = webView.backForwardList.backList
@@ -167,15 +169,15 @@ extension BrowserViewController {
           if backList.count > 1 && backList.last?.url == originalURL {
             let playlistItem = tab.playlistItem
             webView.go(to: backList.last!)
-            PlaylistScriptHandler.updatePlaylistTab(tab: tab, item: playlistItem)
+            await PlaylistScriptHandler.updatePlaylistTab(tab: tab, item: playlistItem)
           } else if !forwardList.isEmpty && forwardList.first?.url == originalURL {
             let playlistItem = tab.playlistItem
             webView.go(to: forwardList.first!)
-            PlaylistScriptHandler.updatePlaylistTab(tab: tab, item: playlistItem)
+            await PlaylistScriptHandler.updatePlaylistTab(tab: tab, item: playlistItem)
           } else {
             let playlistItem = tab.playlistItem
             if webView.load(URLRequest(url: originalURL)) != nil {
-              PlaylistScriptHandler.updatePlaylistTab(tab: tab, item: playlistItem)
+              await PlaylistScriptHandler.updatePlaylistTab(tab: tab, item: playlistItem)
             }
           }
         }

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ShareActivity.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ShareActivity.swift
@@ -73,7 +73,9 @@ extension BrowserViewController {
             title: Strings.toggleReaderMode,
             braveSystemImage: "leo.product.speedreader",
             callback: { [weak self] in
-              self?.toggleReaderMode()
+              Task { @MainActor in
+                await self?.toggleReaderMode()
+              }
             }
           )
         )

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabManagerDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabManagerDelegate.swift
@@ -187,6 +187,8 @@ extension BrowserViewController: TabManagerDelegate {
     if !privateBrowsingManager.isPrivateBrowsing {
       rewards.reportTabClosed(tabId: Int(tab.rewardsId))
     }
+    
+    tab.destroy()
   }
 
   func tabManagerDidAddTabs(_ tabManager: TabManager) {

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ToolbarDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ToolbarDelegate.swift
@@ -127,7 +127,9 @@ extension BrowserViewController: TopToolbarDelegate {
   }
 
   func topToolbarDidPressReaderMode(_ topToolbar: TopToolbarView) {
-    toggleReaderMode()
+    Task { @MainActor in
+      await toggleReaderMode()
+    }
   }
 
   func topToolbarDidPressPlaylistButton(_ urlBar: TopToolbarView) {

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+WKNavigationDelegate.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+WKNavigationDelegate.swift
@@ -1161,6 +1161,7 @@ extension BrowserViewController: WKUIDelegate {
     webView.evaluateSafeJavaScript(functionName: script, contentWorld: .defaultClient, asFunction: false)
   }
 
+  @MainActor
   func handleAlert<T: JSAlertInfo>(webView: WKWebView, alert: inout T, completionHandler: @escaping () -> Void) {
     guard let promptingTab = tabManager[webView], !promptingTab.blockAllAlerts else {
       suppressJSAlerts(webView: webView)
@@ -1169,9 +1170,10 @@ extension BrowserViewController: WKUIDelegate {
       return
     }
     promptingTab.alertShownCount += 1
+    
     let suppressBlock: JSAlertInfo.SuppressHandler = { [unowned self] suppress in
       if suppress {
-        func suppressDialogues(_: UIAlertAction) {
+        @MainActor func suppressDialogues(_: UIAlertAction) {
           self.suppressJSAlerts(webView: webView)
           promptingTab.blockAllAlerts = true
           self.tabManager[webView]?.cancelQueuedAlerts()

--- a/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -1713,6 +1713,7 @@ public class BrowserViewController: UIViewController {
   // to report internal page load to Rewards lib
   var rewardsXHRLoadURL: URL?
 
+  @MainActor
   override public func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {
 
     guard let webView = object as? WKWebView else {
@@ -1945,8 +1946,10 @@ public class BrowserViewController: UIViewController {
       
       Task { @MainActor in
         do {
-          let result = await BraveCertificateUtils.verifyTrust(serverTrust, host: host, port: port)
-          
+          let result = BraveCertificateUtility.verifyTrust(serverTrust,
+                                                           host: host,
+                                                           port: port)
+
           // Cert is valid!
           if result == 0 {
             tab.secureContentState = .secure
@@ -2331,14 +2334,15 @@ public class BrowserViewController: UIViewController {
     }
   }
   
-  func toggleReaderMode() {
+  @MainActor
+  func toggleReaderMode() async {
     guard let tab = tabManager.selectedTab else { return }
     if let readerMode = tab.getContentScript(name: ReaderModeScriptHandler.scriptName) as? ReaderModeScriptHandler {
       switch readerMode.state {
       case .available:
-        enableReaderMode()
+        await enableReaderMode()
       case .active:
-        disableReaderMode()
+        await disableReaderMode()
       case .unavailable:
         break
       }

--- a/Sources/Brave/Frontend/Browser/FaviconHandler.swift
+++ b/Sources/Brave/Frontend/Browser/FaviconHandler.swift
@@ -23,6 +23,7 @@ class FaviconHandler {
     unregister(tabObservers)
   }
 
+  @MainActor
   func loadFaviconURL(
     _ url: URL,
     forTab tab: Tab
@@ -34,6 +35,7 @@ class FaviconHandler {
 }
 
 extension FaviconHandler: TabEventHandler {
+  @MainActor
   func tab(_ tab: Tab, didLoadPageMetadata metadata: PageMetadata) {
     if let currentURL = tab.url {
       if let favicon = FaviconFetcher.getIconFromCache(for: currentURL) {

--- a/Sources/Brave/Frontend/Browser/FingerprintingProtection.swift
+++ b/Sources/Brave/Frontend/Browser/FingerprintingProtection.swift
@@ -30,11 +30,12 @@ class FingerprintingProtection: TabContentScript {
                         in: scriptSandbox)
   }()
 
-  func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage, replyHandler: (Any?, String?) -> Void) {
-    defer { replyHandler(nil, nil) }
+  @MainActor
+  func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) async -> (Any?, String?) {
     if let stats = self.tab?.contentBlocker.stats {
       self.tab?.contentBlocker.stats = stats.adding(fingerprintingCount: 1)
       BraveGlobalShieldStats.shared.fpProtection += 1
     }
+    return (nil, nil)
   }
 }

--- a/Sources/Brave/Frontend/Browser/FrequencyQuery.swift
+++ b/Sources/Brave/Frontend/Browser/FrequencyQuery.swift
@@ -75,6 +75,7 @@ class FrequencyQuery {
     }
   }
     
+  @MainActor
   private func fetchSitesFromTabs(_ tabs: [Tab]) -> [Site] {
     var tabList = [Site]()
         

--- a/Sources/Brave/Frontend/Browser/Helpers/BrowserNavigationHelper.swift
+++ b/Sources/Brave/Frontend/Browser/Helpers/BrowserNavigationHelper.swift
@@ -74,6 +74,7 @@ class BrowserNavigationHelper {
     open(vc, doneButton: DoneButton(style: .done, position: .left))
   }
 
+  @MainActor
   func openShareSheet() {
     guard let bvc = bvc else { return }
     dismissView()

--- a/Sources/Brave/Frontend/Browser/Helpers/MetadataParserHelper.swift
+++ b/Sources/Brave/Frontend/Browser/Helpers/MetadataParserHelper.swift
@@ -21,6 +21,7 @@ class MetadataParserHelper: TabEventHandler {
     unregister(tabObservers)
   }
 
+  @MainActor
   func tab(_ tab: Tab, didChangeURL url: URL) {
     // Get the metadata out of the page-metadata-parser, and into a type safe struct as soon
     // as possible.

--- a/Sources/Brave/Frontend/Browser/Helpers/ScreenshotHelper.swift
+++ b/Sources/Brave/Frontend/Browser/Helpers/ScreenshotHelper.swift
@@ -20,6 +20,7 @@ class ScreenshotHelper {
     self.tabManager = tabManager
   }
 
+  @MainActor
   func takeScreenshot(_ tab: Tab) {
     guard let webView = tab.webView, let url = tab.url else {
       Logger.module.error("Tab webView or url is nil")
@@ -70,6 +71,7 @@ class ScreenshotHelper {
     }
   }
 
+  @MainActor
   func takePendingScreenshots(_ tabs: [Tab]) {
     for tab in tabs where tab.pendingScreenshot {
       tab.pendingScreenshot = false

--- a/Sources/Brave/Frontend/Browser/LinkPreviewViewController.swift
+++ b/Sources/Brave/Frontend/Browser/LinkPreviewViewController.swift
@@ -61,7 +61,9 @@ class LinkPreviewViewController: UIViewController {
   }
   
   deinit {
-    self.currentTab?.navigationDelegate = nil
-    self.currentTab = nil
+    Task { @MainActor in
+      self.currentTab?.navigationDelegate = nil
+      self.currentTab = nil
+    }
   }
 }

--- a/Sources/Brave/Frontend/Browser/NavigationRouter.swift
+++ b/Sources/Brave/Frontend/Browser/NavigationRouter.swift
@@ -15,6 +15,7 @@ public enum DeepLink: String {
 }
 
 // The root navigation for the Router. Look at the tests to see a complete URL
+@MainActor
 public enum NavigationPath: Equatable {
   case url(webURL: URL?, isPrivate: Bool)
   case deepLink(DeepLink)

--- a/Sources/Brave/Frontend/Browser/PageZoom/PageZoomHandler.swift
+++ b/Sources/Brave/Frontend/Browser/PageZoom/PageZoomHandler.swift
@@ -8,6 +8,7 @@ import Shared
 import Data
 import Preferences
 
+@MainActor
 class PageZoomHandler: ObservableObject {
   
   enum ChangeStatus {

--- a/Sources/Brave/Frontend/Browser/Playlist/Controllers/PlaylistCarplayController.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/Controllers/PlaylistCarplayController.swift
@@ -27,6 +27,7 @@ enum PlaylistCarplayError: Error {
   case itemExpired(id: String)
 }
 
+@MainActor
 class PlaylistCarplayController: NSObject {
   private let player: MediaPlayer
   private let mediaStreamer: PlaylistMediaStreamer

--- a/Sources/Brave/Frontend/Browser/Playlist/Controllers/PlaylistViewController.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/Controllers/PlaylistViewController.swift
@@ -99,11 +99,11 @@ class PlaylistViewController: UIViewController {
     if let item = PlaylistCarplayManager.shared.currentPlaylistItem {
       updateLastPlayedItem(item: item)
     }
-
+    
     // Stop picture in picture
     player.pictureInPictureController?.delegate = nil
     player.pictureInPictureController?.stopPictureInPicture()
-
+    
     // Simulator cannot "detect" if Car-Play is enabled, therefore we need to STOP playback
     // When this controller deallocates. The user can still manually resume playback in CarPlay.
     if !PlaylistCarplayManager.shared.isCarPlayAvailable {
@@ -111,16 +111,19 @@ class PlaylistViewController: UIViewController {
       stop(playerView)
       PlaylistCarplayManager.shared.currentPlaylistItem = nil
       PlaylistCarplayManager.shared.currentlyPlayingItemIndex = -1
-
+      
       // Destroy folder observers
       folderObserver = nil
       PlaylistManager.shared.currentFolder = nil
     }
-
+    
     // Cancel all loading.
     listController.stopLoadingSharedPlaylist()
     PlaylistManager.shared.playbackTask = nil
-    PlaylistCarplayManager.shared.playlistController = nil
+    
+    Task { @MainActor in
+      PlaylistCarplayManager.shared.playlistController = nil
+    }
   }
 
   override func viewDidLoad() {

--- a/Sources/Brave/Frontend/Browser/Playlist/Managers & Cache/PlaylistCarplayManager.swift
+++ b/Sources/Brave/Frontend/Browser/Playlist/Managers & Cache/PlaylistCarplayManager.swift
@@ -32,6 +32,7 @@ public class PlaylistCarplayManager: NSObject {
   var isPlaylistControllerPresented = false
 
   // When Picture-In-Picture is enabled, we need to store a reference to the controller to keep it alive, otherwise if it deallocates, the system automatically kills Picture-In-Picture.
+  @MainActor
   var playlistController: PlaylistViewController? {
     didSet {
       // TODO: REFACTOR and Decide what happens to Playlist in multiple windows in the future
@@ -54,6 +55,7 @@ public class PlaylistCarplayManager: NSObject {
     }
   }
   
+  @MainActor
   public func destroyPiP() {
     // This is the only way to have the system kill picture in picture as the restoration controller is deallocated
     // And that means the video is deallocated, its AudioSession is stopped, and the Picture-In-Picture controller is deallocated.
@@ -69,6 +71,7 @@ public class PlaylistCarplayManager: NSObject {
   // in use at any given moment
   public static let shared = PlaylistCarplayManager()
 
+  @MainActor
   func getCarPlayController() -> PlaylistCarplayController? {
     // On iOS 14, we use CPTemplate (Custom UI)
     // We control what gets displayed
@@ -106,6 +109,7 @@ public class PlaylistCarplayManager: NSObject {
     return carPlayController
   }
 
+  @MainActor
   func getPlaylistController(tab: Tab?, initialItem: PlaylistInfo?, initialItemPlaybackOffset: Double) -> PlaylistViewController {
 
     // If background playback is enabled (on iPhone), tabs will continue to play media
@@ -132,6 +136,7 @@ public class PlaylistCarplayManager: NSObject {
     return playlistController
   }
 
+  @MainActor
   func getPlaylistController(tab: Tab?, completion: @escaping (PlaylistViewController) -> Void) {
     if let playlistController = self.playlistController {
       return completion(playlistController)
@@ -157,6 +162,7 @@ public class PlaylistCarplayManager: NSObject {
     }
   }
 
+  @MainActor
   private func attemptInterfaceConnection(isCarPlayAvailable: Bool) {
     self.isCarPlayAvailable = isCarPlayAvailable
 

--- a/Sources/Brave/Frontend/Browser/Tab.swift
+++ b/Sources/Brave/Frontend/Browser/Tab.swift
@@ -30,8 +30,9 @@ protocol TabContentScript: TabContentScriptLoader {
   
   func verifyMessage(message: WKScriptMessage) -> Bool
   func verifyMessage(message: WKScriptMessage, securityToken: String) -> Bool
-  
-  func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage, replyHandler: @escaping (Any?, String?) -> Void)
+
+  @MainActor
+  func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) async -> (Any?, String?)
 }
 
 protocol TabDelegate {
@@ -75,6 +76,7 @@ enum TabSecureContentState {
   }
 }
 
+@MainActor
 class Tab: NSObject {
   let id: UUID
   let rewardsId: UInt32
@@ -493,27 +495,19 @@ class Tab: NSObject {
     }
     webView = nil
   }
-
-  deinit {
+  
+  func destroy() {
     deleteWebView()
     deleteNewTabPageController()
     contentScriptManager.helpers.removeAll()
-    
-    // A number of mojo-powered core objects have to be deconstructed on the same
-    // thread they were constructed
-    var mojoObjects: [Any?] = [
-      _faviconDriver,
-      _syncTab,
-      _walletEthProvider,
-      _walletSolProvider,
-      _walletKeyringService
-    ]
-    
-    DispatchQueue.main.async {
-      // Reference inside to retain it, supress warnings by reading/writing
-      _ = mojoObjects
-      mojoObjects = []
-    }
+  }
+
+  deinit {
+//    Task { @MainActor in
+//      deleteWebView()
+//      deleteNewTabPageController()
+//      contentScriptManager.helpers.removeAll()
+//    }
   }
 
   var loading: Bool {
@@ -902,23 +896,26 @@ extension Tab: TabWebViewDelegate {
 private class TabContentScriptManager: NSObject, WKScriptMessageHandlerWithReply {
   fileprivate var helpers = [String: TabContentScript]()
 
+  @MainActor
   func uninstall(from tab: Tab) {
     helpers.forEach {
       let name = type(of: $0.value).messageHandlerName
       tab.webView?.configuration.userContentController.removeScriptMessageHandler(forName: name)
     }
   }
-
-  @objc func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage, replyHandler: @escaping (Any?, String?) -> Void) {
+  
+  @MainActor
+  func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) async -> (Any?, String?) {
     for helper in helpers.values {
       let scriptMessageHandlerName = type(of: helper).messageHandlerName
       if scriptMessageHandlerName == message.name {
-        helper.userContentController(userContentController, didReceiveScriptMessage: message, replyHandler: replyHandler)
-        return
+        return await helper.userContentController(userContentController, didReceive: message)
       }
     }
+    return (nil, nil)
   }
 
+  @MainActor 
   func addContentScript(_ helper: TabContentScript, name: String, forTab tab: Tab, contentWorld: WKContentWorld) {
     if let _ = helpers[name] {
       assertionFailure("Duplicate helper added: \(name)")
@@ -932,6 +929,7 @@ private class TabContentScriptManager: NSObject, WKScriptMessageHandlerWithReply
     tab.webView?.configuration.userContentController.addScriptMessageHandler(self, contentWorld: contentWorld, name: scriptMessageHandlerName)
   }
   
+  @MainActor 
   func removeContentScript(name: String, forTab tab: Tab, contentWorld: WKContentWorld) {
     if let helper = helpers[name] {
       let scriptMessageHandlerName = type(of: helper).messageHandlerName

--- a/Sources/Brave/Frontend/Browser/TabManager.swift
+++ b/Sources/Brave/Frontend/Browser/TabManager.swift
@@ -45,6 +45,7 @@ class WeakTabManagerDelegate {
 }
 
 // TabManager must extend NSObjectProtocol in order to implement WKNavigationDelegate
+@MainActor
 class TabManager: NSObject {
   fileprivate var delegates = [WeakTabManagerDelegate]()
   fileprivate let tabEventHandlers: [TabEventHandler]

--- a/Sources/Brave/Frontend/Browser/TabType.swift
+++ b/Sources/Brave/Frontend/Browser/TabType.swift
@@ -36,8 +36,8 @@ enum TabType: Int, CustomDebugStringConvertible {
   ///
   /// - parameter tab: An object representing a Tab.
   /// - returns: A Tab type.
+  @MainActor
   static func of(_ tab: Tab?) -> TabType {
     return tab?.type ?? .regular
   }
-
 }

--- a/Sources/Brave/Frontend/Browser/Tabs/TabTray/TabTrayController.swift
+++ b/Sources/Brave/Frontend/Browser/Tabs/TabTray/TabTrayController.swift
@@ -222,12 +222,12 @@ class TabTrayController: AuthenticationController {
   required init?(coder: NSCoder) { fatalError() }
 
   deinit {
-    tabManager.removeDelegate(self)
-    
-    // Remove the open tabs service observer
-    if let observer = openTabsSessionServiceListener {
-      braveCore.openTabsAPI.removeObserver(observer)
-    }
+//    tabManager.removeDelegate(self)
+//
+//    // Remove the open tabs service observer
+//    if let observer = openTabsSessionServiceListener {
+//      braveCore.openTabsAPI.removeObserver(observer)
+//    }
   }
 
   override func viewDidLoad() {
@@ -329,6 +329,17 @@ class TabTrayController: AuthenticationController {
     if isExternallyPresented {
       tabTypeSelector.selectedSegmentIndex = 1
       tabTypeSelector.sendActions(for: UIControl.Event.valueChanged)
+    }
+  }
+  
+  override func viewDidDisappear(_ animated: Bool) {
+    super.viewDidDisappear(animated)
+
+    tabManager.removeDelegate(self)
+    
+    // Remove the open tabs service observer
+    if let observer = openTabsSessionServiceListener {
+      braveCore.openTabsAPI.removeObserver(observer)
     }
   }
   

--- a/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/VPNMenuButton.swift
+++ b/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/VPNMenuButton.swift
@@ -35,6 +35,7 @@ struct VPNMenuButton: View {
   
   @ScaledMetric private var iconSize: CGFloat = 32.0
 
+  @MainActor
   private var isVPNEnabledBinding: Binding<Bool> {
     Binding(
       get: { isVPNEnabled },
@@ -42,6 +43,7 @@ struct VPNMenuButton: View {
     )
   }
 
+  @MainActor
   private func toggleVPN(_ enabled: Bool) {
     if BraveSkusManager.keepShowingSessionExpiredState {
       let alert = BraveSkusManager.sessionExpiredStateAlert(loginCallback: { _ in
@@ -80,6 +82,7 @@ struct VPNMenuButton: View {
     }
   }
 
+  @MainActor
   private var vpnToggle: some View {
     Toggle("Brave VPN", isOn: isVPNEnabledBinding)
       .toggleStyle(SwitchToggleStyle(tint: retryStateActive ? Color(.braveErrorBorder) : .accentColor))

--- a/Sources/Brave/Frontend/Browser/UserScriptManager.swift
+++ b/Sources/Brave/Frontend/Browser/UserScriptManager.swift
@@ -12,6 +12,7 @@ import os.log
 
 private class ScriptLoader: TabContentScriptLoader { }
 
+@MainActor
 class UserScriptManager {
   static let shared = UserScriptManager()
   

--- a/Sources/Brave/Frontend/Rewards/BraveRewards.swift
+++ b/Sources/Brave/Frontend/Rewards/BraveRewards.swift
@@ -176,6 +176,7 @@ public class BraveRewards: NSObject {
   // MARK: - Reporting
 
   /// Report that a tab with a given id was updated
+  @MainActor
   func reportTabUpdated(
     tab: Tab,
     url: URL,

--- a/Sources/Brave/Frontend/Share/ShareExtensionHelper.swift
+++ b/Sources/Brave/Frontend/Share/ShareExtensionHelper.swift
@@ -7,6 +7,7 @@ import Shared
 import UIKit
 
 /// A helper class that aids in the creation of share sheets
+@MainActor
 class ShareExtensionHelper {
   /// Create a activity view controller with the given elements.
   /// - Parameters:

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Internal/SessionRestoreScriptHandler.swift
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Internal/SessionRestoreScriptHandler.swift
@@ -34,20 +34,20 @@ class SessionRestoreScriptHandler: TabContentScript {
                         in: scriptSandbox)
   }()
 
-  func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage, replyHandler: (Any?, String?) -> Void) {
-    defer { replyHandler(nil, nil) }
-    
+  func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) async -> (Any?, String?) {
     if !verifyMessage(message: message, securityToken: UserScriptManager.securityToken) {
       assertionFailure("Missing required security token.")
-      return
+      return (nil, nil)
     }
 
     if let tab = tab, let params = message.body as? [String: AnyObject] {
       if params["name"] as? String == "didRestoreSession" {
-        DispatchQueue.main.async {
+        await MainActor.run {
           self.delegate?.sessionRestore(self, didRestoreSessionForTab: tab)
         }
       }
     }
+    
+    return (nil, nil)
   }
 }

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Internal/Web3IPFSScriptHandler.swift
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Internal/Web3IPFSScriptHandler.swift
@@ -27,11 +27,9 @@ class Web3IPFSScriptHandler: TabContentScript {
   static let scriptSandbox: WKContentWorld = .page
   static let userScript: WKUserScript? = nil
   
-  func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage, replyHandler: (Any?, String?) -> Void) {
-    defer { replyHandler(nil, nil) }
-    
+  func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) async -> (Any?, String?) {
     guard let params = message.body as? [String: String], let originalURL = originalURL else {
-      return
+      return (nil, nil)
     }
     
     if params["type"] == "IPFSDisable" {
@@ -41,5 +39,7 @@ class Web3IPFSScriptHandler: TabContentScript {
     } else {
       assertionFailure("Invalid message: \(message.body)")
     }
+    
+    return (nil, nil)
   }
 }

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Internal/Web3NameServiceScriptHandler.swift
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Internal/Web3NameServiceScriptHandler.swift
@@ -38,11 +38,9 @@ class Web3NameServiceScriptHandler: TabContentScript {
   static let scriptSandbox: WKContentWorld = .page
   static let userScript: WKUserScript? = nil
   
-  func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage, replyHandler: (Any?, String?) -> Void) {
-    defer { replyHandler(nil, nil) }
-    
+  func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) async -> (Any?, String?) {
     guard let params = message.body as? [String: String], let originalURL = originalURL else {
-      return
+      return (nil, nil)
     }
     
     if params[ParamKey.buttonType.rawValue] == ParamValue.disable.rawValue,
@@ -56,5 +54,7 @@ class Web3NameServiceScriptHandler: TabContentScript {
     } else {
       assertionFailure("Invalid message: \(message.body)")
     }
+    
+    return (nil, nil)
   }
 }

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/ContentBlockerScriptHandler.swift
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/ContentBlockerScriptHandler.swift
@@ -47,17 +47,15 @@ extension ContentBlockerHelper: TabContentScript {
     blockedRequests.removeAll()
   }
 
-  func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage, replyHandler: (Any?, String?) -> Void) {
-    defer { replyHandler(nil, nil) }
-    
-    guard let currentTabURL = tab?.webView?.url else {
+  func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) async -> (Any?, String?) {
+    guard let currentTabURL = await tab?.webView?.url else {
       assertionFailure("Missing tab or webView")
-      return
+      return (nil, nil)
     }
     
     if !verifyMessage(message: message, securityToken: UserScriptManager.securityToken) {
       assertionFailure("Missing required security token.")
-      return
+      return (nil, nil)
     }
     
     do {
@@ -134,5 +132,7 @@ extension ContentBlockerHelper: TabContentScript {
     } catch {
       Logger.module.error("\(error.localizedDescription)")
     }
+    
+    return (nil, nil)
   }
 }

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/PlaylistFolderSharingScriptHandler.swift
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/PlaylistFolderSharingScriptHandler.swift
@@ -39,12 +39,10 @@ class PlaylistFolderSharingScriptHandler: NSObject, TabContentScript {
                         in: scriptSandbox)
   }()
 
-  func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage, replyHandler: (Any?, String?) -> Void) {
-    defer { replyHandler(nil, nil) }
-
+  func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) async -> (Any?, String?) {
     if !verifyMessage(message: message) {
       assertionFailure("Missing required security token.")
-      return
+      return (nil, nil)
     }
     
     if let sharingInfo = PlaylistFolderSharingInfo.from(message: message) {
@@ -56,6 +54,7 @@ class PlaylistFolderSharingScriptHandler: NSObject, TabContentScript {
       
       delegate?.openPlaylistSharingFolder(with: sharedFolderPageUrl)
     }
+    return (nil, nil)
   }
 }
 

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/PrintScriptHandler.swift
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/PrintScriptHandler.swift
@@ -36,12 +36,11 @@ class PrintScriptHandler: TabContentScript {
                         in: scriptSandbox)
   }()
 
-  func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage, replyHandler: (Any?, String?) -> Void) {
-    defer { replyHandler(nil, nil) }
-
+  @MainActor
+  func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) async -> (Any?, String?) {
     if !verifyMessage(message: message, securityToken: UserScriptManager.securityToken) {
       assertionFailure("Missing required security token.")
-      return
+      return (nil, nil)
     }
 
     if let tab = tab, let webView = tab.webView, let url = webView.url {
@@ -54,7 +53,7 @@ class PrintScriptHandler: TabContentScript {
       currentDomain = url.baseDomain
 
       if isPresentingController || isBlocking {
-        return
+        return (nil, nil)
       }
 
       let showPrintSheet = { [weak self] in
@@ -105,5 +104,7 @@ class PrintScriptHandler: TabContentScript {
         showPrintSheet()
       }
     }
+    
+    return (nil, nil)
   }
 }

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/ReadyStateScriptHandler.swift
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/ReadyStateScriptHandler.swift
@@ -68,20 +68,19 @@ class ReadyStateScriptHandler: TabContentScript {
                         in: scriptSandbox)
   }()
 
-  func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage, replyHandler: (Any?, String?) -> Void) {
-    
-    defer { replyHandler(nil, nil) }
-    
+  @MainActor
+  func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) async -> (Any?, String?) {
     if !verifyMessage(message: message) {
       assertionFailure("Missing required security token.")
-      return
+      return (nil, nil)
     }
 
     guard let readyState = ReadyState.from(message: message) else {
       Logger.module.error("Invalid Ready State")
-      return
+      return (nil, nil)
     }
     
     tab?.onPageReadyStateChanged?(readyState.state)
+    return  (nil, nil)
   }
 }

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/RewardsReportingScriptHandler.swift
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/RewardsReportingScriptHandler.swift
@@ -34,45 +34,48 @@ class RewardsReportingScriptHandler: TabContentScript {
                         in: scriptSandbox)
   }()
 
-  func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage, replyHandler: (Any?, String?) -> Void) {
-    defer { replyHandler(nil, nil) }
+  func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) async -> (Any?, String?) {
     struct Content: Decodable {
       var method: String
       var url: String
       var data: String?
       var referrerUrl: String?
     }
-
-    if tab?.isPrivate == true || !rewards.isEnabled {
-      return
-    }
     
     if !verifyMessage(message: message) {
       assertionFailure("Missing required security token.")
-      return
+      return (nil, nil)
     }
-
-    do {
+    
+    await MainActor.run {
+      guard let tab = tab, !tab.isPrivate, rewards.isEnabled, let tabURL = tab.url else {
+        return
+      }
+      
       guard let body = message.body as? [String: AnyObject] else {
         return
       }
-
-      if let body = body["data"] as? [String: AnyObject] {
-        let json = try JSONSerialization.data(withJSONObject: body, options: [])
-        var content = try JSONDecoder().decode(Content.self, from: json)
-
-        guard let tab = tab, let tabURL = tab.url else { return }
-
-        if content.url.hasPrefix("//") {
-          content.url = "\(tabURL.scheme ?? "http"):\(content.url)"
+      
+      Task {
+        do {
+          if let body = body["data"] as? [String: AnyObject] {
+            let json = try JSONSerialization.data(withJSONObject: body, options: [])
+            var content = try JSONDecoder().decode(Content.self, from: json)
+            
+            if content.url.hasPrefix("//") {
+              content.url = "\(tabURL.scheme ?? "http"):\(content.url)"
+            }
+            
+            guard let url = URL(string: content.url) else { return }
+            let refURL = URL(string: content.referrerUrl ?? "")
+            rewards.reportXHRLoad(url: url, tabId: Int(tab.rewardsId), firstPartyURL: tabURL, referrerURL: refURL)
+          }
+        } catch {
+          adsRewardsLog.error("Failed to parse message from rewards reporting JS: \(error.localizedDescription)")
         }
-
-        guard let url = URL(string: content.url) else { return }
-        let refURL = URL(string: content.referrerUrl ?? "")
-        rewards.reportXHRLoad(url: url, tabId: Int(tab.rewardsId), firstPartyURL: tabURL, referrerURL: refURL)
       }
-    } catch {
-      adsRewardsLog.error("Failed to parse message from rewards reporting JS: \(error.localizedDescription)")
     }
+    
+    return (nil, nil)
   }
 }

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/URLPartinessScriptHandler.swift
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/URLPartinessScriptHandler.swift
@@ -35,11 +35,10 @@ class URLPartinessScriptHandler: TabContentScript {
     self.tab = tab
   }
   
-  func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage, replyHandler: @escaping (Any?, String?) -> Void) {
+  func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) async -> (Any?, String?) {
     if !verifyMessage(message: message) {
       assertionFailure("Invalid security token. Fix the `SelectorsPollerScript.js` script")
-      replyHandler(nil, nil)
-      return
+      return (nil, nil)
     }
 
     do {
@@ -54,8 +53,7 @@ class URLPartinessScriptHandler: TabContentScript {
           results[urlString] = false
         }
         
-        replyHandler(results, nil)
-        return
+        return (results, nil)
       }
       
       let frameETLD1 = frameURL.baseDomain
@@ -71,10 +69,10 @@ class URLPartinessScriptHandler: TabContentScript {
         results[urlString] = frameETLD1 == etld1
       }
       
-      replyHandler(results, nil)
+      return (results, nil)
     } catch {
       assertionFailure("Invalid type of message. Fix the `RequestBlocking.js` script")
-      replyHandler(nil, nil)
+      return (nil, nil)
     }
   }
 }

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/CustomSearchScriptHandler.swift
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/CustomSearchScriptHandler.swift
@@ -28,8 +28,8 @@ class CustomSearchScriptHandler: TabContentScript {
                         in: scriptSandbox)
   }()
 
-  func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage, replyHandler: (Any?, String?) -> Void) {
-    replyHandler(nil, nil)
+  func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) async -> (Any?, String?) {
     // We don't listen to messages because the BVC calls the searchHelper script by itself.
+    return (nil, nil)
   }
 }

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/FaviconScriptHandler.swift
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/FaviconScriptHandler.swift
@@ -35,39 +35,40 @@ class FaviconScriptHandler: NSObject, TabContentScript {
                         in: scriptSandbox)
   }()
 
-  func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage, replyHandler: (Any?, String?) -> Void) {
-    defer { replyHandler(nil, nil) }
-    guard let tab = tab else { return }
-    
-    Task { @MainActor in
-      // Assign default favicon
-      tab.favicon = Favicon.default
-      
-      guard let webView = message.webView,
-            let url = webView.url else {
-        return
-      }
-      
-      // The WebView has a valid URL
-      // Attempt to fetch the favicon from cache
-      let isPrivate = tab.isPrivate
-      tab.favicon = FaviconFetcher.getIconFromCache(for: url) ?? Favicon.default
-      
-      // If this is an internal page, we don't fetch favicons for such pages from Brave-Core
-      guard !InternalURL.isValid(url: url),
-            !(InternalURL(url)?.isSessionRestore ?? false) else {
-        return
-      }
-      
-      // Update the favicon for this tab, from Brave-Core
-      tab.faviconDriver?.webView(webView, scriptMessage: message) { [weak tab] iconUrl, icon in
-        FaviconScriptHandler.updateFavicon(tab: tab,
-                                           url: url,
-                                           isPrivate: isPrivate,
-                                           icon: icon,
-                                           iconUrl: iconUrl)
-      }
+  @MainActor
+  func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) async -> (Any?, String?) {
+    guard let tab = tab else {
+      return (nil, nil)
     }
+    
+    // Assign default favicon
+    tab.favicon = Favicon.default
+    
+    guard let webView = message.webView,
+          let url = webView.url else {
+      return (nil, nil)
+    }
+    
+    // The WebView has a valid URL
+    // Attempt to fetch the favicon from cache
+    let isPrivate = tab.isPrivate
+    tab.favicon = FaviconFetcher.getIconFromCache(for: url) ?? Favicon.default
+    
+    // If this is an internal page, we don't fetch favicons for such pages from Brave-Core
+    guard !InternalURL.isValid(url: url),
+          !(InternalURL(url)?.isSessionRestore ?? false) else {
+      return (nil, nil)
+    }
+    
+    // Update the favicon for this tab, from Brave-Core
+    tab.faviconDriver?.webView(webView, scriptMessage: message) { [weak tab] iconUrl, icon in
+      FaviconScriptHandler.updateFavicon(tab: tab,
+                                         url: url,
+                                         isPrivate: isPrivate,
+                                         icon: icon,
+                                         iconUrl: iconUrl)
+    }
+    return (nil, nil)
   }
   
   private static func updateFavicon(tab: Tab?, url: URL, isPrivate: Bool, icon: UIImage?, iconUrl: URL?) {

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/FindInPageScriptHandler.swift
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/FindInPageScriptHandler.swift
@@ -28,16 +28,14 @@ class FindInPageScriptHandler: TabContentScript {
   static let scriptSandbox: WKContentWorld = .defaultClient
   static let userScript: WKUserScript? = nil
 
-  func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage, replyHandler: (Any?, String?) -> Void) {
-    defer { replyHandler(nil, nil) }
-    
+  func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) async -> (Any?, String?) {
     if !verifyMessage(message: message, securityToken: UserScriptManager.securityToken) {
       assertionFailure("Missing required security token.")
-      return
+      return (nil, nil)
     }
     
     guard let body = message.body as? [String: AnyObject] else {
-      return
+      return (nil, nil)
     }
 
     guard let data = body["data"] as? [String: Int] else {
@@ -45,7 +43,7 @@ class FindInPageScriptHandler: TabContentScript {
         Logger.module.error("Could not find a message body or the data did not meet expectations: \(body))")
       }
       
-      return
+      return (nil, nil)
     }
 
     if let currentResult = data["currentResult"] {
@@ -55,5 +53,7 @@ class FindInPageScriptHandler: TabContentScript {
     if let totalResults = data["totalResults"] {
       delegate?.findInPageHelper(self, didUpdateTotalResults: totalResults)
     }
+    
+    return (nil, nil)
   }
 }

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/FocusScriptHandler.swift
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/FocusScriptHandler.swift
@@ -20,35 +20,40 @@ class FocusScriptHandler: TabContentScript {
   static let scriptSandbox: WKContentWorld = .defaultClient
   static let userScript: WKUserScript? = nil
 
-  func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage, replyHandler: (Any?, String?) -> Void) {
-    defer { replyHandler(nil, nil) }
-    
+  func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) async -> (Any?, String?) {
     if !verifyMessage(message: message, securityToken: UserScriptManager.securityToken) {
       assertionFailure("Missing required security token.")
-      return
+      return (nil, nil)
     }
 
     guard let body = message.body as? [String: AnyObject] else {
-      return Logger.module.error("FocusHelper.js sent wrong type of message")
+      Logger.module.error("FocusHelper.js sent wrong type of message")
+      return (nil, nil)
     }
 
     guard let data = body["data"] as? [String: String] else {
-      return Logger.module.error("FocusHelper.js sent wrong type of message")
+      Logger.module.error("FocusHelper.js sent wrong type of message")
+      return (nil, nil)
     }
 
     guard let _ = data["elementType"],
       let eventType = data["eventType"]
     else {
-      return Logger.module.error("FocusHelper.js sent wrong keys for message")
+      Logger.module.error("FocusHelper.js sent wrong keys for message")
+      return (nil, nil)
     }
 
-    switch eventType {
-    case "focus":
-      tab?.isEditing = true
-    case "blur":
-      tab?.isEditing = false
-    default:
-      return Logger.module.error("FocusHelper.js sent unhandled eventType")
+    await MainActor.run {
+      switch eventType {
+      case "focus":
+        tab?.isEditing = true
+      case "blur":
+        tab?.isEditing = false
+      default:
+        return Logger.module.error("FocusHelper.js sent unhandled eventType")
+      }
     }
+    
+    return (nil, nil)
   }
 }

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/LoginsScriptHandler.swift
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/LoginsScriptHandler.swift
@@ -30,27 +30,26 @@ class LoginsScriptHandler: TabContentScript {
   static let messageHandlerName = "loginsScriptMessageHandler"
   static let userScript: WKUserScript? = nil
 
-  func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage, replyHandler: (Any?, String?) -> Void) {
-    defer { replyHandler(nil, nil) }
+  func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) async -> (Any?, String?) {
     if !verifyMessage(message: message, securityToken: UserScriptManager.securityToken) {
       assertionFailure("Missing required security token.")
-      return
+      return (nil, nil)
     }
     
     guard let body = message.body as? [String: AnyObject] else {
-      return
+      return (nil, nil)
     }
 
-    guard let res = body["data"] as? [String: AnyObject] else { return }
-    guard let type = res["type"] as? String else { return }
+    guard let res = body["data"] as? [String: AnyObject],
+          let type = res["type"] as? String else { return (nil, nil) }
 
     // Check to see that we're in the foreground before trying to check the logins. We want to
     // make sure we don't try accessing the logins database while we're backgrounded to avoid
     // the system from terminating our app due to background disk access.
     //
     // See https://bugzilla.mozilla.org/show_bug.cgi?id=1307822 for details.
-    guard UIApplication.shared.applicationState == .active && !profile.isShutdown else {
-      return
+    guard await UIApplication.shared.applicationState == .active && !profile.isShutdown else {
+      return (nil, nil)
     }
 
     // We don't use the WKWebView's URL since the page can spoof the URL by using document.location
@@ -59,26 +58,24 @@ class LoginsScriptHandler: TabContentScript {
       // Since responses go to the main frame, make sure we only listen for main frame requests
       // to avoid XSS attacks.
       if type == "request" {
-        passwordAPI.getSavedLogins(for: url, formScheme: .typeHtml) { [weak self] logins in
-          guard let self = self else { return }
-
-          if let requestId = res["requestId"] as? String {
-            self.autoFillRequestedCredentials(
-              formSubmitURL: res["formSubmitURL"] as? String ?? "",
-              logins: logins,
-              requestId: requestId,
-              frameInfo: message.frameInfo)
-          }
+        let logins = await passwordAPI.savedLogins(for: url, formScheme: .typeHtml)
+        if let requestId = res["requestId"] as? String {
+          await self.autoFillRequestedCredentials(
+            formSubmitURL: res["formSubmitURL"] as? String ?? "",
+            logins: logins,
+            requestId: requestId,
+            frameInfo: message.frameInfo)
         }
       } else if type == "submit" {
         if Preferences.General.saveLogins.value {
-          updateORSaveCredentials(for: url, script: res)
+          await updateORSaveCredentials(for: url, script: res)
         }
       }
     }
+    return (nil, nil)
   }
 
-  private func updateORSaveCredentials(for url: URL, script: [String: Any]) {
+  private func updateORSaveCredentials(for url: URL, script: [String: Any]) async {
     guard let scriptCredentials = passwordAPI.fetchFromScript(url, script: script),
       let username = scriptCredentials.usernameValue,
       scriptCredentials.usernameElement != nil,
@@ -94,41 +91,34 @@ class LoginsScriptHandler: TabContentScript {
       return
     }
 
-    passwordAPI.getSavedLogins(for: url, formScheme: .typeHtml) { [weak self] logins in
-      guard let self = self else { return }
-
-      for login in logins {
-        guard let usernameLogin = login.usernameValue else {
-          continue
-        }
-
-        if usernameLogin.caseInsensitivelyEqual(to: username) {
-          if password == login.passwordValue {
-            return
-          }
-
-          self.showUpdatePrompt(from: login, to: scriptCredentials)
-          return
-        } else {
-          self.showAddPrompt(for: scriptCredentials)
-          return
-        }
+    let logins = await passwordAPI.savedLogins(for: url, formScheme: .typeHtml)
+    for login in logins {
+      guard let usernameLogin = login.usernameValue else {
+        continue
       }
 
-      self.showAddPrompt(for: scriptCredentials)
+      if usernameLogin.caseInsensitivelyEqual(to: username) {
+        if password == login.passwordValue {
+          return
+        }
+
+        await self.showUpdatePrompt(from: login, to: scriptCredentials)
+        return
+      }
     }
+
+    await self.showAddPrompt(for: scriptCredentials)
   }
 
+  @MainActor
   private func showAddPrompt(for login: PasswordForm) {
     addSnackBarForPrompt(for: login, isUpdating: false) { [weak self] in
       guard let self = self else { return }
-
-      DispatchQueue.main.async {
-        self.passwordAPI.addLogin(login)
-      }
+      self.passwordAPI.addLogin(login)
     }
   }
 
+  @MainActor
   private func showUpdatePrompt(from old: PasswordForm, to new: PasswordForm) {
     addSnackBarForPrompt(for: new, isUpdating: true) { [weak self] in
       guard let self = self else { return }
@@ -137,6 +127,7 @@ class LoginsScriptHandler: TabContentScript {
     }
   }
 
+  @MainActor
   private func addSnackBarForPrompt(for login: PasswordForm, isUpdating: Bool, _ completion: @escaping () -> Void) {
     guard let username = login.usernameValue else {
       return
@@ -182,6 +173,7 @@ class LoginsScriptHandler: TabContentScript {
     }
   }
 
+  @MainActor
   private func autoFillRequestedCredentials(formSubmitURL: String, logins: [PasswordForm], requestId: String, frameInfo: WKFrameInfo) {
     let securityOrigin = frameInfo.securityOrigin
 

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/NightModeScriptHandler.swift
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/NightModeScriptHandler.swift
@@ -32,10 +32,12 @@ class NightModeScriptHandler: TabContentScript {
                         in: scriptSandbox)
   }()
 
-  func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage, replyHandler: @escaping (Any?, String?) -> Void) {
+  func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) async -> (Any?, String?) {
     // Do nothing.
+    return (nil, nil)
   }
 
+  @MainActor
   static func setNightMode(tabManager: TabManager, enabled: Bool) {
     Preferences.General.nightModeEnabled.value = enabled
 

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/ReaderModeScriptHandler.swift
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/ReaderModeScriptHandler.swift
@@ -281,16 +281,14 @@ class ReaderModeScriptHandler: TabContentScript {
     delegate?.readerMode(self, didParseReadabilityResult: readabilityResult, forTab: tab)
   }
 
-  func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage, replyHandler: (Any?, String?) -> Void) {
-    defer { replyHandler(nil, nil) }
-    
+  func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) async -> (Any?, String?) {
     if !verifyMessage(message: message, securityToken: UserScriptManager.securityToken) {
       assertionFailure("Missing required security token.")
-      return
+      return (nil, nil)
     }
     
     guard let body = message.body as? [String: AnyObject] else {
-      return
+      return (nil, nil)
     }
 
     if let msg = body["data"] as? Dictionary<String, Any> {
@@ -313,8 +311,11 @@ class ReaderModeScriptHandler: TabContentScript {
         }
       }
     }
+    
+    return (nil, nil)
   }
 
+  @MainActor
   var style: ReaderModeStyle = DefaultReaderModeStyle {
     didSet {
       if state == ReaderModeState.active {
@@ -325,6 +326,7 @@ class ReaderModeScriptHandler: TabContentScript {
     }
   }
 
+  @MainActor
   static func cache(for tab: Tab?) -> ReaderModeCache {
     switch TabType.of(tab) {
     case .regular:

--- a/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/WindowRenderScriptHandler.swift
+++ b/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/WindowRenderScriptHandler.swift
@@ -31,11 +31,14 @@ class WindowRenderScriptHandler: TabContentScript {
                         in: scriptSandbox)
   }()
 
-  func userContentController(_ userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage, replyHandler: (Any?, String?) -> Void) {
+  func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) async -> (Any?, String?) {
     // Do nothing with the messages received.
     // For now.. It's useful for debugging though.
+    
+    return (nil, nil)
   }
 
+  @MainActor
   static func executeScript(for tab: Tab) {
     tab.webView?.evaluateSafeJavaScript(functionName: "window.__firefox__.\(resizeWindowFunction).resizeWindow", contentWorld: scriptSandbox)
   }

--- a/Sources/Brave/Helpers/TabEventHandlers.swift
+++ b/Sources/Brave/Helpers/TabEventHandlers.swift
@@ -5,6 +5,7 @@
 import Foundation
 import Shared
 
+@MainActor
 class TabEventHandlers {
   static func create(with prefs: Prefs) -> [TabEventHandler] {
     return [

--- a/Sources/Brave/Helpers/UserActivityHandler.swift
+++ b/Sources/Brave/Helpers/UserActivityHandler.swift
@@ -13,6 +13,7 @@ private let browsingActivityType: String = "com.brave.ios.browsing"
 
 private let searchableIndex = CSSearchableIndex(name: "firefox")
 
+@MainActor
 class UserActivityHandler {
   private var tabObservers: TabObservers!
 

--- a/Sources/Brave/Shortcuts/ActivityShortcutManager.swift
+++ b/Sources/Brave/Shortcuts/ActivityShortcutManager.swift
@@ -147,6 +147,7 @@ public class ActivityShortcutManager: NSObject {
     }
   }
 
+  @MainActor
   private func handleActivityDetails(type: ActivityType, using bvc: BrowserViewController) {
     switch type {
     case .newTab:

--- a/Sources/Favicon/FaviconFetcher.swift
+++ b/Sources/Favicon/FaviconFetcher.swift
@@ -44,6 +44,7 @@ public class FaviconFetcher {
   /// 4. Fetch Monogram Icons
   /// Notes: Does NOT make a request to fetch icons from the page.
   ///      Requests are only made in FaviconScriptHandler, when the user visits the page.
+  nonisolated
   public static func loadIcon(url: URL, kind: FaviconFetcher.Kind = .smallIcon, persistent: Bool) async throws -> Favicon {
     try Task.checkCancellation()
     
@@ -80,7 +81,7 @@ public class FaviconFetcher {
   /// Creates a monogram Favicon with the following conditions
   /// 1. If `monogramString` is not null, it is used to render the Favicon image.
   /// 2. If `monogramString` is null, the first character of the URL's domain is used to render the Favicon image.
-  public static func monogramIcon(url: URL, monogramString: Character? = nil, persistent: Bool) async throws -> Favicon {
+  nonisolated public static func monogramIcon(url: URL, monogramString: Character? = nil, persistent: Bool) async throws -> Favicon {
     try Task.checkCancellation()
     
     if let favicon = getFromCache(for: url) {

--- a/Sources/Playlist/PlaylistMediaStreamer.swift
+++ b/Sources/Playlist/PlaylistMediaStreamer.swift
@@ -110,6 +110,7 @@ public class PlaylistMediaStreamer {
       }
       
       let newItem = await webLoader.load(url: url)
+      webLoader.stop()
       webLoader.removeFromSuperview()
       self.webLoader = nil
       

--- a/Sources/Playlist/PlaylistSharedFolder.swift
+++ b/Sources/Playlist/PlaylistSharedFolder.swift
@@ -159,16 +159,18 @@ public struct PlaylistSharedFolderNetwork {
       }
       
       let webLoader = webLoaderFactory.makeWebLoader()
-//      let webLoader = PlaylistWebLoader().then {
       viewForInvisibleWebView.insertSubview(webLoader, at: 0)
-//      }
-      
+
       guard let newItem = await webLoader.load(url: url) else {
         // Destroy the web loader.
         webLoader.stop()
         webLoader.removeFromSuperview()
         throw PlaylistMediaStreamer.PlaybackError.cannotLoadMedia
       }
+      
+      // Destroy the web loader.
+      webLoader.stop()
+      webLoader.removeFromSuperview()
       
       return await withCheckedContinuation { continuation in
         PlaylistManager.shared.getAssetDuration(item: newItem) { duration in
@@ -184,10 +186,6 @@ public struct PlaylistSharedFolderNetwork {
                                   tagId: item.tagId,
                                   order: item.order,
                                   isInvisible: newItem.isInvisible)
-          
-          // Destroy the web loader when the callback is complete.
-          webLoader.stop()
-          webLoader.removeFromSuperview()
           continuation.resume(returning: item)
         }
       }


### PR DESCRIPTION
## Summary of Changes
- Added `@MainActor` to Tab and all places that use it
- Made script injection use `async-await` and isolate to `@MainActor` when necessary
- Note: Scripts have NOT changed (There is no changes to Javascript and the like). This is entirely just switching from completion blocks/callbacks to async-await.

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #8762

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [x] Light & dark mode
  - [x] Different size classes (iPhone, landscape, iPad)
  - [x] Different dynamic type sizes

## Test Plan:
- Test that reader-mode and playlist work
- Test brave-skus for VPN still works
- Test night-mode still works
- Test that switching tabs and tab-switcher still works
- Test that favicons still work


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
