### PR TITLE
Fix brave-browser #36266: Buy/Send/Swap button is not opening in Asset Details Screen.

### DIFF
--- a/Sources/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
+++ b/Sources/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
@@ -98,12 +98,12 @@ struct AssetDetailView: View {
 
   @ViewBuilder private var accountsBalanceView: some View {
     VStack {
-      if assetDetailStore.accounts.isEmpty {
+      if assetDetailStore.nonZeroBalanceAccounts.isEmpty {
         emptyAccountState
       } else {
         accountsBalanceHeader
         
-        ForEach(assetDetailStore.accounts) { viewModel in
+        ForEach(assetDetailStore.nonZeroBalanceAccounts) { viewModel in
           accontBalanceRow(viewModel)
         }
       }
@@ -192,7 +192,7 @@ struct AssetDetailView: View {
             kind: .buy,
             initialToken: assetDetailStore.assetDetailToken
           )
-          if assetDetailStore.accounts.isEmpty {
+          if assetDetailStore.allAccountsForTokenCoin.isEmpty {
             onAccountCreationNeeded(destination)
           } else {
             buySendSwapDestination = destination
@@ -205,7 +205,7 @@ struct AssetDetailView: View {
             kind: .send,
             initialToken: assetDetailStore.assetDetailToken
           )
-          if assetDetailStore.accounts.isEmpty {
+          if assetDetailStore.allAccountsForTokenCoin.isEmpty {
             onAccountCreationNeeded(destination)
           } else {
             buySendSwapDestination = destination
@@ -218,7 +218,7 @@ struct AssetDetailView: View {
             kind: .swap,
             initialToken: assetDetailStore.assetDetailToken
           )
-          if assetDetailStore.accounts.isEmpty {
+          if assetDetailStore.allAccountsForTokenCoin.isEmpty {
             onAccountCreationNeeded(destination)
           } else {
             buySendSwapDestination = destination
@@ -274,7 +274,7 @@ struct AssetDetailView: View {
         tokenContentContainer
           .padding(.bottom, 12)
         
-        if (selectedContent == .accounts && !assetDetailStore.accounts.isEmpty) || (selectedContent == .transactions && !assetDetailStore.transactionSections.isEmpty) {
+        if (selectedContent == .accounts && !assetDetailStore.nonZeroBalanceAccounts.isEmpty) || (selectedContent == .transactions && !assetDetailStore.transactionSections.isEmpty) {
           Text(Strings.Wallet.coinGeckoDisclaimer)
             .multilineTextAlignment(.center)
             .font(.footnote)
@@ -446,6 +446,25 @@ struct AssetDetailView: View {
         isShowingAuroraBridgeAlert = false
       }
     }
+    .addAccount(
+      keyringStore: keyringStore,
+      networkStore: networkStore,
+      accountNetwork: networkStore.network(for: assetDetailStore.assetDetailToken),
+      isShowingConfirmation: $isPresentingAddAccountConfirmation,
+      isShowingAddAccount: $isPresentingAddAccount,
+      onConfirmAddAccount: { isPresentingAddAccount = true },
+      onCancelAddAccount: nil,
+      onAddAccountDismissed: {
+        Task { @MainActor in
+          if await assetDetailStore.handleDismissAddAccount() {
+            if let savedBSSDestination {
+              buySendSwapDestination = savedBSSDestination
+              self.savedBSSDestination = nil
+            }
+          }
+        }
+      }
+    )
   }
   
   private func onAccountCreationNeeded(_ destination: BuySendSwapDestination) {

--- a/Sources/BraveWallet/Crypto/Stores/AssetDetailStore.swift
+++ b/Sources/BraveWallet/Crypto/Stores/AssetDetailStore.swift
@@ -48,7 +48,7 @@ class AssetDetailStore: ObservableObject, WalletObserverStore {
     }
   }
   @Published private(set) var isLoadingAccountBalances: Bool = false
-  @Published private(set) var accounts: [AccountAssetViewModel] = []
+  @Published private(set) var nonZeroBalanceAccounts: [AccountAssetViewModel] = []
   @Published private(set) var transactionSections: [TransactionSection] = []
   @Published private(set) var isBuySupported: Bool = false
   @Published private(set) var isSendSupported: Bool = false
@@ -67,7 +67,7 @@ class AssetDetailStore: ObservableObject, WalletObserverStore {
   let currencyFormatter: NumberFormatter = .usdCurrencyFormatter
 
   var totalBalance: Double {
-    accounts
+    nonZeroBalanceAccounts
       .compactMap { Double($0.balance) }
       .reduce(0, +)
   }
@@ -120,6 +120,9 @@ class AssetDetailStore: ObservableObject, WalletObserverStore {
     keyringServiceObserver != nil && txServiceObserver != nil && walletServiceObserver != nil
   }
 
+  // All account info that has the same coin type as this asset's
+  var allAccountsForTokenCoin: [BraveWallet.AccountInfo] = []
+  
   init(
     assetRatioService: BraveWalletAssetRatioService,
     keyringService: BraveWalletKeyringService,
@@ -207,7 +210,7 @@ class AssetDetailStore: ObservableObject, WalletObserverStore {
         self.isSwapSupported = await swapService.isSwapSupported(token.chainId)
         
         // fetch accounts
-        let allAccountsForTokenCoin = await keyringService.allAccounts().accounts.filter { $0.coin == token.coin }
+        self.allAccountsForTokenCoin = await keyringService.allAccounts().accounts.filter { $0.coin == token.coin }
         var updatedAccounts = allAccountsForTokenCoin.map {
           AccountAssetViewModel(account: $0, decimalBalance: 0.0, balance: "", fiatBalance: "")
         }
@@ -233,7 +236,7 @@ class AssetDetailStore: ObservableObject, WalletObserverStore {
         }
         
         // fetch accounts balance
-        self.accounts = await fetchAccountBalances(updatedAccounts, network: network)
+        self.nonZeroBalanceAccounts = await fetchAccountBalances(updatedAccounts, network: network)
         
         // fetch transactions
         let userAssets = assetManager.getAllUserAssetsInNetworkAssets(networks: [network], includingUserDeleted: true).flatMap { $0.tokens }
@@ -315,7 +318,8 @@ class AssetDetailStore: ObservableObject, WalletObserverStore {
         // below is all not supported from Market tab
         self.isSendSupported = false
         self.isSwapSupported = false
-        self.accounts = []
+        self.allAccountsForTokenCoin = []
+        self.nonZeroBalanceAccounts = []
         self.transactionSections =  []
       }
     }

--- a/Tests/BraveWalletTests/AssetDetailStoreTests.swift
+++ b/Tests/BraveWalletTests/AssetDetailStoreTests.swift
@@ -156,7 +156,7 @@ class AssetDetailStoreTests: XCTestCase {
         XCTAssertEqual($0, "1%")
       }
       .store(in: &cancellables)
-    store.$accounts
+    store.$nonZeroBalanceAccounts
       .dropFirst()
       .sink { accounts in
         defer { assetDetailException.fulfill() }
@@ -368,7 +368,7 @@ class AssetDetailStoreTests: XCTestCase {
       .sink { values in
         defer {
           XCTAssertNil(store.network)
-          XCTAssertTrue(store.accounts.isEmpty)
+          XCTAssertTrue(store.nonZeroBalanceAccounts.isEmpty)
           XCTAssertTrue(store.transactionSections.isEmpty)
 
           assetDetailBitcoinException.fulfill()
@@ -450,7 +450,7 @@ class AssetDetailStoreTests: XCTestCase {
       .sink {
         defer {
           XCTAssertNil(store.network)
-          XCTAssertTrue(store.accounts.isEmpty)
+          XCTAssertTrue(store.nonZeroBalanceAccounts.isEmpty)
           XCTAssertTrue(store.transactionSections.isEmpty)
           
           assetDetailNonBitcoinException.fulfill()
@@ -484,7 +484,7 @@ class AssetDetailStoreTests: XCTestCase {
       .sink { values in
         defer {
           XCTAssertNil(store.network)
-          XCTAssertTrue(store.accounts.isEmpty)
+          XCTAssertTrue(store.nonZeroBalanceAccounts.isEmpty)
           XCTAssertTrue(store.transactionSections.isEmpty)
           
           assetDetailNonBitcoinException.fulfill()


### PR DESCRIPTION
Ref: 
https://github.com/brave/brave-core/pull/22229

<!-- *Thank you for submitting a pull request, your contributions are greatly appreciated!* -->

## Summary of Changes
Copy over the fix from brave-core to brave-ios for 1.62.x hotfix. 

<!-- Enter a ticket number for this PR, create a new one if it is not there yet. -->
This pull request fixes #<number>

## Submitter Checklist:

- [x] *Unit Tests* are updated to cover new or changed functionality
- [x] User-facing strings use `NSLocalizableString()`
- [x] New or updated UI has been tested across:
  - [ ] Light & dark mode
  - [ ] Different size classes (iPhone, landscape, iPad)
  - [ ] Different dynamic type sizes

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
Go to an asset details that no wallet account has balance of it
click Buy/Send/Swap button
button should open correct screen for users to buy/send/swap


## Screenshots:
<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->


## Reviewer Checklist:

- [ ] Issues include necessary QA labels:
  - `QA/(Yes|No)`
  - `bug` / `enhancement`
- [ ] Necessary [security reviews](https://github.com/brave/security/issues/new/choose) have taken place.
- [ ] Adequate unit test coverage exists to prevent regressions.
- [ ] Adequate test plan exists for QA to validate (if applicable).
- [ ] Issue and pull request is assigned to a milestone (should happen at merge time).
